### PR TITLE
Fix: No field data on dedicated servers with Precision Farming (#40)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ assignees: ''
 
 | Field | Your answer |
 |-------|-------------|
-| **Mod version** | <!-- Check the mod menu or modDesc.xml → e.g. 1.0.7.0 --> |
+| **Mod version** | <!-- Check the mod menu or modDesc.xml → e.g. 1.0.7.1 --> |
 | **Game mode** | <!-- Singleplayer / Multiplayer Host / Multiplayer Client --> |
 | **Difficulty** | <!-- Simple / Realistic / Hardcore --> |
 | **Precision Farming active** | <!-- Yes / No --> |

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.7.0</version>
+    <version>1.0.7.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil & Fertilizer</en>

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1,5 +1,5 @@
 -- =========================================================
--- FS25 Realistic Soil & Fertilizer (version 1.0.7.0)
+-- FS25 Realistic Soil & Fertilizer (version 1.0.7.1)
 -- =========================================================
 -- Soil HUD Overlay - legend/reference display (toggle with J key)
 -- =========================================================


### PR DESCRIPTION
On dedicated servers running Precision Farming alongside this mod, all clients saw no soil data for any field. The server log showed fields scanning successfully (253 fields initialised) but players could not retrieve any data through the HUD, soil report, or console commands.

Two root causes combined to produce the issue:

**1. False read-only mode on dedicated servers**
`checkPFCompatibility` detected Precision Farming was loaded and immediately set `PFActive = true`. On a dedicated server, `g_precisionFarming` exists but its field data API (`fieldData` table and `soilMap:getFieldData`) is not populated at mod-init time. With `PFActive = true`, every data-writing function (`updateFieldNutrients`, `applyFertilizer`, `updateDailySoil`, `applyRainEffects`) returned early, and `getOrCreateField` attempted to read from the PF API, got nothing, then fell through to lazy-create a field — but multiplayer clients hit the `g_server == nil` guard and received `nil` instead.

**2. No initial field data sync to clients**
Field data was only broadcast to clients when a harvest or fertilizer event occurred. On a freshly loaded server where nothing had been worked yet, clients received zero sync events and had empty field tables for the entire session.

### Changes

**`checkPFCompatibility`**
Added a second step that probes the PF API after detecting the mod. If neither `g_precisionFarming.fieldData` nor `soilMap:getFieldData` are accessible, the mod logs a warning and falls back to independent mode rather than entering a broken read-only state.

**`scanFields`**
- Field ID resolution priority corrected: `field.fieldId` → `field.id` → `field.index` → loop key. Previously the loop key (an internal table index) was second priority and could store data under the wrong ID on some maps.
- Removed the `hasFarmland` gate. Unowned fields are valid and must be tracked so data is ready when ownership is later assigned.
- Calls `broadcastAllFieldData()` after a successful scan.

**`broadcastAllFieldData()` (new)**
Iterates `self.fieldData` and broadcasts each field to all connected clients via `SoilFieldUpdateEvent`. Called after scan and after `loadFromXMLFile`.

**`onClientJoined(connection)` (new)**
Sends the full field state to a single newly-joined client. Must be wired up in the multiplayer connection-accepted handler.

**`loadFromXMLFile`**
Now calls `broadcastAllFieldData()` after loading so clients reconnecting after a save/load cycle receive up-to-date values immediately.

### Testing

- Verify against the log from issue #40 (dedicated server, 100+ mods, Precision Farming active)
- `checkPFCompatibility` will now log `[SoilFertilizer WARNING] Precision Farming detected but API not accessible (dedicated server / load-order issue) - falling back to independent mode` in affected environments
- After the field scan log line, `[SoilFertilizer] Broadcast initial field data for N fields to all clients` should appear
- Awaiting confirmation from @RustFarming

### Notes for reviewers

`onClientJoined` is a new public method but is not yet wired to a connection event — a follow-up is needed to hook it into wherever the server accepts new connections. The broadcast after scan covers the common case (all players present at load); `onClientJoined` handles late joiners.