### PR TITLE
fix: Resolve critical Lua syntax error and module reference issues

### DIFF
--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -33,7 +33,7 @@ function SoilSettingsGUI:registerConsoleCommands()
     addConsoleCommand("SoilDebug", "Toggle debug mode", "consoleCommandDebug", self)
     addConsoleCommand("soilfertility", "Show all soil commands", "consoleCommandHelp", self)
 
-    Logging.info("[SoilFertilizer] Console commands registered")
+    SoilLogger.info("[SoilFertilizer] Console commands registered")
 end
 
 function SoilSettingsGUI:consoleCommandHelp()
@@ -62,7 +62,7 @@ end
 function SoilSettingsGUI:consoleCommandSetDifficulty(difficulty)
     local diff = tonumber(difficulty)
     if not diff or diff < 1 or diff > 3 then
-        Logging.warning("Invalid difficulty. Use 1 (Simple), 2 (Realistic), or 3 (Hardcore)")
+        SoilLogger.warning("Invalid difficulty. Use 1 (Simple), 2 (Realistic), or 3 (Hardcore)")
         return "Invalid difficulty"
     end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then


### PR DESCRIPTION
This PR fixes critical bugs that prevent the mod from loading in Farming Simulator 25.

## Changes Made

### 1. Lua Syntax Error Fix (SoilFertilityManager.lua)
- **Line 500**: Used reserved Lua keyword \`function\` as a table key
- **Before**: \`function = checkFunction\`
- **After**: \`checkFunc = checkFunction\`
- Also fixed the reference in \`runHealthChecks()\` from \`check.function\` to \`check.checkFunc\`

### 2. Module Reference Fix (SoilSettingsGUI.lua)
- Used undefined \`Logging\` module which was never loaded
- Changed \`Logging.info()\` to \`SoilLogger.info()\`
- Changed \`Logging.warning()\` to \`SoilLogger.warning()\`

Close #42 