### PR TITLE
fix: correct field ID lookup using farmland.id (v1.0.8.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.7.3</version>
+    <version>1.0.8.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil & Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -461,34 +461,16 @@ function SoilFertilitySystem:scanFields()
     end
 
     -- TRUE FS25 SOURCE OF TRUTH
-    -- Field ID priority: field.fieldId → field.id → field.index → loop key (last resort)
-    -- The loop key is an internal table index that may not match the in-game field ID
-    -- on all maps, so it is only used as a fallback.
-    -- NOTE: hasFarmland is logged for debug but no longer gates initialization —
-    -- unowned fields are valid and must be tracked so data is ready when ownership changes.
-    for fieldId, field in pairs(g_fieldManager.fields) do
-        local numericFieldId = tonumber(fieldId) or fieldId
-
+    -- field.fieldId / field.id / field.index do NOT exist in FS25 — all return nil.
+    -- The correct field identifier is field.farmland.id (confirmed in-game).
+    local fields = g_currentMission.fieldManager:getFields()
+    for _, field in ipairs(fields) do
         if field and type(field) == "table" then
-            local actualFieldId = nil
-
-            if field.fieldId and field.fieldId > 0 then
-                actualFieldId = field.fieldId
-            elseif field.id and field.id > 0 then
-                actualFieldId = field.id
-            elseif field.index and field.index > 0 then
-                actualFieldId = field.index
-            elseif type(numericFieldId) == "number" and numericFieldId > 0 then
-                actualFieldId = numericFieldId  -- last resort
-            end
+            local actualFieldId = field.farmland and field.farmland.id
 
             if actualFieldId and actualFieldId > 0 then
-                -- Log farmland status for debug but don't gate on it
                 if self.settings.debugMode then
-                    local hasFarmland = (field.farmland and field.farmland.id and field.farmland.id > 0)
-                                     or (field.farmlandId and field.farmlandId > 0)
-                    print(string.format("[SoilFertilizer DEBUG] Found field %d (farmland: %s)",
-                        actualFieldId, tostring(hasFarmland)))
+                    print(string.format("[SoilFertilizer DEBUG] Found field %d", actualFieldId))
                 end
 
                 self:getOrCreateField(actualFieldId, true)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -282,29 +282,29 @@ function HookManager:installPlowingHook()
                 local z = (workArea[2] + workArea[5]) / 2
 
                 if g_farmlandManager then
-                    local farmlandId = g_farmlandManager:getFarmlandIdAtWorldPosition(x, z)
-                    if farmlandId and farmlandId > 0 and g_fieldManager then
-                        local field = g_fieldManager:getFieldByFarmland(farmlandId)
-                        if field and field.fieldId then
-                            -- Check if this is a plowing implement (various types trigger soil benefits)
-                            -- spec_plow: Traditional plows, moldboard plows
-                            -- spec_subsoiler: Deep loosening tools (improve OM mixing)
-                            -- spec_cultivator with deep work: Some cultivators act as plows
-                            local isPlowingTool = cultivatorSelf.spec_plow ~= nil or
-                                                  cultivatorSelf.spec_subsoiler ~= nil
+                    -- getFarmlandAtWorldPosition returns a farmland object; .id is the field identifier.
+                    -- getFarmlandIdAtWorldPosition and getFieldByFarmland do NOT exist in FS25.
+                    local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
+                    local farmlandId = farmland and farmland.id
+                    if farmlandId and farmlandId > 0 then
+                        -- Check if this is a plowing implement (various types trigger soil benefits)
+                        -- spec_plow: Traditional plows, moldboard plows
+                        -- spec_subsoiler: Deep loosening tools (improve OM mixing)
+                        -- spec_cultivator with deep work: Some cultivators act as plows
+                        local isPlowingTool = cultivatorSelf.spec_plow ~= nil or
+                                              cultivatorSelf.spec_subsoiler ~= nil
 
-                            -- Some cultivators work deep enough to act as plows
-                            if not isPlowingTool and cultivatorSelf.spec_cultivator then
-                                local cultivatorSpec = cultivatorSelf.spec_cultivator
-                                -- Check if working depth is significant (deep plowing threshold)
-                                if cultivatorSpec.workingDepth and cultivatorSpec.workingDepth > SoilConstants.PLOWING.MIN_DEPTH_FOR_PLOWING then
-                                    isPlowingTool = true
-                                end
+                        -- Some cultivators work deep enough to act as plows
+                        if not isPlowingTool and cultivatorSelf.spec_cultivator then
+                            local cultivatorSpec = cultivatorSelf.spec_cultivator
+                            -- Check if working depth is significant (deep plowing threshold)
+                            if cultivatorSpec.workingDepth and cultivatorSpec.workingDepth > SoilConstants.PLOWING.MIN_DEPTH_FOR_PLOWING then
+                                isPlowingTool = true
                             end
+                        end
 
-                            if isPlowingTool then
-                                g_SoilFertilityManager.soilSystem:onPlowing(field.fieldId)
-                            end
+                        if isPlowingTool then
+                            g_SoilFertilityManager.soilSystem:onPlowing(farmlandId)
                         end
                     end
                 end


### PR DESCRIPTION
## Summary
- `field.fieldId`, `field.id`, `field.index` do not exist in FS25 — all return nil, silently breaking field tracking
- `g_farmlandManager:getFarmlandIdAtWorldPosition()` and `g_fieldManager:getFieldByFarmland()` also do not exist
- Fixes field initialization scan in `SoilFertilitySystem` and plow hook in `HookManager`

## Changes
- **SoilFertilitySystem.lua**: Replaced broken 4-way field ID fallback chain with `field.farmland.id` via `fieldManager:getFields()`
- **HookManager.lua**: Fixed plow hook to use `getFarmlandAtWorldPosition(x, z)` → farmland object → `farmland.id`
- **modDesc.xml**: Bumped version to 1.0.8.0

## Test plan
- [ ] Place a plow on any field and work it — confirm `[SoilFertilizer]` log shows plowing event for correct field ID
- [ ] Start a new game — confirm all fields are scanned and initialized in log (`Scanned X farmlands and initialized Y fields`)
- [ ] Load a saved game — confirm field fertility data is preserved per field