### PR TITLE
feat: add Custom HUD position (v1.1.3.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.1.2.0</version>
+    <version>1.1.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil & Fertilizer</en>
@@ -507,6 +507,20 @@
             <uk>Центр правий</uk>
             <ru>Центр правый</ru>
             <hu>Középen jobbra</hu>
+        </text>
+
+        <text name="sf_hud_pos_6">
+            <en>Custom</en>
+            <de>Benutzerdefiniert</de>
+            <fr>Personnalisé</fr>
+            <pl>Niestandardowy</pl>
+            <es>Personalizado</es>
+            <it>Personalizzato</it>
+            <cz>Vlastní</cz>
+            <br>Personalizado</br>
+            <uk>Власний</uk>
+            <ru>Пользовательский</ru>
+            <hu>Egyéni</hu>
         </text>
 
         <text name="sf_hud_color_theme_short">

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -66,9 +66,9 @@ SettingsSchema.definitions = {
     {
         id = "hudPosition",
         type = "number",
-        default = 1,  -- 1=Top Right, 2=Top Left, 3=Bottom Right, 4=Bottom Left, 5=Center Right
+        default = 1,  -- 1=Top Right, 2=Top Left, 3=Bottom Right, 4=Bottom Left, 5=Center Right, 6=Custom
         min = 1,
-        max = 5,
+        max = 6,
         uiId = "sf_hud_position",
         pfProtected = false,
         localOnly = true,  -- per-player display preference, not synced to server

--- a/src/settings/SoilSettingsUI.lua
+++ b/src/settings/SoilSettingsUI.lua
@@ -247,7 +247,8 @@ function SoilSettingsUI:onFrameOpen(frame)
             g_i18n:getText("sf_hud_pos_2") or "Top Left",
             g_i18n:getText("sf_hud_pos_3") or "Bottom Right",
             g_i18n:getText("sf_hud_pos_4") or "Bottom Left",
-            g_i18n:getText("sf_hud_pos_5") or "Center Right"
+            g_i18n:getText("sf_hud_pos_5") or "Center Right",
+            g_i18n:getText("sf_hud_pos_6") or "Custom"
         }
 
         local ok5, hudPosElement = pcall(UIHelper.createMultiOption, layout, SoilSettingsUI, "onHudPositionChanged", hudPosOptions,

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -118,6 +118,8 @@ end
 
 -- ── Position preset ──────────────────────────────────────
 function SoilHUD:updatePosition()
+    -- hudPosition 6 = Custom: use whatever loadLayout() restored, don't overwrite
+    if (self.settings.hudPosition or 1) == 6 then return end
     local pos = SoilConstants.HUD.POSITIONS[self.settings.hudPosition or 1]
     if pos then
         self.panelX = pos.x
@@ -129,6 +131,7 @@ end
 function SoilHUD:enterEditMode()
     self.editMode = true
     self.dragging = false
+    self.movedInEditMode = false
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(true)
     end
@@ -154,6 +157,15 @@ function SoilHUD:exitEditMode()
         g_inputBinding:setShowMouseCursor(false)
     end
     self:saveLayout()
+    -- If the player actually moved/resized, switch setting to Custom (6)
+    if self.movedInEditMode then
+        self.movedInEditMode = false
+        self.settings.hudPosition = 6
+        self.settings:save()
+        if g_SoilFertilityManager and g_SoilFertilityManager.settingsUI then
+            g_SoilFertilityManager.settingsUI:refreshUI()
+        end
+    end
     SoilLogger.info("[SoilHUD] Edit mode OFF — pos=(%.3f,%.3f) scale=%.2f",
         self.panelX, self.panelY, self.scale)
 end
@@ -257,12 +269,14 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button)
             self.resizing = true ; self.dragging = false
             self.resizeStartX = posX ; self.resizeStartY = posY
             self.resizeStartScale = self.scale
+            self.movedInEditMode = true
             return
         end
         if self:isPointerOverHUD(posX, posY) then
             self.dragging = true ; self.resizing = false
             self.dragOffsetX = posX - self.panelX
             self.dragOffsetY = posY - self.panelY
+            self.movedInEditMode = true
         end
         return
     end


### PR DESCRIPTION
## Summary
- Adds a 6th **Custom** option to the HUD Position setting
- When the player drags or resizes the HUD in edit mode, the setting switches to **Custom** automatically (via `movedInEditMode` flag set on LMB down)
- `updatePosition()` skips preset application when hudPosition == 6, so the saved layout is used instead
- Selecting any preset from the dropdown still works as before
- UI dropdown refreshes immediately after dragging to reflect the change

## Test plan
- [ ] Drag HUD to new position → dropdown switches to "Custom"
- [ ] Save game, reload → HUD appears at custom position
- [ ] Select a preset from dropdown → HUD snaps to preset
- [ ] Right-click HUD to enter edit mode, right-click again without moving → does NOT switch to Custom