### PR TITLE
fix: MP dedicated server — soil fertility hook desync

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.1.4.0</version>
+    <version>1.1.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil & Fertilizer</en>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -158,6 +158,7 @@ function HookManager:installHarvestHook()
     FruitUtil.fruitPickupEvent = Utils.appendedFunction(
         original,
         function(fruitTypeIndex, x, z, fieldId, liters)
+            if not g_currentMission:getIsServer() then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled or
@@ -356,6 +357,7 @@ function HookManager:installOwnershipHook()
     g_farmlandManager.fieldOwnershipChanged = Utils.appendedFunction(
         original,
         function(fieldId, farmlandId, farmId)
+            if not g_currentMission:getIsServer() then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled then
@@ -396,6 +398,7 @@ function HookManager:installWeatherHook()
     env.update = Utils.appendedFunction(
         original,
         function(envSelf, dt, ...)
+            if not g_currentMission:getIsServer() then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled or
@@ -431,6 +434,7 @@ function HookManager:installPlowingHook()
     Cultivator.processCultivatorArea = Utils.appendedFunction(
         original,
         function(cultivatorSelf, superFunc, workArea, dt)
+            if not g_currentMission:getIsServer() then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled or


### PR DESCRIPTION
## Summary

- Harvest, field ownership, weather, and plowing hooks now check `g_currentMission:getIsServer()` before modifying field fertility state
- Prevents field nutrient data desync in MP/dedicated server where both server and client were applying the same soil mutations
- The sprayer hook already had its own `self.isServer` guard and was not changed
- Version bumped to 1.1.5.0

## Test plan

- [ ] Start a listen MP session (host + 1 client) and harvest a field — verify only the server applies the fertility depletion
- [ ] Apply fertilizer in MP — verify only the server tracks the nutrient change
- [ ] Plow a field in MP — verify only the server applies the plowing bonus
- [ ] Verify clients still see updated soil data via the existing network sync path
- [ ] Load on a dedicated server — verify no Lua errors in log.txt