### PR TITLE
fix: patch fill type HUD icons via Lua ( not resolved in fillTypes.xml)

### DIFF
--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -3,29 +3,31 @@
     <fillTypes>
 
         <!-- ── LIQUID NITROGEN SOURCES ───────────────────────── -->
+        <!-- HUD icons are patched via Lua in loadedMission() using modDirectory  -->
+        <!-- $modDir is not resolved in this XML loading context                  -->
 
         <fillType name="UAN32" title="$l10n_sf_uan32_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="1.32" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.60"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_UAN32.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
         </fillType>
 
         <fillType name="UAN28" title="$l10n_sf_uan28_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="1.28" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.50"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_UAN28.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
         </fillType>
 
         <fillType name="ANHYDROUS" title="$l10n_sf_anhydrous_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.61" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.85"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_anhydrous.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
         </fillType>
 
         <fillType name="STARTER" title="$l10n_sf_starter_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="1.10" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.70"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_Starter.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
         </fillType>
 
         <!-- ── SOLID GRANULAR SOURCES ─────────────────────────── -->
@@ -33,56 +35,31 @@
         <fillType name="UREA" title="$l10n_sf_urea_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.77" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.65"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_UREA.dds"/>
-            <fillPlane
-                diffuseMapFilename="$modDir/textures/fillPlanes/urea_diffuse.dds"
-                normalMapFilename="$modDir/textures/fillPlanes/urea_normal.dds"
-                heightMapFilename="$modDir/textures/fillPlanes/urea_height.dds"
-                displacementMapFilename="$modDir/textures/fillPlanes/urea_displacement.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
         </fillType>
 
         <fillType name="AMS" title="$l10n_sf_ams_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.87" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.40"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_AMS.dds"/>
-            <fillPlane
-                diffuseMapFilename="$modDir/textures/fillPlanes/AMS_diffuse.dds"
-                normalMapFilename="$modDir/textures/fillPlanes/AMS_normal.dds"
-                heightMapFilename="$modDir/textures/fillPlanes/AMS_height.dds"
-                displacementMapFilename="$modDir/textures/fillPlanes/AMS_displacement.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
         </fillType>
 
         <fillType name="MAP" title="$l10n_sf_map_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.95"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_map.dds"/>
-            <fillPlane
-                diffuseMapFilename="$modDir/textures/fillPlanes/MAP_diffuse.dds"
-                normalMapFilename="$modDir/textures/fillPlanes/MAP_normal.dds"
-                heightMapFilename="$modDir/textures/fillPlanes/MAP_height.dds"
-                displacementMapFilename="$modDir/textures/fillPlanes/MAP_displacement.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
         </fillType>
 
         <fillType name="DAP" title="$l10n_sf_dap_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.75"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_dap.dds"/>
-            <fillPlane
-                diffuseMapFilename="$modDir/textures/fillPlanes/DAP_diffuse.dds"
-                normalMapFilename="$modDir/textures/fillPlanes/DAP_normal.dds"
-                heightMapFilename="$modDir/textures/fillPlanes/DAP_height.dds"
-                displacementMapFilename="$modDir/textures/fillPlanes/DAP_displacement.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
         </fillType>
 
         <fillType name="POTASH" title="$l10n_sf_potash_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.95" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.80"/>
-            <image hud="$modDir/hud/fillTypes/hud_fill_potash.dds"/>
-            <fillPlane
-                diffuseMapFilename="$modDir/textures/fillPlanes/potash_diffuse.dds"
-                normalMapFilename="$modDir/textures/fillPlanes/potash_normal.dds"
-                heightMapFilename="$modDir/textures/fillPlanes/potash_height.dds"
-                displacementMapFilename="$modDir/textures/fillPlanes/potash_displacement.dds"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
         </fillType>
 
     </fillTypes>

--- a/src/main.lua
+++ b/src/main.lua
@@ -75,6 +75,30 @@ local function loadedMission(mission, node)
     if not isEnabled() or mission.cancelLoading then return end
     sfm:onMissionLoaded()
 
+    -- $modDir is not resolved in the fillTypes.xml loading context, so we patch
+    -- the HUD icon filenames directly via Lua using the captured modDirectory.
+    if g_fillTypeManager then
+        local hudDir = modDirectory .. "hud/fillTypes/"
+        local icons = {
+            UAN32     = "hud_fill_UAN32.dds",
+            UAN28     = "hud_fill_UAN28.dds",
+            ANHYDROUS = "hud_fill_anhydrous.dds",
+            STARTER   = "hud_fill_Starter.dds",
+            UREA      = "hud_fill_UREA.dds",
+            AMS       = "hud_fill_AMS.dds",
+            MAP       = "hud_fill_map.dds",
+            DAP       = "hud_fill_dap.dds",
+            POTASH    = "hud_fill_potash.dds",
+        }
+        for name, file in pairs(icons) do
+            local ft = g_fillTypeManager:getFillTypeByName(name)
+            if ft then
+                ft.hudOverlayFilename = hudDir .. file
+            end
+        end
+        SoilLogger.info("Custom HUD icons patched for mod fill types")
+    end
+
     -- Note: Multiplayer sync is handled in loadFromXMLFile hook
 end
 


### PR DESCRIPTION
## Summary

- `$modDir` is not substituted in the `fillTypes.xml` loading context, causing `Error: Missing dds file 'modDir/hud/...'` in the log
- Reverted `fillTypes.xml` HUD paths back to vanilla `$dataS` fallbacks to eliminate errors
- Added Lua patch in `loadedMission()` that sets `hudOverlayFilename` on all 9 mod fill types using the captured `modDirectory` — guaranteed path resolution regardless of XML loading context
- Removed `<fillPlane>` entries from `fillTypes.xml` (same `$modDir` issue would affect them; textures remain in the repo for future wiring)

## Test plan

- [ ] Load map — confirm no `Missing dds file` errors in log.txt
- [ ] Confirm log shows `Custom HUD icons patched for mod fill types`
- [ ] Verify each fertilizer type shows its custom icon in vehicle HUD