### PR TITLE
fix(#99): use farmland.id loop to find field for live crop detection

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.0.0</version>
+    <version>1.3.0.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil & Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -91,6 +91,31 @@ end
 ---@param liters number Amount harvested in liters
 ---@param strawRatio number 0.0-1.0 fraction of straw that was chopped (0 = dropped/collected, 1 = fully chopped)
 function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRatio)
+    -- Apply weed pressure yield penalty before nutrient update so the penalty
+    -- is applied to the actual liters harvested (not already depleted).
+    if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
+        local field = self.fieldData[fieldId]
+        if field then
+            local wp = SoilConstants.WEED_PRESSURE
+            local pressure = field.weedPressure or 0
+            local penalty
+            if pressure < wp.LOW then
+                penalty = wp.YIELD_PENALTY_LOW
+            elseif pressure < wp.MEDIUM then
+                penalty = wp.YIELD_PENALTY_MID
+            elseif pressure < wp.HIGH then
+                penalty = wp.YIELD_PENALTY_HIGH
+            else
+                penalty = wp.YIELD_PENALTY_PEAK
+            end
+            if penalty > 0 then
+                liters = liters * (1.0 - penalty)
+                self:log("Weed penalty field %d: pressure=%.0f, penalty=%.0f%%",
+                    fieldId, pressure, penalty * 100)
+            end
+        end
+    end
+
     self:updateFieldNutrients(fieldId, fruitTypeIndex, liters, strawRatio)
 
     SoilLogger.debug("Harvest: Field %d, Crop %d, %.0fL", fieldId, fruitTypeIndex, liters)
@@ -215,6 +240,14 @@ function SoilFertilitySystem:onPlowing(fieldId)
         changed = true
     end
 
+    -- Plowing benefit 3: Reset weed pressure to 0 (tillage buries weed seeds/roots)
+    if self.settings.weedPressure and (field.weedPressure or 0) > 0 then
+        self:log("[Plowing] Field %d: weed pressure %.0f -> 0 (tillage reset)", fieldId, field.weedPressure)
+        field.weedPressure = 0
+        field.herbicideDaysLeft = 0
+        changed = true
+    end
+
     -- Debug logging
     if self.settings.debugMode and changed then
         self:info("[Plowing] Field %d: OM %.1f->%.1f, pH %.2f->%.2f",
@@ -224,6 +257,34 @@ function SoilFertilitySystem:onPlowing(fieldId)
     -- Broadcast to clients if server in multiplayer
     if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo.isMultiplayer then
         if field and SoilFieldUpdateEvent then
+            g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+        end
+    end
+end
+
+--- Called when herbicide is applied to a field.
+--- Reduces weed pressure and activates suppression window.
+---@param fieldId number
+---@param effectiveness number 0.0-1.0 herbicide effectiveness multiplier
+function SoilFertilitySystem:onHerbicideApplied(fieldId, effectiveness)
+    if not self.settings.weedPressure then return end
+    if not SoilConstants.WEED_PRESSURE then return end
+
+    local field = self:getOrCreateField(fieldId, false)
+    if not field then return end
+
+    local wp = SoilConstants.WEED_PRESSURE
+    local reduction = wp.HERBICIDE_PRESSURE_REDUCTION * (effectiveness or 1.0)
+    local before = field.weedPressure or 0
+    field.weedPressure = math.max(0, before - reduction)
+    field.herbicideDaysLeft = wp.HERBICIDE_DURATION_DAYS
+
+    self:log("[Herbicide] Field %d: weed pressure %.0f -> %.0f, protected for %d days",
+        fieldId, before, field.weedPressure, field.herbicideDaysLeft)
+
+    -- Broadcast in multiplayer
+    if g_server and g_currentMission and g_currentMission.missionDynamicInfo.isMultiplayer then
+        if SoilFieldUpdateEvent then
             g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
         end
     end
@@ -549,7 +610,9 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing)
                 lastHarvest = 0,
                 fertilizerApplied = 0,
                 initialized = true,
-                fromPF = true
+                fromPF = true,
+                weedPressure = 0,
+                herbicideDaysLeft = 0,
             }
             self:log("Created field %d from PF data", fieldId)
             return self.fieldData[fieldId]
@@ -579,7 +642,9 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing)
         lastHarvest = 0,
         fertilizerApplied = 0,
         initialized = true,
-        fromPF = false
+        fromPF = false,
+        weedPressure = 0,
+        herbicideDaysLeft = 0,
     }
 
     self:log("Lazy-created field %d with natural soil variation", fieldId)
@@ -622,6 +687,46 @@ function SoilFertilitySystem:updateDailySoil()
             field.pH = math.min(limits.PH_NEUTRAL_LOW, field.pH + phNorm.RATE)
         elseif field.pH > limits.PH_NEUTRAL_HIGH then
             field.pH = math.max(limits.PH_NEUTRAL_HIGH, field.pH - phNorm.RATE)
+        end
+
+        -- Weed pressure daily growth
+        if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
+            local wp = SoilConstants.WEED_PRESSURE
+            local pressure = field.weedPressure or 0
+            local herbDays = field.herbicideDaysLeft or 0
+
+            -- Decrement herbicide protection
+            if herbDays > 0 then
+                field.herbicideDaysLeft = herbDays - 1
+            end
+
+            -- Only grow when not under herbicide protection
+            if (field.herbicideDaysLeft or 0) <= 0 then
+                -- Base rate by current pressure tier
+                local baseRate
+                if pressure < wp.LOW then
+                    baseRate = wp.GROWTH_RATE_LOW
+                elseif pressure < wp.MEDIUM then
+                    baseRate = wp.GROWTH_RATE_MID
+                elseif pressure < wp.HIGH then
+                    baseRate = wp.GROWTH_RATE_HIGH
+                else
+                    baseRate = wp.GROWTH_RATE_PEAK
+                end
+
+                -- Seasonal multiplier
+                local seasonMult = 1.0
+                if g_currentMission and g_currentMission.environment then
+                    local season = g_currentMission.environment.currentSeason
+                    if season == 1 then seasonMult = wp.SEASONAL_SPRING
+                    elseif season == 2 then seasonMult = wp.SEASONAL_SUMMER
+                    elseif season == 3 then seasonMult = wp.SEASONAL_FALL
+                    elseif season == 4 then seasonMult = wp.SEASONAL_WINTER
+                    end
+                end
+
+                field.weedPressure = math.min(100, pressure + baseRate * seasonMult)
+            end
         end
     end
 
@@ -945,9 +1050,19 @@ function SoilFertilitySystem:getFieldInfo(fieldId)
     -- Resolve current crop name: prefer the live growing fruit (what's actually in
     -- the ground right now) over lastCrop, which is only set on harvest and will be
     -- stale as soon as the next crop is sown.
+    -- #99 fix: field.id / field.fieldId are nil in FS25; our fieldId is farmland.id.
+    -- g_fieldManager:getFieldById() searches by field.id which is always nil, so it
+    -- returns the wrong field or nil depending on list position.
+    -- Correct approach: iterate g_fieldManager.fields and match farmland.id.
     local cropName = nil
-    if g_fieldManager then
-        local fsField = g_fieldManager:getFieldById(fieldId)
+    if g_fieldManager and g_fieldManager.fields then
+        local fsField = nil
+        for _, f in ipairs(g_fieldManager.fields) do
+            if f and f.farmland and f.farmland.id == fieldId then
+                fsField = f
+                break
+            end
+        end
         if fsField then
             local ok, fieldState = pcall(function() return fsField:getFieldState() end)
             if ok and fieldState and fieldState.fruitTypeIndex ~= FruitType.UNKNOWN then
@@ -973,6 +1088,8 @@ function SoilFertilitySystem:getFieldInfo(fieldId)
         lastCrop = cropName,
         daysSinceHarvest = field.lastHarvest > 0 and (currentDay - field.lastHarvest) or 0,
         fertilizerApplied = field.fertilizerApplied or 0,
+        weedPressure = field.weedPressure or 0,
+        herbicideActive = (field.herbicideDaysLeft or 0) > 0,
         needsFertilization = not self.PFActive and (
             field.nitrogen < fertThresholds.nitrogen or
             field.phosphorus < fertThresholds.phosphorus or
@@ -1025,6 +1142,8 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             setXMLString(xmlFile, fieldKey .. "#lastCrop", field.lastCrop or "")
             setXMLInt(xmlFile, fieldKey .. "#lastHarvest", field.lastHarvest or 0)
             setXMLFloat(xmlFile, fieldKey .. "#fertilizerApplied", field.fertilizerApplied or 0)
+            setXMLFloat(xmlFile, fieldKey .. "#weedPressure", field.weedPressure or 0)
+            setXMLInt(xmlFile, fieldKey .. "#herbicideDaysLeft", field.herbicideDaysLeft or 0)
 
             index = index + 1
         else
@@ -1062,6 +1181,8 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             lastCrop = getXMLString(xmlFile, fieldKey .. "#lastCrop"),
             lastHarvest = getXMLInt(xmlFile, fieldKey .. "#lastHarvest") or 0,
             fertilizerApplied = getXMLFloat(xmlFile, fieldKey .. "#fertilizerApplied") or 0,
+            weedPressure = getXMLFloat(xmlFile, fieldKey .. "#weedPressure") or 0,
+            herbicideDaysLeft = getXMLInt(xmlFile, fieldKey .. "#herbicideDaysLeft") or 0,
             initialized = true
         }
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -496,3 +496,54 @@ SoilConstants.SPRAYER_RATE = {
     L_PER_HA_TO_GAL_PER_AC = 0.10694,  -- multiply L/ha by this for gal/ac
     KG_PER_HA_TO_LB_PER_AC = 0.89218,  -- multiply kg/ha by this for lb/ac
 }
+
+-- ========================================
+-- WEED PRESSURE (Issue #98)
+-- ========================================
+-- Field-level 0-100 score representing weed density.
+-- Grows daily with seasonal/rain multipliers.
+-- Herbicide spray reduces pressure and temporarily suppresses growth.
+-- Tillage (any cultivator/plow) resets pressure to 0.
+-- Harvest applies a yield penalty proportional to pressure tier.
+SoilConstants.WEED_PRESSURE = {
+    -- Daily base growth rate (points/day) by current pressure tier
+    -- Growth slows as pressure approaches capacity
+    GROWTH_RATE_LOW    = 1.2,   -- 0-20:  slow germination phase
+    GROWTH_RATE_MID    = 2.0,   -- 20-50: active competition phase
+    GROWTH_RATE_HIGH   = 1.2,   -- 50-75: density self-limiting
+    GROWTH_RATE_PEAK   = 0.4,   -- 75-100: near carrying capacity
+
+    -- Seasonal growth multipliers (season index matches FS25 environment.currentSeason)
+    -- Season 1=Spring, 2=Summer, 3=Fall, 4=Winter (matches SoilConstants.SEASONAL_EFFECTS)
+    SEASONAL_SPRING = 1.4,  -- peak germination
+    SEASONAL_SUMMER = 1.6,  -- maximum growth
+    SEASONAL_FALL   = 0.7,  -- slowing down
+    SEASONAL_WINTER = 0.05, -- near dormancy
+
+    -- Rain bonus added to base daily rate when it is raining
+    RAIN_BONUS = 0.5,
+
+    -- Herbicide fill type names → effectiveness multiplier (0.0-1.0)
+    -- Any fill type not listed here is NOT treated as herbicide
+    HERBICIDE_TYPES = {
+        HERBICIDE = 1.0,
+        PESTICIDE = 0.8,
+    },
+    -- Pressure points removed on a single herbicide application
+    HERBICIDE_PRESSURE_REDUCTION = 30,
+    -- Number of in-game days herbicide suppresses weed growth after application
+    HERBICIDE_DURATION_DAYS = 14,
+
+    -- Tillage resets pressure to 0 (handled in onPlowing)
+
+    -- Harvest yield penalty at each pressure tier
+    YIELD_PENALTY_LOW    = 0.00,  -- 0-20:  none
+    YIELD_PENALTY_MID    = 0.05,  -- 20-50: -5%
+    YIELD_PENALTY_HIGH   = 0.15,  -- 50-75: -15%
+    YIELD_PENALTY_PEAK   = 0.30,  -- 75-100: -30%
+
+    -- HUD tier thresholds
+    LOW    = 20,
+    MEDIUM = 50,
+    HIGH   = 75,
+}

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -125,6 +125,13 @@ SettingsSchema.definitions = {
         pfProtected = true,
     },
     {
+        id = "weedPressure",
+        type = "boolean",
+        default = true,
+        uiId = "sf_weed_pressure",
+        pfProtected = false,
+    },
+    {
         id = "difficulty",
         type = "number",
         default = 2,

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -265,7 +265,12 @@ function HookManager:installSprayerAreaHook()
                 local fillType = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
                 if not fillType then return end
 
-                if not SoilConstants.FERTILIZER_PROFILES[fillType.name] then return end
+                -- Check herbicide first (mutually exclusive with fertilizer profiles)
+                local herbTypes = SoilConstants.WEED_PRESSURE and SoilConstants.WEED_PRESSURE.HERBICIDE_TYPES
+                local herbEffectiveness = herbTypes and herbTypes[fillType.name]
+                local isFertilizer = SoilConstants.FERTILIZER_PROFILES[fillType.name] ~= nil
+
+                if not isFertilizer and not herbEffectiveness then return end
 
                 -- Resolve field from vehicle root position
                 local x, _, z = getWorldTranslation(self.rootNode)
@@ -292,7 +297,14 @@ function HookManager:installSprayerAreaHook()
                 SoilLogger.debug("Sprayer/Spreader hook: Field %d, %s, %.1fL (x%.2f rate)",
                     fieldId, fillType.name, effectiveLiters, rateMultiplier)
 
-                g_SoilFertilityManager.soilSystem:onFertilizerApplied(fieldId, fillTypeIndex, effectiveLiters)
+                if isFertilizer then
+                    g_SoilFertilityManager.soilSystem:onFertilizerApplied(fieldId, fillTypeIndex, effectiveLiters)
+                end
+
+                -- Herbicide application reduces weed pressure
+                if herbEffectiveness and g_SoilFertilityManager.soilSystem.onHerbicideApplied then
+                    g_SoilFertilityManager.soilSystem:onHerbicideApplied(fieldId, herbEffectiveness)
+                end
 
                 -- Over-application burn check (nutrient fertilizers only, not lime)
                 local entry = SoilConstants.FERTILIZER_PROFILES[fillType.name]

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -296,6 +296,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
     self.settings.seasonalEffects = streamReadBool(streamId)
     self.settings.rainEffects = streamReadBool(streamId)
     self.settings.plowingBonus = streamReadBool(streamId)
+    self.settings.weedPressure = streamReadBool(streamId)
     self.settings.difficulty = streamReadInt32(streamId)
 
     -- Read field data
@@ -352,6 +353,8 @@ function SoilFullSyncEvent:readStream(streamId, connection)
                 lastCrop = lastCrop,
                 lastHarvest = lastHarvest,
                 fertilizerApplied = fertilizerApplied,
+                weedPressure = 0,
+                herbicideDaysLeft = 0,
                 initialized = true
             }
             -- Clear empty strings
@@ -380,6 +383,7 @@ function SoilFullSyncEvent:writeStream(streamId, connection)
     streamWriteBool(streamId, self.settings.seasonalEffects)
     streamWriteBool(streamId, self.settings.rainEffects)
     streamWriteBool(streamId, self.settings.plowingBonus)
+    streamWriteBool(streamId, self.settings.weedPressure == true)
     streamWriteInt32(streamId, self.settings.difficulty)
 
     -- Write field data
@@ -419,6 +423,7 @@ function SoilFullSyncEvent:run(connection)
     settings.seasonalEffects = self.settings.seasonalEffects
     settings.rainEffects = self.settings.rainEffects
     settings.plowingBonus = self.settings.plowingBonus
+    settings.weedPressure = self.settings.weedPressure
     settings.difficulty = self.settings.difficulty
 
     -- Apply field data (server-authoritative)

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -19,7 +19,7 @@ SoilHUD.RESIZE_HANDLE_SIZE = 0.008
 
 -- ── Base panel dimensions at scale 1.0 ─────────────────
 SoilHUD.BASE_W = 0.190
-SoilHUD.BASE_H = 0.202   -- expanded to accommodate yield forecast row
+SoilHUD.BASE_H = 0.228   -- expanded to accommodate yield forecast + weed pressure rows
 
 -- ── Layout constants at scale 1.0 ──────────────────────
 SoilHUD.TITLE_H   = 0.024   -- title accent bar height
@@ -694,6 +694,51 @@ function SoilHUD:drawPanel()
             setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], SoilHUD.C_DIM[4])
             renderText(px + pw - pad, cy, 0.009 * fontMult * s, tierData.label)
             setTextAlignment(RenderText.ALIGN_LEFT)
+            cy = cy - SoilHUD.LINE_H * s
+
+            -- Divider before weed row
+            cy = cy - pad * 0.5
+            self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+            cy = cy - pad * 0.8
+        end
+
+        -- Weed pressure row (always shown when info available and setting enabled)
+        if g_SoilFertilityManager and g_SoilFertilityManager.settings.weedPressure then
+            local pressure = info.weedPressure or 0
+            local wp = SoilConstants.WEED_PRESSURE
+            local weedColor
+            if pressure < wp.LOW then
+                weedColor = SoilHUD.C_GOOD
+            elseif pressure < wp.MEDIUM then
+                weedColor = SoilHUD.C_FAIR
+            elseif pressure < wp.HIGH then
+                weedColor = {1.0, 0.55, 0.10, 1.0}  -- orange
+            else
+                weedColor = SoilHUD.C_POOR
+            end
+
+            setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
+            renderText(tx, cy, 0.010 * fontMult * s, "Weeds")
+
+            -- Progress bar (reuse BAR geometry)
+            local barX = tx + 0.038*s
+            local barH = SoilHUD.BAR_H * s
+            local barW = SoilHUD.BAR_W * s
+            local barY = cy + (SoilHUD.LINE_H * s - barH) * 0.5
+            self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
+            local fill = math.max(0, math.min(1, pressure / 100))
+            if fill > 0 then
+                self:drawRect(barX, barY, barW * fill, barH, weedColor)
+            end
+
+            -- Value + herbicide indicator
+            local weedLabel = string.format("%.0f%%", pressure)
+            if info.herbicideActive then weedLabel = weedLabel .. " (protected)" end
+            setTextAlignment(RenderText.ALIGN_RIGHT)
+            setTextColor(weedColor[1], weedColor[2], weedColor[3], 1.0)
+            renderText(px + pw - pad, cy, 0.009 * fontMult * s, weedLabel)
+            setTextAlignment(RenderText.ALIGN_LEFT)
+
             cy = cy - SoilHUD.LINE_H * s
 
             -- Divider before hint


### PR DESCRIPTION
fix(#98): add Weed Pressure system with daily growth, herbicide suppression, tillage reset, harvest yield penalty, and HUD display row

- #99: getFieldInfo was calling g_fieldManager:getFieldById(fieldId) which searches field.id — always nil in FS25. Fields are now found by iterating g_fieldManager.fields and matching farmland.id, matching the same pattern used in scanFields() and the HUD field detector.

- #98: Weed Pressure (0-100) grows daily with seasonal multipliers (spring/ summer peak, winter dormant). Herbicide spray reduces pressure by 30 pts and suppresses growth for 14 days. Any tillage/plow resets pressure to 0. Harvest applies a yield multiplier penalty (0% / 5% / 15% / 30%) based on the current pressure tier. HUD shows a bar row with color coding and a "protected" indicator while herbicide is active. Feature is toggleable via new weedPressure setting (default: true). Data persisted in savegame XML and synced to MP clients via SoilFullSyncEvent.

Bumps version to 1.3.0.0.
