### PR TITLE
fix: settings text broken (i18n mod name capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.1.0] - 2026-04-04
+## [1.3.3.0] - 2026-04-04
+
+### Fixed
+
+- **Settings page showing raw key names instead of translated text**: All UI text lookups now correctly use the mod-scoped i18n instance. Root cause: `g_currentModName` is only valid at mod load time, not at UI construction time. The mod name is now captured in a local variable (`SF_MOD_NAME`) at file load time and used in all translation lookups across `SoilSettingsUI`, `SoilReportDialog`, and `UIHelper`. Affected 1.3.2.0 users on all languages.
+
+---
+
+## [1.3.2.0] - 2026-04-04
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **1.3.1.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization inline in `modDesc.xml`.
+**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **1.3.3.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.3.1.0
+**Version**: 1.3.3.0
 **Last Updated**: 2026-04-04
 
 ---

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.3.1.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.3.3.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.3.2.0</version>
+    <version>1.3.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil & Fertilizer</en>

--- a/src/settings/SoilSettingsUI.lua
+++ b/src/settings/SoilSettingsUI.lua
@@ -14,10 +14,13 @@
 SoilSettingsUI = {}
 local SoilSettingsUI_mt = Class(SoilSettingsUI)
 
+-- Capture mod name at load time — g_currentModName is only valid during loading.
+local SF_MOD_NAME = g_currentModName
+
 -- Resolve a translation key using the mod-scoped i18n instance.
 -- g_i18n is the base-game global and does not know about mod keys.
 local function tr(key, fallback)
-    local modEnv = g_modEnvironments and g_modEnvironments[g_currentModName]
+    local modEnv = g_modEnvironments and g_modEnvironments[SF_MOD_NAME]
     local i18n = (modEnv and modEnv.i18n) or g_i18n
     if i18n then
         local text = i18n:getText(key)

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -11,9 +11,12 @@
 SoilReportDialog = {}
 local SoilReportDialog_mt = Class(SoilReportDialog, ScreenElement)
 
+-- Capture mod name at load time — g_currentModName is only valid during loading.
+local SF_MOD_NAME = g_currentModName
+
 -- Resolve a translation key using the mod-scoped i18n instance.
 local function tr(key, fallback)
-    local modEnv = g_modEnvironments and g_modEnvironments[g_currentModName]
+    local modEnv = g_modEnvironments and g_modEnvironments[SF_MOD_NAME]
     local i18n = (modEnv and modEnv.i18n) or g_i18n
     if i18n then
         local text = i18n:getText(key)

--- a/src/utils/UIHelper.lua
+++ b/src/utils/UIHelper.lua
@@ -10,10 +10,13 @@
 ---@class UIHelper
 UIHelper = {}
 
+-- Capture mod name at load time — g_currentModName is only valid during loading.
+local SF_MOD_NAME = g_currentModName
+
 local function getTextSafe(key)
     -- Use mod-scoped i18n so mod translation keys are resolved correctly.
     -- g_i18n is the global (base-game) object and does not contain mod keys.
-    local modEnv = g_modEnvironments and g_modEnvironments[g_currentModName]
+    local modEnv = g_modEnvironments and g_modEnvironments[SF_MOD_NAME]
     local i18n = (modEnv and modEnv.i18n) or g_i18n
     if not i18n then
         return key


### PR DESCRIPTION
## Summary

- `g_currentModName` is only valid at mod load time, not when UI functions are called later
- All three UI files now capture the mod name in `SF_MOD_NAME` at file scope
- Fixes settings page and soil report showing raw key names (`sf_diff_1`, `sf_enabled`, etc.) instead of translated text
- Bumps to **v1.3.3.0**

## Root Cause

```lua
-- BROKEN: g_currentModName is nil at call time
local modEnv = g_modEnvironments[g_currentModName]

-- FIXED: captured once at load time
local SF_MOD_NAME = g_currentModName
local modEnv = g_modEnvironments[SF_MOD_NAME]
```

Affects: `SoilSettingsUI.lua`, `SoilReportDialog.lua`, `UIHelper.lua`

## Test plan
- [ ] Open settings in singleplayer — all labels show translated text
- [ ] Open soil report (K key) — all labels show translated text  
- [ ] Verify on dedicated server client