### PR TITLE
fix: fertilizer application when implement is off & report dialog sync

### DIFF
--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -686,6 +686,8 @@ function HookManager:installSprayerAreaHook()
             local liters        = spec.workAreaParameters.usage
             local sprayFillLevel = spec.workAreaParameters.sprayFillLevel
 
+            if self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then return end
+
             if not fillTypeIndex or fillTypeIndex <= 0 then return end
             if not liters or liters <= 0 then return end
             if not sprayFillLevel or sprayFillLevel <= 0 then return end

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -299,6 +299,8 @@ function SoilReportDialog:collectFieldData()
     if self.totalPages < 1 then
         self.totalPages = 1
     end
+
+    return true
 end
 
 --- Update all display elements


### PR DESCRIPTION
- Added getIsTurnedOn() guard to Sprayer hook to prevent nutrient application and notifications while driving with implement turned off.
- Added missing return true in SoilReportDialog to fix the dialog being permanently stuck in the ownership syncing state.
