### PR TITLE
v1.5.2.0 — Soil Report accuracy, pressure scale fix, and i18n polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.1.0] - 2026-04-09
+
+### Fixed
+
+- **HUD text missing in 24 languages (issue #130)**: The HUD overlay was showing raw
+  translation key names (`sf_hud_title`, `sf_hud_fallow`, `sf_hud_yield`, etc.) for
+  every language except English and Ukrainian. Root cause: 13 `sf_hud_*` keys were
+  added when the live HUD was implemented but never propagated to the 24 non-EN
+  language files. English text added as fallback in all 24 files — proper per-language
+  translations can follow in community PRs.
+  Credit: sava4903-coder for identifying this in issue #130.
+
+- **Mouse event double-firing in vehicles (issue #130)**: The `soilMouseHandler`
+  registered via `addModEventListener` was not checking the `eventUsed` flag before
+  processing mouse input and was not returning it afterward. In vehicles where the
+  camera or another listener had already consumed an RMB event, the HUD would still
+  try to enter edit mode from a stale or mis-positioned cursor.
+  Fix: `soilMouseHandler` now guards on `not eventUsed` and returns the flag.
+  `SoilHUD:onMouseEvent` now accepts and returns `eventUsed`, and uses
+  `Input.MOUSE_BUTTON_RIGHT` / `Input.MOUSE_BUTTON_LEFT` constants (LUADOC-verified).
+
+---
+
 ## [1.5.0.0] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.2.0] - 2026-04-10
+
+### Fixed
+
+- **Pressure values displayed as 4-digit percentages in Soil Report**: Weed, pest, and disease
+  pressure are stored internally as 0–100. The report dialog was multiplying them by 100 again,
+  producing values like "6500%" and always rendering red status regardless of actual severity.
+  Fixed in table rows and in the detail view. *(Silent bug — only visible when any pressure > 0.)*
+
+- **Overall status badge ignores pH, OM, and bio-pressures**: The "Good / Fair / Poor" status
+  shown in the Soil Report table and the HUD title bar only considered N/P/K. A field with poor
+  pH, low organic matter, or high weed/pest/disease pressure could still show "Good". Now all
+  five soil parameters plus all three pressure scores are included in the worst-case ranking.
+
+- **Farm Health % uses uneven scoring weights**: Farm Health was calculated using 100 / 55 / 10
+  for Good / Fair / Poor. The non-linear gap between Fair (55) and Poor (10) made the percentage
+  drop unnaturally sharp. Changed to 100 / 50 / 0 — a clean linear scale.
+
+### Improved
+
+- **Soil Report detail view fully localized**: Several status labels in the field detail panel
+  were hardcoded English strings — including pH status ("Optimal" / "Monitor" / "Adjust"),
+  OM status ("Optimal" / "Maintain" / "Increase"), pressure level labels ("Low" / "Moderate" /
+  "High"), yield hint text, and the N/P/K "optimal" hint lines. All replaced with `tr()` calls
+  backed by 12 new i18n keys. DE, FR, ES/EA, and PL receive translated values; remaining 21
+  languages carry EN fallbacks and can be improved by community PRs.
+
+- **`yieldSuffix` pattern in recommendation engine removed**: The
+  `getFertilizationRecommendation()` function assembled a yield penalty suffix as a separate
+  string then stripped its leading comma with `string.gsub`. Replaced with a direct
+  `table.insert` into the recommendations list — same output, no roundabout string surgery.
+
+- **Weed/pest/disease HUD rows extracted to `drawPressureRow()` helper**: The three pressure bar
+  rows in `SoilHUD:drawPanel()` were near-identical 30-line blocks. Extracted to a single
+  reusable method, removing ~60 lines of duplication. Color scale simplified to 3 levels
+  (green / yellow / red) to match N/P/K bars and avoid the inconsistent orange tier.
+
+---
+
 ## [1.5.1.0] - 2026-04-09
 
 ### Fixed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.5.0.0
-**Last Updated**: 2026-04-07
+**Version**: 1.5.2.0
+**Last Updated**: 2026-04-10
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.5.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.5.1.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/gui/SoilReportDialog.xml
+++ b/gui/SoilReportDialog.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
     <GuiElement profile="newLayer" />
     <Bitmap profile="dialogFullscreenBg" id="dialogBg" />
 
-    <GuiElement profile="dialogBg" id="dialogElement" size="960px 520px">
+    <!-- Main dialog: wider and taller for more breathing room -->
+    <GuiElement profile="dialogBg" id="dialogElement" size="1100px 680px">
         <ThreePartBitmap profile="fs25_dialogBgMiddle" />
         <ThreePartBitmap profile="fs25_dialogBgTop" />
         <ThreePartBitmap profile="fs25_dialogBgBottom" />
@@ -14,269 +15,562 @@
             <Text profile="fs25_dialogTitle" id="dialogTitleElement" position="0px -25px" text="$l10n_sf_report_title"/>
 
             <!-- ===== SUMMARY SECTION ===== -->
-            <GuiElement profile="srSectionContainer" position="0px -60px">
+            <GuiElement profile="srSectionContainer" position="0px -62px">
                 <Bitmap profile="srSectionBg" position="0px 0px"/>
-                <Text profile="srSummaryLabel" position="-310px -8px" text="$l10n_sf_report_fields_tracked"/>
-                <Text profile="srSummaryValue" id="fieldCountText" position="-210px -8px" text="0"/>
-                <Text profile="srSummaryLabel" position="-100px -8px" text="$l10n_sf_report_need_fert"/>
-                <Text profile="srSummaryWarnValue" id="needFertText" position="10px -8px" text="0"/>
-                <Text profile="srSummaryLabel" position="120px -8px" text="$l10n_sf_report_difficulty"/>
-                <Text profile="srSummaryValue" id="difficultyText" position="210px -8px" text="Realistic"/>
+                <!-- Fields tracked -->
+                <Text profile="srSummaryLabel" position="-400px -10px" text="$l10n_sf_report_fields_tracked"/>
+                <Text profile="srSummaryValue" id="fieldCountText" position="-300px -10px" text="0"/>
+                <!-- Critical -->
+                <Text profile="srSummaryLabel" position="-200px -10px" text="$l10n_sf_report_need_fert"/>
+                <Text profile="srSummaryWarnValue" id="needFertText" position="-100px -10px" text="0"/>
+                <!-- Farm health -->
+                <Text profile="srSummaryLabel" position="10px -10px" text="$l10n_sf_report_farm_health"/>
+                <Text profile="srSummaryValue" id="farmHealthText" position="120px -10px" text="--"/>
+                <!-- Difficulty -->
+                <Text profile="srSummaryLabel" position="240px -10px" text="$l10n_sf_report_difficulty"/>
+                <Text profile="srSummaryValue" id="difficultyText" position="340px -10px" text="Realistic"/>
             </GuiElement>
 
-            <!-- ===== TABLE HEADER ===== -->
-            <GuiElement profile="srRowSection" position="0px -100px">
-                <Bitmap profile="srHeaderBg" position="0px 0px"/>
-                <Text profile="srHeaderText" position="-310px -4px" text="$l10n_sf_report_col_field"/>
-                <Text profile="srHeaderText" position="-230px -4px" text="N"/>
-                <Text profile="srHeaderText" position="-155px -4px" text="P"/>
-                <Text profile="srHeaderText" position="-80px -4px" text="K"/>
-                <Text profile="srHeaderText" position="0px -4px" text="pH"/>
-                <Text profile="srHeaderText" position="80px -4px" text="OM%"/>
-                <Text profile="srHeaderText" position="170px -4px" text="$l10n_sf_report_col_last_crop"/>
-                <Text profile="srHeaderTextWide" position="290px -4px" text="$l10n_sf_report_col_fert"/>
+            <!-- ===== TABLE VIEW (hidden when in detail mode) ===== -->
+            <GuiElement id="tableView" profile="srFullWidth" position="0px 0px">
+
+                <!-- TABLE HEADER -->
+                <GuiElement profile="srRowSection" position="0px -100px">
+                    <Bitmap profile="srHeaderBg" position="0px 0px"/>
+                    <Text profile="srHeaderTextNarrow" position="-460px -5px" text="$l10n_sf_report_col_field"/>
+                    <Text profile="srHeaderText"       position="-380px -5px" text="N"/>
+                    <Text profile="srHeaderText"       position="-300px -5px" text="P"/>
+                    <Text profile="srHeaderText"       position="-220px -5px" text="K"/>
+                    <Text profile="srHeaderText"       position="-145px -5px" text="pH"/>
+                    <Text profile="srHeaderText"       position="-68px -5px" text="OM%"/>
+                    <Text profile="srHeaderText"       position="14px -5px" text="Weed"/>
+                    <Text profile="srHeaderText"       position="95px -5px" text="Pest"/>
+                    <Text profile="srHeaderTextWide"   position="195px -5px" text="$l10n_sf_report_col_last_crop"/>
+                    <Text profile="srHeaderTextStatus" position="360px -5px" text="Status"/>
+                </GuiElement>
+
+                <!-- Row 0 -->
+                <GuiElement id="fieldRow0" profile="srRowSection" position="0px -132px" visible="false">
+                    <Bitmap profile="srRowBg" id="fieldRow0Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow0Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow0Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow0Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow0Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn0" position="475px -5px" text="â–º" onClick="onClickDetail0"/>
+                </GuiElement>
+
+                <!-- Row 1 -->
+                <GuiElement id="fieldRow1" profile="srRowSection" position="0px -164px" visible="false">
+                    <Bitmap profile="srRowBgAlt" id="fieldRow1Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow1Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow1Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow1Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow1Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn1" position="475px -5px" text="â–º" onClick="onClickDetail1"/>
+                </GuiElement>
+
+                <!-- Row 2 -->
+                <GuiElement id="fieldRow2" profile="srRowSection" position="0px -196px" visible="false">
+                    <Bitmap profile="srRowBg" id="fieldRow2Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow2Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow2Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow2Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow2Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn2" position="475px -5px" text="â–º" onClick="onClickDetail2"/>
+                </GuiElement>
+
+                <!-- Row 3 -->
+                <GuiElement id="fieldRow3" profile="srRowSection" position="0px -228px" visible="false">
+                    <Bitmap profile="srRowBgAlt" id="fieldRow3Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow3Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow3Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow3Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow3Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn3" position="475px -5px" text="â–º" onClick="onClickDetail3"/>
+                </GuiElement>
+
+                <!-- Row 4 -->
+                <GuiElement id="fieldRow4" profile="srRowSection" position="0px -260px" visible="false">
+                    <Bitmap profile="srRowBg" id="fieldRow4Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow4Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow4Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow4Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow4Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn4" position="475px -5px" text="â–º" onClick="onClickDetail4"/>
+                </GuiElement>
+
+                <!-- Row 5 -->
+                <GuiElement id="fieldRow5" profile="srRowSection" position="0px -292px" visible="false">
+                    <Bitmap profile="srRowBgAlt" id="fieldRow5Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow5Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow5Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow5Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow5Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn5" position="475px -5px" text="â–º" onClick="onClickDetail5"/>
+                </GuiElement>
+
+                <!-- Row 6 -->
+                <GuiElement id="fieldRow6" profile="srRowSection" position="0px -324px" visible="false">
+                    <Bitmap profile="srRowBg" id="fieldRow6Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow6Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow6Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow6Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow6Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn6" position="475px -5px" text="â–º" onClick="onClickDetail6"/>
+                </GuiElement>
+
+                <!-- Row 7 -->
+                <GuiElement id="fieldRow7" profile="srRowSection" position="0px -356px" visible="false">
+                    <Bitmap profile="srRowBgAlt" id="fieldRow7Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow7Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow7Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow7Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow7Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn7" position="475px -5px" text="â–º" onClick="onClickDetail7"/>
+                </GuiElement>
+
+                <!-- Row 8 -->
+                <GuiElement id="fieldRow8" profile="srRowSection" position="0px -388px" visible="false">
+                    <Bitmap profile="srRowBg" id="fieldRow8Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow8Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow8Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow8Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow8Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn8" position="475px -5px" text="â–º" onClick="onClickDetail8"/>
+                </GuiElement>
+
+                <!-- Row 9 -->
+                <GuiElement id="fieldRow9" profile="srRowSection" position="0px -420px" visible="false">
+                    <Bitmap profile="srRowBgAlt" id="fieldRow9Bg" position="0px 0px"/>
+                    <Text profile="srRowTextNarrow"  id="fieldRow9Id"   position="-460px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9N"    position="-380px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9P"    position="-300px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9K"    position="-220px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9pH"   position="-145px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9OM"   position="-68px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9Weed" position="14px -5px" text=""/>
+                    <Text profile="srRowText"        id="fieldRow9Pest" position="95px -5px" text=""/>
+                    <Text profile="srRowTextCrop"    id="fieldRow9Crop" position="195px -5px" text=""/>
+                    <Text profile="srRowTextStatus"  id="fieldRow9Stat" position="360px -5px" text=""/>
+                    <Button profile="srDetailBtn" id="detailBtn9" position="475px -5px" text="â–º" onClick="onClickDetail9"/>
+                </GuiElement>
+
+                <!-- Pagination Info -->
+                <Text profile="srPageInfo" id="pageInfoText" position="0px -455px" text=""/>
+
+                <!-- No Data Message -->
+                <Text profile="srNoData" id="noDataText" position="0px -270px" visible="false" text="$l10n_sf_report_no_data"/>
+
             </GuiElement>
+            <!-- END tableView -->
 
-            <!-- Row 0 -->
-            <GuiElement id="fieldRow0" profile="srRowSection" position="0px -124px" visible="false">
-                <Bitmap profile="srRowBg" id="fieldRow0Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow0Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow0N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow0P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow0K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow0pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow0OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow0Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow0Fert" position="290px -4px" text=""/>
+            <!-- ===== FIELD DETAIL VIEW (shown when â–º is pressed) ===== -->
+            <GuiElement id="detailView" profile="srFullWidth" position="0px 0px" visible="false">
+
+                <!-- Detail header bar -->
+                <GuiElement profile="srDetailHeader" position="0px -100px">
+                    <Bitmap profile="srDetailHeaderBg" position="0px 0px"/>
+                    <Text profile="srDetailTitle" id="detailFieldLabel" position="-300px -8px" text="Field --"/>
+                    <Text profile="srDetailCrop"  id="detailCropLabel"  position="100px -8px" text=""/>
+                    <Text profile="srDetailOverall" id="detailOverallLabel" position="380px -8px" text=""/>
+                </GuiElement>
+
+                <!-- Nutrients section header -->
+                <Text profile="srDetailSectionLabel" position="-380px -140px" text="NUTRIENTS (ppm)"/>
+
+                <!-- N row -->
+                <GuiElement profile="srDetailRow" position="0px -162px">
+                    <Bitmap profile="srDetailRowBg" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Nitrogen (N)"/>
+                    <Text profile="srDetailValue"  id="detailN"      position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailNStat"  position="-140px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailNHint"  position="80px -6px" text=""/>
+                </GuiElement>
+
+                <!-- P row -->
+                <GuiElement profile="srDetailRow" position="0px -192px">
+                    <Bitmap profile="srDetailRowBgAlt" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Phosphorus (P)"/>
+                    <Text profile="srDetailValue"  id="detailP"      position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailPStat"  position="-140px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailPHint"  position="80px -6px" text=""/>
+                </GuiElement>
+
+                <!-- K row -->
+                <GuiElement profile="srDetailRow" position="0px -222px">
+                    <Bitmap profile="srDetailRowBg" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Potassium (K)"/>
+                    <Text profile="srDetailValue"  id="detailK"      position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailKStat"  position="-140px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailKHint"  position="80px -6px" text=""/>
+                </GuiElement>
+
+                <!-- pH + OM row -->
+                <GuiElement profile="srDetailRow" position="0px -252px">
+                    <Bitmap profile="srDetailRowBgAlt" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="pH"/>
+                    <Text profile="srDetailValue"  id="detailPH"     position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailPHStat" position="-140px -6px" text=""/>
+                    <Text profile="srDetailLabel"  position="80px -6px" text="Organic Matter"/>
+                    <Text profile="srDetailValue"  id="detailOM"     position="260px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailOMStat" position="370px -6px" text=""/>
+                </GuiElement>
+
+                <!-- Pressure section header -->
+                <Text profile="srDetailSectionLabel" position="-380px -288px" text="PRESSURES"/>
+
+                <!-- Weed row -->
+                <GuiElement profile="srDetailRow" position="0px -310px">
+                    <Bitmap profile="srDetailRowBg" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Weed Pressure"/>
+                    <Text profile="srDetailValue"  id="detailWeed"     position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailWeedStat" position="-140px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailWeedHint" position="80px -6px" text=""/>
+                </GuiElement>
+
+                <!-- Pest row -->
+                <GuiElement profile="srDetailRow" position="0px -340px">
+                    <Bitmap profile="srDetailRowBgAlt" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Pest Pressure"/>
+                    <Text profile="srDetailValue"  id="detailPest"     position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailPestStat" position="-140px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailPestHint" position="80px -6px" text=""/>
+                </GuiElement>
+
+                <!-- Disease row -->
+                <GuiElement profile="srDetailRow" position="0px -370px">
+                    <Bitmap profile="srDetailRowBg" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Disease Pressure"/>
+                    <Text profile="srDetailValue"  id="detailDisease"     position="-250px -6px" text=""/>
+                    <Text profile="srDetailStatus" id="detailDiseaseStat" position="-140px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailDiseaseHint" position="80px -6px" text=""/>
+                </GuiElement>
+
+                <!-- Yield forecast row -->
+                <GuiElement profile="srDetailRow" position="0px -400px">
+                    <Bitmap profile="srDetailRowBgAlt" position="0px 0px"/>
+                    <Text profile="srDetailLabel"  position="-430px -6px" text="Yield Forecast"/>
+                    <Text profile="srDetailValue"  id="detailYield"  position="-250px -6px" text=""/>
+                    <Text profile="srDetailHint"   id="detailYieldHint" position="80px -6px" text=""/>
+                </GuiElement>
+
+                <Bitmap profile="srDivider" position="0px -424px"/>
+
+                <!-- Recommendation section -->
+                <Text profile="srDetailSectionLabel" position="-380px -432px" text="ACTION PLAN"/>
+                <GuiElement profile="srDetailRecContainer" position="0px -450px">
+                    <Bitmap profile="srDetailRecBg" id="detailRecBg" position="0px 0px"/>
+                    <Text profile="srDetailRec" id="detailRecText" position="0px -12px" text=""/>
+                </GuiElement>
+
             </GuiElement>
-
-            <!-- Row 1 -->
-            <GuiElement id="fieldRow1" profile="srRowSection" position="0px -148px" visible="false">
-                <Bitmap profile="srRowBgAlt" id="fieldRow1Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow1Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow1N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow1P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow1K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow1pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow1OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow1Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow1Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 2 -->
-            <GuiElement id="fieldRow2" profile="srRowSection" position="0px -172px" visible="false">
-                <Bitmap profile="srRowBg" id="fieldRow2Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow2Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow2N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow2P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow2K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow2pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow2OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow2Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow2Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 3 -->
-            <GuiElement id="fieldRow3" profile="srRowSection" position="0px -196px" visible="false">
-                <Bitmap profile="srRowBgAlt" id="fieldRow3Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow3Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow3N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow3P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow3K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow3pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow3OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow3Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow3Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 4 -->
-            <GuiElement id="fieldRow4" profile="srRowSection" position="0px -220px" visible="false">
-                <Bitmap profile="srRowBg" id="fieldRow4Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow4Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow4N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow4P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow4K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow4pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow4OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow4Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow4Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 5 -->
-            <GuiElement id="fieldRow5" profile="srRowSection" position="0px -244px" visible="false">
-                <Bitmap profile="srRowBgAlt" id="fieldRow5Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow5Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow5N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow5P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow5K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow5pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow5OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow5Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow5Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 6 -->
-            <GuiElement id="fieldRow6" profile="srRowSection" position="0px -268px" visible="false">
-                <Bitmap profile="srRowBg" id="fieldRow6Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow6Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow6N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow6P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow6K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow6pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow6OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow6Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow6Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 7 -->
-            <GuiElement id="fieldRow7" profile="srRowSection" position="0px -292px" visible="false">
-                <Bitmap profile="srRowBgAlt" id="fieldRow7Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow7Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow7N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow7P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow7K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow7pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow7OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow7Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow7Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 8 -->
-            <GuiElement id="fieldRow8" profile="srRowSection" position="0px -316px" visible="false">
-                <Bitmap profile="srRowBg" id="fieldRow8Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow8Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow8N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow8P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow8K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow8pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow8OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow8Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow8Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Row 9 -->
-            <GuiElement id="fieldRow9" profile="srRowSection" position="0px -340px" visible="false">
-                <Bitmap profile="srRowBgAlt" id="fieldRow9Bg" position="0px 0px"/>
-                <Text profile="srRowText" id="fieldRow9Id" position="-310px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow9N" position="-230px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow9P" position="-155px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow9K" position="-80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow9pH" position="0px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow9OM" position="80px -4px" text=""/>
-                <Text profile="srRowText" id="fieldRow9Crop" position="170px -4px" text=""/>
-                <Text profile="srRowTextWide" id="fieldRow9Fert" position="290px -4px" text=""/>
-            </GuiElement>
-
-            <!-- Pagination Info -->
-            <Text profile="srPageInfo" id="pageInfoText" position="0px -370px" text=""/>
-
-            <!-- No Data Message -->
-            <Text profile="srNoData" id="noDataText" position="0px -220px" visible="false" text="$l10n_sf_report_no_data"/>
+            <!-- END detailView -->
 
         </GuiElement>
 
         <BoxLayout profile="fs25_dialogButtonBox">
-            <Button profile="buttonActivate" id="prevButton" text="$l10n_sf_report_prev" onClick="onPrevPage"/>
+            <!-- Table mode buttons -->
+            <Button profile="buttonActivate" id="prevButton"   text="$l10n_sf_report_prev"  onClick="onPrevPage"/>
             <Bitmap profile="fs25_dialogButtonBoxSeparator"/>
-            <Button profile="buttonActivate" id="nextButton" text="$l10n_sf_report_next" onClick="onNextPage"/>
+            <Button profile="buttonActivate" id="nextButton"   text="$l10n_sf_report_next"  onClick="onNextPage"/>
             <Bitmap profile="fs25_dialogButtonBoxSeparator"/>
-            <Button profile="buttonBack" id="closeButton" text="$l10n_button_close" onClick="onCloseDialog"/>
+            <!-- Back button: only visible in detail mode -->
+            <Button profile="buttonActivate" id="backButton"   text="$l10n_sf_report_back"  onClick="onBackFromDetail" visible="false"/>
+            <Bitmap profile="fs25_dialogButtonBoxSeparator" id="backSep" visible="false"/>
+            <Button profile="buttonBack"     id="closeButton"  text="$l10n_button_close"    onClick="onCloseDialog"/>
         </BoxLayout>
 
     </GuiElement>
 
     <GUIProfiles>
-        <!-- ========== SECTION CONTAINERS ========== -->
+        <!-- ========== CONTAINERS ========== -->
+        <Profile name="srFullWidth" extends="emptyPanel" with="anchorTopCenter">
+            <size value="1060px 580px"/>
+        </Profile>
+
         <Profile name="srSectionContainer" extends="emptyPanel" with="anchorTopCenter">
-            <size value="900px 30px"/>
+            <size value="1020px 36px"/>
         </Profile>
 
         <Profile name="srRowSection" extends="emptyPanel" with="anchorTopCenter">
-            <size value="900px 24px"/>
+            <size value="1020px 32px"/>
+        </Profile>
+
+        <Profile name="srDetailHeader" extends="emptyPanel" with="anchorTopCenter">
+            <size value="1020px 36px"/>
+        </Profile>
+
+        <Profile name="srDetailRow" extends="emptyPanel" with="anchorTopCenter">
+            <size value="1020px 30px"/>
+        </Profile>
+
+        <Profile name="srDetailRecContainer" extends="emptyPanel" with="anchorTopCenter">
+            <size value="980px 80px"/>
         </Profile>
 
         <!-- ========== BACKGROUNDS ========== -->
         <Profile name="srSectionBg" extends="baseReference" with="anchorTopCenter">
-            <size value="900px 30px"/>
+            <size value="1020px 36px"/>
             <imageColor value="0.08 0.08 0.12 0.9"/>
         </Profile>
 
         <Profile name="srHeaderBg" extends="baseReference" with="anchorTopCenter">
-            <size value="900px 24px"/>
-            <imageColor value="0.15 0.15 0.2 1"/>
+            <size value="1020px 32px"/>
+            <imageColor value="0.15 0.15 0.22 1"/>
         </Profile>
 
         <Profile name="srRowBg" extends="baseReference" with="anchorTopCenter">
-            <size value="900px 24px"/>
-            <imageColor value="0.1 0.1 0.1 1"/>
+            <size value="1020px 32px"/>
+            <imageColor value="0.10 0.10 0.10 1"/>
         </Profile>
 
         <Profile name="srRowBgAlt" extends="baseReference" with="anchorTopCenter">
-            <size value="900px 24px"/>
+            <size value="1020px 32px"/>
             <imageColor value="0.12 0.12 0.14 1"/>
         </Profile>
 
-        <!-- ========== TEXT PROFILES ========== -->
+        <Profile name="srDetailHeaderBg" extends="baseReference" with="anchorTopCenter">
+            <size value="1020px 36px"/>
+            <imageColor value="0.10 0.14 0.20 1"/>
+        </Profile>
+
+        <Profile name="srDetailRowBg" extends="baseReference" with="anchorTopCenter">
+            <size value="1020px 30px"/>
+            <imageColor value="0.09 0.09 0.11 1"/>
+        </Profile>
+
+        <Profile name="srDetailRowBgAlt" extends="baseReference" with="anchorTopCenter">
+            <size value="1020px 30px"/>
+            <imageColor value="0.11 0.11 0.13 1"/>
+        </Profile>
+
+        <Profile name="srDetailRecBg" extends="baseReference" with="anchorTopCenter">
+            <size value="980px 80px"/>
+            <imageColor value="0.10 0.10 0.12 0.9"/>
+        </Profile>
+
+        <Profile name="srDivider" extends="baseReference" with="anchorTopCenter">
+            <size value="1020px 1px"/>
+            <imageColor value="0.2 0.25 0.35 0.5"/>
+        </Profile>
+
+        <!-- ========== SUMMARY TEXT ========== -->
         <Profile name="srSummaryLabel" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="110px 18px"/>
+            <size value="130px 20px"/>
             <textSize value="12px"/>
-            <textColor value="0.6 0.6 0.6 1"/>
+            <textColor value="0.7 0.7 0.7 1"/>
         </Profile>
 
         <Profile name="srSummaryValue" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="80px 18px"/>
+            <size value="90px 20px"/>
             <textSize value="13px"/>
             <textBold value="true"/>
             <textColor value="0.8 0.9 1 1"/>
         </Profile>
 
         <Profile name="srSummaryWarnValue" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="80px 18px"/>
+            <size value="90px 20px"/>
             <textSize value="13px"/>
             <textBold value="true"/>
             <textColor value="1 0.6 0.3 1"/>
         </Profile>
 
+        <!-- ========== TABLE TEXT ========== -->
         <Profile name="srHeaderText" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="80px 18px"/>
+            <size value="75px 22px"/>
             <textSize value="11px"/>
             <textBold value="true"/>
-            <textColor value="0.8 0.8 0.8 1"/>
+            <textColor value="0.65 0.80 0.95 1"/>
+        </Profile>
+
+        <Profile name="srHeaderTextNarrow" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="55px 22px"/>
+            <textSize value="11px"/>
+            <textBold value="true"/>
+            <textColor value="0.65 0.80 0.95 1"/>
         </Profile>
 
         <Profile name="srHeaderTextWide" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="200px 18px"/>
+            <size value="140px 22px"/>
             <textSize value="11px"/>
             <textBold value="true"/>
-            <textColor value="0.8 0.8 0.8 1"/>
+            <textColor value="0.65 0.80 0.95 1"/>
             <textAlignment value="left"/>
+        </Profile>
+
+        <Profile name="srHeaderTextStatus" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="100px 22px"/>
+            <textSize value="11px"/>
+            <textBold value="true"/>
+            <textColor value="0.65 0.80 0.95 1"/>
         </Profile>
 
         <Profile name="srRowText" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="80px 18px"/>
+            <size value="75px 22px"/>
             <textSize value="11px"/>
             <textColor value="1 1 1 1"/>
         </Profile>
 
-        <Profile name="srRowTextWide" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="200px 18px"/>
+        <Profile name="srRowTextNarrow" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="55px 22px"/>
             <textSize value="11px"/>
             <textColor value="1 1 1 1"/>
+        </Profile>
+
+        <Profile name="srRowTextCrop" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="140px 22px"/>
+            <textSize value="11px"/>
+            <textColor value="0.7 0.7 0.7 1"/>
             <textAlignment value="left"/>
         </Profile>
 
+        <Profile name="srRowTextStatus" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="100px 22px"/>
+            <textSize value="11px"/>
+            <textBold value="true"/>
+            <textColor value="1 1 1 1"/>
+        </Profile>
+
+        <Profile name="srDetailBtn" extends="buttonActivate" with="anchorTopCenter">
+            <size value="40px 22px"/>
+            <textSize value="11px"/>
+        </Profile>
+
         <Profile name="srPageInfo" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="900px 20px"/>
+            <size value="1020px 20px"/>
             <textSize value="12px"/>
             <textColor value="0.6 0.6 0.6 1"/>
             <textAlignment value="center"/>
         </Profile>
 
         <Profile name="srNoData" extends="fs25_textDefault" with="anchorTopCenter">
-            <size value="900px 30px"/>
+            <size value="1020px 30px"/>
             <textSize value="14px"/>
             <textColor value="0.6 0.6 0.6 1"/>
             <textAlignment value="center"/>
         </Profile>
+
+        <!-- ========== DETAIL VIEW TEXT ========== -->
+        <Profile name="srDetailTitle" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="300px 26px"/>
+            <textSize value="16px"/>
+            <textBold value="true"/>
+            <textColor value="0.95 0.95 1 1"/>
+            <textAlignment value="left"/>
+        </Profile>
+
+        <Profile name="srDetailCrop" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="200px 22px"/>
+            <textSize value="13px"/>
+            <textColor value="0.7 0.75 0.8 1"/>
+            <textAlignment value="left"/>
+        </Profile>
+
+        <Profile name="srDetailOverall" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="120px 22px"/>
+            <textSize value="14px"/>
+            <textBold value="true"/>
+            <textAlignment value="center"/>
+        </Profile>
+
+        <Profile name="srDetailSectionLabel" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="300px 18px"/>
+            <textSize value="11px"/>
+            <textBold value="true"/>
+            <textColor value="0.65 0.80 0.95 1"/>
+            <textAlignment value="left"/>
+        </Profile>
+
+        <Profile name="srDetailLabel" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="160px 20px"/>
+            <textSize value="12px"/>
+            <textColor value="0.65 0.65 0.65 1"/>
+            <textAlignment value="left"/>
+        </Profile>
+
+        <Profile name="srDetailValue" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="90px 20px"/>
+            <textSize value="13px"/>
+            <textBold value="true"/>
+            <textColor value="1 1 1 1"/>
+            <textAlignment value="right"/>
+        </Profile>
+
+        <Profile name="srDetailStatus" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="90px 20px"/>
+            <textSize value="12px"/>
+            <textBold value="true"/>
+            <textColor value="1 1 1 1"/>
+        </Profile>
+
+        <Profile name="srDetailHint" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="400px 20px"/>
+            <textSize value="11px"/>
+            <textColor value="0.55 0.55 0.65 1"/>
+            <textAlignment value="left"/>
+        </Profile>
+
+        <Profile name="srDetailRec" extends="fs25_textDefault" with="anchorTopCenter">
+            <size value="960px 60px"/>
+            <textSize value="13px"/>
+            <textColor value="0.9 0.9 0.9 1"/>
+            <textAlignment value="center"/>
+        </Profile>
     </GUIProfiles>
 </GUI>
+
+

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.5.1.0</version>
+    <version>1.5.2.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.5.0.0</version>
+    <version>1.5.1.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/main.lua
+++ b/src/main.lua
@@ -237,12 +237,15 @@ end)
 hookSaveLoadEvents()
 
 -- Route mouse events to SoilHUD (for drag/resize edit mode)
--- RMB only enters edit mode when cursor is over the panel (no cross-contamination)
+-- RMB only enters edit mode when cursor is over the panel (no cross-contamination).
+-- eventUsed is checked before processing and returned after, per FS25 standard pattern
+-- (prevents double-handling when vehicle camera or another listener already consumed the event).
 local soilMouseHandler = {}
 function soilMouseHandler:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
-    if sfm and sfm.soilHUD then
-        sfm.soilHUD:onMouseEvent(posX, posY, isDown, isUp, button)
+    if not eventUsed and sfm and sfm.soilHUD then
+        eventUsed = sfm.soilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed) or eventUsed
     end
+    return eventUsed
 end
 addModEventListener(soilMouseHandler)
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -19,7 +19,7 @@ SoilHUD.RESIZE_HANDLE_SIZE = 0.008
 
 -- ── Base panel dimensions at scale 1.0 ─────────────────
 SoilHUD.BASE_W = 0.190
-SoilHUD.BASE_H = 0.228   -- expanded to accommodate yield forecast + weed pressure rows
+SoilHUD.BASE_H = 0.228   -- Default fallback height
 
 -- ── Layout constants at scale 1.0 ──────────────────────
 SoilHUD.TITLE_H   = 0.024   -- title accent bar height
@@ -206,9 +206,51 @@ function SoilHUD:loadLayout()
 end
 
 -- ── Geometry helpers ─────────────────────────────────────
+function SoilHUD:calculateHeight()
+    local h = SoilHUD.TITLE_H + SoilHUD.PAD
+
+    local info = self.cachedFieldInfo
+    local ys = SoilConstants and SoilConstants.YIELD_SENSITIVITY
+    
+    if info then
+        h = h + SoilHUD.LINE_H
+        h = h + SoilHUD.PAD * 1.6
+        
+        h = h + SoilHUD.ROW_H * 3
+        h = h + SoilHUD.PAD * 1.3
+        
+        h = h + SoilHUD.LINE_H
+        h = h + SoilHUD.PAD * 1.3
+        
+        local cropLower = info.lastCrop and string.lower(info.lastCrop) or nil
+        if not cropLower or cropLower == "" or not (ys and ys.NON_CROP_NAMES and ys.NON_CROP_NAMES[cropLower]) then
+            h = h + SoilHUD.LINE_H
+            h = h + SoilHUD.PAD * 1.3
+        end
+        
+        local mgr = g_SoilFertilityManager
+        if mgr and mgr.settings then
+            if mgr.settings.weedPressure and (info.weedPressure or 0) >= 0 then h = h + SoilHUD.LINE_H end
+            if mgr.settings.pestPressure and (info.pestPressure or 0) >= 0 then h = h + SoilHUD.LINE_H end
+            if mgr.settings.diseasePressure and (info.diseasePressure or 0) >= 0 then h = h + SoilHUD.LINE_H end
+        end
+        
+        h = h + SoilHUD.PAD * 1.3
+    else
+        h = h + SoilHUD.LINE_H
+        h = h + SoilHUD.LINE_H * 4
+    end
+
+    h = h + SoilHUD.LINE_H
+    h = h + SoilHUD.PAD
+
+    self.currentHeight = h
+end
+
 function SoilHUD:getHUDRect()
     local s = self.scale
-    return self.panelX, self.panelY, SoilHUD.BASE_W * s, SoilHUD.BASE_H * s
+    local h = self.currentHeight or SoilHUD.BASE_H
+    return self.panelX, self.panelY, SoilHUD.BASE_W * s, h * s
 end
 
 function SoilHUD:isPointerOverHUD(posX, posY)
@@ -240,9 +282,10 @@ end
 
 function SoilHUD:clampPosition()
     local s = self.scale
-    local pw, ph = SoilHUD.BASE_W * s, SoilHUD.BASE_H * s
+    local h = self.currentHeight or SoilHUD.BASE_H
+    local pw, ph = SoilHUD.BASE_W * s, h * s
     self.panelX = math.max(0.01, math.min(1.0 - pw - 0.01, self.panelX))
-    self.panelY = math.max(ph + 0.01, math.min(0.98, self.panelY))
+    self.panelY = math.max(0.01, math.min(0.98 - ph, self.panelY))
 end
 
 -- ── Mouse event ──────────────────────────────────────────
@@ -324,23 +367,12 @@ end
 -- ── Update ───────────────────────────────────────────────
 function SoilHUD:update(dt)
     self.animTimer = self.animTimer + dt
+    self:calculateHeight()
 
     local currentPosition = self.settings.hudPosition or 1
     if not self.editMode and not self.dragging and self.lastHudPosition ~= currentPosition then
         self:updatePosition()
         self.lastHudPosition = currentPosition
-    end
-
-    -- Detection for initial RMB click when cursor might be hidden
-    if not self.editMode and self.initialized and self.settings.enabled and self.settings.showHUD and self.visible then
-        if g_inputBinding and g_inputBinding:getIsInputButtonDown(InputButton.RIGHT) then
-            -- Note: posX/posY might not be perfectly accurate if hidden, but we check last known
-            if g_inputBinding.mousePosXLast and g_inputBinding.mousePosYLast then
-                if self:isPointerOverHUD(g_inputBinding.mousePosXLast, g_inputBinding.mousePosYLast) then
-                    self:enterEditMode()
-                end
-            end
-        end
     end
 
     if self.editMode then
@@ -550,7 +582,7 @@ function SoilHUD:drawPanel()
     local px  = self.panelX
     local py  = self.panelY
     local pw  = SoilHUD.BASE_W * s
-    local ph  = SoilHUD.BASE_H * s
+    local ph  = (self.currentHeight or SoilHUD.BASE_H) * s
 
     local alpha = SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3]
     local fontMult = SoilConstants.HUD.FONT_SIZE_MULTIPLIERS[self.settings.hudFontSize or 2]

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -540,9 +540,32 @@ end
 function SoilHUD:overallStatus(info)
     local rank = {Good = 1, Fair = 2, Poor = 3}
     local worst = 1
+    -- N / P / K
     for _, key in ipairs({"nitrogen", "phosphorus", "potassium"}) do
         local r = rank[info[key].status] or 3
         if r > worst then worst = r end
+    end
+    -- pH
+    if info.pH then
+        local r = rank[self:pHColor(info.pH) == SoilHUD.C_POOR and "Poor"
+                    or self:pHColor(info.pH) == SoilHUD.C_FAIR and "Fair"
+                    or "Good"] or 1
+        if r > worst then worst = r end
+    end
+    -- OM
+    if info.organicMatter then
+        local r = rank[self:omColor(info.organicMatter) == SoilHUD.C_POOR and "Poor"
+                    or self:omColor(info.organicMatter) == SoilHUD.C_FAIR and "Fair"
+                    or "Good"] or 1
+        if r > worst then worst = r end
+    end
+    -- Weed / pest / disease pressures (0-100, 3-level: <25 Good, <60 Fair, else Poor)
+    for _, key in ipairs({"weedPressure", "pestPressure", "diseasePressure"}) do
+        local val = info[key]
+        if val and val >= 0 then
+            local r = (val >= 60) and 3 or (val >= 25) and 2 or 1
+            if r > worst then worst = r end
+        end
     end
     if worst == 1 then return "Good", SoilHUD.C_GOOD
     elseif worst == 2 then return "Fair", SoilHUD.C_FAIR
@@ -758,103 +781,21 @@ function SoilHUD:drawPanel()
             cy = cy - pad * 0.8
         end
 
-        -- Weed pressure row (always shown when info available and setting enabled)
-        if g_SoilFertilityManager and g_SoilFertilityManager.settings.weedPressure then
-            local pressure = info.weedPressure or 0
-            local wp = SoilConstants.WEED_PRESSURE
-            local weedColor
-            if pressure < wp.LOW then
-                weedColor = SoilHUD.C_GOOD
-            elseif pressure < wp.MEDIUM then
-                weedColor = SoilHUD.C_FAIR
-            elseif pressure < wp.HIGH then
-                weedColor = {1.0, 0.55, 0.10, 1.0}  -- orange
-            else
-                weedColor = SoilHUD.C_POOR
+        -- Weed / pest / disease pressure rows
+        local mgr = g_SoilFertilityManager
+        if mgr then
+            if mgr.settings.weedPressure then
+                cy = self:drawPressureRow("sf_hud_weeds", info.weedPressure or 0,
+                    info.herbicideActive, px, cy, pw, s, fontMult)
             end
-
-            setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-            renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_weeds"))
-
-            -- Progress bar (reuse BAR geometry)
-            local barX = tx + 0.038*s
-            local barH = SoilHUD.BAR_H * s
-            local barW = SoilHUD.BAR_W * s
-            local barY = cy + (SoilHUD.LINE_H * s - barH) * 0.5
-            self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
-            local fill = math.max(0, math.min(1, pressure / 100))
-            if fill > 0 then
-                self:drawRect(barX, barY, barW * fill, barH, weedColor)
+            if mgr.settings.pestPressure then
+                cy = self:drawPressureRow("sf_hud_pests", info.pestPressure or 0,
+                    info.insecticideActive, px, cy, pw, s, fontMult)
             end
-
-            -- Value + herbicide indicator
-            local weedLabel = string.format("%.0f%%", pressure)
-            if info.herbicideActive then weedLabel = weedLabel .. " " .. g_i18n:getText("sf_hud_protected") end
-            setTextAlignment(RenderText.ALIGN_RIGHT)
-            setTextColor(weedColor[1], weedColor[2], weedColor[3], 1.0)
-            renderText(px + pw - pad, cy, 0.010 * fontMult * s, weedLabel)
-            setTextAlignment(RenderText.ALIGN_LEFT)
-            cy = cy - SoilHUD.LINE_H * s
-        end
-
-        -- Pest pressure row
-        if g_SoilFertilityManager and g_SoilFertilityManager.settings.pestPressure then
-            local pressure = info.pestPressure or 0
-            local pp = SoilConstants.PEST_PRESSURE
-            local pestColor
-            if pressure < pp.LOW then pestColor = SoilHUD.C_GOOD
-            elseif pressure < pp.MEDIUM then pestColor = SoilHUD.C_FAIR
-            elseif pressure < pp.HIGH then pestColor = {1.0, 0.55, 0.10, 1.0}
-            else pestColor = SoilHUD.C_POOR end
-
-            setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-            renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_pests"))
-
-            local barX = tx + 0.038*s
-            local barH = SoilHUD.BAR_H * s
-            local barW = SoilHUD.BAR_W * s
-            local barY = cy + (SoilHUD.LINE_H * s - barH) * 0.5
-            self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
-            local fill = math.max(0, math.min(1, pressure / 100))
-            if fill > 0 then self:drawRect(barX, barY, barW * fill, barH, pestColor) end
-
-            local pestLabel = string.format("%.0f%%", pressure)
-            if info.insecticideActive then pestLabel = pestLabel .. " " .. g_i18n:getText("sf_hud_protected") end
-            setTextAlignment(RenderText.ALIGN_RIGHT)
-            setTextColor(pestColor[1], pestColor[2], pestColor[3], 1.0)
-            renderText(px + pw - pad, cy, 0.010 * fontMult * s, pestLabel)
-            setTextAlignment(RenderText.ALIGN_LEFT)
-            cy = cy - SoilHUD.LINE_H * s
-        end
-
-        -- Disease pressure row
-        if g_SoilFertilityManager and g_SoilFertilityManager.settings.diseasePressure then
-            local pressure = info.diseasePressure or 0
-            local dp = SoilConstants.DISEASE_PRESSURE
-            local diseaseColor
-            if pressure < dp.LOW then diseaseColor = SoilHUD.C_GOOD
-            elseif pressure < dp.MEDIUM then diseaseColor = SoilHUD.C_FAIR
-            elseif pressure < dp.HIGH then diseaseColor = {1.0, 0.55, 0.10, 1.0}
-            else diseaseColor = SoilHUD.C_POOR end
-
-            setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-            renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_disease"))
-
-            local barX = tx + 0.038*s
-            local barH = SoilHUD.BAR_H * s
-            local barW = SoilHUD.BAR_W * s
-            local barY = cy + (SoilHUD.LINE_H * s - barH) * 0.5
-            self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
-            local fill = math.max(0, math.min(1, pressure / 100))
-            if fill > 0 then self:drawRect(barX, barY, barW * fill, barH, diseaseColor) end
-
-            local diseaseLabel = string.format("%.0f%%", pressure)
-            if info.fungicideActive then diseaseLabel = diseaseLabel .. " " .. g_i18n:getText("sf_hud_protected") end
-            setTextAlignment(RenderText.ALIGN_RIGHT)
-            setTextColor(diseaseColor[1], diseaseColor[2], diseaseColor[3], 1.0)
-            renderText(px + pw - pad, cy, 0.010 * fontMult * s, diseaseLabel)
-            setTextAlignment(RenderText.ALIGN_LEFT)
-            cy = cy - SoilHUD.LINE_H * s
+            if mgr.settings.diseasePressure then
+                cy = self:drawPressureRow("sf_hud_disease", info.diseasePressure or 0,
+                    info.fungicideActive, px, cy, pw, s, fontMult)
+            end
         end
 
         -- Divider before hint
@@ -946,6 +887,46 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult)
     setTextAlignment(RenderText.ALIGN_LEFT)
 
     return cy
+end
+
+-- ── Pressure bar row ─────────────────────────────────────
+-- Draws a single weed/pest/disease pressure row.
+-- pressure is 0-100.  isProtected shows "(protected)" suffix when true.
+-- Returns updated cy after the row.
+function SoilHUD:drawPressureRow(labelKey, pressure, isProtected, px, cy, pw, s, fontMult)
+    local pad  = SoilHUD.PAD * s
+    local barH = SoilHUD.BAR_H * s
+    local barW = SoilHUD.BAR_W * s
+    local tx   = px + pad
+
+    -- 3-level color (matches getPressureColor in SoilReportDialog)
+    local col
+    if pressure < 25 then     col = SoilHUD.C_GOOD
+    elseif pressure < 60 then col = SoilHUD.C_FAIR
+    else                      col = SoilHUD.C_POOR end
+
+    -- Label
+    setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
+    renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText(labelKey))
+
+    -- Bar
+    local barX = tx + 0.038*s
+    local barY = cy + (SoilHUD.LINE_H * s - barH) * 0.5
+    self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
+    local fill = math.max(0, math.min(1, pressure / 100))
+    if fill > 0 then
+        self:drawRect(barX, barY, barW * fill, barH, col)
+    end
+
+    -- Value + protection tag
+    local label = string.format("%.0f%%", pressure)
+    if isProtected then label = label .. " " .. g_i18n:getText("sf_hud_protected") end
+    setTextAlignment(RenderText.ALIGN_RIGHT)
+    setTextColor(col[1], col[2], col[3], 1.0)
+    renderText(px + pw - pad, cy, 0.010 * fontMult * s, label)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+
+    return cy - SoilHUD.LINE_H * s
 end
 
 -- ── Sprayer fill-type helpers ─────────────────────────────

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -246,53 +246,63 @@ function SoilHUD:clampPosition()
 end
 
 -- ── Mouse event ──────────────────────────────────────────
-function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button)
-    if not self.initialized then return end
-    if not self.settings.enabled then return end
-    if not self.settings.showHUD then return end
-    if not self.visible then return end
+-- Returns true when the event is consumed so the caller can propagate eventUsed correctly.
+function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    if not self.initialized then return false end
+    if not self.settings.enabled then return false end
+    if not self.settings.showHUD then return false end
+    if not self.visible then return false end
 
-    if isDown and button == 3 then
+    -- RMB: toggle edit mode (only consume when cursor is over panel or already in edit mode)
+    if isDown and button == Input.MOUSE_BUTTON_RIGHT then
         if self.editMode then
             self:exitEditMode()
+            return true
         elseif self:isPointerOverHUD(posX, posY) then
             self:enterEditMode()
+            return true
         end
-        return
+        return false
     end
 
-    if not self.editMode then return end
+    if not self.editMode then return false end
 
-    if isDown and button == 1 then
+    -- LMB down: start drag or resize
+    if isDown and button == Input.MOUSE_BUTTON_LEFT then
         local corner = self:hitTestCorner(posX, posY)
         if corner then
             self.resizing = true ; self.dragging = false
             self.resizeStartX = posX ; self.resizeStartY = posY
             self.resizeStartScale = self.scale
             self.movedInEditMode = true
-            return
+            return true
         end
         if self:isPointerOverHUD(posX, posY) then
             self.dragging = true ; self.resizing = false
             self.dragOffsetX = posX - self.panelX
             self.dragOffsetY = posY - self.panelY
             self.movedInEditMode = true
+            return true
         end
-        return
+        return false
     end
 
-    if isUp and button == 1 then
+    -- LMB up: release drag/resize
+    if isUp and button == Input.MOUSE_BUTTON_LEFT then
         if self.dragging or self.resizing then
             self.dragging = false ; self.resizing = false
             self:clampPosition()
+            return true
         end
-        return
+        return false
     end
 
+    -- Mouse move: update drag/resize/hover
     if self.dragging then
         local pw = SoilHUD.BASE_W * self.scale
         self.panelX = math.max(0.0, math.min(1.0 - pw, posX - self.dragOffsetX))
         self.panelY = math.max(0.05, math.min(0.95, posY - self.dragOffsetY))
+        return true
     end
 
     if self.resizing then
@@ -304,11 +314,11 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button)
         self.scale = math.max(SoilHUD.MIN_SCALE,
             math.min(SoilHUD.MAX_SCALE, self.resizeStartScale + delta))
         self:clampPosition()
+        return true
     end
 
-    if not self.dragging and not self.resizing then
-        self.hoverCorner = self:hitTestCorner(posX, posY)
-    end
+    self.hoverCorner = self:hitTestCorner(posX, posY)
+    return false
 end
 
 -- ── Update ───────────────────────────────────────────────

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -262,22 +262,73 @@ function SoilReportDialog:collectFieldData()
     return true
 end
 
+-- ── Status color helpers ──────────────────────────────────────────────
+
+local function getStatusColor(status)
+    if status == "Good" then return SoilReportDialog.COLOR_GOOD
+    elseif status == "Fair" then return SoilReportDialog.COLOR_FAIR
+    elseif status == "Poor" then return SoilReportDialog.COLOR_POOR
+    end
+    return SoilReportDialog.COLOR_WHITE
+end
+
+local function getPHColor(ph)
+    local rc = SoilConstants.REPORT_COLORS
+    if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return SoilReportDialog.COLOR_GOOD
+    elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return SoilReportDialog.COLOR_FAIR
+    end
+    return SoilReportDialog.COLOR_POOR
+end
+
+local function getOMColor(om)
+    local rc = SoilConstants.REPORT_COLORS
+    if om >= rc.OM_GOOD then return SoilReportDialog.COLOR_GOOD
+    elseif om >= rc.OM_FAIR then return SoilReportDialog.COLOR_FAIR
+    end
+    return SoilReportDialog.COLOR_POOR
+end
+
+local function getPressureColor(pct)
+    if pct < 25 then return SoilReportDialog.COLOR_GOOD
+    elseif pct < 60 then return SoilReportDialog.COLOR_FAIR
+    else return SoilReportDialog.COLOR_POOR end
+end
+
 -- ── Overall status helpers ────────────────────────────────────────────
 
---- Compute the overall field status (worst of N/P/K/pH/OM).
+--- Compute the overall field status (worst of N/P/K/pH/OM/weed/pest/disease).
 ---@param info table
 ---@return string "Good"|"Fair"|"Poor"
 ---@return table color RGBA
 local function getOverallStatus(info)
-    local function nutrientRank(s)
-        if s == "Poor" then return 3
-        elseif s == "Fair" then return 2
+    local function colorRank(c)
+        if c == SoilReportDialog.COLOR_POOR then return 3
+        elseif c == SoilReportDialog.COLOR_FAIR then return 2
         else return 1 end
     end
     local worst = 1
+    -- N / P / K
     for _, key in ipairs({"nitrogen", "phosphorus", "potassium"}) do
-        local r = nutrientRank(info[key].status)
+        local s = info[key].status
+        local r = (s == "Poor") and 3 or (s == "Fair") and 2 or 1
         if r > worst then worst = r end
+    end
+    -- pH and OM
+    if info.pH then
+        local r = colorRank(getPHColor(info.pH))
+        if r > worst then worst = r end
+    end
+    if info.organicMatter then
+        local r = colorRank(getOMColor(info.organicMatter))
+        if r > worst then worst = r end
+    end
+    -- Weed / pest / disease pressures (stored as 0-100)
+    for _, key in ipairs({"weedPressure", "pestPressure", "diseasePressure"}) do
+        local val = info[key]
+        if val and val >= 0 then
+            local r = colorRank(getPressureColor(math.floor(val + 0.5)))
+            if r > worst then worst = r end
+        end
     end
     if worst == 3 then return "Poor", SoilReportDialog.COLOR_POOR
     elseif worst == 2 then return "Fair", SoilReportDialog.COLOR_FAIR
@@ -297,8 +348,8 @@ function SoilReportDialog:computeFarmHealth()
         if info then
             local status, _ = getOverallStatus(info)
             if status == "Good" then scoreSum = scoreSum + 100
-            elseif status == "Fair" then scoreSum = scoreSum + 55
-            else scoreSum = scoreSum + 10 end
+            elseif status == "Fair" then scoreSum = scoreSum + 50
+            else scoreSum = scoreSum + 0 end
         end
     end
 
@@ -373,38 +424,6 @@ function SoilReportDialog:setDetailMode(isDetail)
     if self.backSep    then self.backSep:setVisible(isDetail) end
 end
 
--- ── Status color helpers ──────────────────────────────────────────────
-
-local function getStatusColor(status)
-    if status == "Good" then return SoilReportDialog.COLOR_GOOD
-    elseif status == "Fair" then return SoilReportDialog.COLOR_FAIR
-    elseif status == "Poor" then return SoilReportDialog.COLOR_POOR
-    end
-    return SoilReportDialog.COLOR_WHITE
-end
-
-local function getPHColor(ph)
-    local rc = SoilConstants.REPORT_COLORS
-    if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return SoilReportDialog.COLOR_GOOD
-    elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return SoilReportDialog.COLOR_FAIR
-    end
-    return SoilReportDialog.COLOR_POOR
-end
-
-local function getOMColor(om)
-    local rc = SoilConstants.REPORT_COLORS
-    if om >= rc.OM_GOOD then return SoilReportDialog.COLOR_GOOD
-    elseif om >= rc.OM_FAIR then return SoilReportDialog.COLOR_FAIR
-    end
-    return SoilReportDialog.COLOR_POOR
-end
-
-local function getPressureColor(pct)
-    if pct < 25 then return SoilReportDialog.COLOR_GOOD
-    elseif pct < 60 then return SoilReportDialog.COLOR_FAIR
-    else return SoilReportDialog.COLOR_POOR end
-end
-
 --- Set text and color on a text element
 local function setColoredText(element, text, color)
     if element then
@@ -471,7 +490,7 @@ function SoilReportDialog:getFertilizationRecommendation(info)
         overallStatus = "Poor"
     end
 
-    local yieldSuffix = ""
+    -- Yield penalty entry (added directly to recommendations list)
     local ys = SoilConstants.YIELD_SENSITIVITY
     if ys then
         local cropLower = info.lastCrop and string.lower(info.lastCrop) or nil
@@ -480,13 +499,13 @@ function SoilReportDialog:getFertilizationRecommendation(info)
             local tierData = ys.TIERS and ys.TIERS[tier]
             local thresh   = ys.OPTIMAL_THRESHOLD or 70
             if tierData then
-                local nDef   = math.max(0, thresh - info.nitrogen.value)   / thresh
-                local pDef   = math.max(0, thresh - info.phosphorus.value) / thresh
-                local kDef   = math.max(0, thresh - info.potassium.value)  / thresh
+                local nDef       = math.max(0, thresh - info.nitrogen.value)   / thresh
+                local pDef       = math.max(0, thresh - info.phosphorus.value) / thresh
+                local kDef       = math.max(0, thresh - info.potassium.value)  / thresh
                 local penalty    = math.min(ys.MAX_PENALTY, (nDef + pDef + kDef) / 3 * tierData.scale)
                 local penaltyPct = math.floor(penalty * 100 + 0.5)
                 if penaltyPct > 0 then
-                    yieldSuffix = string.format(", Yield ~-%d%%", penaltyPct)
+                    table.insert(recommendations, string.format(tr("sf_report_yield_loss", "Yield ~-%d%%"), penaltyPct))
                     if overallStatus == "Good" then overallStatus = "Fair" end
                 end
             end
@@ -498,35 +517,21 @@ function SoilReportDialog:getFertilizationRecommendation(info)
         -- Format as bulleted grid, 3 items per line
         local lines = {}
         local currentLine = {}
-        
-        for i, rec in ipairs(recommendations) do
+        for _, rec in ipairs(recommendations) do
             table.insert(currentLine, "- " .. rec)
             if #currentLine >= 3 then
                 table.insert(lines, table.concat(currentLine, "   "))
                 currentLine = {}
             end
         end
-        
-        if yieldSuffix ~= "" then
-            -- Yield suffix is typically the last item, remove the leading comma/space if any
-            local yieldText = "- " .. string.gsub(yieldSuffix, "^,%s*", "")
-            table.insert(currentLine, yieldText)
-        end
-        
         if #currentLine > 0 then
             table.insert(lines, table.concat(currentLine, "   "))
         end
-
         recStr   = table.concat(lines, "\n")
         recColor = (overallStatus == "Poor") and SoilReportDialog.COLOR_POOR or SoilReportDialog.COLOR_FAIR
     else
-        if yieldSuffix ~= "" then
-            recStr   = tr("sf_report_rec_optimal", "Soil Health: Optimal") .. yieldSuffix
-            recColor = SoilReportDialog.COLOR_FAIR
-        else
-            recStr   = tr("sf_report_rec_optimal", "Soil Health: Optimal")
-            recColor = SoilReportDialog.COLOR_GOOD
-        end
+        recStr   = tr("sf_report_rec_optimal", "Soil Health: Optimal")
+        recColor = SoilReportDialog.COLOR_GOOD
     end
 
     return recStr, recColor, overallStatus
@@ -562,18 +567,16 @@ function SoilReportDialog:updateFieldRows()
                     -- Organic Matter
                     setColoredText(row.om, string.format("%.1f", info.organicMatter), getOMColor(info.organicMatter))
 
-                    -- Weed pressure
+                    -- Weed pressure (stored as 0-100)
                     if row.weed then
-                        local wp = info.weedPressure or 0
-                        local wpPct = math.floor(wp * 100 + 0.5)
-                        setColoredText(row.weed, string.format("%d%%", wpPct), getPressureColor(wpPct))
+                        local wp = math.floor((info.weedPressure or 0) + 0.5)
+                        setColoredText(row.weed, string.format("%d%%", wp), getPressureColor(wp))
                     end
 
-                    -- Pest pressure
+                    -- Pest pressure (stored as 0-100)
                     if row.pest then
-                        local pp = info.pestPressure or 0
-                        local ppPct = math.floor(pp * 100 + 0.5)
-                        setColoredText(row.pest, string.format("%d%%", ppPct), getPressureColor(ppPct))
+                        local pp = math.floor((info.pestPressure or 0) + 0.5)
+                        setColoredText(row.pest, string.format("%d%%", pp), getPressureColor(pp))
                     end
 
                     -- Last Crop
@@ -693,21 +696,21 @@ function SoilReportDialog:updateDetailView(fieldId)
         if hintEl then hintEl:setText(hintText or "") end
     end
 
-    local nHint = (info.nitrogen.status == "Poor") and tr("sf_report_rec_n_poor", "Apply nitrogen fertilizer")
-               or (info.nitrogen.status == "Fair") and tr("sf_report_rec_n_fair", "Consider light N top-dress")
-               or "Nitrogen levels optimal"
+    local nHint = (info.nitrogen.status == "Poor") and tr("sf_report_rec_n_poor", "Needs Nitrogen")
+               or (info.nitrogen.status == "Fair") and tr("sf_report_rec_n_fair", "Low Nitrogen")
+               or tr("sf_report_detail_n_ok", "Nitrogen: Optimal")
     fillNutrient(self.detailN, self.detailNStat, self.detailNHint,
         info.nitrogen.value,   ppm.N, info.nitrogen.status,   nHint)
 
-    local pHint = (info.phosphorus.status == "Poor") and tr("sf_report_rec_p_poor", "Apply phosphorus fertilizer")
-               or (info.phosphorus.status == "Fair") and tr("sf_report_rec_p_fair", "Monitor phosphorus levels")
-               or "Phosphorus levels optimal"
+    local pHint = (info.phosphorus.status == "Poor") and tr("sf_report_rec_p_poor", "Needs Phosphorus")
+               or (info.phosphorus.status == "Fair") and tr("sf_report_rec_p_fair", "Low Phosphorus")
+               or tr("sf_report_detail_p_ok", "Phosphorus: Optimal")
     fillNutrient(self.detailP, self.detailPStat, self.detailPHint,
         info.phosphorus.value, ppm.P, info.phosphorus.status, pHint)
 
-    local kHint = (info.potassium.status == "Poor") and tr("sf_report_rec_k_poor", "Apply potash fertilizer")
-               or (info.potassium.status == "Fair") and tr("sf_report_rec_k_fair", "Monitor potassium levels")
-               or "Potassium levels optimal"
+    local kHint = (info.potassium.status == "Poor") and tr("sf_report_rec_k_poor", "Needs Potassium")
+               or (info.potassium.status == "Fair") and tr("sf_report_rec_k_fair", "Low Potassium")
+               or tr("sf_report_detail_k_ok", "Potassium: Optimal")
     fillNutrient(self.detailK, self.detailKStat, self.detailKHint,
         info.potassium.value,  ppm.K, info.potassium.status,  kHint)
 
@@ -719,9 +722,9 @@ function SoilReportDialog:updateDetailView(fieldId)
     end
     if self.detailPHStat then
         local phColor = getPHColor(info.pH)
-        local phStatus = (phColor == SoilReportDialog.COLOR_GOOD) and "Optimal"
-                      or (phColor == SoilReportDialog.COLOR_FAIR) and "Monitor"
-                      or "Adjust"
+        local phStatus = (phColor == SoilReportDialog.COLOR_GOOD) and tr("sf_hud_optimal", "Optimal")
+                      or (phColor == SoilReportDialog.COLOR_FAIR) and tr("sf_report_status_monitor", "Monitor")
+                      or tr("sf_report_status_adjust", "Adjust")
         self.detailPHStat:setText(phStatus)
         self.detailPHStat:setTextColor(phColor[1], phColor[2], phColor[3], 1)
     end
@@ -734,18 +737,20 @@ function SoilReportDialog:updateDetailView(fieldId)
     end
     if self.detailOMStat then
         local omColor = getOMColor(info.organicMatter)
-        local omStatus = (omColor == SoilReportDialog.COLOR_GOOD) and "Optimal"
-                      or (omColor == SoilReportDialog.COLOR_FAIR) and "Maintain"
-                      or "Increase"
+        local omStatus = (omColor == SoilReportDialog.COLOR_GOOD) and tr("sf_hud_optimal", "Optimal")
+                      or (omColor == SoilReportDialog.COLOR_FAIR) and tr("sf_report_status_maintain", "Maintain")
+                      or tr("sf_report_status_increase", "Increase")
         self.detailOMStat:setText(omStatus)
         self.detailOMStat:setTextColor(omColor[1], omColor[2], omColor[3], 1)
     end
 
     -- Pressures
     local function fillPressure(valueEl, statEl, hintEl, rawVal, protectedFlag, protectedKey)
-        local pct = math.floor((rawVal or 0) * 100 + 0.5)
+        local pct = math.floor((rawVal or 0) + 0.5)   -- stored as 0-100
         local color = getPressureColor(pct)
-        local level = (pct < 25) and "Low" or (pct < 60) and "Moderate" or "High"
+        local level = (pct < 25) and tr("sf_report_pressure_low", "Low")
+                   or (pct < 60) and tr("sf_report_pressure_moderate", "Moderate")
+                   or tr("sf_report_pressure_high", "High")
         if valueEl then
             valueEl:setText(string.format("%d%%", pct))
             valueEl:setTextColor(color[1], color[2], color[3], 1)
@@ -785,7 +790,7 @@ function SoilReportDialog:updateDetailView(fieldId)
                 local penalty    = math.min(ys.MAX_PENALTY, (nDef + pDef + kDef) / 3 * tierData.scale)
                 local penaltyPct = math.floor(penalty * 100 + 0.5)
                 if penaltyPct > 0 then
-                    yieldText  = string.format("~-%d%% loss", penaltyPct)
+                    yieldText  = string.format(tr("sf_report_yield_loss", "Yield ~-%d%%"), penaltyPct)
                     yieldColor = (penaltyPct >= 20) and SoilReportDialog.COLOR_POOR or SoilReportDialog.COLOR_FAIR
                 end
             end
@@ -795,8 +800,7 @@ function SoilReportDialog:updateDetailView(fieldId)
         self.detailYield:setTextColor(yieldColor[1], yieldColor[2], yieldColor[3], 1)
     end
     if self.detailYieldHint then
-        local hint = "Based on N/P/K vs optimal threshold"
-        self.detailYieldHint:setText(hint)
+        self.detailYieldHint:setText(tr("sf_report_yield_hint", "Based on N/P/K vs optimal threshold"))
     end
 
     -- Recommendations summary

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -2,8 +2,9 @@
 -- FS25 Realistic Soil & Fertilizer (Soil Report Dialog)
 -- =========================================================
 -- Full-farm soil report: paginated table of all tracked fields
--- with color-coded N/P/K/pH/OM values.
+-- with color-coded N/P/K/pH/OM/Weed/Pest values.
 -- Press K to open (SF_SOIL_REPORT action).
+-- ► button on any row opens the field detail view.
 -- =========================================================
 -- Author: TisonK
 -- =========================================================
@@ -34,6 +35,7 @@ SoilReportDialog.COLOR_GOOD  = {0.3, 1.0, 0.3, 1}
 SoilReportDialog.COLOR_FAIR  = {1.0, 0.9, 0.3, 1}
 SoilReportDialog.COLOR_POOR  = {1.0, 0.4, 0.4, 1}
 SoilReportDialog.COLOR_WHITE = {1.0, 1.0, 1.0, 1}
+SoilReportDialog.COLOR_DIM   = {0.6, 0.6, 0.6, 1}
 
 function SoilReportDialog.getInstance(modDirectory)
     if SoilReportDialog.instance == nil then
@@ -57,33 +59,34 @@ function SoilReportDialog.new(target, customMt)
     self.totalPages = 1
     self.fieldRows = {}
     self.isBackAllowed = true
+    self.detailMode = false
+    self.detailFieldId = nil
 
     return self
 end
 
 function SoilReportDialog:onCreate()
-    -- Cache row elements
+    -- Cache table row elements (now includes weed, pest, stat, and detail btn)
     for i = 0, SoilReportDialog.MAX_ROWS - 1 do
         local rowId = "fieldRow" .. i
         self.fieldRows[i] = {
-            row   = self[rowId],
-            bg    = self[rowId .. "Bg"],
-            id    = self[rowId .. "Id"],
-            n     = self[rowId .. "N"],
-            p     = self[rowId .. "P"],
-            k     = self[rowId .. "K"],
-            ph    = self[rowId .. "pH"],
-            om    = self[rowId .. "OM"],
-            crop  = self[rowId .. "Crop"],
-            fert  = self[rowId .. "Fert"],
+            row    = self[rowId],
+            bg     = self[rowId .. "Bg"],
+            id     = self[rowId .. "Id"],
+            n      = self[rowId .. "N"],
+            p      = self[rowId .. "P"],
+            k      = self[rowId .. "K"],
+            ph     = self[rowId .. "pH"],
+            om     = self[rowId .. "OM"],
+            weed   = self[rowId .. "Weed"],
+            pest   = self[rowId .. "Pest"],
+            crop   = self[rowId .. "Crop"],
+            stat   = self[rowId .. "Stat"],
         }
     end
 end
 
 --- Show dialog with current soil data.
---- In multiplayer, ownership data may not have synced yet for joining clients.
---- When that happens the dialog opens immediately with a "syncing" message and
---- an AsyncRetryHandler polls until ownership is ready, then refreshes the view.
 function SoilReportDialog:show()
     if g_gui.currentGui ~= nil then return end
 
@@ -93,11 +96,11 @@ function SoilReportDialog:show()
     end
 
     self.currentPage = 1
+    self.detailMode = false
+    self.detailFieldId = nil
 
     local ready = self:collectFieldData()
     if not ready then
-        -- Ownership hasn't synced yet — open the dialog with a syncing message
-        -- and start a background retry loop (fix for issue #120).
         self:showSyncingState()
         g_gui:showDialog("SoilReportDialog")
         self:startOwnershipSyncRetry()
@@ -110,13 +113,11 @@ end
 
 --- Put the dialog into a "waiting for sync" visual state.
 function SoilReportDialog:showSyncingState()
-    -- Clear any stale rows first
     self.sortedFieldIds = {}
     self.fieldInfos = {}
     self.totalPages = 1
     self:updateDisplay()
 
-    -- Reuse the existing noDataText element to show the syncing message.
     if self.noDataText then
         self.noDataText:setText(tr("sf_ui_soilReport_syncing", "Syncing field ownership data, please wait..."))
         self.noDataText:setVisible(true)
@@ -126,35 +127,29 @@ end
 --- Start an AsyncRetryHandler that re-runs collectFieldData() until ownership
 --- has synced, then refreshes the display. Retries every 2s for up to 30s.
 function SoilReportDialog:startOwnershipSyncRetry()
-    -- Cancel any previous retry that may still be running.
     if self.ownershipRetry then
         self.ownershipRetry:reset()
     end
 
-    local dialog = self  -- capture for callbacks
+    local dialog = self
 
     self.ownershipRetry = AsyncRetryHandler.new({
         name        = "SoilReport.OwnershipSync",
         maxAttempts = 15,
         delays      = {2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000},
         condition   = function()
-            -- Considered ready once collectFieldData() succeeds
             local ready = dialog:collectFieldData()
             return ready
         end,
-        onAttempt   = function()
-            -- condition() does the actual work; nothing extra needed here
-        end,
+        onAttempt   = function() end,
         onSuccess   = function()
             SoilLogger.info("[SoilReport] Ownership synced, refreshing dialog")
-            -- Only update if the dialog is still open
             if g_gui.currentGui and g_gui.currentGui.name == "SoilReportDialog" then
                 dialog:updateDisplay()
             end
         end,
         onFailure   = function()
             SoilLogger.warning("[SoilReport] Ownership sync timed out after retries")
-            -- Leave the syncing message visible; player can close and reopen.
             if dialog.noDataText then
                 dialog.noDataText:setText(tr("sf_ui_soilReport_syncTimeout",
                     "Could not load field ownership. Please close and reopen the report."))
@@ -183,74 +178,44 @@ local function getLocalFarmId()
         if user and user.farmId and user.farmId > 0 then return user.farmId end
     end
 
-    return 1  -- singleplayer is always farm 1
+    return 1
 end
 
---- Returns true if the farmland is owned by the given farm.
---- Uses g_farmlandManager:getFarmlandOwner(farmlandId) — the authoritative
---- FS25 ownership API (confirmed in FarmlandManager.lua source).
 ---@param farmlandId number
 ---@param localFarmId number
 ---@return boolean
 local function isFarmlandOwnedByFarm(farmlandId, localFarmId)
-    if not g_farmlandManager then
-        return false
-    end
+    if not g_farmlandManager then return false end
     return g_farmlandManager:getFarmlandOwner(farmlandId) == localFarmId
 end
 
---- Returns true if farmland data has synced.
---- In multiplayer, ownership data arrives asynchronously after the client joins.
---- We wait until either the player's own land is visible, or any land ownership
---- is visible (indicating the server has sent the initial state).
 ---@param localFarmId number
 ---@return boolean
 local function isOwnershipSynced(localFarmId)
-    if not g_farmlandManager then
-        return false
-    end
+    if not g_farmlandManager then return false end
 
-    -- Ensure map data is loaded
     local farmlands = g_farmlandManager:getFarmlands()
-    if not farmlands or next(farmlands) == nil then
-        return false
-    end
+    if not farmlands or next(farmlands) == nil then return false end
 
-    -- Singleplayer and host always have ownership present immediately.
     if not g_currentMission.missionDynamicInfo.isMultiplayer or g_currentMission:getIsServer() then
         return true
     end
 
-    -- For joining clients in MP, the mapping starts empty and fills in asynchronously.
-    -- Check if we own any land.
     local ownedIds = g_farmlandManager:getOwnedFarmlandIdsByFarmId(localFarmId)
-    if ownedIds and #ownedIds > 0 then
-        return true
-    end
+    if ownedIds and #ownedIds > 0 then return true end
 
-    -- Check if ANYONE owns land (common for map start).
-    -- Using the public API to avoid direct table access issues.
     for id, _ in pairs(farmlands) do
-        if g_farmlandManager:getFarmlandOwner(id) ~= 0 then
-            return true
-        end
+        if g_farmlandManager:getFarmlandOwner(id) ~= 0 then return true end
     end
 
-    -- Fallback: if the mission is fully started/HUD is visible, assume sync is complete
-    -- even if all land is currently unowned (e.g. survival start).
     if g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isStarted then
         return true
     end
-    if g_currentMission.hud ~= nil then
-        return true
-    end
+    if g_currentMission.hud ~= nil then return true end
 
     return false
 end
 
---- Collect field data limited to fields owned by the local player's farm.
---- Returns true if data was collected successfully, false if ownership has not
---- synced yet (caller should retry).
 ---@return boolean ready
 function SoilReportDialog:collectFieldData()
     self.fieldInfos = {}
@@ -261,10 +226,6 @@ function SoilReportDialog:collectFieldData()
 
     local localFarmId = getLocalFarmId()
 
-    -- Guard: in multiplayer the farmlandMapping may not have synced yet for the
-    -- joining client. If it isn't ready we return false so the caller can retry
-    -- rather than falling through to the "show all fields" fallback that was
-    -- causing issue #120 (client saw the host's fields).
     if not isOwnershipSynced(localFarmId) then
         SoilLogger.warning("[SoilReport] Ownership data not yet synced for farmId %s - will retry", tostring(localFarmId))
         return false
@@ -277,24 +238,15 @@ function SoilReportDialog:collectFieldData()
         end
     end
 
-    -- If ownership IS synced but the player genuinely owns no tracked fields,
-    -- leave sortedFieldIds empty (the "no data" message will show). Never fall
-    -- back to showing all fields — that was the root cause of issue #120.
     self.sortedFieldIds = filtered
 
     table.sort(self.sortedFieldIds, function(a, b)
         local urgencyA = soilSystem:getFieldUrgency(a)
         local urgencyB = soilSystem:getFieldUrgency(b)
-        
-        -- If urgencies are roughly equal, sort by field ID
-        if math.abs(urgencyA - urgencyB) < 0.1 then
-            return a < b
-        end
-        -- Highest urgency first
+        if math.abs(urgencyA - urgencyB) < 0.1 then return a < b end
         return urgencyA > urgencyB
     end)
 
-    -- Build info for each field
     for _, fieldId in ipairs(self.sortedFieldIds) do
         local info = soilSystem:getFieldInfo(fieldId)
         if info then
@@ -304,24 +256,74 @@ function SoilReportDialog:collectFieldData()
         end
     end
 
-    -- Calculate pages
     self.totalPages = math.ceil(#self.sortedFieldIds / SoilReportDialog.MAX_ROWS)
-    if self.totalPages < 1 then
-        self.totalPages = 1
-    end
+    if self.totalPages < 1 then self.totalPages = 1 end
 
     return true
 end
 
---- Update all display elements
+-- ── Overall status helpers ────────────────────────────────────────────
+
+--- Compute the overall field status (worst of N/P/K/pH/OM).
+---@param info table
+---@return string "Good"|"Fair"|"Poor"
+---@return table color RGBA
+local function getOverallStatus(info)
+    local function nutrientRank(s)
+        if s == "Poor" then return 3
+        elseif s == "Fair" then return 2
+        else return 1 end
+    end
+    local worst = 1
+    for _, key in ipairs({"nitrogen", "phosphorus", "potassium"}) do
+        local r = nutrientRank(info[key].status)
+        if r > worst then worst = r end
+    end
+    if worst == 3 then return "Poor", SoilReportDialog.COLOR_POOR
+    elseif worst == 2 then return "Fair", SoilReportDialog.COLOR_FAIR
+    else return "Good", SoilReportDialog.COLOR_GOOD end
+end
+
+--- Compute average farm health across all owned fields.
+---@return string label e.g. "Good (82%)"
+---@return table color RGBA
+function SoilReportDialog:computeFarmHealth()
+    local total = #self.sortedFieldIds
+    if total == 0 then return "--", SoilReportDialog.COLOR_DIM end
+
+    local scoreSum = 0
+    for _, fieldId in ipairs(self.sortedFieldIds) do
+        local info = self.fieldInfos[fieldId]
+        if info then
+            local status, _ = getOverallStatus(info)
+            if status == "Good" then scoreSum = scoreSum + 100
+            elseif status == "Fair" then scoreSum = scoreSum + 55
+            else scoreSum = scoreSum + 10 end
+        end
+    end
+
+    local avg = scoreSum / total
+    local label, color
+    if avg >= 75 then
+        label = string.format("%s (%d%%)", tr("sf_report_rec_good", "Good"), math.floor(avg + 0.5))
+        color = SoilReportDialog.COLOR_GOOD
+    elseif avg >= 40 then
+        label = string.format("%s (%d%%)", tr("sf_report_rec_fair", "Fair"), math.floor(avg + 0.5))
+        color = SoilReportDialog.COLOR_FAIR
+    else
+        label = string.format("%s (%d%%)", tr("sf_report_rec_poor", "Poor"), math.floor(avg + 0.5))
+        color = SoilReportDialog.COLOR_POOR
+    end
+    return label, color
+end
+
+-- ── Display update ────────────────────────────────────────────────────
+
 function SoilReportDialog:updateDisplay()
-    -- Summary section
     local totalFields = #self.sortedFieldIds
     local needFertCount = 0
     for _, info in pairs(self.fieldInfos) do
-        if info.needsFertilization then
-            needFertCount = needFertCount + 1
-        end
+        if info.needsFertilization then needFertCount = needFertCount + 1 end
     end
 
     if self.fieldCountText then
@@ -338,66 +340,85 @@ function SoilReportDialog:updateDisplay()
     if self.difficultyText and g_SoilFertilityManager.settings then
         self.difficultyText:setText(g_SoilFertilityManager.settings:getDifficultyName())
     end
-
-    -- Show/hide no-data message
-    local hasData = totalFields > 0
-    if self.noDataText then
-        self.noDataText:setVisible(not hasData)
+    if self.farmHealthText then
+        local healthLabel, healthColor = self:computeFarmHealth()
+        self.farmHealthText:setText(healthLabel)
+        self.farmHealthText:setTextColor(healthColor[1], healthColor[2], healthColor[3], healthColor[4])
     end
 
-    self:updateFieldRows()
-    self:updatePagination()
+    local hasData = totalFields > 0
+    if self.noDataText then
+        self.noDataText:setVisible(not hasData and not self.detailMode)
+    end
+
+    self:setDetailMode(self.detailMode)
+    if self.detailMode and self.detailFieldId then
+        self:updateDetailView(self.detailFieldId)
+    else
+        self:updateFieldRows()
+        self:updatePagination()
+    end
 end
 
---- Get status color for a nutrient value
----@param status string "Good", "Fair", or "Poor"
----@return table RGBA color
+--- Show/hide the correct panel and buttons based on mode.
+function SoilReportDialog:setDetailMode(isDetail)
+    self.detailMode = isDetail
+
+    if self.tableView  then self.tableView:setVisible(not isDetail) end
+    if self.detailView then self.detailView:setVisible(isDetail) end
+
+    if self.prevButton then self.prevButton:setVisible(not isDetail) end
+    if self.nextButton then self.nextButton:setVisible(not isDetail) end
+    if self.backButton then self.backButton:setVisible(isDetail) end
+    if self.backSep    then self.backSep:setVisible(isDetail) end
+end
+
+-- ── Status color helpers ──────────────────────────────────────────────
+
 local function getStatusColor(status)
-    if status == "Good" then
-        return SoilReportDialog.COLOR_GOOD
-    elseif status == "Fair" then
-        return SoilReportDialog.COLOR_FAIR
-    elseif status == "Poor" then
-        return SoilReportDialog.COLOR_POOR
+    if status == "Good" then return SoilReportDialog.COLOR_GOOD
+    elseif status == "Fair" then return SoilReportDialog.COLOR_FAIR
+    elseif status == "Poor" then return SoilReportDialog.COLOR_POOR
     end
     return SoilReportDialog.COLOR_WHITE
 end
 
---- Get pH status color
----@param ph number
----@return table RGBA color
 local function getPHColor(ph)
     local rc = SoilConstants.REPORT_COLORS
-    if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then
-        return SoilReportDialog.COLOR_GOOD
-    elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then
-        return SoilReportDialog.COLOR_FAIR
+    if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return SoilReportDialog.COLOR_GOOD
+    elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return SoilReportDialog.COLOR_FAIR
     end
     return SoilReportDialog.COLOR_POOR
 end
 
---- Get organic matter color
----@param om number
----@return table RGBA color
 local function getOMColor(om)
     local rc = SoilConstants.REPORT_COLORS
-    if om >= rc.OM_GOOD then
-        return SoilReportDialog.COLOR_GOOD
-    elseif om >= rc.OM_FAIR then
-        return SoilReportDialog.COLOR_FAIR
+    if om >= rc.OM_GOOD then return SoilReportDialog.COLOR_GOOD
+    elseif om >= rc.OM_FAIR then return SoilReportDialog.COLOR_FAIR
     end
     return SoilReportDialog.COLOR_POOR
 end
 
---- Get fertilization recommendation and color based on field info
----@param info table Field information from SoilFertilitySystem:getFieldInfo
----@return string Recommendation text
----@return table RGBA color for the recommendation text
+local function getPressureColor(pct)
+    if pct < 25 then return SoilReportDialog.COLOR_GOOD
+    elseif pct < 60 then return SoilReportDialog.COLOR_FAIR
+    else return SoilReportDialog.COLOR_POOR end
+end
+
+--- Set text and color on a text element
+local function setColoredText(element, text, color)
+    if element then
+        element:setText(text)
+        element:setTextColor(color[1], color[2], color[3], color[4])
+    end
+end
+
+-- ── Table rows ────────────────────────────────────────────────────────
+
 function SoilReportDialog:getFertilizationRecommendation(info)
     local recommendations = {}
-    local overallStatus = "Good" -- Start optimistic, downgrade as needed
+    local overallStatus = "Good"
 
-    -- Check individual nutrient statuses
     if info.nitrogen.status == "Poor" then
         table.insert(recommendations, tr("sf_report_rec_n_poor", "N (Poor)"))
         overallStatus = "Poor"
@@ -422,42 +443,34 @@ function SoilReportDialog:getFertilizationRecommendation(info)
         if overallStatus == "Good" then overallStatus = "Fair" end
     end
 
-    -- Check pH status
     local phColor = getPHColor(info.pH)
     if phColor == SoilReportDialog.COLOR_POOR then
-        table.insert(recommendations, tr("sf_report_rec_ph_adjust", "Adjust pH (Poor)"))
+        table.insert(recommendations, tr("sf_report_rec_ph_adjust", "Adjust pH"))
         overallStatus = "Poor"
     elseif phColor == SoilReportDialog.COLOR_FAIR then
-        table.insert(recommendations, tr("sf_report_rec_ph_monitor", "Monitor pH (Fair)"))
+        table.insert(recommendations, tr("sf_report_rec_ph_monitor", "Monitor pH"))
         if overallStatus == "Good" then overallStatus = "Fair" end
     end
 
-    -- Check Organic Matter status
     local omColor = getOMColor(info.organicMatter)
     if omColor == SoilReportDialog.COLOR_POOR then
-        table.insert(recommendations, tr("sf_report_rec_om_increase", "Increase OM (Poor)"))
+        table.insert(recommendations, tr("sf_report_rec_om_increase", "Increase OM"))
         overallStatus = "Poor"
     elseif omColor == SoilReportDialog.COLOR_FAIR then
-        table.insert(recommendations, tr("sf_report_rec_om_maintain", "Maintain OM (Fair)"))
+        table.insert(recommendations, tr("sf_report_rec_om_maintain", "Maintain OM"))
         if overallStatus == "Good" then overallStatus = "Fair" end
     end
 
-    -- Check Pest Pressure
     if info.pestPressure and info.pestPressure >= SoilConstants.PEST_PRESSURE.MEDIUM then
         table.insert(recommendations, tr("sf_report_rec_pest", "Pest Risk"))
         overallStatus = "Poor"
     end
 
-    -- Check Disease Pressure
     if info.diseasePressure and info.diseasePressure >= SoilConstants.DISEASE_PRESSURE.MEDIUM then
         table.insert(recommendations, tr("sf_report_rec_disease", "Disease Risk"))
         overallStatus = "Poor"
     end
 
-    local recommendationString
-    local recommendationColor
-
-    -- Yield forecast penalty (same logic as SoilHUD)
     local yieldSuffix = ""
     local ys = SoilConstants.YIELD_SENSITIVITY
     if ys then
@@ -470,8 +483,7 @@ function SoilReportDialog:getFertilizationRecommendation(info)
                 local nDef   = math.max(0, thresh - info.nitrogen.value)   / thresh
                 local pDef   = math.max(0, thresh - info.phosphorus.value) / thresh
                 local kDef   = math.max(0, thresh - info.potassium.value)  / thresh
-                local avgDef = (nDef + pDef + kDef) / 3
-                local penalty    = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
+                local penalty    = math.min(ys.MAX_PENALTY, (nDef + pDef + kDef) / 3 * tierData.scale)
                 local penaltyPct = math.floor(penalty * 100 + 0.5)
                 if penaltyPct > 0 then
                     yieldSuffix = string.format(", Yield ~-%d%%", penaltyPct)
@@ -481,40 +493,48 @@ function SoilReportDialog:getFertilizationRecommendation(info)
         end
     end
 
+    local recStr, recColor
     if #recommendations > 0 then
-        recommendationString = tr("sf_report_rec_needs", "Needs: ") .. table.concat(recommendations, ", ") .. yieldSuffix
-        if overallStatus == "Poor" then
-            recommendationColor = SoilReportDialog.COLOR_POOR
-        else
-            recommendationColor = SoilReportDialog.COLOR_FAIR
+        -- Format as bulleted grid, 3 items per line
+        local lines = {}
+        local currentLine = {}
+        
+        for i, rec in ipairs(recommendations) do
+            table.insert(currentLine, "- " .. rec)
+            if #currentLine >= 3 then
+                table.insert(lines, table.concat(currentLine, "   "))
+                currentLine = {}
+            end
         end
+        
+        if yieldSuffix ~= "" then
+            -- Yield suffix is typically the last item, remove the leading comma/space if any
+            local yieldText = "- " .. string.gsub(yieldSuffix, "^,%s*", "")
+            table.insert(currentLine, yieldText)
+        end
+        
+        if #currentLine > 0 then
+            table.insert(lines, table.concat(currentLine, "   "))
+        end
+
+        recStr   = table.concat(lines, "\n")
+        recColor = (overallStatus == "Poor") and SoilReportDialog.COLOR_POOR or SoilReportDialog.COLOR_FAIR
     else
         if yieldSuffix ~= "" then
-            recommendationString = tr("sf_report_rec_optimal", "Soil Health: Optimal") .. yieldSuffix
-            recommendationColor = SoilReportDialog.COLOR_FAIR
+            recStr   = tr("sf_report_rec_optimal", "Soil Health: Optimal") .. yieldSuffix
+            recColor = SoilReportDialog.COLOR_FAIR
         else
-            recommendationString = tr("sf_report_rec_optimal", "Soil Health: Optimal")
-            recommendationColor = SoilReportDialog.COLOR_GOOD
+            recStr   = tr("sf_report_rec_optimal", "Soil Health: Optimal")
+            recColor = SoilReportDialog.COLOR_GOOD
         end
     end
 
-    return recommendationString, recommendationColor
+    return recStr, recColor, overallStatus
 end
 
---- Set text and color on a text element
----@param element table GUI text element
----@param text string
----@param color table RGBA
-local function setColoredText(element, text, color)
-    if element then
-        element:setText(text)
-        element:setTextColor(color[1], color[2], color[3], color[4])
-    end
-end
-
---- Update field rows for current page
 function SoilReportDialog:updateFieldRows()
     local startIndex = (self.currentPage - 1) * SoilReportDialog.MAX_ROWS + 1
+    local ppm = SoilConstants.PPM_DISPLAY or { N = 1, P = 1, K = 1 }
 
     for i = 0, SoilReportDialog.MAX_ROWS - 1 do
         local dataIndex = startIndex + i
@@ -523,78 +543,64 @@ function SoilReportDialog:updateFieldRows()
         if row and row.row then
             if dataIndex <= #self.sortedFieldIds then
                 local fieldId = self.sortedFieldIds[dataIndex]
-                local info = self.fieldInfos[fieldId]
+                local info    = self.fieldInfos[fieldId]
 
                 row.row:setVisible(true)
 
                 if info then
                     -- Field ID
-                    if row.id then
-                        row.id:setText(tostring(fieldId))
+                    if row.id then row.id:setText(tostring(fieldId)) end
+
+                    -- N / P / K (ppm, color-coded)
+                    setColoredText(row.n, tostring(math.floor(info.nitrogen.value   * ppm.N + 0.5)), getStatusColor(info.nitrogen.status))
+                    setColoredText(row.p, tostring(math.floor(info.phosphorus.value * ppm.P + 0.5)), getStatusColor(info.phosphorus.status))
+                    setColoredText(row.k, tostring(math.floor(info.potassium.value  * ppm.K + 0.5)), getStatusColor(info.potassium.status))
+
+                    -- pH
+                    setColoredText(row.ph, string.format("%.1f", info.pH), getPHColor(info.pH))
+
+                    -- Organic Matter
+                    setColoredText(row.om, string.format("%.1f", info.organicMatter), getOMColor(info.organicMatter))
+
+                    -- Weed pressure
+                    if row.weed then
+                        local wp = info.weedPressure or 0
+                        local wpPct = math.floor(wp * 100 + 0.5)
+                        setColoredText(row.weed, string.format("%d%%", wpPct), getPressureColor(wpPct))
                     end
 
-                    -- N / P / K displayed in ppm (soil-test units).
-                    -- SoilConstants.PPM_DISPLAY converts the internal 0-100 scale
-                    -- to agronomic ppm values matching standard Mehlich-3 lab benchmarks.
-                    local ppm = SoilConstants.PPM_DISPLAY or { N = 1, P = 1, K = 1 }
-
-                    -- Nitrogen (color-coded, ppm)
-                    local nColor = getStatusColor(info.nitrogen.status)
-                    local nPpm = tostring(math.floor(info.nitrogen.value * ppm.N + 0.5))
-                    setColoredText(row.n, nPpm, nColor)
-
-                    -- Phosphorus (color-coded, ppm)
-                    local pColor = getStatusColor(info.phosphorus.status)
-                    local pPpm = tostring(math.floor(info.phosphorus.value * ppm.P + 0.5))
-                    setColoredText(row.p, pPpm, pColor)
-
-                    -- Potassium (color-coded, ppm)
-                    local kColor = getStatusColor(info.potassium.status)
-                    local kPpm = tostring(math.floor(info.potassium.value * ppm.K + 0.5))
-                    setColoredText(row.k, kPpm, kColor)
-
-                    -- Debug: first row of each page — confirm ppm conversion is live
-                    if i == 0 then
-                        SoilLogger.debug("SoilReport page row0 field=%s N=%s ppm P=%s ppm K=%s ppm",
-                            tostring(fieldId), nPpm, pPpm, kPpm)
+                    -- Pest pressure
+                    if row.pest then
+                        local pp = info.pestPressure or 0
+                        local ppPct = math.floor(pp * 100 + 0.5)
+                        setColoredText(row.pest, string.format("%d%%", ppPct), getPressureColor(ppPct))
                     end
-
-                    -- pH (color-coded)
-                    local phColor = getPHColor(info.pH)
-                    setColoredText(row.ph, string.format("%.1f", info.pH), phColor)
-
-                    -- Organic Matter (color-coded)
-                    local omColor = getOMColor(info.organicMatter)
-                    setColoredText(row.om, string.format("%.1f", info.organicMatter), omColor)
 
                     -- Last Crop
                     if row.crop then
                         local noneText = tr("sf_report_none", "None")
                         local cropName = info.lastCrop or noneText
-                        -- Capitalize first letter
-                        if cropName ~= noneText then
+                        if cropName ~= noneText and cropName ~= "" then
                             cropName = cropName:sub(1,1):upper() .. cropName:sub(2)
                         end
                         row.crop:setText(cropName)
                         row.crop:setTextColor(0.7, 0.7, 0.7, 1)
                     end
 
-                    -- Needs Fertilization
-                    if row.fert then
-                        local recommendationText, recommendationColor = self:getFertilizationRecommendation(info)
-                        setColoredText(row.fert, recommendationText, recommendationColor)
+                    -- Overall status badge
+                    if row.stat then
+                        local status, statColor = getOverallStatus(info)
+                        setColoredText(row.stat, tr("sf_report_rec_" .. status:lower(), status), statColor)
                     end
 
-                    -- Row background tint for fields needing attention
+                    -- Row background tint
                     if row.bg then
                         if info.needsFertilization then
-                            row.bg:setImageColor(nil, 0.18, 0.1, 0.1, 1)
+                            row.bg:setImageColor(nil, 0.18, 0.10, 0.10, 1)
+                        elseif i % 2 == 0 then
+                            row.bg:setImageColor(nil, 0.10, 0.10, 0.10, 1)
                         else
-                            if i % 2 == 0 then
-                                row.bg:setImageColor(nil, 0.1, 0.1, 0.1, 1)
-                            else
-                                row.bg:setImageColor(nil, 0.12, 0.12, 0.14, 1)
-                            end
+                            row.bg:setImageColor(nil, 0.12, 0.12, 0.14, 1)
                         end
                     end
                 end
@@ -605,13 +611,14 @@ function SoilReportDialog:updateFieldRows()
     end
 end
 
---- Update pagination controls
+-- ── Pagination ────────────────────────────────────────────────────────
+
 function SoilReportDialog:updatePagination()
     local totalFields = #self.sortedFieldIds
 
     if totalFields > 0 then
         local startIndex = (self.currentPage - 1) * SoilReportDialog.MAX_ROWS + 1
-        local endIndex = math.min(startIndex + SoilReportDialog.MAX_ROWS - 1, totalFields)
+        local endIndex   = math.min(startIndex + SoilReportDialog.MAX_ROWS - 1, totalFields)
 
         if self.pageInfoText then
             local pageFmt = tr("sf_report_page_info", "Fields %d-%d of %d  |  Page %d of %d")
@@ -620,9 +627,7 @@ function SoilReportDialog:updatePagination()
             self.pageInfoText:setVisible(true)
         end
     else
-        if self.pageInfoText then
-            self.pageInfoText:setVisible(false)
-        end
+        if self.pageInfoText then self.pageInfoText:setVisible(false) end
     end
 
     if self.prevButton then
@@ -631,6 +636,207 @@ function SoilReportDialog:updatePagination()
     if self.nextButton then
         self.nextButton:setDisabled(self.currentPage >= self.totalPages or totalFields == 0)
     end
+end
+
+-- ── Detail view ───────────────────────────────────────────────────────
+
+--- Open the detail panel for a specific field (by page-row index 0–9).
+function SoilReportDialog:openDetailForRow(rowIndex)
+    local startIndex = (self.currentPage - 1) * SoilReportDialog.MAX_ROWS + 1
+    local dataIndex  = startIndex + rowIndex
+    if dataIndex > #self.sortedFieldIds then return end
+
+    local fieldId = self.sortedFieldIds[dataIndex]
+    if not fieldId then return end
+
+    self.detailFieldId = fieldId
+    self:setDetailMode(true)
+    self:updateDetailView(fieldId)
+end
+
+--- Populate the detail panel with data for the given fieldId.
+function SoilReportDialog:updateDetailView(fieldId)
+    local info = self.fieldInfos[fieldId]
+    if not info then return end
+
+    local ppm = SoilConstants.PPM_DISPLAY or { N = 1, P = 1, K = 1 }
+
+    -- Header
+    if self.detailFieldLabel then
+        self.detailFieldLabel:setText(string.format("Field %d", fieldId))
+    end
+    if self.detailCropLabel then
+        local cropName = info.lastCrop or tr("sf_report_none", "None")
+        if cropName ~= "" then
+            cropName = cropName:sub(1,1):upper() .. cropName:sub(2)
+        end
+        self.detailCropLabel:setText(cropName)
+    end
+    if self.detailOverallLabel then
+        local status, statColor = getOverallStatus(info)
+        self.detailOverallLabel:setText(tr("sf_report_rec_" .. status:lower(), status))
+        self.detailOverallLabel:setTextColor(statColor[1], statColor[2], statColor[3], statColor[4])
+    end
+
+    -- Nutrients
+    local function fillNutrient(valueEl, statEl, hintEl, rawVal, ppmMult, status, hintText)
+        local ppmVal = math.floor(rawVal * ppmMult + 0.5)
+        local color  = getStatusColor(status)
+        if valueEl then
+            valueEl:setText(string.format("%d ppm", ppmVal))
+            valueEl:setTextColor(color[1], color[2], color[3], 1)
+        end
+        if statEl then
+            statEl:setText(tr("sf_report_rec_" .. status:lower(), status))
+            statEl:setTextColor(color[1], color[2], color[3], 1)
+        end
+        if hintEl then hintEl:setText(hintText or "") end
+    end
+
+    local nHint = (info.nitrogen.status == "Poor") and tr("sf_report_rec_n_poor", "Apply nitrogen fertilizer")
+               or (info.nitrogen.status == "Fair") and tr("sf_report_rec_n_fair", "Consider light N top-dress")
+               or "Nitrogen levels optimal"
+    fillNutrient(self.detailN, self.detailNStat, self.detailNHint,
+        info.nitrogen.value,   ppm.N, info.nitrogen.status,   nHint)
+
+    local pHint = (info.phosphorus.status == "Poor") and tr("sf_report_rec_p_poor", "Apply phosphorus fertilizer")
+               or (info.phosphorus.status == "Fair") and tr("sf_report_rec_p_fair", "Monitor phosphorus levels")
+               or "Phosphorus levels optimal"
+    fillNutrient(self.detailP, self.detailPStat, self.detailPHint,
+        info.phosphorus.value, ppm.P, info.phosphorus.status, pHint)
+
+    local kHint = (info.potassium.status == "Poor") and tr("sf_report_rec_k_poor", "Apply potash fertilizer")
+               or (info.potassium.status == "Fair") and tr("sf_report_rec_k_fair", "Monitor potassium levels")
+               or "Potassium levels optimal"
+    fillNutrient(self.detailK, self.detailKStat, self.detailKHint,
+        info.potassium.value,  ppm.K, info.potassium.status,  kHint)
+
+    -- pH
+    if self.detailPH then
+        local phColor = getPHColor(info.pH)
+        self.detailPH:setText(string.format("%.1f", info.pH))
+        self.detailPH:setTextColor(phColor[1], phColor[2], phColor[3], 1)
+    end
+    if self.detailPHStat then
+        local phColor = getPHColor(info.pH)
+        local phStatus = (phColor == SoilReportDialog.COLOR_GOOD) and "Optimal"
+                      or (phColor == SoilReportDialog.COLOR_FAIR) and "Monitor"
+                      or "Adjust"
+        self.detailPHStat:setText(phStatus)
+        self.detailPHStat:setTextColor(phColor[1], phColor[2], phColor[3], 1)
+    end
+
+    -- OM
+    if self.detailOM then
+        local omColor = getOMColor(info.organicMatter)
+        self.detailOM:setText(string.format("%.1f%%", info.organicMatter))
+        self.detailOM:setTextColor(omColor[1], omColor[2], omColor[3], 1)
+    end
+    if self.detailOMStat then
+        local omColor = getOMColor(info.organicMatter)
+        local omStatus = (omColor == SoilReportDialog.COLOR_GOOD) and "Optimal"
+                      or (omColor == SoilReportDialog.COLOR_FAIR) and "Maintain"
+                      or "Increase"
+        self.detailOMStat:setText(omStatus)
+        self.detailOMStat:setTextColor(omColor[1], omColor[2], omColor[3], 1)
+    end
+
+    -- Pressures
+    local function fillPressure(valueEl, statEl, hintEl, rawVal, protectedFlag, protectedKey)
+        local pct = math.floor((rawVal or 0) * 100 + 0.5)
+        local color = getPressureColor(pct)
+        local level = (pct < 25) and "Low" or (pct < 60) and "Moderate" or "High"
+        if valueEl then
+            valueEl:setText(string.format("%d%%", pct))
+            valueEl:setTextColor(color[1], color[2], color[3], 1)
+        end
+        if statEl then
+            statEl:setText(level)
+            statEl:setTextColor(color[1], color[2], color[3], 1)
+        end
+        if hintEl then
+            local hint = protectedFlag and tr("sf_hud_protected", "(protected)") or ""
+            hintEl:setText(hint)
+        end
+    end
+
+    fillPressure(self.detailWeed,    self.detailWeedStat,    self.detailWeedHint,
+        info.weedPressure,    info.herbicideActive,  "sf_hud_protected")
+    fillPressure(self.detailPest,    self.detailPestStat,    self.detailPestHint,
+        info.pestPressure,    info.insecticideActive, "sf_hud_protected")
+    fillPressure(self.detailDisease, self.detailDiseaseStat, self.detailDiseaseHint,
+        info.diseasePressure, info.fungicideActive,   "sf_hud_protected")
+
+    -- Yield forecast
+    if self.detailYield then
+        local ys = SoilConstants.YIELD_SENSITIVITY
+        local cropLower = info.lastCrop and string.lower(info.lastCrop) or nil
+        local yieldText = tr("sf_hud_optimal", "Optimal")
+        local yieldColor = SoilReportDialog.COLOR_GOOD
+
+        if ys and not (cropLower and ys.NON_CROP_NAMES and ys.NON_CROP_NAMES[cropLower]) then
+            local tier     = (cropLower and ys.CROP_TIERS and ys.CROP_TIERS[cropLower]) or ys.DEFAULT_TIER
+            local tierData = ys.TIERS and ys.TIERS[tier]
+            local thresh   = ys.OPTIMAL_THRESHOLD or 70
+            if tierData then
+                local nDef = math.max(0, thresh - info.nitrogen.value)   / thresh
+                local pDef = math.max(0, thresh - info.phosphorus.value) / thresh
+                local kDef = math.max(0, thresh - info.potassium.value)  / thresh
+                local penalty    = math.min(ys.MAX_PENALTY, (nDef + pDef + kDef) / 3 * tierData.scale)
+                local penaltyPct = math.floor(penalty * 100 + 0.5)
+                if penaltyPct > 0 then
+                    yieldText  = string.format("~-%d%% loss", penaltyPct)
+                    yieldColor = (penaltyPct >= 20) and SoilReportDialog.COLOR_POOR or SoilReportDialog.COLOR_FAIR
+                end
+            end
+        end
+
+        self.detailYield:setText(yieldText)
+        self.detailYield:setTextColor(yieldColor[1], yieldColor[2], yieldColor[3], 1)
+    end
+    if self.detailYieldHint then
+        local hint = "Based on N/P/K vs optimal threshold"
+        self.detailYieldHint:setText(hint)
+    end
+
+    -- Recommendations summary
+    if self.detailRecText then
+        local recStr, recColor, overallStatus = self:getFertilizationRecommendation(info)
+        self.detailRecText:setText(recStr)
+        self.detailRecText:setTextColor(recColor[1], recColor[2], recColor[3], 1)
+        
+        if self.detailRecBg then
+            if overallStatus == "Poor" then
+                self.detailRecBg:setImageColor(nil, 0.25, 0.08, 0.08, 0.9)
+            elseif overallStatus == "Fair" then
+                self.detailRecBg:setImageColor(nil, 0.25, 0.20, 0.05, 0.9)
+            else
+                self.detailRecBg:setImageColor(nil, 0.08, 0.20, 0.08, 0.9)
+            end
+        end
+    end
+end
+
+-- ── Per-row detail button callbacks ──────────────────────────────────
+-- FS25 GUI onClick requires distinct method names per button.
+function SoilReportDialog:onClickDetail0() self:openDetailForRow(0) end
+function SoilReportDialog:onClickDetail1() self:openDetailForRow(1) end
+function SoilReportDialog:onClickDetail2() self:openDetailForRow(2) end
+function SoilReportDialog:onClickDetail3() self:openDetailForRow(3) end
+function SoilReportDialog:onClickDetail4() self:openDetailForRow(4) end
+function SoilReportDialog:onClickDetail5() self:openDetailForRow(5) end
+function SoilReportDialog:onClickDetail6() self:openDetailForRow(6) end
+function SoilReportDialog:onClickDetail7() self:openDetailForRow(7) end
+function SoilReportDialog:onClickDetail8() self:openDetailForRow(8) end
+function SoilReportDialog:onClickDetail9() self:openDetailForRow(9) end
+
+-- ── Navigation buttons ────────────────────────────────────────────────
+
+function SoilReportDialog:onBackFromDetail()
+    self.detailFieldId = nil
+    self:setDetailMode(false)
+    self:updateFieldRows()
+    self:updatePagination()
 end
 
 function SoilReportDialog:onPrevPage()
@@ -661,7 +867,11 @@ function SoilReportDialog:inputEvent(action, value, eventUsed)
     eventUsed = SoilReportDialog:superClass().inputEvent(self, action, value, eventUsed)
 
     if not eventUsed and action == InputAction.MENU_BACK and value > 0 then
-        g_gui:closeDialogByName("SoilReportDialog")
+        if self.detailMode then
+            self:onBackFromDetail()
+        else
+            g_gui:closeDialogByName("SoilReportDialog")
+        end
         eventUsed = true
     end
 
@@ -674,7 +884,8 @@ function SoilReportDialog:onClose()
     self.sortedFieldIds = {}
     self.currentPage = 1
     self.totalPages = 1
-    -- Cancel any in-progress ownership sync retry (fix for issue #120)
+    self.detailMode = false
+    self.detailFieldId = nil
     if self.ownershipRetry then
         self.ownershipRetry:reset()
         self.ownershipRetry = nil
@@ -682,7 +893,6 @@ function SoilReportDialog:onClose()
 end
 
 --- Called from SoilFertilityManager:update(dt) every frame.
---- Drives the AsyncRetryHandler for MP ownership sync (fix for issue #120).
 ---@param dt number Delta time in milliseconds
 function SoilReportDialog:update(dt)
     if self.ownershipRetry and self.ownershipRetry:isPending() then

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Médio" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Escuro" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Sólido" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Unidades imperiais" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Exibir taxas em gal/ac e lb/ac (desativado = L/ha e kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Restaurar configurações solo" eh="467bc2f5" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Precisa:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Saúde solo: Ótima" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Fertilizante nitrogenado (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Fertilizante nitrogenado (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Amônia anidra (N)" eh="3fc85c02" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Střední" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Tmavý" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Plný" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Imperiální jednotky" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Zobrazit dávky v gal/ac a lb/ac (vypnuto = L/ha a kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Resetovat nastavení půdy" eh="467bc2f5" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Potřebuje:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Zdraví půdy: Optimální" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Dusíkaté hnojivo (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Dusíkaté hnojivo (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Bezvodý amoniak (N)" eh="3fc85c02" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Stickstoff: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphor: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Kalium: Optimal" />
+    <e k="sf_report_status_monitor" v="Überwachen" />
+    <e k="sf_report_status_adjust" v="Anpassen" />
+    <e k="sf_report_status_maintain" v="Halten" />
+    <e k="sf_report_status_increase" v="Erhöhen" />
+    <e k="sf_report_pressure_low" v="Niedrig" />
+    <e k="sf_report_pressure_moderate" v="Mittel" />
+    <e k="sf_report_pressure_high" v="Hoch" />
+    <e k="sf_report_yield_hint" v="Basierend auf N/P/K vs. optimalem Schwellenwert" />
+    <e k="sf_report_yield_loss" v="Ertrag ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Bedarf:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Bodengesundheit: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Stickstoffdünger (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Stickstoffdünger (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Flüssigammoniak (N)" eh="3fc85c02" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Mittel" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Dunkel" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Fest" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Imperiale Einheiten" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Ausbringmengen in gal/ac und lb/ac (aus = L/ha und kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Bodeneinstellungen zurücksetzen" eh="467bc2f5" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrógeno: Óptimo" />
+    <e k="sf_report_detail_p_ok" v="Fósforo: Óptimo" />
+    <e k="sf_report_detail_k_ok" v="Potasio: Óptimo" />
+    <e k="sf_report_status_monitor" v="Monitorear" />
+    <e k="sf_report_status_adjust" v="Ajustar" />
+    <e k="sf_report_status_maintain" v="Mantener" />
+    <e k="sf_report_status_increase" v="Aumentar" />
+    <e k="sf_report_pressure_low" v="Bajo" />
+    <e k="sf_report_pressure_moderate" v="Moderado" />
+    <e k="sf_report_pressure_high" v="Alto" />
+    <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" />
+    <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -156,6 +156,18 @@
     <e k="sf_hud_optimal" v="Optimal" />
     <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
     <e k="sf_hud_hint_normal" v="RMB: move/resize" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -77,9 +77,11 @@
     <e k="input_SF_RATE_UP" v="Increase Fertilizer Rate" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Toggle Auto Rate" eh="a8642cf0" />
-    <e k="sf_report_title" v="Soil &amp;amp; Fertilizer Report" eh="e4d0126a" />
+    <e k="sf_report_title" v="Soil &amp; Fertilizer Report" eh="e4d0126a" />
     <e k="sf_report_fields_tracked" v="Fields Tracked:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Need Fertilizer:" eh="110b60f2" />
+    <e k="sf_report_farm_health" v="Farm Health:" />
+    <e k="sf_report_back" v="Back" />
     <e k="sf_report_difficulty" v="Difficulty:" eh="3abaf54f" />
     <e k="sf_report_col_field" v="Field" eh="6f16a5f8" />
     <e k="sf_report_col_last_crop" v="Last Crop" eh="ff41e5eb" />
@@ -104,6 +106,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="c342956b" />
     <e k="sf_report_rec_needs" v="Needs:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Fertilizer (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Fertilizer (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Nitrógeno: Óptimo" />
+    <e k="sf_report_detail_p_ok" v="Fósforo: Óptimo" />
+    <e k="sf_report_detail_k_ok" v="Potasio: Óptimo" />
+    <e k="sf_report_status_monitor" v="Monitorear" />
+    <e k="sf_report_status_adjust" v="Ajustar" />
+    <e k="sf_report_status_maintain" v="Mantener" />
+    <e k="sf_report_status_increase" v="Aumentar" />
+    <e k="sf_report_pressure_low" v="Bajo" />
+    <e k="sf_report_pressure_moderate" v="Moderado" />
+    <e k="sf_report_pressure_high" v="Alto" />
+    <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" />
+    <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Necesita:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Salud suelo: Óptima" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Fertilizante nitrogenado (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Fertilizante nitrogenado (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Amoníaco anhidro (N)" eh="3fc85c02" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Medio" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Oscuro" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Sólido" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Unidades imperiales" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Mostrar tasas en gal/ac y lb/ac (apagado = L/ha y kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Restablecer config. suelo" eh="467bc2f5" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Moyen" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Sombre" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Solide" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Unités impériales" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Afficher les doses en gal/ac et lb/ac (désactivé = L/ha et kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Réinitialiser paramètres sol" eh="467bc2f5" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Besoins:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Santé sol: Optimale" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Engrais azoté (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Engrais azoté (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Ammoniac anhydre (N)" eh="3fc85c02" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Engrais starter (liquide)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Azote: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphore: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Surveiller" />
+    <e k="sf_report_status_adjust" v="Ajuster" />
+    <e k="sf_report_status_maintain" v="Maintenir" />
+    <e k="sf_report_status_increase" v="Augmenter" />
+    <e k="sf_report_pressure_low" v="Faible" />
+    <e k="sf_report_pressure_moderate" v="Modéré" />
+    <e k="sf_report_pressure_high" v="Élevé" />
+    <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" />
+    <e k="sf_report_yield_loss" v="Rendement ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Közepes" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Sötét" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Tömör" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Angolszász mértékegységek" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Kijuttatási normák gal/ac és lb/ac egységben (ki = L/ha és kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Szükséges:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Talaj egészség: Optimális" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Nitrogén műtrágya (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Nitrogén műtrágya (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Vízmentes ammónia (N)" eh="3fc85c02" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Necessita:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Salute suolo: Ottimale" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Fertilizzante azotato (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Fertilizzante azotato (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Ammoniaca anidra (N)" eh="3fc85c02" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Medio" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Scuro" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Solido" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Unità imperiali" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Mostra le dosi in gal/ac e lb/ac (off = L/ha e kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Ripristina impostazioni suolo" eh="467bc2f5" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Nawóz startowy (ciekły)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Azot: Optymalny" />
+    <e k="sf_report_detail_p_ok" v="Fosfor: Optymalny" />
+    <e k="sf_report_detail_k_ok" v="Potas: Optymalny" />
+    <e k="sf_report_status_monitor" v="Monitoruj" />
+    <e k="sf_report_status_adjust" v="Dostosuj" />
+    <e k="sf_report_status_maintain" v="Utrzymaj" />
+    <e k="sf_report_status_increase" v="Zwiększ" />
+    <e k="sf_report_pressure_low" v="Niski" />
+    <e k="sf_report_pressure_moderate" v="Umiarkowany" />
+    <e k="sf_report_pressure_high" v="Wysoki" />
+    <e k="sf_report_yield_hint" v="Na podstawie N/P/K vs próg optymalny" />
+    <e k="sf_report_yield_loss" v="Plon ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Średni" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Ciemny" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Solidny" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Jednostki imperialne" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Wyświetlaj dawki w gal/ac i lb/ac (wyłączone = L/ha i kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Resetuj ustawienia gleby" eh="467bc2f5" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Potrzeby:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Zdrowie gleby: Optymalne" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Nawóz azotowy (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Nawóz azotowy (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Amoniak bezwodny (N)" eh="3fc85c02" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -152,5 +152,17 @@
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Стартовое удобрение (жидкое)" eh="2c36ea57" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -67,6 +67,19 @@
     <e k="sf_hud_trans_3" v="Средний" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Тёмный" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Сплошной" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
     <e k="sf_use_imperial_short" v="Ð˜Ð¼Ð¿ÐµÑ€ÑÐºÐ¸Ðµ ÐµÐ´Ð¸Ð½Ð¸Ñ†Ñ‹" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Отображать нормы в gal/ac и lb/ac (откл. = L/ha и kg/ha)" eh="17efa489" />
     <e k="sf_reset" v="Ð¡Ð±Ñ€Ð¾ÑÐ¸Ñ‚ÑŒ Ð½Ð°ÑÑ‚Ñ€Ð¾Ð¹ÐºÐ¸ Ð¿Ð¾Ñ‡Ð²Ñ‹" eh="467bc2f5" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -115,6 +115,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="ÐÑƒÐ¶Ð½Ð¾:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Здоровье почвы: Оптимальное" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 ÐÐ·Ð¾Ñ‚Ð½Ð¾Ðµ ÑƒÐ´Ð¾Ð±Ñ€ÐµÐ½Ð¸Ðµ (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 ÐÐ·Ð¾Ñ‚Ð½Ð¾Ðµ ÑƒÐ´Ð¾Ð±Ñ€ÐµÐ½Ð¸Ðµ (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Безводный аммиак (N)" eh="3fc85c02" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -152,5 +152,17 @@
     <e k="sf_hud_optimal" v="Оптимально" />
     <e k="sf_hud_hint_edit" v="Перетягування: рух   Кут: розмір   ПКМ: готово" />
     <e k="sf_hud_hint_normal" v="ПКМ: рух/розмір" />
+    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
     </elements>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -102,6 +102,9 @@
     <e k="sf_report_rec_disease" v="Ризик хвороб" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Потреби:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Здоров'я ґрунту: Оптимальне" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
     <e k="sf_uan32_title" v="UAN 32 Азотне добриво (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Азотне добриво (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Безводний аміак (N)" eh="3fc85c02" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -73,6 +73,9 @@
     <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Good" />
+    <e k="sf_report_rec_fair" v="Fair" />
+    <e k="sf_report_rec_poor" v="Poor" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -152,5 +152,17 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    </elements>
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" />
+    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" />
+    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" />
+    <e k="sf_report_status_monitor" v="Monitor" />
+    <e k="sf_report_status_adjust" v="Adjust" />
+    <e k="sf_report_status_maintain" v="Maintain" />
+    <e k="sf_report_status_increase" v="Increase" />
+    <e k="sf_report_pressure_low" v="Low" />
+    <e k="sf_report_pressure_moderate" v="Moderate" />
+    <e k="sf_report_pressure_high" v="High" />
+    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" />
+    <e k="sf_report_yield_loss" v="Yield ~-%d%%" />
+    </elements>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -25,6 +25,19 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="SOIL MONITOR" />
+    <e k="sf_hud_field" v="Field %d" />
+    <e k="sf_hud_noField" v="Walk onto a field" />
+    <e k="sf_hud_fallow" v="Fallow" />
+    <e k="sf_hud_weeds" v="Weeds" />
+    <e k="sf_hud_pests" v="Pests" />
+    <e k="sf_hud_disease" v="Disease" />
+    <e k="sf_hud_protected" v="(protected)" />
+    <e k="sf_hud_yield" v="Yield" />
+    <e k="sf_hud_estYield" v="Est. Yield" />
+    <e k="sf_hud_optimal" v="Optimal" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" />
+    <e k="sf_hud_hint_normal" v="RMB: move/resize" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />


### PR DESCRIPTION
## Summary

A surprise between-version polish pass on the Soil Report and HUD that started as a code review and turned into finding a real data bug.

- **Bug: pressure values displaying as 6500% in Soil Report** — weed, pest, and disease pressure are stored as 0–100, but `updateFieldRows` and `updateDetailView` were multiplying by 100 again. Any field with active pressure showed multi-thousand-percent values and permanent red status. Fixed in all three callsites.
- **Bug: overall status badge ignoring pH, OM, and bio-pressures** — the "Good / Fair / Poor" badge shown in the report table and the HUD title bar only ranked N/P/K. A field with bad pH or 80% weed pressure still showed "Good". Extended to include all five soil dimensions plus weed/pest/disease. Fixed in both `getOverallStatus()` (SoilReportDialog) and `overallStatus()` (SoilHUD).
- **Fix: farm health uses uneven scoring weights** — 100/55/10 for Good/Fair/Poor; the 55 was arbitrary and made the % drop unnaturally. Changed to 100/50/0 (clean linear scale).
- **i18n: detail view was English-only for 25 languages** — all status labels in the field detail panel (pH: Optimal/Monitor/Adjust; OM: Optimal/Maintain/Increase; pressure: Low/Moderate/High; yield hint; N/P/K optimal hints) were hardcoded English strings bypassing `tr()`. 12 new i18n keys added across all 26 translation files. DE, FR, ES/EA, PL get quality translations; 21 others carry EN fallbacks.
- **Code: `yieldSuffix` string surgery removed** — the leading-comma-then-gsub pattern in `getFertilizationRecommendation()` replaced with a direct table.insert.
- **Code: `drawPressureRow()` helper extracted** — three near-identical 30-line weed/pest/disease draw blocks collapsed into one method (~60 lines removed). Color scale unified to 3 levels matching N/P/K.

## Files changed

| File | Change |
|------|--------|
| `src/ui/SoilReportDialog.lua` | Pressure scale bug, overall status, farm health, i18n, yield suffix |
| `src/ui/SoilHUD.lua` | Overall status, drawPressureRow() extraction |
| `translations/translation_*.xml` (×26) | 12 new i18n keys |
| `modDesc.xml` | Version 1.5.2.0 |
| `CHANGELOG.md` | Release notes |
| `DEVELOPMENT.md` | Version bump |

## Test plan

- [ ] Open Soil Report on a farm with active weed/pest pressure — values should show as e.g. "45%" not "4500%"
- [ ] Field with poor pH should show "Fair" or "Poor" in the status badge, not "Good"
- [ ] Farm Health % should update proportionally across a spread of field statuses
- [ ] Switch to DE/FR/ES in game settings — detail view labels should show in those languages
- [ ] Yield penalty entries should appear in recommendations without duplicate commas
- [ ] HUD weed/pest/disease bars render with correct height and color (no orange)