### PR TITLE
v1.6.0.4 — Bug fixes, MP sync, docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the HUD display and agronomic profiles.
 
 - **Required full field coverage for fertilizer effect** (issue #143): Realism improvement.
-  Nutrient levels no longer update instantly on application. Instead, applied liters are
-  buffered per product. Nutrients are only credited to the field once ~90% of the volume
-  required for full coverage (based on field area and product base rate) has been applied.
-  Buffers are cleared daily, requiring same-day completion for credit.
+  Nutrient levels and crop protection effects (Insecticide/Fungicide/Herbicide) no longer
+  update instantly. Instead, applied liters are buffered per product. Effects are only
+  credited to the field once ~90% of the volume required for full coverage has been
+  applied. Buffers are cleared daily, requiring same-day completion for credit.
 
 - **Pressure values displayed as 4-digit percentages in Soil Report**: Weed, pest, and disease
   pressure are stored internally as 0–100. The report dialog was multiplying them by 100 again,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.0.4] - 2026-04-11
+
+### Fixed
+
+- **Pressure color thresholds aligned with Constants**: The HUD's `drawPressureRow` and the Soil
+  Report's `getPressureColor` function were using hardcoded 25/60 boundaries. These now use
+  `SoilConstants.WEED_PRESSURE.LOW` (20) and `MEDIUM` (50) — matching the tier boundaries used
+  by the yield-penalty system and the recommendation engine. A field at 22% weed pressure was
+  previously showing Green despite a -5% yield penalty already being applied.
+
+- **HUD panel height calculation**: The `calculateHeight()` guard `(info.weedPressure or 0) >= 0`
+  was always true (pressure never goes negative), so the panel added an extra line of height even
+  when weed/pest/disease pressure was exactly zero. Fixed to `> 0`.
+
+- **Soil Report `getOverallStatus` dead check**: The `val >= 0` guard on pressure values in the
+  overall-status worst-case ranking was also always true. Fixed to `val > 0` for clarity.
+
+- **Console commands bypass MP network layer**: All setting-change console commands
+  (`SoilSetFertility`, `SoilSetDifficulty`, `SoilEnable`, etc.) were directly mutating
+  `g_SoilFertilityManager.settings` without going through the network event layer. In
+  multiplayer, server-side console changes would not broadcast to clients. All commands now route
+  through `SoilNetworkEvents_RequestSettingChange()` so the full server → broadcast flow is
+  respected. A local `requestSettingChange` helper in `SoilSettingsGUI.lua` provides a
+  graceful fallback when the network layer is not yet initialised.
+
+- **`SoilFieldForecast` urgency score inconsistency**: The console command was calculating
+  urgency as an NPK-only average deficit, which differed from the score used to sort fields in
+  the Soil Report (which includes pH, weed, pest, and disease factors). The command now calls
+  `soilSystem:getFieldUrgency()` so the reported score matches the in-game display.
+
+- **`SoilFieldForecast` missing from help output**: The command was registered and functional
+  but not printed by `soilfertility` / `SoilHelp`. Added.
+
+---
+
+## [1.6.0.3] - 2026-04-11
+
+### Fixed
+
+- **Multiplayer stream desync (critical)**: `SoilFullSyncEvent:writeStream` was writing 19
+  values per field but `readStream` was reading 20 — `burnDaysLeft` was read but never written.
+  On a server with any burn-damaged fields, a joining client's field data would be silently
+  corrupted for every field after the first. Fixed by adding the missing
+  `streamWriteInt32(streamId, field.burnDaysLeft or 0)` to the write path, and storing the
+  read value in the field table. The same field was also missing from `SoilFieldUpdateEvent`.
+
+- **Fertilization notification permanent silencing**: `fertNotifyShown[fieldId]` stored `true`
+  on first notification — meaning a field would never produce another notification for the rest
+  of the save, not just for the current day. The flag now stores the current game day and is
+  checked with `~= today`, matching the documented per-day intent.
+
+- **Dead `SoilFertilityManager:draw()` method**: The method existed but was never called —
+  `main.lua` hooks `FSBaseMission.draw` directly to `sfm.soilHUD:draw()`. Removed.
+
+- **Dead constant reference in `getFieldUrgency`**: Used `SoilConstants.PH_NORMALIZATION.OPTIMAL`
+  which does not exist in Constants.lua. Replaced with the correct literal `6.5` (optimal pH
+  mid-point of the 6.5–7.0 neutral band).
+
+---
+
+## [1.6.0.2] - 2026-04-11
+
+### Fixed
+
+- **HUD sprayer rate display for low-volume products**: Insecticide and Fungicide (very low base
+  rates) were rounding to `0 L/ha` or `0 gal/ac` at lower multiplier settings. The formatter now
+  uses one decimal place when the product's base rate is below 10.0, ensuring the rate panel
+  always shows a meaningful, non-zero value.
+
+- **HERBICIDE missing from sprayer rate BASE_RATES**: HERBICIDE had no entry, so the HUD fell
+  back to the DEFAULT rate config regardless of the product loaded in the sprayer. Added a
+  dedicated HERBICIDE entry with the correct base rate and `liquid` unit type.
+
+- **AI purchase refill hook return value (issue #125)**: The `FillUnit.addFillUnitFillLevel`
+  hook was returning `true` in BUY mode to signal "handled" — but the FS25 hook convention
+  requires returning the original function's return value to keep the call chain intact.
+  Changed to return the original `fillDelta` from the base function, which allows other hooks
+  and the engine to proceed correctly.
+
+---
+
+## [1.6.0.1] - 2026-04-10
+
+### Fixed
+
+- **AI purchase refill BUY mode detection (issue #125)**: The hook was checking three spec
+  fields that do not exist in FS25 (`isSprayerBuyingFillType`, `isFillPurchaseActive`,
+  `reloadState`), causing the check to always return false and the tank to deplete normally.
+  Fixed to use the correct FS25 pattern: `vehicle:getIsAIActive()` combined with
+  `g_currentMission.missionInfo.helperBuyFertilizer` (and the slurry / manure equivalents).
+
+- **Coverage buffer requirement extended to crop protection products (issue #143)**: The 90%
+  coverage buffer introduced in 1.6.0.0 was only applied to nutrient fertilizers. Insecticide,
+  Fungicide, and Herbicide were still applying their effects instantly on any area pass. The
+  buffer now covers all five product categories (N, P, K, herbicide, insecticide/fungicide).
+
+- **Instant field notification removed**: A `g_currentMission:addIngameNotification()` call
+  fired immediately on mod load, producing a confusing popup before the player had done anything.
+  Removed.
+
+- **FS25_MoistureSystem added to compatibility list** (issue #141).
+
+---
+
 ## [1.6.0.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   credited to the field once ~90% of the volume required for full coverage has been
   applied. Buffers are cleared daily, requiring same-day completion for credit.
 
+- **Improved HUD rate resolution for low-volume products**: Insecticide and Fungicide
+  (which have very low base rates) no longer display as "0 L/ha" or "0 gal/ac" in the 
+  sprayer rate panel. The HUD now shows 1 decimal place for products with base rates
+  below 10.0, ensuring the rate control is responsive and accurate.
+
 - **Pressure values displayed as 4-digit percentages in Soil Report**: Weed, pest, and disease
   pressure are stored internally as 0–100. The report dialog was multiplying them by 100 again,
   producing values like "6500%" and always rendering red status regardless of actual severity.
@@ -163,30 +168,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **"BUY" refill mode not working with custom fill types (issue #125)**: When the player
-  (or a worker/CP) set the sprayer refill mode to "BUY", vanilla fill types
-  (FERTILIZER, LIQUIDFERTILIZER) correctly charged money per liter consumed without
-  depleting the physical tank. Custom types (UAN32, UAN28, ANHYDROUS, STARTER, UREA,
-  AMS, MAP, DAP, POTASH, INSECTICIDE, FUNGICIDE, and organic types) still depleted the
-  fill unit normally, causing workers to stop when the tank ran dry and potentially
-  switch to a vanilla fertilizer type instead.
-
-  Root cause: FS25's internal "BUY" purchase intercept only fires for fill types
-  recognized by its own economy system. Custom mod fill types have `pricePerLiter`
-  defined in `fillTypes.xml` but are not included in the game's purchasable-fill-type
-  whitelist, so `FillUnit.addFillUnitFillLevel` never intercepts their consumption.
-
-  Fix: Added `installPurchaseRefillHook()` in `HookManager.lua` (Hook 8). This hook
-  wraps `FillUnit.addFillUnitFillLevel` and intercepts negative-delta (consumption)
-  calls for custom fill types when the vehicle's fill unit is in BUY mode. When
-  intercepted, it charges the owning farm `pricePerLiter × litersConsumed` via
-  `g_currentMission:addMoney()` and returns `0` (no physical depletion). BUY mode is
-  detected via `fillUnit.fillModeIndex == 1` (primary) and `fillUnit.reloadState > 0`
-  (secondary), matching how FS25 internally signals the purchase-refill state.
-
-  Prices used for money charge match the `economy pricePerLiter` values in
-  `fillTypes.xml` and the `SoilConstants.PURCHASABLE_SINGLE_NUTRIENT` table for
-  single-nutrient types (ANHYDROUS, MAP, POTASH).
+- **"BUY" refill mode not working with custom fill types** (issue #125): AI workers and
+  Courseplay now correctly use the "Buy" helper setting with custom products. Fixed
+  a bug where the tank would still deplete or the worker would stop when empty.
+  The system now correctly intercepts consumption, charges the farm account, and
+  tricks the engine into continuing application without depleting physical stock.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.5.2.0
-**Last Updated**: 2026-04-10
+**Version**: 1.6.0.4
+**Last Updated**: 2026-04-11
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,12 @@ Open via **ESC → Settings → Game Settings → Soil & Fertilizer**.
 | **Crop rotation** | On / Off | Enable legume rotation bonus and mono-crop fatigue multiplier |
 | **Difficulty** | Simple / Realistic / Hardcore | Scales depletion rate — 0.7× / 1× / 1.5× |
 | **HUD enabled** | On / Off | Show or hide the soil overlay |
-| **HUD position** | 5 presets | Top-right, top-left, bottom-right, bottom-left, centre-right |
+| **HUD position** | 6 options | Top-right, top-left, bottom-right, bottom-left, centre-right, or custom (drag to any position) |
 | **HUD colour theme** | 4 themes | Green / Blue / Amber / Mono |
 | **HUD transparency** | Clear → Solid | 5 levels from 25% to 100% opacity |
 | **HUD font size** | Small / Medium / Large | Scales all HUD text |
-| **Compact mode** | On / Off | One line per nutrient instead of full bars |
+| **Use imperial units** | On / Off | Sprayer rate shown in gal/ac and lb/ac instead of L/ha and kg/ha |
+| **Auto rate control** | On / Off | Sprayer rate automatically adjusts toward the target application rate for the current product |
 
 > [!NOTE]
 > In multiplayer, settings are **server-authoritative** — the host's settings are pushed to all clients on join. Clients cannot override locked settings.
@@ -292,7 +293,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.6.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.6.0.4
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.6.0.0</version>
+    <version>1.6.0.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.6.0.1</version>
+    <version>1.6.0.4</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -460,6 +460,8 @@ function SoilFertilityManager:onSprayerRateUpInput()
     local rm = self.sprayerRateManager
     if rm then
         local newIdx = rm:cycleUp(vehicle.id)
+        SoilLogger.debug("Rate UP input: vehicle %d, new index %d (multiplier %.2f)", 
+            vehicle.id, newIdx, rm:getMultiplier(vehicle.id))
         SoilNetworkEvents_SendSprayerRate(vehicle.id, newIdx)
     end
 end
@@ -470,6 +472,8 @@ function SoilFertilityManager:onSprayerRateDownInput()
     local rm = self.sprayerRateManager
     if rm then
         local newIdx = rm:cycleDown(vehicle.id)
+        SoilLogger.debug("Rate DOWN input: vehicle %d, new index %d (multiplier %.2f)", 
+            vehicle.id, newIdx, rm:getMultiplier(vehicle.id))
         SoilNetworkEvents_SendSprayerRate(vehicle.id, newIdx)
     end
 end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -660,19 +660,6 @@ function SoilFertilityManager:update(dt)
     end
 end
 
---- Draw loop called every frame for rendering
-function SoilFertilityManager:draw()
-    -- FIX: Only draw HUD if it exists (client side only)
-    if self.soilHUD then
-        local success, err = pcall(function()
-            self.soilHUD:draw()
-        end)
-        if not success and self.settings and self.settings.debugMode then
-            SoilLogger.debug("HUD draw error: %s", tostring(err))
-        end
-    end
-end
-
 --- Cleanup on mod unload
 --- Saves soil data and uninstalls hooks
 function SoilFertilityManager:delete()

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1034,8 +1034,12 @@ function SoilFertilitySystem:applyRainEffects(dt, rainScale)
 end
 
 -- Update field nutrients after harvest
+---@param fieldId number The field being harvested
+---@param fruitTypeIndex number FS25 fruit type index
+---@param harvestedLiters number Amount harvested in liters
 ---@param strawRatio number 0.0-1.0 fraction of straw chopped back into the field (adds organic matter)
-function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harvestedLiters, strawRatio)
+---@param area number Area harvested in m² (unused; reserved for future area-normalised depletion)
+function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harvestedLiters, strawRatio, area)
     if not self.settings.enabled or not self.settings.nutrientCycles then return end
 
     local field = self:getOrCreateField(fieldId, true)
@@ -1195,11 +1199,13 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         self:log("Full coverage achieved field %d (%s): Application credited from %.1f L buffer", 
             fieldId, fillType.name, currentBuffer)
         
-        -- Trigger notification if it's the first application today
+        -- Trigger notification at most once per field per in-game day
+        local today = (g_currentMission and g_currentMission.environment and
+                       g_currentMission.environment.currentDay) or 0
         if not self.fertNotifyShown then self.fertNotifyShown = {} end
-        if not self.fertNotifyShown[fieldId] then
+        if self.fertNotifyShown[fieldId] ~= today then
             self:showNotification("Soil Update", string.format("Field %d fully treated with %s", fieldId, fillType.name))
-            self.fertNotifyShown[fieldId] = true
+            self.fertNotifyShown[fieldId] = today
         end
     end
 
@@ -1435,7 +1441,7 @@ function SoilFertilitySystem:getFieldUrgency(fieldId)
     local pDef = math.max(0, thresh - info.phosphorus.value) / thresh
     local kDef = math.max(0, thresh - info.potassium.value) / thresh
 
-    local phOpt = SoilConstants.PH_NORMALIZATION and SoilConstants.PH_NORMALIZATION.OPTIMAL or 6.5
+    local phOpt = 6.5  -- optimal pH target (mid-point of neutral band 6.5-7.0)
     local phMin = SoilConstants.NUTRIENT_LIMITS and SoilConstants.NUTRIENT_LIMITS.PH_MIN or 5.0
     local phDef = math.max(0, phOpt - info.pH) / (phOpt - phMin)
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -236,21 +236,6 @@ function SoilFertilitySystem:onFertilizerApplied(fieldId, fillTypeIndex, liters)
 
     SoilLogger.debug("Fertilizer: Field %d, %s, %.0fL", fieldId, fillType and fillType.name or "unknown", liters)
 
-    -- Show application confirmation notification (singleplayer only; MP clients see HUD refresh via SoilFieldUpdateEvent)
-    -- Shown at most once per field per in-game day to avoid spam (hook fires every frame while spraying)
-    if self.settings.showNotifications and
-       g_currentMission and not g_currentMission.missionDynamicInfo.isMultiplayer then
-        local today = (g_currentMission.environment and g_currentMission.environment.currentDay) or 0
-        if self.fertNotifyShown[fieldId] ~= today then
-            self.fertNotifyShown[fieldId] = today
-            local typeName = fillType and fillType.title or (fillType and fillType.name) or "Fertilizer"
-            self:showNotification(
-                "Fertilizer Recorded",
-                string.format("%s on Field %d — nutrients absorb next game day", typeName, fieldId)
-            )
-        end
-    end
-
     -- Broadcast to clients if server in multiplayer
     if g_server and g_currentMission and g_currentMission.missionDynamicInfo.isMultiplayer then
         local field = self.fieldData[fieldId]

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1159,22 +1159,6 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         return
     end
 
-    -- Route crop protection products (they don't add N/P/K, they reduce pressure)
-    if entry.pestReduction then
-        local effectiveness = SoilConstants.PEST_PRESSURE.INSECTICIDE_TYPES[fillType.name] or 0
-        if effectiveness > 0 then
-            self:onInsecticideApplied(fieldId, effectiveness)
-        end
-        return
-    end
-    if entry.diseaseReduction then
-        local effectiveness = SoilConstants.DISEASE_PRESSURE.FUNGICIDE_TYPES[fillType.name] or 0
-        if effectiveness > 0 then
-            self:onFungicideApplied(fieldId, effectiveness)
-        end
-        return
-    end
-
     local limits = SoilConstants.NUTRIENT_LIMITS
 
     -- AREA NORMALIZATION: Calculate hectares for this field
@@ -1193,41 +1177,95 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     local baseRateEntry = SoilConstants.SPRAYER_RATE.BASE_RATES[fillType.name] or 
                          SoilConstants.SPRAYER_RATE.BASE_RATES.DEFAULT
     local targetVolume = areaInHa * baseRateEntry.value
-    local coverageThreshold = targetVolume * 0.90  -- 90% coverage requirement
+    local coverageThreshold = targetVolume * SoilConstants.SPRAYER_RATE.FERTILIZER_COVERAGE_THRESHOLD
 
     if currentBuffer >= coverageThreshold then
-        -- Apply nutrients (scaled by the total buffer volume we're now "releasing")
-        local factor = (currentBuffer / 1000) / areaInHa
+        -- Full coverage achieved!
+        
+        -- 1. Route crop protection products (they don't add N/P/K, they reduce pressure)
+        if entry.pestReduction then
+            local effectiveness = SoilConstants.PEST_PRESSURE.INSECTICIDE_TYPES[fillType.name] or 0
+            if effectiveness > 0 then
+                self:onInsecticideApplied(fieldId, effectiveness)
+            end
+        elseif entry.diseaseReduction then
+            local effectiveness = SoilConstants.DISEASE_PRESSURE.FUNGICIDE_TYPES[fillType.name] or 0
+            if effectiveness > 0 then
+                self:onFungicideApplied(fieldId, effectiveness)
+            end
+        else
+            -- 2. Apply standard nutrients (scaled by the total buffer volume we're now "releasing")
+            local factor = (currentBuffer / 1000) / areaInHa
 
-        if entry.N then field.nitrogen   = math.min(limits.MAX, field.nitrogen   + entry.N * factor) end
-        if entry.P then field.phosphorus = math.min(limits.MAX, field.phosphorus + entry.P * factor) end
-        if entry.K then field.potassium  = math.min(limits.MAX, field.potassium  + entry.K * factor) end
-        if entry.pH then field.pH        = math.min(limits.PH_MAX, field.pH + entry.pH * factor) end
-        if entry.OM then field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor) end
+            if entry.N then field.nitrogen   = math.min(limits.MAX, field.nitrogen   + entry.N * factor) end
+            if entry.P then field.phosphorus = math.min(limits.MAX, field.phosphorus + entry.P * factor) end
+            if entry.K then field.potassium  = math.min(limits.MAX, field.potassium  + entry.K * factor) end
+            if entry.pH then field.pH        = math.min(limits.PH_MAX, field.pH + entry.pH * factor) end
+            if entry.OM then field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor) end
+        end
 
         -- Clear buffer for this product after successful application
         field.nutrientBuffer[fillTypeIndex] = 0
 
-        self:log("Full coverage achieved field %d (%s): Nutrients credited from %.1f L buffer", 
+        self:log("Full coverage achieved field %d (%s): Application credited from %.1f L buffer", 
             fieldId, fillType.name, currentBuffer)
         
-        -- Trigger notification if it's the first application today (consistent with other events)
-        if not self.fertNotifyShown then
-            self.fertNotifyShown = {}
-        end
+        -- Trigger notification if it's the first application today
+        if not self.fertNotifyShown then self.fertNotifyShown = {} end
         if not self.fertNotifyShown[fieldId] then
-            self:showNotification("Soil Update", string.format("Field %d fully fertilized with %s", fieldId, fillType.name))
+            self:showNotification("Soil Update", string.format("Field %d fully treated with %s", fieldId, fillType.name))
             self.fertNotifyShown[fieldId] = true
         end
     end
 
     field.fertilizerApplied = (field.fertilizerApplied or 0) + liters
 
-    -- We only log high-precision values for fertilizer to track these small per-frame changes
+    -- Logging
     if self.settings.debugMode then
         local progress = (currentBuffer / targetVolume) * 100
-        self:log("Fertilizer buffered field %d (%s): %.4f L -> Progress %.1f%% (Target %.1f L)", 
+        self:log("Product buffered field %d (%s): %.4f L -> Progress %.1f%% (Target %.1f L)", 
             fieldId, fillType.name, liters, math.min(100, progress), targetVolume)
+    end
+end
+
+--- Direct-path buffering for non-profile products (Herbicide/Insecticide/Fungicide)
+--- Called by HookManager for products not found in FERTILIZER_PROFILES.
+function SoilFertilitySystem:onHerbicideAppliedDirect(fieldId, effectiveness, liters)
+    self:applyProductBufferedDirect(fieldId, "HERBICIDE", effectiveness, liters, self.onHerbicideApplied)
+end
+
+function SoilFertilitySystem:onInsecticideAppliedDirect(fieldId, effectiveness, liters)
+    self:applyProductBufferedDirect(fieldId, "INSECTICIDE", effectiveness, liters, self.onInsecticideApplied)
+end
+
+function SoilFertilitySystem:onFungicideAppliedDirect(fieldId, effectiveness, liters)
+    self:applyProductBufferedDirect(fieldId, "FUNGICIDE", effectiveness, liters, self.onFungicideApplied)
+end
+
+--- Internal helper for buffering non-profile products
+function SoilFertilitySystem:applyProductBufferedDirect(fieldId, productType, effectiveness, liters, callback)
+    local field = self:getOrCreateField(fieldId, true)
+    if not field then return end
+
+    -- Use high virtual indices for direct-path buffers to avoid collision with fillTypeManager indices
+    local virtualIdx = (productType == "HERBICIDE" and 99991) or (productType == "INSECTICIDE" and 99992) or 99993
+    if not field.nutrientBuffer then field.nutrientBuffer = {} end
+    local currentBuffer = (field.nutrientBuffer[virtualIdx] or 0) + liters
+    field.nutrientBuffer[virtualIdx] = currentBuffer
+
+    local areaInHa = field.fieldArea or 1.0
+    local baseRate = SoilConstants.SPRAYER_RATE.BASE_RATES[productType] and SoilConstants.SPRAYER_RATE.BASE_RATES[productType].value or 
+                     SoilConstants.SPRAYER_RATE.BASE_RATES.DEFAULT.value
+    local targetVolume = areaInHa * baseRate
+    local threshold = targetVolume * SoilConstants.SPRAYER_RATE.FERTILIZER_COVERAGE_THRESHOLD
+
+    if currentBuffer >= threshold then
+        callback(self, fieldId, effectiveness)
+        field.nutrientBuffer[virtualIdx] = 0
+        
+        if self.settings.debugMode then
+            self:log("[Direct] Full coverage achieved field %d (%s): Credit released", fieldId, productType)
+        end
     end
 end
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -526,6 +526,7 @@ SoilConstants.SPRAYER_RATE = {
         -- Crop protection
         INSECTICIDE = { value = 1.5, unit = "liquid" },  -- ~0.16 gal/ac
         FUNGICIDE   = { value = 1.5, unit = "liquid" },  -- ~0.16 gal/ac
+        HERBICIDE   = { value = 1.5, unit = "liquid" },
         -- Fallback for unrecognized fill types
         DEFAULT           = { value =    93.5, unit = "liquid" },
     },

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -461,8 +461,6 @@ SoilConstants.NETWORK = {
     }
 }
 
-SoilLogger.info("Constants loaded")
-
 -- ========================================
 -- SPRAYER APPLICATION RATE
 -- ========================================
@@ -723,3 +721,5 @@ SoilConstants.DISEASE_PRESSURE = {
     MEDIUM = 50,
     HIGH   = 75,
 }
+
+SoilLogger.info("Constants loaded")

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -770,18 +770,18 @@ function HookManager:installSprayerAreaHook()
                 end
 
                 -- Herbicide application reduces weed pressure (direct path: non-profile products only)
-                if herbOnlyDirect and g_SoilFertilityManager.soilSystem.onHerbicideApplied then
-                    g_SoilFertilityManager.soilSystem:onHerbicideApplied(fieldId, herbEffectiveness)
+                if herbOnlyDirect and g_SoilFertilityManager.soilSystem.onHerbicideAppliedDirect then
+                    g_SoilFertilityManager.soilSystem:onHerbicideAppliedDirect(fieldId, herbEffectiveness, effectiveLiters)
                 end
 
                 -- Insecticide application reduces pest pressure (direct path: non-profile products only)
-                if pestOnlyDirect and g_SoilFertilityManager.soilSystem.onInsecticideApplied then
-                    g_SoilFertilityManager.soilSystem:onInsecticideApplied(fieldId, pestEffectiveness)
+                if pestOnlyDirect and g_SoilFertilityManager.soilSystem.onInsecticideAppliedDirect then
+                    g_SoilFertilityManager.soilSystem:onInsecticideAppliedDirect(fieldId, pestEffectiveness, effectiveLiters)
                 end
 
                 -- Fungicide application reduces disease pressure (direct path: non-profile products only)
-                if diseaseOnlyDirect and g_SoilFertilityManager.soilSystem.onFungicideApplied then
-                    g_SoilFertilityManager.soilSystem:onFungicideApplied(fieldId, diseaseEffectiveness)
+                if diseaseOnlyDirect and g_SoilFertilityManager.soilSystem.onFungicideAppliedDirect then
+                    g_SoilFertilityManager.soilSystem:onFungicideAppliedDirect(fieldId, diseaseEffectiveness, effectiveLiters)
                 end
 
                 -- Over-application burn check (nutrient fertilizers only, not lime)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1236,18 +1236,49 @@ function HookManager:installPurchaseRefillHook()
     local function isInBuyMode(vehicle, fillUnitIndex, fillTypeIndex)
         if not vehicle then return false end
 
-        -- Only applies when AI (game helper or Courseplay) is driving
-        local ok, isAI = pcall(function() return vehicle:getIsAIActive() end)
-        if not (ok and isAI) then
+        -- 1. Check if AI is active (Standard Helper or Courseplay)
+        -- We check both getIsAIActive and the spec_aiVehicle presence
+        local isAI = false
+        local ok, res = pcall(function() return vehicle:getIsAIActive() end)
+        if ok and res then 
+            isAI = true 
+        elseif vehicle.spec_aiVehicle and vehicle.spec_aiVehicle.isActive then
+            isAI = true
+        end
+
+        if not isAI then
             return false
         end
 
-        -- AI is active — check the player's opt-in flags in mission settings
+        -- 2. AI is active — check the mission settings for buy mode
         if g_currentMission and g_currentMission.missionInfo then
             local mi = g_currentMission.missionInfo
-            if mi.helperBuyFertilizer then return true end
-            if mi.helperSlurrySource  and mi.helperSlurrySource  == 2 then return true end
-            if mi.helperManureSource  and mi.helperManureSource  == 2 then return true end
+            
+            -- Identify product category to check the right helper setting
+            local fillType = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
+            local ftName = fillType and fillType.name or "UNKNOWN"
+            
+            local isSlurry = (ftName == "LIQUIDMANURE" or ftName == "DIGESTATE")
+            local isManure = (ftName == "MANURE")
+            
+            local buyActive = false
+            if isSlurry then
+                buyActive = (mi.helperSlurrySource == 2)
+            elseif isManure then
+                buyActive = (mi.helperManureSource == 2)
+            else
+                -- Fertilizer, Lime, Herbicide, and all our custom NPK/Crop-Protection types
+                buyActive = mi.helperBuyFertilizer
+            end
+
+            -- Detailed debug logging (only when AI is active to avoid spam)
+            if SoilLogger then
+                SoilLogger.debug("BUY check: veh=%d, type=%s, buyActive=%s (AI=%s, SlurrySrc=%s, ManureSrc=%s, BuyFert=%s)",
+                    vehicle.id or 0, ftName, tostring(buyActive), tostring(isAI),
+                    tostring(mi.helperSlurrySource), tostring(mi.helperManureSource), tostring(mi.helperBuyFertilizer))
+            end
+
+            return buyActive
         end
 
         return false
@@ -1270,32 +1301,31 @@ function HookManager:installPurchaseRefillHook()
             return original(vehicle, fillUnitIndex, fillLevelDelta, fillTypeIndex, toolType, fillPositionData, noEventSend)
         end
 
-        -- BUY mode active for a custom fill type: charge money, skip depletion.
-        -- |fillLevelDelta| is the liters consumed this frame.
-        local litersConsumed = -fillLevelDelta  -- positive value
+        -- |fillLevelDelta| is the liters consumed this frame (negative value).
+        local litersConsumed = -fillLevelDelta
         local cost = litersConsumed * pricePerLiter
 
         -- Charge the owning farm
         local farmId = vehicle.ownerFarmId or (vehicle.spec_enterable and vehicle.spec_enterable.activeFarmId)
         if farmId and farmId > 0 and g_currentMission and g_currentMission.economyManager then
-            -- g_currentMission.economyManager:updateStats handles the money transaction
-            -- and shows the cost in the farm account. We call removeMoney directly if
-            -- economyManager doesn't expose a direct debit for arbitrary types.
             local ok, err = pcall(function()
-                g_currentMission:addMoney(-cost, farmId, MoneyType.VEHICLE_RUNNING_COSTS, true, true)
+                g_currentMission:addMoney(-cost, farmId, MoneyType.PURCHASE_FERTILIZER, true, true)
             end)
             if not ok then
-                -- Fallback: removeMoney directly
                 pcall(function()
                     g_currentMission.economyManager:updateBudget(farmId, -cost)
                 end)
             end
         end
 
-        -- Return 0 — no actual fill level change (tank stays full)
-        -- The game expects addFillUnitFillLevel to return the actual delta applied.
-        -- Returning 0 means "nothing was consumed from the physical tank."
-        return 0
+        -- Return the original delta — this tells the game "yes, we consumed this much"
+        -- so the sprayer logic continues normally, but since we didn't call the 
+        -- original function, the physical tank level is never actually subtracted.
+        if SoilLogger and SoilLogger.debug then
+            SoilLogger.debug("BUY SUCCESS: veh=%d, type=%d, liters=%.2f, cost=%.2f (returned delta %.4f)", 
+                vehicle.id or 0, fillTypeIndex, litersConsumed, cost, fillLevelDelta)
+        end
+        return fillLevelDelta
     end
 
     self:registerCleanup("FillUnit.addFillUnitFillLevel (purchase refill)", function()

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -348,6 +348,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
                 diseasePressure = diseasePressure,
                 fungicideDaysLeft = diseaseDays,
                 dryDayCount = dryDays,
+                burnDaysLeft = burnDays,
                 initialized = true
             }
             -- Clear empty strings
@@ -416,6 +417,7 @@ function SoilFullSyncEvent:writeStream(streamId, connection)
         streamWriteFloat32(streamId, field.diseasePressure or 0)
         streamWriteInt32(streamId, field.fungicideDaysLeft or 0)
         streamWriteInt32(streamId, field.dryDayCount or 0)
+        streamWriteInt32(streamId, field.burnDaysLeft or 0)
     end
 end
 
@@ -513,6 +515,7 @@ function SoilFieldUpdateEvent:readStream(streamId, connection)
     local diseasePressure = streamReadFloat32(streamId)
     local diseaseDays = streamReadInt32(streamId)
     local dryDays = streamReadInt32(streamId)
+    local burnDays = streamReadInt32(streamId)
 
     -- Clamp all values to valid ranges
     self.field = {
@@ -539,6 +542,7 @@ function SoilFieldUpdateEvent:readStream(streamId, connection)
         diseasePressure = math.max(0, math.min(100, diseasePressure)),
         fungicideDaysLeft = math.max(0, diseaseDays),
         dryDayCount = math.max(0, dryDays),
+        burnDaysLeft = math.max(0, burnDays),
         initialized = true
     }
 
@@ -576,6 +580,7 @@ function SoilFieldUpdateEvent:writeStream(streamId, connection)
     streamWriteFloat32(streamId, self.field.diseasePressure or 0)
     streamWriteInt32(streamId, self.field.fungicideDaysLeft or 0)
     streamWriteInt32(streamId, self.field.dryDayCount or 0)
+    streamWriteInt32(streamId, self.field.burnDaysLeft or 0)
 end
 
 function SoilFieldUpdateEvent:run(connection)

--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -1,5 +1,5 @@
 -- =========================================================
--- FS25 Realistic Soil & Fertilizer (version 1.0.6.0)
+-- FS25 Realistic Soil & Fertilizer - Settings
 -- =========================================================
 -- Settings domain object - uses SettingsSchema for defaults/validation
 -- =========================================================

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -8,6 +8,17 @@
 SoilSettingsGUI = {}
 local SoilSettingsGUI_mt = Class(SoilSettingsGUI)
 
+-- Route a setting change through the network layer so all MP clients are notified.
+-- Falls back to direct mutation only when the network layer is not yet ready.
+local function requestSettingChange(settingId, value)
+    if SoilNetworkEvents_RequestSettingChange then
+        SoilNetworkEvents_RequestSettingChange(settingId, value)
+    else
+        g_SoilFertilityManager.settings[settingId] = value
+        g_SoilFertilityManager.settings:save()
+    end
+end
+
 function SoilSettingsGUI.new()
     local self = setmetatable({}, SoilSettingsGUI_mt)
     return self
@@ -52,6 +63,7 @@ function SoilSettingsGUI:consoleCommandHelp()
     print("SoilSetPlowingBonus true|false - Toggle plowing bonus")
     print("SoilShowSettings - Show current settings")
     print("SoilFieldInfo <fieldId> - Show soil info for field")
+    print("SoilFieldForecast <fieldId> - Show yield forecast for field")
     print("SoilListFields - List all fields with soil data")
     print("SoilResetSettings - Reset to defaults")
     print("SoilSaveData - Force save soil data")
@@ -67,17 +79,16 @@ function SoilSettingsGUI:consoleCommandSetDifficulty(difficulty)
         return "Invalid difficulty"
     end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings:setDifficulty(diff)
-        g_SoilFertilityManager.settings:save()
-        return string.format("Difficulty set to: %s", g_SoilFertilityManager.settings:getDifficultyName())
+        requestSettingChange("difficulty", diff)
+        local diffNames = {[1]="Simple", [2]="Realistic", [3]="Hardcore"}
+        return string.format("Difficulty set to: %s", diffNames[diff] or tostring(diff))
     end
     return "Error: Soil Mod not initialized"
 end
 
 function SoilSettingsGUI:consoleCommandSoilEnable()
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.enabled = true
-        g_SoilFertilityManager.settings:save()
+        requestSettingChange("enabled", true)
         if g_SoilFertilityManager.soilSystem then
             g_SoilFertilityManager.soilSystem:initialize()
         end
@@ -88,8 +99,7 @@ end
 
 function SoilSettingsGUI:consoleCommandSoilDisable()
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.enabled = false
-        g_SoilFertilityManager.settings:save()
+        requestSettingChange("enabled", false)
         return "Soil & Fertilizer Mod disabled"
     end
     return "Error: Soil Mod not initialized"
@@ -100,9 +110,9 @@ function SoilSettingsGUI:consoleCommandSetFertility(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.fertilitySystem = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Fertility system %s", g_SoilFertilityManager.settings.fertilitySystem and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("fertilitySystem", newVal)
+        return string.format("Fertility system %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -112,9 +122,9 @@ function SoilSettingsGUI:consoleCommandSetNutrients(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.nutrientCycles = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Nutrient cycles %s", g_SoilFertilityManager.settings.nutrientCycles and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("nutrientCycles", newVal)
+        return string.format("Nutrient cycles %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -124,9 +134,9 @@ function SoilSettingsGUI:consoleCommandSetFertilizerCosts(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.fertilizerCosts = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Fertilizer costs %s", g_SoilFertilityManager.settings.fertilizerCosts and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("fertilizerCosts", newVal)
+        return string.format("Fertilizer costs %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -136,9 +146,9 @@ function SoilSettingsGUI:consoleCommandSetNotifications(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.showNotifications = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Notifications %s", g_SoilFertilityManager.settings.showNotifications and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("showNotifications", newVal)
+        return string.format("Notifications %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -149,9 +159,9 @@ function SoilSettingsGUI:consoleCommandSetSeasonalEffects(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.seasonalEffects = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Seasonal effects %s", g_SoilFertilityManager.settings.seasonalEffects and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("seasonalEffects", newVal)
+        return string.format("Seasonal effects %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -161,9 +171,9 @@ function SoilSettingsGUI:consoleCommandSetRainEffects(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.rainEffects = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Rain effects %s", g_SoilFertilityManager.settings.rainEffects and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("rainEffects", newVal)
+        return string.format("Rain effects %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -173,18 +183,18 @@ function SoilSettingsGUI:consoleCommandSetPlowingBonus(enabled)
     local enable = enabled:lower()
     if enable ~= "true" and enable ~= "false" then return "Invalid value. Use 'true' or 'false'" end
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.plowingBonus = (enable == "true")
-        g_SoilFertilityManager.settings:save()
-        return string.format("Plowing bonus %s", g_SoilFertilityManager.settings.plowingBonus and "enabled" or "disabled")
+        local newVal = (enable == "true")
+        requestSettingChange("plowingBonus", newVal)
+        return string.format("Plowing bonus %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
 
 function SoilSettingsGUI:consoleCommandDebug()
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
-        g_SoilFertilityManager.settings.debugMode = not g_SoilFertilityManager.settings.debugMode
-        g_SoilFertilityManager.settings:save()
-        return string.format("Debug mode %s", g_SoilFertilityManager.settings.debugMode and "enabled" or "disabled")
+        local newVal = not g_SoilFertilityManager.settings.debugMode
+        requestSettingChange("debugMode", newVal)
+        return string.format("Debug mode %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
 end
@@ -275,7 +285,8 @@ function SoilSettingsGUI:consoleCommandFieldForecast(fieldId)
 
             local penalty    = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
             local penaltyPct = math.floor(penalty * 100 + 0.5)
-            local urgency    = math.floor(avgDef * 100 + 0.5)
+            -- Use getFieldUrgency so this score matches the Soil Report sort order
+            local urgency    = math.floor(soilSystem:getFieldUrgency(fid) + 0.5)
 
             -- Recommendations
             local recs = {}

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -230,9 +230,9 @@ function SoilHUD:calculateHeight()
         
         local mgr = g_SoilFertilityManager
         if mgr and mgr.settings then
-            if mgr.settings.weedPressure and (info.weedPressure or 0) >= 0 then h = h + SoilHUD.LINE_H end
-            if mgr.settings.pestPressure and (info.pestPressure or 0) >= 0 then h = h + SoilHUD.LINE_H end
-            if mgr.settings.diseasePressure and (info.diseasePressure or 0) >= 0 then h = h + SoilHUD.LINE_H end
+            if mgr.settings.weedPressure and (info.weedPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
+            if mgr.settings.pestPressure and (info.pestPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
+            if mgr.settings.diseasePressure and (info.diseasePressure or 0) > 0 then h = h + SoilHUD.LINE_H end
         end
         
         h = h + SoilHUD.PAD * 1.3
@@ -899,11 +899,12 @@ function SoilHUD:drawPressureRow(labelKey, pressure, isProtected, px, cy, pw, s,
     local barW = SoilHUD.BAR_W * s
     local tx   = px + pad
 
-    -- 3-level color (matches getPressureColor in SoilReportDialog)
+    -- 3-level color (matches getPressureColor in SoilReportDialog — aligned with Constants thresholds)
+    local wp = SoilConstants.WEED_PRESSURE  -- LOW=20, MEDIUM=50 (shared by weed/pest/disease)
     local col
-    if pressure < 25 then     col = SoilHUD.C_GOOD
-    elseif pressure < 60 then col = SoilHUD.C_FAIR
-    else                      col = SoilHUD.C_POOR end
+    if pressure < wp.LOW    then col = SoilHUD.C_GOOD
+    elseif pressure < wp.MEDIUM then col = SoilHUD.C_FAIR
+    else                         col = SoilHUD.C_POOR end
 
     -- Label
     setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -968,17 +968,22 @@ function SoilHUD:formatRate(multiplier, rateConfig)
     local imperial = (self.settings.useImperialUnits ~= false)
     local conv     = SoilConstants.SPRAYER_RATE
 
+    -- For very low base rates (Insecticide/Fungicide), show 1 decimal place
+    local fmt = (rateConfig.value < 10.0) and "%.1f" or "%.0f"
+
     if rateConfig.unit == "liquid" then
         if imperial then
-            return string.format("%d gal/ac", math.floor(value * conv.L_PER_HA_TO_GAL_PER_AC + 0.5))
+            local impVal = value * conv.L_PER_HA_TO_GAL_PER_AC
+            return string.format(fmt .. " gal/ac", impVal)
         else
-            return string.format("%d L/ha", math.floor(value + 0.5))
+            return string.format(fmt .. " L/ha", value)
         end
     else
         if imperial then
-            return string.format("%d lb/ac", math.floor(value * conv.KG_PER_HA_TO_LB_PER_AC + 0.5))
+            local impVal = value * conv.KG_PER_HA_TO_LB_PER_AC
+            return string.format(fmt .. " lb/ac", impVal)
         else
-            return string.format("%d kg/ha", math.floor(value + 0.5))
+            return string.format(fmt .. " kg/ha", value)
         end
     end
 end
@@ -989,17 +994,20 @@ function SoilHUD:formatRateNumber(multiplier, rateConfig)
     local imperial = (self.settings.useImperialUnits ~= false)
     local conv     = SoilConstants.SPRAYER_RATE
 
+    -- For very low base rates, show 1 decimal place
+    local fmt = (rateConfig.value < 10.0) and "%.1f" or "%.0f"
+
     if rateConfig.unit == "liquid" then
         if imperial then
-            return string.format("%d", math.floor(value * conv.L_PER_HA_TO_GAL_PER_AC + 0.5))
+            return string.format(fmt, value * conv.L_PER_HA_TO_GAL_PER_AC)
         else
-            return string.format("%d", math.floor(value + 0.5))
+            return string.format(fmt, value)
         end
     else
         if imperial then
-            return string.format("%d", math.floor(value * conv.KG_PER_HA_TO_LB_PER_AC + 0.5))
+            return string.format(fmt, value * conv.KG_PER_HA_TO_LB_PER_AC)
         else
-            return string.format("%d", math.floor(value + 0.5))
+            return string.format(fmt, value)
         end
     end
 end

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -289,8 +289,10 @@ local function getOMColor(om)
 end
 
 local function getPressureColor(pct)
-    if pct < 25 then return SoilReportDialog.COLOR_GOOD
-    elseif pct < 60 then return SoilReportDialog.COLOR_FAIR
+    -- Aligned with SoilConstants.WEED_PRESSURE thresholds (LOW=20, MEDIUM=50, same for pest/disease)
+    local wp = SoilConstants.WEED_PRESSURE
+    if pct < wp.LOW    then return SoilReportDialog.COLOR_GOOD
+    elseif pct < wp.MEDIUM then return SoilReportDialog.COLOR_FAIR
     else return SoilReportDialog.COLOR_POOR end
 end
 
@@ -325,7 +327,7 @@ local function getOverallStatus(info)
     -- Weed / pest / disease pressures (stored as 0-100)
     for _, key in ipairs({"weedPressure", "pestPressure", "diseasePressure"}) do
         local val = info[key]
-        if val and val >= 0 then
+        if val and val > 0 then
             local r = colorRank(getPressureColor(math.floor(val + 0.5)))
             if r > worst then worst = r end
         end


### PR DESCRIPTION
## Summary

- Pressure color thresholds in HUD and Soil Report aligned with `SoilConstants` (LOW=20, MEDIUM=50) — previously hardcoded 25/60 meant Green showed below the first yield-penalty tier
- HUD panel height `>= 0` always-true condition fixed to `> 0`
- All console setting commands now route through `SoilNetworkEvents_RequestSettingChange()` — previously bypassed the MP broadcast layer entirely
- `SoilFieldForecast` urgency score now calls `getFieldUrgency()` to match the Soil Report's sort order
- `SoilFieldForecast` added to `soilfertility` help output
- CHANGELOG entries written for 1.6.0.1–1.6.0.4
- README: removed phantom "Compact mode" setting, added `useImperialUnits` and `autoRateControl`, fixed HUD position count (5→6)
- DEVELOPMENT.md version bumped from 1.5.2.0 → 1.6.0.4

## Earlier fixes included in this release (since v1.6.0.0)

- Critical multiplayer stream desync in `SoilFullSyncEvent` (`burnDaysLeft` missing from writeStream)
- Fertilization notification permanent silencing bug (`fertNotifyShown` stored `true` forever)
- AI purchase refill BUY mode detection (two rounds of fixes — issue #125)
- 90% coverage buffer extended to crop protection products — issue #143
- HUD sprayer rate display for low-volume products (Insecticide/Fungicide)
- HERBICIDE missing from `BASE_RATES`
- Instant notification on mod load removed

## Test plan

- [ ] Open Soil Report — pressure color bands: 0–19 = green, 20–49 = yellow, 50+ = red
- [ ] HUD panel height: pressure rows only appear when pressure > 0
- [ ] Console `SoilSetFertility false` in MP — verify all clients see the change
- [ ] Console `soilfertility` — verify SoilFieldForecast listed
- [ ] Console `SoilFieldForecast <id>` — urgency score matches field sort order in Soil Report
- [ ] AI worker with BUY mode — tank should not deplete (issue #125)