### PR TITLE
feat: v1.8.7.0 — fill type transfer + polygon overlay fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.7.0] - 2026-04-16
+
+### Fixed
+
+- **Custom fill types blocked from vehicle-to-vehicle transfer**: UREA, UAN32, DAP, and all
+  other custom fill types could only be loaded from a shop big-bag trigger. Discharging from
+  an auger wagon into a spreader, or pumping from a tanker into a sprayer, was blocked because
+  `Dischargeable:dischargeToObject` calls `getFillUnitSupportsFillType` before transferring —
+  a method some FS25 versions route through a C++ fast-path that bypasses the `supportedFillTypes`
+  table we already patched. Fixed by also hooking `FillUnit.getFillUnitSupportsFillType` directly:
+  if the vehicle supports the vanilla base type (FERTILIZER or LIQUIDFERTILIZER), it now also
+  returns `true` for the matching custom type.
+
+### Improved
+
+- **Soil map overlay fills entire field polygon**: The overlay previously placed a single dot at
+  each field's centroid. It now fills the full field area with a 15-metre grid of coloured tiles
+  so field boundaries are clearly visible on the map. Field polygon vertices are read from the
+  i3d scene via `Field.polygonPoints`; a ray-casting point-in-polygon test filters out grid
+  positions outside the boundary. Polygon points are cached per-field and invalidated on layer
+  switch. Dot size reduced from 14 px to 10 px; per-tile borders removed for performance.
+  `MAX_POINTS` raised from 850 to 3000 to accommodate larger maps.
+
+---
+
 ## [1.8.6.0] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.6.0] - 2026-04-16
+
+### Fixed
+
+- **Soil map overlay dots never rendered**: The `onDrawPostIngameMap` callback targeted by
+  the soil map hook does not exist as a callable method in FS25. The appended function was
+  registering silently but never firing, so no overlay dots were drawn on the in-game map.
+  Fixed by hooking `IngameMapElement.draw` at the class level instead. The new hook walks
+  the parent chain (up to 6 levels) to locate the `InGameMenuMapFrame` that owns the element,
+  then checks whether the soil map page is active before delegating to `SoilMapOverlay:onDraw()`.
+
+- **Lua multi-return truncation in `getMapRenderBounds`**: Chained `return` of multiple
+  return values caused single-value truncation in some call sites. Fixed by assigning to
+  explicit local variables before returning.
+
+- **`worldToScreenPosition` inconsistent layout reference**: Now consistently uses
+  `fullScreenLayout` instead of mixing layout sources across callers.
+
+- **`pointPool` nil crash**: The pool system was referenced in `delete()` but never
+  initialized, causing a nil-index crash on mod unload. Removed entirely; `samplePoints`
+  is now a plain table reset on each update cycle.
+
+- **Overlay sampling switched to per-field centroids**: `updateSamplePoints` was using a
+  34×34 world-space grid, producing dots at arbitrary coordinates unrelated to actual fields.
+  Now samples one dot per tracked field using `fsField.posX / posZ` — one correctly coloured
+  dot per field, no off-field scatter.
+
+- **Missing `cycleLayer()` and `requestGenerate()` on `SoilMapOverlay`**: The PDA screen and
+  map frame called these methods but they were never defined, causing nil-call crashes when
+  switching layers or refreshing the overlay. Both are now implemented.
+
+- **Sidebar layer toggle re-click behaviour**: Re-clicking the currently active overlay layer
+  button now turns the overlay off (toggles to layer 0) instead of re-selecting the same layer.
+
+- **Dark border on map dots**: Added a 1-pixel dark outline to each overlay dot for readability
+  against light terrain colours.
+
+---
+
 ## [1.8.5.0] - 2026-04-15
 
 ### Added

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.8.5.0
-**Last Updated**: 2026-04-15
+**Version**: 1.8.6.0
+**Last Updated**: 2026-04-16
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.8.6.0
+**Version**: 1.8.7.0
 **Last Updated**: 2026-04-16
 
 ---

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.8.6.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.8.7.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.6.0.4
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.8.6.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.8.6.0</version>
+    <version>1.8.7.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1181,6 +1181,48 @@ function HookManager:installFillUnitHook()
     self:register(FillUnit, "onPostLoad", original, "FillUnit.onPostLoad")
     SoilLogger.info("[OK] FillUnit hook installed - custom types injected into compatible vehicles")
 
+    -- Build customToBase: custom fill type index → vanilla base type index.
+    -- Used by getFillUnitSupportsFillType hook below.
+    local customToBase = {}
+    if fertIndex then
+        for _, idx in ipairs(solidIndices) do
+            customToBase[idx] = fertIndex
+        end
+    end
+    if liqFertIndex then
+        for _, idx in ipairs(liquidIndices) do
+            customToBase[idx] = liqFertIndex
+        end
+    end
+
+    -- Hook getFillUnitSupportsFillType so Dischargeable:dischargeToObject (vehicle-to-vehicle
+    -- auger wagon → spreader, tanker → sprayer, etc.) passes the fill type check for our
+    -- custom types. Patching supportedFillTypes covers the table lookup, but some FS25
+    -- versions / specializations call this method via a C++ fast-path that bypasses the Lua
+    -- table. Wrapping the method directly is the belt-and-suspenders fix.
+    --
+    -- Logic: if the vehicle supports the corresponding vanilla base type (FERTILIZER or
+    -- LIQUIDFERTILIZER), it also supports the matching custom type.
+    if FillUnit.getFillUnitSupportsFillType then
+        local origGetSupports = FillUnit.getFillUnitSupportsFillType
+        FillUnit.getFillUnitSupportsFillType = function(vehicleSelf, fillUnitIndex, fillType)
+            -- Short-circuit: original already knows about this type (vanilla or already patched table)
+            if origGetSupports(vehicleSelf, fillUnitIndex, fillType) then
+                return true
+            end
+            -- Custom type? Check if the vehicle supports the corresponding vanilla base type.
+            local baseType = customToBase[fillType]
+            if baseType then
+                return origGetSupports(vehicleSelf, fillUnitIndex, baseType)
+            end
+            return false
+        end
+        self:register(FillUnit, "getFillUnitSupportsFillType", origGetSupports, "FillUnit.getFillUnitSupportsFillType")
+        SoilLogger.info("[OK] getFillUnitSupportsFillType hook installed - vehicle-to-vehicle transfer enabled")
+    else
+        SoilLogger.warning("FillUnit.getFillUnitSupportsFillType not available - skipping transfer hook")
+    end
+
     -- Retroactively patch all vehicles already in memory.
     -- On save/load, FillUnit.onPostLoad fires during Mission00.load (before our deferred
     -- hook installation runs), so saved sprayers miss the injection entirely. Patching them

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -23,7 +23,8 @@ SoilMapOverlay.ALPHA          = 0.72
 
 -- Sampling constants
 SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 4500
-SoilMapOverlay.MAX_POINTS = 850
+SoilMapOverlay.MAX_POINTS       = 3000   -- increased to support full polygon fill
+SoilMapOverlay.POLYGON_STEP     = 15     -- world-unit grid spacing for polygon sampling (meters)
 
 -- Status colors (match SoilHUD palette)
 SoilMapOverlay.C_POOR = {0.88, 0.25, 0.25}
@@ -77,6 +78,10 @@ function SoilMapOverlay.new(soilSystem, settings)
     self.isMapOpen = false
     self.isReady = false
 
+    -- Cache of polygon fill points per field: fieldId → array of {x, z} world coords.
+    -- Populated lazily in getFieldFillPoints; cleared on requestRefresh.
+    self.fieldPolyCache = {}
+
     -- Manual Button Rects for click detection
     self.buttonRects = {}
 
@@ -129,6 +134,7 @@ end
 
 function SoilMapOverlay:requestRefresh()
     self.nextSampleUpdateTime = 0
+    self.fieldPolyCache = {}
 end
 
 -- ── Layer selection ───────────────────────────────────────
@@ -173,6 +179,101 @@ function SoilMapOverlay:onSideBarClick(posX, posY)
     return false
 end
 
+-- ── Polygon Fill Helpers ──────────────────────────────────
+
+-- Ray-casting point-in-polygon test (2D, XZ plane).
+-- verts is an array of {x, z} tables.
+local function isPointInPoly(px, pz, verts)
+    local n = #verts
+    if n < 3 then return false end
+    local inside = false
+    local j = n
+    for i = 1, n do
+        local xi, zi = verts[i].x, verts[i].z
+        local xj, zj = verts[j].x, verts[j].z
+        if ((zi > pz) ~= (zj > pz)) and
+           (px < (xj - xi) * (pz - zi) / (zj - zi) + xi) then
+            inside = not inside
+        end
+        j = i
+    end
+    return inside
+end
+
+--- Return an array of world {x, z} sample points that fill the field polygon.
+--- Results are cached in self.fieldPolyCache keyed by fsField.fieldId (or a fallback key).
+--- The grid step is SoilMapOverlay.POLYGON_STEP meters; points outside the polygon are rejected.
+---@param fsField table FS25 Field object with polygonPoints and fieldId
+---@return table Array of {x, z}
+function SoilMapOverlay:getFieldFillPoints(fsField)
+    local cacheKey = fsField.fieldId or tostring(fsField)
+    if self.fieldPolyCache[cacheKey] then
+        return self.fieldPolyCache[cacheKey]
+    end
+
+    local pts = {}
+
+    -- Collect polygon vertices from the i3d node array
+    local polyNodes = fsField.polygonPoints
+    local verts = {}
+    if polyNodes and #polyNodes > 0 then
+        for i = 1, #polyNodes do
+            local nodeId = polyNodes[i]
+            if nodeId and nodeId ~= 0 then
+                local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+                if ok and wx then
+                    table.insert(verts, {x = wx, z = wz})
+                end
+            end
+        end
+    end
+
+    -- Fallback: if polygon data unavailable, return the single centroid point
+    if #verts < 3 then
+        if fsField.posX and fsField.posZ then
+            table.insert(pts, {x = fsField.posX, z = fsField.posZ})
+        end
+        self.fieldPolyCache[cacheKey] = pts
+        return pts
+    end
+
+    -- Compute bounding box
+    local minX, maxX = verts[1].x, verts[1].x
+    local minZ, maxZ = verts[1].z, verts[1].z
+    for i = 2, #verts do
+        if verts[i].x < minX then minX = verts[i].x end
+        if verts[i].x > maxX then maxX = verts[i].x end
+        if verts[i].z < minZ then minZ = verts[i].z end
+        if verts[i].z > maxZ then maxZ = verts[i].z end
+    end
+
+    -- Grid-sample the bounding box, keep points inside the polygon
+    local step = SoilMapOverlay.POLYGON_STEP
+    -- Offset start by half-step so points land near field centre, not edges
+    local startX = minX + step * 0.5
+    local startZ = minZ + step * 0.5
+    local x = startX
+    while x <= maxX do
+        local z = startZ
+        while z <= maxZ do
+            if isPointInPoly(x, z, verts) then
+                table.insert(pts, {x = x, z = z})
+            end
+            z = z + step
+        end
+        x = x + step
+    end
+
+    -- Ensure at least the centroid if the grid produced nothing
+    -- (can happen for very small or narrow fields)
+    if #pts == 0 and fsField.posX and fsField.posZ then
+        table.insert(pts, {x = fsField.posX, z = fsField.posZ})
+    end
+
+    self.fieldPolyCache[cacheKey] = pts
+    return pts
+end
+
 -- ── Point Sampling (DMF Pattern) ─────────────────────────
 
 function SoilMapOverlay:updateSamplePoints(force)
@@ -196,29 +297,39 @@ function SoilMapOverlay:updateSamplePoints(force)
         return
     end
 
-    -- One dot per field at its polygon centroid (fsField.posX/posZ, set by Field:load()).
-    -- We match fields to our soil data via farmland.id (that is the key fieldData uses).
+    -- Fill each field polygon with a grid of coloured sample points.
+    -- We match fields to our soil data via farmland.id (the key fieldData uses).
+    -- getFieldFillPoints() handles the grid sampling and caching; it falls back to
+    -- a single centroid point for very small fields or when polygon data is absent.
     local fields = g_fieldManager.fields
     if fields == nil then
         SoilLogger.info("SoilMapOverlay: g_fieldManager.fields is nil")
         return
     end
 
+    local totalPoints = 0
     for _, fsField in ipairs(fields) do
-        if fsField and fsField.farmland and fsField.posX and fsField.posZ then
+        if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
             if farmlandId and farmlandId > 0 then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
                     local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
-                    table.insert(self.samplePoints, {x = fsField.posX, z = fsField.posZ, r = r, g = g, b = b})
+                    local polyPts = self:getFieldFillPoints(fsField)
+                    for _, pt in ipairs(polyPts) do
+                        if totalPoints < SoilMapOverlay.MAX_POINTS then
+                            table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                            totalPoints = totalPoints + 1
+                        end
+                    end
                 end
             end
         end
     end
 
-    if #self.samplePoints > 0 then
-        SoilLogger.info("SoilMapOverlay: Sampled %d field centroids for layer %d", #self.samplePoints, layerIdx)
+    if totalPoints > 0 then
+        SoilLogger.info("SoilMapOverlay: Sampled %d polygon fill points for layer %d (fields: %d)",
+                        totalPoints, layerIdx, #fields)
     else
         SoilLogger.info("SoilMapOverlay: No fields found to sample (fields count: %d)", #fields)
     end
@@ -241,23 +352,18 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
     local mapMaxX = mapX + mapWidth
     local mapMaxY = mapY + mapHeight
 
+    -- Pre-compute normalised dot size once (same for all points)
+    local sizeX, sizeY = getNormalizedScreenValues(10, 10)
+    local halfX, halfY = sizeX * 0.5, sizeY * 0.5
+
     for _, point in ipairs(self.samplePoints) do
         local screenX, screenY = self:worldToScreenPosition(ingameMap, point.x, point.z)
         if screenX ~= nil and screenY ~= nil
            and screenX >= mapX and screenX <= mapMaxX
            and screenY >= mapY and screenY <= mapMaxY then
-            -- Draw a solid dot with a dark border for readability
-            local sizePx = 14
-            local borderPx = 2
-            local sizeX, sizeY = getNormalizedScreenValues(sizePx, sizePx)
-            local borderX, borderY = getNormalizedScreenValues(borderPx, borderPx)
-            -- Border (dark)
-            drawFilledRect(screenX - sizeX * 0.5 - borderX, screenY - sizeY * 0.5 - borderY,
-                           sizeX + borderX * 2, sizeY + borderY * 2,
-                           0, 0, 0, 0.7)
-            -- Colored fill
-            drawFilledRect(screenX - sizeX * 0.5, screenY - sizeY * 0.5, sizeX, sizeY,
-                           point.r, point.g, point.b, 0.92)
+            -- Draw polygon fill tile (no per-tile border — too expensive at 3000+ pts)
+            drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
+                           point.r, point.g, point.b, SoilMapOverlay.ALPHA)
         end
     end
 end


### PR DESCRIPTION
## Summary

- **Fill type vehicle-to-vehicle transfer**: Custom fill types (UREA, UAN32, DAP, all 22) can now be transferred between vehicles via auger wagons, tankers, and any Dischargeable-spec equipment. Root cause: `Dischargeable:dischargeToObject` calls `getFillUnitSupportsFillType`, which some FS25 versions route through a C++ fast-path that bypasses the `supportedFillTypes` table we already patched. Fix: hook `FillUnit.getFillUnitSupportsFillType` directly — if the vehicle supports FERTILIZER or LIQUIDFERTILIZER, it now also returns `true` for the matching custom type.
- **Polygon overlay fill**: The soil map overlay now fills the entire field polygon with a 15m grid of coloured tiles instead of a single centroid dot. Uses `Field.polygonPoints` i3d node IDs → `getWorldTranslation` → bounding box → ray-casting point-in-polygon test. Points cached per-field; cache cleared on layer switch. Dot size 14 → 10 px, `MAX_POINTS` 850 → 3000.
- Version bumped 1.8.6.0 → 1.8.7.0 across all files.

## Test plan

- [ ] Load a saved game with a spreader already in the field — confirm it accepts UREA/DAP from an auger wagon (discharge mode)
- [ ] Confirm liquid tanker → liquid sprayer transfer works for UAN32/ANHYDROUS
- [ ] Confirm big-bag trigger refill still works (regression check)
- [ ] Open in-game map (Shift+M), select N layer — field area should appear filled, not a single dot
- [ ] Switch layers — confirm polygon fill updates color correctly
- [ ] Check log.txt for `[SoilFert]` errors