### PR TITLE
v1.8.9.0 — AI buy-mode fix, fill plane visuals, spray/spread effects

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.8.8.0</version>
+    <version>1.8.9.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -123,6 +123,14 @@ function HookManager:installAll(soilSystem)
     local purchaseRefillOk = self:installPurchaseRefillHook()
     if purchaseRefillOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
+    -- Fix AI external fill: prevent empty-tank fallback to vanilla FERTILIZER for our types
+    local extFillOk = self:installExternalFillHook()
+    if extFillOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    -- Fix fill plane and fill volume texture for custom fill types
+    local fillMatOk = self:installFillTypeMaterialHook()
+    if fillMatOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
     SoilLogger.info("Hook installation complete: %d/%d successful, %d failed",
         successCount, successCount + failCount, failCount)
 
@@ -325,6 +333,7 @@ function HookManager:installEffectTypeHook()
     end
     if liqIdx then
         for _, name in ipairs({ "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
+                                 "INSECTICIDE", "FUNGICIDE",
                                  "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }) do
             local idx = fm:getFillTypeIndexByName(name)
             if idx then remap[idx] = liqIdx end
@@ -479,6 +488,7 @@ function HookManager:installSprayTypeEffectsHook()
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
     -- Liquid custom types visually match LIQUIDFERTILIZER spraying
     local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
+                          "INSECTICIDE", "FUNGICIDE",
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
 
     -- Shared helper: walk a vehicle's sprayType entries and inject our names
@@ -788,6 +798,13 @@ function HookManager:installSprayerAreaHook()
                     local spx, _, spz = getWorldTranslation(self.rootNode)
                     g_SoilFertilityManager.soilSystem._lastSprayX = spx
                     g_SoilFertilityManager.soilSystem._lastSprayZ = spz
+                end
+
+                -- Track last custom fill type so getExternalFill hook can identify the
+                -- intended product when the tank hits empty (fillType becomes UNKNOWN).
+                local _hm = g_SoilFertilityManager.hookManager
+                if _hm and _hm.customFillTypePrices and _hm.customFillTypePrices[fillTypeIndex] then
+                    self._soilLastCustomFillType = fillTypeIndex
                 end
 
                 if isFertilizer then
@@ -1454,5 +1471,172 @@ function HookManager:installPurchaseRefillHook()
     self.customFillTypePrices = customPrices
 
     SoilLogger.info("[OK] Purchase refill hook installed - BUY mode enabled for %d custom fill types", count)
+    return true
+end
+
+-- =========================================================
+-- HOOK 9: Fix AI "external fill" for custom fertilizer types
+-- =========================================================
+-- When getIsSprayerExternallyFilled() returns true (AI + helperBuyFertilizer) and the
+-- vehicle's tank is empty (fillType == FillType.UNKNOWN), FS25's getExternalFill
+-- matches the condition:
+--   (fillType == UNKNOWN and (allowLiquidFertilizer or allowFertilizer or allowHerbicide))
+-- Because we patched the fill unit to also accept vanilla FERTILIZER/LIQUIDFERTILIZER
+-- (via installFillUnitHook), allowFertilizer == true even on a spreader loaded with UREA.
+-- getExternalFill then returns vanilla FERTILIZER with buy-mode charging — silently
+-- applying the wrong product to the terrain density map.
+--
+-- Fix: wrap getExternalFill. When fillType is one of our custom types (direct match),
+-- OR fillType == UNKNOWN but the vehicle was last spraying a custom type
+-- (_soilLastCustomFillType), intercept:
+--   • Buy mode active → charge our price (1.5× AI premium), return our custom type.
+--   • Buy mode inactive → return (UNKNOWN, 0) so the AI stops rather than falling
+--     through to vanilla FERTILIZER.
+---@return boolean success
+function HookManager:installExternalFillHook()
+    if not Sprayer or type(Sprayer.getExternalFill) ~= "function" then
+        SoilLogger.warning("External fill hook: Sprayer.getExternalFill not available - skipping")
+        return false
+    end
+
+    local original = Sprayer.getExternalFill
+
+    Sprayer.getExternalFill = function(sprayerSelf, fillType, dt)
+        local hookMgr = g_SoilFertilityManager and g_SoilFertilityManager.hookManager
+        local prices  = hookMgr and hookMgr.customFillTypePrices
+
+        if not prices then
+            return original(sprayerSelf, fillType, dt)
+        end
+
+        -- Identify the intended custom product
+        local customIdx = nil
+        if fillType and fillType ~= FillType.UNKNOWN and prices[fillType] then
+            customIdx = fillType
+        elseif (not fillType or fillType == FillType.UNKNOWN) and sprayerSelf._soilLastCustomFillType then
+            customIdx = sprayerSelf._soilLastCustomFillType
+        end
+
+        if not customIdx then
+            return original(sprayerSelf, fillType, dt)
+        end
+
+        local mi = g_currentMission and g_currentMission.missionInfo
+        if not mi then
+            return FillType.UNKNOWN, 0
+        end
+
+        local fm = g_fillTypeManager
+        local ft = fm and fm:getFillTypeByIndex(customIdx)
+        local ftName = ft and ft.name or ""
+
+        local buyActive = false
+        if ftName == "LIQUIDMANURE" or ftName == "DIGESTATE" then
+            buyActive = (mi.helperSlurrySource == 2)
+        elseif ftName == "MANURE" then
+            buyActive = (mi.helperManureSource == 2)
+        else
+            buyActive = (mi.helperBuyFertilizer == true)
+        end
+
+        if not buyActive then
+            -- No buy mode: don't fall through to vanilla FERTILIZER; AI stops when empty.
+            return FillType.UNKNOWN, 0
+        end
+
+        -- Buy mode active: charge our price and return the custom type so the
+        -- correct product is written to the terrain density map.
+        local usage = sprayerSelf:getSprayerUsage(customIdx, dt)
+        if sprayerSelf.isServer and usage > 0 then
+            local pricePerLiter = prices[customIdx] or 1.0
+            local price = usage * pricePerLiter * 1.5  -- 1.5× AI premium (matches vanilla)
+            local farmId = sprayerSelf:getActiveFarm()
+            local statsFarmId = farmId
+            pcall(function() statsFarmId = sprayerSelf:getLastTouchedFarmlandFarmId() end)
+            pcall(function()
+                g_farmManager:updateFarmStats(statsFarmId, "expenses", price)
+                g_currentMission:addMoney(-price, farmId, MoneyType.PURCHASE_FERTILIZER)
+            end)
+            SoilLogger.debug("ExternalFill BUY: veh=%d type=%s liters=%.2f price=%.2f",
+                sprayerSelf.id or 0, ftName, usage, price)
+        end
+
+        return customIdx, usage
+    end
+
+    self:register(Sprayer, "getExternalFill", original, "Sprayer.getExternalFill")
+    SoilLogger.info("[OK] External fill hook installed (Sprayer.getExternalFill)")
+    return true
+end
+
+-- =========================================================
+-- HOOK 10: Fix fill plane and fill volume texture for custom types
+-- =========================================================
+-- updateFillUnitFillPlane (FillUnit) and FillVolume:onUpdate both call:
+--   g_fillTypeManager:getTextureArrayIndexByFillTypeIndex(fillType)
+-- to set the "fillTypeId" shader parameter that selects which texture in the
+-- terrain fill-type array is shown on the fill plane / fill volume mesh.
+-- Custom fill types are not registered with texture array entries, so the
+-- call returns nil and the visual never updates — the fill plane and hopper
+-- mesh stay on whatever they showed before (or show nothing/wrong colour).
+--
+-- Fix: wrap getTextureArrayIndexByFillTypeIndex. When the index belongs to one
+-- of our custom types and the original returns nil, remap to the vanilla
+-- equivalent (FERTILIZER for solid types, LIQUIDFERTILIZER for liquid types)
+-- and return its texture array index. Purely cosmetic — nutrient tracking is
+-- unaffected.
+---@return boolean success
+function HookManager:installFillTypeMaterialHook()
+    if not g_fillTypeManager or type(g_fillTypeManager.getTextureArrayIndexByFillTypeIndex) ~= "function" then
+        SoilLogger.warning("Fill type material hook: getTextureArrayIndexByFillTypeIndex not available - skipping")
+        return false
+    end
+
+    local fm = g_fillTypeManager
+    local fertIdx    = fm:getFillTypeIndexByName("FERTILIZER")
+    local liqFertIdx = fm:getFillTypeIndexByName("LIQUIDFERTILIZER")
+
+    local remap = {}
+    if fertIdx then
+        for _, name in ipairs({ "UREA", "AMS", "MAP", "DAP", "POTASH",
+                                 "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }) do
+            local idx = fm:getFillTypeIndexByName(name)
+            if idx then remap[idx] = fertIdx end
+        end
+    end
+    if liqFertIdx then
+        for _, name in ipairs({ "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
+                                 "INSECTICIDE", "FUNGICIDE",
+                                 "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }) do
+            local idx = fm:getFillTypeIndexByName(name)
+            if idx then remap[idx] = liqFertIdx end
+        end
+    end
+
+    if not next(remap) then
+        SoilLogger.warning("Fill type material hook: no custom fill types found — skipping")
+        return false
+    end
+
+    local count = 0
+    for _ in pairs(remap) do count = count + 1 end
+
+    local origGetTexIdx = fm.getTextureArrayIndexByFillTypeIndex
+    fm.getTextureArrayIndexByFillTypeIndex = function(mgr, fillTypeIndex, ...)
+        local result = origGetTexIdx(mgr, fillTypeIndex, ...)
+        if result == nil and fillTypeIndex then
+            local mapped = remap[fillTypeIndex]
+            if mapped then
+                result = origGetTexIdx(mgr, mapped, ...)
+            end
+        end
+        return result
+    end
+
+    self:registerCleanup("g_fillTypeManager.getTextureArrayIndexByFillTypeIndex", function()
+        fm.getTextureArrayIndexByFillTypeIndex = origGetTexIdx
+    end)
+
+    SoilLogger.info("[OK] Fill type material hook installed - %d custom types mapped to vanilla textures", count)
     return true
 end

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -362,36 +362,36 @@
     <e k="sf_pda_map_instructions" v="Drücken Sie Umschalt+M im Spiel, um Bodenebenen zu wechseln." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Bodenkarte öffnen" eh="0901ae30" />
     <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
-		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
-		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
-		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
+		<e k="sf_map_health_overall" v="Durchschn. Bodengesundheit" eh="5533cbe3" />
+		<e k="sf_map_btn_report" v="Hofübersicht öffnen" eh="6f0800e8" />
+		<e k="sf_map_btn_help" v="Hilfe" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ebene wechseln" />
     <e k="sf_map_btn_treatment" v="Behandlungsplan" />
     <e k="sf_map_btn_disable" v="Overlay deaktivieren" />
     <e k="sf_treat_action_ok" v="OK" />
-    <e k="sf_help_title" v="Soil Quick Reference" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." />
-    <e k="sf_help_status_header" v="STATUS LEVELS" />
-    <e k="sf_help_good" v="Good - No action needed." />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." />
+    <e k="sf_help_title" v="Boden-Schnellreferenz" />
+    <e k="sf_help_nutrients_header" v="NÄHRSTOFFE" />
+    <e k="sf_help_n" v="N  (Stickstoff)   - Schnell erschöpft. UAN, Harnstoff oder Mist ausbringen." />
+    <e k="sf_help_p" v="P  (Phosphor)     - Langanhaltend. MAP oder DAP ausbringen." />
+    <e k="sf_help_k" v="K  (Kalium)       - Kali ausbringen. Wichtig für Wurzeln." />
+    <e k="sf_help_om" v="OS (Organisch)    - Baut sich langsam auf. Mist/Kompost einpflügen." />
+    <e k="sf_help_soil_header" v="BODENCHEMIE" />
+    <e k="sf_help_ph" v="pH  6,5-7,0 = Ideal.  &lt; 6,5 Kalk ausbringen.  &gt; 7,5 Gips ausbringen." />
+    <e k="sf_help_pressure_header" v="PFLANZENDRUCK" />
+    <e k="sf_help_weed" v="Unkraut  &gt; 20% - Herbizid ausbringen." />
+    <e k="sf_help_pest" v="Schädling &gt; 20% - Insektizid ausbringen." />
+    <e k="sf_help_disease" v="Krankheit &gt; 20% - Fungizid ausbringen." />
+    <e k="sf_help_status_header" v="STATUSNIVEAUS" />
+    <e k="sf_help_good" v="Gut - Keine Aktion erforderlich." />
+    <e k="sf_help_fair" v="Mittel - Beobachten / vorbeugend nachdüngen." />
+    <e k="sf_help_poor" v="Schlecht - Sofortige Behandlung erforderlich." />
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Alle Felder" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Feld" eh="6f16a5f8" />
     <e k="sf_pda_col_n" v="N%" eh="30740562" />
     <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
-		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
-		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
+		<e k="sf_pda_filter_all" v="Filter: Alle Felder" eh="a46a8cb2" />
+		<e k="sf_pda_filter_owned" v="Filter: Nur eigene Felder" eh="258cb971" />
     <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
     <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
@@ -456,12 +456,12 @@
     <e k="sf_detail_rotation_fatigue" v="Ermüdung (x1,15 Verarmung)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Keine Daten verfügbar." eh="c6d95d5e" />
     <e k="sf_detail_no_crop" v="Nichts aufgezeichnet" eh="a4b5a996" />
-    <e k="sf_pda_btn_help" v="Entwicklernotiz" eh="5320d63f" />
+    <e k="sf_pda_btn_help" v="Hilfe" eh="5320d63f" />
     <e k="sf_pda_help_github" v="DEIN FEEDBACK ZÄHLT! Wenn du Fehler findest, Vorschläge für neue Funktionen hast oder zum Code beitragen möchtest, besuche das Projekt auf GitHub. Du kannst jederzeit ein Issue oder einen Pull Request öffnen, um diesen Mod für alle zu verbessern. Danke fürs Testen!" eh="3a10b023" />
-		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
+		<e k="sf_pda_help_note" v="Hinweis: Die Bodenkartenebenen sind jetzt direkt über ESC → Karte erreichbar." eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Hallo, ich bin der Entwickler! Wie du sehen kannst, ist diese Seite noch stark in Arbeit. Die Kartenebenen sind derzeit nur visuelle Vorschauen (für die Auswahl nicht funktionsfähig), und viele UI-Elemente brauchen noch den letzten Schliff." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Klicke auf ein Feld, um es auf der Karte anzuzeigen" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="Die Bodenkartenebenen wurden verschoben! Alle Bodenebenen sind jetzt direkt über die native PDA-Karte erreichbar (ESC → Karte). Suche nach der Kategorie 'Bodenebenen' in der Seitenleiste." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Gesamt benötigt Aufmerksamkeit" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Die rechts aufgelisteten Felder benötigen Behandlung. Klicke auf eine Zeile, um empfohlene Mittel und geschätzte Mengen zu sehen." eh="5748d316" />
     </elements>


### PR DESCRIPTION
## Summary

- **AI empty-tank vanilla fallback fixed**: When the AI helper's custom fertilizer tank ran dry, `getExternalFill` fell through to vanilla FERTILIZER due to our fill unit patch. New hook on `Sprayer.getExternalFill` intercepts per-vehicle `_soilLastCustomFillType` to return the correct custom product (with 1.5× AI buy-mode pricing) or stop cleanly if buy mode is off. Closes #125.
- **Fill planes now show correct material** (issue #180): `updateFillUnitFillPlane` and `FillVolume.onUpdate` both call `getTextureArrayIndexByFillTypeIndex` — nil for our custom types → shader never updated. New hook remaps custom indices to vanilla equivalents (solid → FERTILIZER, liquid → LIQUIDFERTILIZER) so fill planes and hopper meshes display the correct colour.
- **Spray/spread visual effects restored**: Same fill type material hook also fixes `FillVolume.onUpdate`'s hopper mesh shader. Additionally, INSECTICIDE and FUNGICIDE were missing from the effect type remap and spray type injection arrays — both now added.

## Test plan

- [ ] Load spreader with custom solid type (e.g. UREA) — confirm fill plane shows granule colour
- [ ] Load sprayer with custom liquid type (e.g. UAN32) — confirm tank fill plane shows liquid colour
- [ ] Run AI helper with custom fertilizer + Buy Fertilizer ON — verify correct product applied and cost deducted, no vanilla fallback
- [ ] Run AI helper until tank empties, Buy Fertilizer OFF — verify AI stops cleanly (no vanilla substitution)
- [ ] Spread INSECTICIDE / FUNGICIDE — confirm spray particles and animation appear