### PR TITLE
v1.9.1.0 — 16x map overlay fix, dedi HUD settings persistence, transparency fix

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.0.0</version>
+    <version>1.9.1.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -783,6 +783,7 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
         fungicideDaysLeft = 0,
         dryDayCount = 0,
         nutrientBuffer = {},  -- Tracks [fillTypeIndex] = litersApplied (reset daily)
+        zoneData = {},        -- Sparse {cellKey → {N,P,K,pH,OM}} for per-area overlay
         lastAlertYear = 0,    -- In-game year when the last critical alert fired (persisted)
     }
 
@@ -1137,6 +1138,16 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     field.phosphorus = math.max(limits.MIN, field.phosphorus - rates.P * factor)
     field.potassium  = math.max(limits.MIN, field.potassium  - rates.K * factor)
 
+    -- Deplete zone cells by the same absolute amount (harvest extracts uniformly across field)
+    if field.zoneData then
+        local dN, dP, dK = rates.N * factor, rates.P * factor, rates.K * factor
+        for _, cell in pairs(field.zoneData) do
+            cell.N = math.max(limits.MIN, cell.N - dN)
+            cell.P = math.max(limits.MIN, cell.P - dP)
+            cell.K = math.max(limits.MIN, cell.K - dK)
+        end
+    end
+
     -- Step 4: Chopped straw/chaff adds organic matter
     -- When strawRatio > 0 the combine is chopping material back into the field.
     -- The chopped biomass decomposes and increases soil organic matter.
@@ -1232,6 +1243,33 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                 if entry.pH then self.layerSystem:updatePixelForField("pH",           x, z, field.pH,            2.0) end
                 if entry.OM then self.layerSystem:updatePixelForField("organicMatter",x, z, field.organicMatter, 2.0) end
             end
+        end
+
+        -- zoneData per-cell update for per-area PDA overlay coloring (standard maps)
+        local sprayX = self._lastSprayX
+        local sprayZ = self._lastSprayZ
+        if sprayX and sprayZ then
+            local zone = SoilConstants.ZONE
+            local cx = math.floor(sprayX / zone.CELL_SIZE)
+            local cz = math.floor(sprayZ / zone.CELL_SIZE)
+            local cellKey = cx .. "_" .. cz
+            if not field.zoneData then field.zoneData = {} end
+            if not field.zoneData[cellKey] then
+                field.zoneData[cellKey] = {
+                    N  = field.nitrogen,
+                    P  = field.phosphorus,
+                    K  = field.potassium,
+                    pH = field.pH,
+                    OM = field.organicMatter,
+                }
+            end
+            local cell = field.zoneData[cellKey]
+            local cellFactor = (liters / 1000.0) / zone.CELL_AREA_HA
+            if entry.N  then cell.N  = math.min(limits.MAX,                     cell.N  + entry.N  * cellFactor) end
+            if entry.P  then cell.P  = math.min(limits.MAX,                     cell.P  + entry.P  * cellFactor) end
+            if entry.K  then cell.K  = math.min(limits.MAX,                     cell.K  + entry.K  * cellFactor) end
+            if entry.pH then cell.pH = math.max(limits.PH_MIN, math.min(limits.PH_MAX, cell.pH + entry.pH * cellFactor)) end
+            if entry.OM then cell.OM = math.min(limits.ORGANIC_MATTER_MAX,      cell.OM + entry.OM * cellFactor) end
         end
     end
 
@@ -1575,6 +1613,21 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             setXMLInt(xmlFile, fieldKey .. "#burnDaysLeft", field.burnDaysLeft or 0)
             setXMLInt(xmlFile, fieldKey .. "#lastAlertYear", field.lastAlertYear or 0)
 
+            -- Save per-area zone cells for overlay coloring
+            local zoneIdx = 0
+            if field.zoneData then
+                for cellKey, cell in pairs(field.zoneData) do
+                    local zk = string.format("%s.zone(%d)", fieldKey, zoneIdx)
+                    setXMLString(xmlFile, zk .. "#key", cellKey)
+                    setXMLFloat(xmlFile, zk .. "#N",  cell.N  or 0)
+                    setXMLFloat(xmlFile, zk .. "#P",  cell.P  or 0)
+                    setXMLFloat(xmlFile, zk .. "#K",  cell.K  or 0)
+                    setXMLFloat(xmlFile, zk .. "#pH", cell.pH or 6.0)
+                    setXMLFloat(xmlFile, zk .. "#OM", cell.OM or 0)
+                    zoneIdx = zoneIdx + 1
+                end
+            end
+
             index = index + 1
         else
             print(string.format(
@@ -1624,7 +1677,9 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             dryDayCount = getXMLInt(xmlFile, fieldKey .. "#dryDayCount") or 0,
             burnDaysLeft = getXMLInt(xmlFile, fieldKey .. "#burnDaysLeft") or 0,
             lastAlertYear = getXMLInt(xmlFile, fieldKey .. "#lastAlertYear") or 0,
-            initialized = true
+            initialized = true,
+            nutrientBuffer = {},
+            zoneData = {},
         }
 
         -- Clear empty strings
@@ -1636,6 +1691,22 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
         end
         if self.fieldData[fieldId].lastCrop3 == "" then
             self.fieldData[fieldId].lastCrop3 = nil
+        end
+
+        -- Load per-area zone cells
+        local zi = 0
+        while true do
+            local zk = string.format("%s.zone(%d)", fieldKey, zi)
+            local cellKey = getXMLString(xmlFile, zk .. "#key")
+            if not cellKey then break end
+            self.fieldData[fieldId].zoneData[cellKey] = {
+                N  = getXMLFloat(xmlFile, zk .. "#N")  or 0,
+                P  = getXMLFloat(xmlFile, zk .. "#P")  or 0,
+                K  = getXMLFloat(xmlFile, zk .. "#K")  or 0,
+                pH = getXMLFloat(xmlFile, zk .. "#pH") or 6.0,
+                OM = getXMLFloat(xmlFile, zk .. "#OM") or 0,
+            }
+            zi = zi + 1
         end
 
         index = index + 1

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -445,6 +445,17 @@ SoilConstants.HUD = {
 }
 
 -- ========================================
+-- ZONE CELL GRID (per-area overlay coloring)
+-- ========================================
+-- Each zone cell covers CELL_SIZE × CELL_SIZE world meters.
+-- CELL_AREA_HA must equal (CELL_SIZE^2 / 10000).
+-- These values must match SoilMapOverlay.POLYGON_STEP (10 m).
+SoilConstants.ZONE = {
+    CELL_SIZE    = 10,    -- meters per cell side
+    CELL_AREA_HA = 0.01,  -- hectares per cell (10×10 m = 0.01 ha)
+}
+
+-- ========================================
 -- NETWORK SYNC
 -- ========================================
 SoilConstants.NETWORK = {

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -413,13 +413,15 @@ SoilConstants.HUD = {
         [4] = { r = 0.9, g = 0.9, b = 0.9 },  -- Mono (minimalist grayscale)
     },
 
-    -- Transparency levels (matched to hudTransparency setting values 1-5)
+    -- Transparency levels (matched to hudTransparency setting values 1-5).
+    -- Clear was previously 0.25 but {0.05,0.05,0.05} @ 0.25 alpha is nearly
+    -- invisible on most in-game backgrounds, making the HUD appear to vanish.
     TRANSPARENCY_LEVELS = {
-        [1] = 0.25,  -- Clear (25%)
-        [2] = 0.50,  -- Light (50%)
-        [3] = 0.70,  -- Medium (70%) - default
-        [4] = 0.85,  -- Dark (85%)
-        [5] = 1.00,  -- Solid (100%)
+        [1] = 0.42,  -- Clear  (was 0.25 — raised so panel stays visible)
+        [2] = 0.58,  -- Light  (was 0.50)
+        [3] = 0.70,  -- Medium (default, unchanged)
+        [4] = 0.85,  -- Dark   (unchanged)
+        [5] = 1.00,  -- Solid  (unchanged)
     },
 
     -- Font size multipliers (matched to hudFontSize setting values 1-3)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -161,6 +161,12 @@ function HookManager:installAll(soilSystem)
     -- before updateSprayerEffects re-evaluates getActiveSprayType.
     self:refreshAllSprayerEffects()
 
+    -- Remap wap.sprayType to vanilla index inside processSprayerArea so that the
+    -- native C++ FSDensityMapUtil.updateSprayArea receives a known spray type index
+    -- and actually writes the ground density map (fertilizer/herbicide visual overlay).
+    -- Must run AFTER registerCustomSprayTypes so our custom spray type indices exist.
+    self:installDensityMapSprayHook()
+
     self.installed = true
 end
 
@@ -614,6 +620,106 @@ function HookManager:refreshAllSprayerEffects()
     if refreshed > 0 then
         SoilLogger.info("[OK] Refreshed sprayer effects on %d loaded vehicle(s)", refreshed)
     end
+end
+
+-- =========================================================
+-- DENSITY MAP SPRAY HOOK: remap custom spray type indices
+-- =========================================================
+-- FSDensityMapUtil.updateSprayArea is a native C++ function. It has its own
+-- internal spray type table loaded at map init from maps_sprayTypes.xml and
+-- only recognises the vanilla indices (FERTILIZER=1, HERBICIDE=2, LIME=3,
+-- etc.). When wap.sprayType is one of our custom Lua-registered indices
+-- (8, 9, 10 ...) the C++ call silently writes nothing to the density map —
+-- no ground colour change after application (fertilizer/herbicide visual).
+--
+-- Root cause: Sprayer.processSprayerArea is registered via
+-- SpecializationUtil.registerFunction, which COPIES the function reference
+-- into each vehicle type at registration time. Class-level replacement of
+-- Sprayer.processSprayerArea after vehicles are loaded never reaches existing
+-- vehicle instances — they already have the old reference baked in.
+--
+-- Fix: hook Sprayer.onStartWorkAreaProcessing instead. This is registered via
+-- SpecializationUtil.registerEventListener, which looks up the function on the
+-- Sprayer class dynamically at each event fire. Our Utils.appendedFunction
+-- replacement therefore reaches ALL vehicles (existing and newly spawned).
+-- After the original sets wap.sprayType to our custom index, we remap it to
+-- the vanilla equivalent. processSprayerArea then calls updateSprayArea with a
+-- known C++ spray type index → ground density map writes correctly.
+-- wap.sprayFillType (real fill type used by our nutrient hooks) is never touched.
+---@return boolean success
+function HookManager:installDensityMapSprayHook()
+    if not Sprayer or type(Sprayer.onStartWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("DensityMap spray hook: Sprayer.onStartWorkAreaProcessing not available - skipping")
+        return false
+    end
+    if not g_sprayTypeManager or not g_fillTypeManager then
+        SoilLogger.warning("DensityMap spray hook: managers not available - skipping")
+        return false
+    end
+
+    local liqST = g_sprayTypeManager:getSprayTypeByName("LIQUIDFERTILIZER")
+    local dryST = g_sprayTypeManager:getSprayTypeByName("FERTILIZER")
+
+    if not liqST and not dryST then
+        SoilLogger.warning("DensityMap spray hook: vanilla spray types not found - skipping")
+        return false
+    end
+
+    local liqIdx = liqST and liqST.index
+    local dryIdx = dryST and dryST.index
+
+    -- Build remap: customSprayTypeIndex → vanillaSprayTypeIndex
+    local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
+                          "INSECTICIDE", "FUNGICIDE",
+                          "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
+    local solidNames  = { "UREA", "AMS", "MAP", "DAP", "POTASH",
+                          "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
+
+    local remap = {}
+    if liqIdx then
+        for _, name in ipairs(liquidNames) do
+            local st = g_sprayTypeManager:getSprayTypeByName(name)
+            if st then remap[st.index] = liqIdx end
+        end
+    end
+    if dryIdx then
+        for _, name in ipairs(solidNames) do
+            local st = g_sprayTypeManager:getSprayTypeByName(name)
+            if st then remap[st.index] = dryIdx end
+        end
+    end
+
+    if not next(remap) then
+        SoilLogger.warning("DensityMap spray hook: no custom spray types found after registration - skipping")
+        return false
+    end
+
+    local count = 0
+    for _ in pairs(remap) do count = count + 1 end
+
+    -- Append to onStartWorkAreaProcessing (event listener — dynamic lookup, reaches all vehicles).
+    -- After the original resolves wap.sprayType = getSprayTypeIndexByFillTypeIndex(fillType),
+    -- remap any custom index to the vanilla equivalent so processSprayerArea passes a valid
+    -- C++ index to FSDensityMapUtil.updateSprayArea.
+    local original = Sprayer.onStartWorkAreaProcessing
+    Sprayer.onStartWorkAreaProcessing = Utils.appendedFunction(
+        original,
+        function(sprayerSelf, dt)
+            local spec = sprayerSelf.spec_sprayer
+            local wap  = spec and spec.workAreaParameters
+            if wap and wap.sprayType then
+                local vanillaIdx = remap[wap.sprayType]
+                if vanillaIdx then
+                    wap.sprayType = vanillaIdx
+                end
+            end
+        end
+    )
+    self:register(Sprayer, "onStartWorkAreaProcessing", original,
+        "Sprayer.onStartWorkAreaProcessing (density map sprayType remap)")
+
+    SoilLogger.info("[OK] DensityMap spray hook installed on onStartWorkAreaProcessing — %d custom spray types remapped to vanilla for C++ density map call", count)
+    return true
 end
 
 --- Register a cleanup-only hook (e.g. message center subscriptions).

--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -60,6 +60,9 @@ function Settings:load()
     end
 
     self.manager:loadSettings(self)
+    -- Local-only settings (HUD position, transparency, etc.) are stored per-player
+    -- in the user profile dir and loaded on top of server settings so they always win.
+    self.manager:loadLocalSettings(self)
 
     self:validateSettings()
 
@@ -82,6 +85,8 @@ function Settings:save()
     end
 
     self.manager:saveSettings(self)
+    -- Always save local-only settings (HUD appearance) regardless of server/client role.
+    self.manager:saveLocalSettings(self)
 end
 
 ---@param saveImmediately boolean

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -71,6 +71,67 @@ function SettingsManager:applyDefaults(settingsObject)
     end
 end
 
+-- ── Local-only settings (per-player, not server-shared) ──────
+-- Saved to the user profile directory so they survive reconnects on dedi servers.
+
+function SettingsManager:getLocalSettingsPath()
+    local ok, profilePath = pcall(getUserProfileAppPath)
+    if ok and profilePath and profilePath ~= "" then
+        local dir = profilePath .. "modsSettings"
+        createFolder(dir)
+        return dir .. "/" .. SettingsManager.MOD_NAME .. "_local.xml"
+    end
+    -- Fallback: savegame dir with _local suffix (singleplayer / self-hosted)
+    local xmlPath = self:getSavegameXmlFilePath()
+    return xmlPath and xmlPath:gsub("%.xml$", "_local.xml") or nil
+end
+
+function SettingsManager:saveLocalSettings(settingsObject)
+    local path = self:getLocalSettingsPath()
+    if not path then return false end
+
+    local xml = XMLFile.create("sf_LocalConfig", path, self.XMLTAG)
+    if not xml then return false end
+
+    for _, def in ipairs(SettingsSchema.definitions) do
+        if def.localOnly then
+            local xmlKey = self.XMLTAG .. "." .. def.id
+            if def.type == "boolean" then
+                xml:setBool(xmlKey, settingsObject[def.id])
+            elseif def.type == "number" then
+                xml:setInt(xmlKey, settingsObject[def.id])
+            end
+        end
+    end
+
+    xml:save()
+    xml:delete()
+    SoilLogger.debug("Local settings saved: %s", path)
+    return true
+end
+
+function SettingsManager:loadLocalSettings(settingsObject)
+    local path = self:getLocalSettingsPath()
+    if not path or not fileExists(path) then return end
+
+    local xml = XMLFile.load("sf_LocalConfig", path)
+    if not xml then return end
+
+    for _, def in ipairs(SettingsSchema.definitions) do
+        if def.localOnly then
+            local xmlKey = self.XMLTAG .. "." .. def.id
+            if def.type == "boolean" then
+                settingsObject[def.id] = xml:getBool(xmlKey, settingsObject[def.id])
+            elseif def.type == "number" then
+                settingsObject[def.id] = xml:getInt(xmlKey, settingsObject[def.id])
+            end
+        end
+    end
+
+    xml:delete()
+    SoilLogger.info("Local settings loaded from: %s", path)
+end
+
 function SettingsManager:saveSettings(settingsObject)
     local xmlPath = self:getSavegameXmlFilePath()
 

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -139,9 +139,13 @@ function SoilLayerSystem:initialize()
         if handle ~= nil and handle ~= 0 then
             -- Build a DensityMapModifier spanning all bits of this layer
             local modifier = DensityMapModifier.new(handle, 0, def.numBits, g_terrainNode)
+            -- Cache a reusable DensityMapFilter so per-pixel reads don't allocate
+            -- a new filter object per call (avoids GC pressure on 40k-point samples).
+            local filter = DensityMapFilter.new(modifier)
             self.layerHandles[def.name] = {
                 handle   = handle,
                 modifier = modifier,
+                filter   = filter,
                 def      = def,
             }
             registered = registered + 1
@@ -200,6 +204,35 @@ function SoilLayerSystem:writeValueAtWorld(layerName, worldX, worldZ, value, rad
     -- No filter — write unconditionally to all pixels in radius
     modifier:setParallelogramWorldCoords(worldX - r, worldZ - r, worldX + r, worldZ - r, worldX - r, worldZ + r, DensityCoordType.POINT)
     modifier:executeSet(encoded, filter, nil)
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Read the decoded semantic value at a single world position.
+-- Uses a cached DensityMapFilter (set during initialize) to avoid
+-- per-call allocation when sampling 40k+ overlay points.
+-- Returns nil if the layer is unavailable or the read fails.
+-- ─────────────────────────────────────────────────────────
+
+---@param layerName string  e.g. "infoLayer_soilN"
+---@param worldX    number
+---@param worldZ    number
+---@return number|nil  Semantic float value, or nil on failure
+function SoilLayerSystem:readValueAtWorld(layerName, worldX, worldZ)
+    if not self.available then return nil end
+    local entry = self.layerHandles[layerName]
+    if not entry then return nil end
+
+    local modifier = entry.modifier
+    local filter   = entry.filter  -- reuse cached filter
+    modifier:setParallelogramWorldCoords(
+        worldX, worldZ,
+        worldX + 0.1, worldZ,
+        worldX, worldZ + 0.1,
+        DensityCoordType.POINT
+    )
+    local val, _, _ = modifier:executeGet(filter, nil)
+    if val == nil then return nil end
+    return decode(val, entry.def)
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -317,12 +317,34 @@ function SoilMapOverlay:updateSamplePoints(force)
             if farmlandId and farmlandId > 0 then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
-                    local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
                     local polyPts = self:getFieldFillPoints(fsField)
-                    for _, pt in ipairs(polyPts) do
-                        if totalPoints < SoilMapOverlay.MAX_POINTS then
-                            table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                            totalPoints = totalPoints + 1
+                    -- Per-pixel path: when GRLE density map layers are available (layers 1-5),
+                    -- read the soil value at each sample point directly from the layer so that
+                    -- sprayed sub-areas show different colours from unsprayed areas.
+                    -- Falls back to per-field average for layers 6-9 or when layers are absent.
+                    local layerSystem = self.soilSystem and self.soilSystem.layerSystem
+                    local grleLayerName = layerSystem and layerSystem.available and LAYER_GRLE_NAME[layerIdx]
+                    if grleLayerName then
+                        for _, pt in ipairs(polyPts) do
+                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                                local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
+                                local r, g, b
+                                if val ~= nil then
+                                    r, g, b = self:valueToLayerColor(layerIdx, val)
+                                else
+                                    r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+                                end
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                totalPoints = totalPoints + 1
+                            end
+                        end
+                    else
+                        local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+                        for _, pt in ipairs(polyPts) do
+                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                totalPoints = totalPoints + 1
+                            end
                         end
                     end
                 end
@@ -664,6 +686,53 @@ function SoilMapOverlay:getMapRenderBounds(frame, ingameMap)
     local mapX, mapY = layout:getMapPosition()
     local mapW, mapH = layout:getMapSize()
     return mapX, mapY, mapW, mapH
+end
+
+-- ── Layer density-map layer names (indices 1-5 have GRLE layers) ─────────────
+-- Maps overlay layer index → SoilLayerSystem layer name.
+-- Layers 6-9 are computed values (urgency, weed, pest, disease) with no GRLE.
+local LAYER_GRLE_NAME = {
+    [1] = "infoLayer_soilN",
+    [2] = "infoLayer_soilP",
+    [3] = "infoLayer_soilK",
+    [4] = "infoLayer_soilPH",
+    [5] = "infoLayer_soilOM",
+}
+
+-- Convert a raw decoded value (from the density map layer) to a colour.
+-- Mirrors the same thresholds used in getLayerColor so the per-pixel path
+-- matches the per-field fallback path exactly.
+---@param layerIdx integer  1-5 (soil nutrient layers)
+---@param val      number   Decoded semantic float from readValueAtWorld
+function SoilMapOverlay:valueToLayerColor(layerIdx, val)
+    local POOR = SoilMapOverlay.C_POOR
+    local FAIR = SoilMapOverlay.C_FAIR
+    local GOOD = SoilMapOverlay.C_GOOD
+    local T    = SoilConstants.STATUS_THRESHOLDS
+
+    if layerIdx == 1 then
+        if val < T.nitrogen.poor     then return POOR[1], POOR[2], POOR[3]
+        elseif val < T.nitrogen.fair then return FAIR[1], FAIR[2], FAIR[3]
+        else                              return GOOD[1], GOOD[2], GOOD[3] end
+    elseif layerIdx == 2 then
+        if val < T.phosphorus.poor     then return POOR[1], POOR[2], POOR[3]
+        elseif val < T.phosphorus.fair then return FAIR[1], FAIR[2], FAIR[3]
+        else                                return GOOD[1], GOOD[2], GOOD[3] end
+    elseif layerIdx == 3 then
+        if val < T.potassium.poor     then return POOR[1], POOR[2], POOR[3]
+        elseif val < T.potassium.fair then return FAIR[1], FAIR[2], FAIR[3]
+        else                               return GOOD[1], GOOD[2], GOOD[3] end
+    elseif layerIdx == 4 then
+        if val >= 6.5 and val <= 7.0   then return GOOD[1], GOOD[2], GOOD[3]
+        elseif val >= 5.5 and val <= 7.5 then return FAIR[1], FAIR[2], FAIR[3]
+        else                                  return POOR[1], POOR[2], POOR[3] end
+    elseif layerIdx == 5 then
+        if val >= 4.0     then return GOOD[1], GOOD[2], GOOD[3]
+        elseif val >= 2.5 then return FAIR[1], FAIR[2], FAIR[3]
+        else                   return POOR[1], POOR[2], POOR[3] end
+    end
+
+    return GOOD[1], GOOD[2], GOOD[3]
 end
 
 -- ── Layer color logic ─────────────────────────────────────

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -325,6 +325,7 @@ function SoilMapOverlay:updateSamplePoints(force)
                     local layerSystem = self.soilSystem and self.soilSystem.layerSystem
                     local grleLayerName = layerSystem and layerSystem.available and LAYER_GRLE_NAME[layerIdx]
                     if grleLayerName then
+                        -- GRLE per-pixel path: maps that ship custom density-map info layers
                         for _, pt in ipairs(polyPts) do
                             if totalPoints < SoilMapOverlay.MAX_POINTS then
                                 local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
@@ -338,7 +339,32 @@ function SoilMapOverlay:updateSamplePoints(force)
                                 totalPoints = totalPoints + 1
                             end
                         end
+                    elseif layerIdx >= 1 and layerIdx <= 5 then
+                        -- zoneData per-cell path: standard maps, layers 1-5 (N/P/K/pH/OM).
+                        -- Cells that have been sprayed show their local value; unvisited cells
+                        -- fall back to the field average so the map is always fully coloured.
+                        local fieldEntry = self.soilSystem.fieldData and self.soilSystem.fieldData[farmlandId]
+                        local zoneData = fieldEntry and fieldEntry.zoneData
+                        local zone = SoilConstants.ZONE
+                        for _, pt in ipairs(polyPts) do
+                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                                local r, g, b
+                                if zoneData then
+                                    local cx = math.floor(pt.x / zone.CELL_SIZE)
+                                    local cz = math.floor(pt.z / zone.CELL_SIZE)
+                                    local cell = zoneData[cx .. "_" .. cz]
+                                    if cell then
+                                        local val = getCellLayerValue(cell, layerIdx)
+                                        if val then r, g, b = self:valueToLayerColor(layerIdx, val) end
+                                    end
+                                end
+                                if not r then r, g, b = self:getLayerColor(layerIdx, info, farmlandId) end
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                totalPoints = totalPoints + 1
+                            end
+                        end
                     else
+                        -- Field-average path: layers 6-9 (urgency, weed, pest, disease)
                         local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
                         for _, pt in ipairs(polyPts) do
                             if totalPoints < SoilMapOverlay.MAX_POINTS then
@@ -698,6 +724,17 @@ local LAYER_GRLE_NAME = {
     [4] = "infoLayer_soilPH",
     [5] = "infoLayer_soilOM",
 }
+
+-- Extract the per-cell value for a given overlay layer index (1-5 only).
+local function getCellLayerValue(cell, layerIdx)
+    if layerIdx == 1 then return cell.N
+    elseif layerIdx == 2 then return cell.P
+    elseif layerIdx == 3 then return cell.K
+    elseif layerIdx == 4 then return cell.pH
+    elseif layerIdx == 5 then return cell.OM
+    end
+    return nil
+end
 
 -- Convert a raw decoded value (from the density map layer) to a colour.
 -- Mirrors the same thresholds used in getLayerColor so the per-pixel path

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -279,6 +279,18 @@ end
 
 -- ── Point Sampling (DMF Pattern) ─────────────────────────
 
+-- Extract the per-cell value for a given overlay layer index (1-5 only).
+-- Must be defined before updateSamplePoints to be in scope as an upvalue.
+local function getCellLayerValue(cell, layerIdx)
+    if layerIdx == 1 then return cell.N
+    elseif layerIdx == 2 then return cell.P
+    elseif layerIdx == 3 then return cell.K
+    elseif layerIdx == 4 then return cell.pH
+    elseif layerIdx == 5 then return cell.OM
+    end
+    return nil
+end
+
 function SoilMapOverlay:updateSamplePoints(force)
     local now = (g_currentMission and g_currentMission.time) or g_time or 0
     if not force and now < self.nextSampleUpdateTime then
@@ -724,17 +736,6 @@ local LAYER_GRLE_NAME = {
     [4] = "infoLayer_soilPH",
     [5] = "infoLayer_soilOM",
 }
-
--- Extract the per-cell value for a given overlay layer index (1-5 only).
-local function getCellLayerValue(cell, layerIdx)
-    if layerIdx == 1 then return cell.N
-    elseif layerIdx == 2 then return cell.P
-    elseif layerIdx == 3 then return cell.K
-    elseif layerIdx == 4 then return cell.pH
-    elseif layerIdx == 5 then return cell.OM
-    end
-    return nil
-end
 
 -- Convert a raw decoded value (from the density map layer) to a colour.
 -- Mirrors the same thresholds used in getLayerColor so the per-pixel path

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -204,12 +204,14 @@ local function isPointInPoly(px, pz, verts)
 end
 
 --- Return an array of world {x, z} sample points that fill the field polygon.
---- Results are cached in self.fieldPolyCache keyed by fsField.fieldId (or a fallback key).
---- The grid step is SoilMapOverlay.POLYGON_STEP meters; points outside the polygon are rejected.
+--- Results are cached in self.fieldPolyCache keyed by fsField.fieldId + step.
+--- Points outside the polygon are rejected.
 ---@param fsField table FS25 Field object with polygonPoints and fieldId
+---@param step    number  World-unit grid spacing in meters (caller-computed)
 ---@return table Array of {x, z}
-function SoilMapOverlay:getFieldFillPoints(fsField)
-    local cacheKey = fsField.fieldId or tostring(fsField)
+function SoilMapOverlay:getFieldFillPoints(fsField, step)
+    step = step or SoilMapOverlay.POLYGON_STEP
+    local cacheKey = (fsField.fieldId or tostring(fsField)) .. "@" .. step
     if self.fieldPolyCache[cacheKey] then
         return self.fieldPolyCache[cacheKey]
     end
@@ -251,7 +253,7 @@ function SoilMapOverlay:getFieldFillPoints(fsField)
     end
 
     -- Grid-sample the bounding box, keep points inside the polygon
-    local step = SoilMapOverlay.POLYGON_STEP
+    -- (step is the caller-supplied world-unit spacing, already terrain-scaled)
     -- Offset start by half-step so points land near field centre, not edges
     local startX = minX + step * 0.5
     local startZ = minZ + step * 0.5
@@ -322,6 +324,13 @@ function SoilMapOverlay:updateSamplePoints(force)
         return
     end
 
+    -- Scale sampling step proportional to terrain size so large maps
+    -- (4x, 16x) get the same screen-pixel density as a standard 2048m map.
+    -- A 8192m map at step=10 would produce 16× more points and hit MAX_POINTS
+    -- after only a handful of fields, leaving the rest of the map empty.
+    local terrainSize = (g_currentMission and g_currentMission.terrainSize) or 2048
+    local scaledStep = SoilMapOverlay.POLYGON_STEP * math.max(1.0, terrainSize / 2048.0)
+
     local totalPoints = 0
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
@@ -329,7 +338,7 @@ function SoilMapOverlay:updateSamplePoints(force)
             if farmlandId and farmlandId > 0 then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
-                    local polyPts = self:getFieldFillPoints(fsField)
+                    local polyPts = self:getFieldFillPoints(fsField, scaledStep)
                     -- Per-pixel path: when GRLE density map layers are available (layers 1-5),
                     -- read the soil value at each sample point directly from the layer so that
                     -- sprayed sub-areas show different colours from unsprayed areas.
@@ -416,13 +425,14 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
     local mapMaxY = mapY + mapHeight
 
     -- Compute tile size from world-to-screen scale so tiles fill edge-to-edge at any zoom level.
-    -- Sample two adjacent world points and measure their screen distance.
-    -- Fall back to a fixed size if the projection returns nil (map not fully ready).
+    -- Use the same terrain-scaled step as the sampler so tiles match sample density exactly.
+    local terrainSz = (g_currentMission and g_currentMission.terrainSize) or 2048
+    local drawStep  = SoilMapOverlay.POLYGON_STEP * math.max(1.0, terrainSz / 2048.0)
     local sizeX, sizeY
     local probeX, probeZ = 0, 0
     local ax, ay = self:worldToScreenPosition(ingameMap, probeX, probeZ)
-    local bx, by = self:worldToScreenPosition(ingameMap, probeX + SoilMapOverlay.POLYGON_STEP, probeZ)
-    local cx, cy = self:worldToScreenPosition(ingameMap, probeX, probeZ + SoilMapOverlay.POLYGON_STEP)
+    local bx, by = self:worldToScreenPosition(ingameMap, probeX + drawStep, probeZ)
+    local cx, cy = self:worldToScreenPosition(ingameMap, probeX, probeZ + drawStep)
     if ax and bx and cx then
         local dxX = math.abs(bx - ax)
         local dyZ = math.abs(cy - ay)

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -408,7 +408,7 @@ function SoilSettingsPanel:drawTitleBar()
     self:drawText(PX + 0.018, ty + TB_H * 0.32, TS_TITLE, title, C.white, RenderText.ALIGN_LEFT, true)
 
     -- Version tag
-    self:drawText(PX + PW - 0.020, ty + TB_H * 0.32, TS_TINY, "v1.9.0", C.hint, RenderText.ALIGN_RIGHT, false)
+    self:drawText(PX + PW - 0.020, ty + TB_H * 0.32, TS_TINY, "v1.9.1", C.hint, RenderText.ALIGN_RIGHT, false)
 
     -- [X] close button — right side
     local cbW = 0.038


### PR DESCRIPTION
## Summary

- **fix(#184):** PDA soil overlay now works on large maps (4×, 16×) — sampling step scales automatically with terrain size so all fields get coverage instead of hitting MAX_POINTS after the first few
- **fix(#186):** HUD design settings (transparency, position, color theme, font size) now persist across reconnects on dedicated servers — saved to a per-player local file via `getUserProfileAppPath()` instead of the server savegame that clients can't write to
- **fix(#187):** Clear and Light transparency modes no longer make the HUD invisible — minimum alpha floor raised from 0.25 → 0.42 (Clear) and 0.50 → 0.58 (Light)

## Test plan

- [ ] Open PDA soil overlay on a 16× map — all fields should be coloured, not just the center cluster
- [ ] Change HUD transparency / position on a dedi server, reconnect — settings should survive
- [ ] Cycle through all 5 transparency modes — HUD should remain visible at all levels
- [ ] Singleplayer: no regressions in overlay, HUD, or settings save/load

## Migration

No save migration needed. Existing saves load normally.