### PR TITLE
v1.9.2.0 — Fix HUD crash on transparency change + color theme wired to background

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.1.0</version>
+    <version>1.9.2.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -620,11 +620,19 @@ function SoilHUD:drawPanel()
     local alpha = SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3]
     local fontMult = SoilConstants.HUD.FONT_SIZE_MULTIPLIERS[self.settings.hudFontSize or 2]
 
+    -- Blend the chosen color theme into the background so transparency changes are visible.
+    -- Pure black at any alpha looks identical; a slight tint from the theme accent makes
+    -- the difference between Clear (0.42) and Solid (1.00) actually perceptible.
+    local theme = SoilConstants.HUD.COLOR_THEMES[self.settings.hudColorTheme or 1]
+    local bgR = 0.05 + theme.r * 0.04
+    local bgG = 0.05 + theme.g * 0.04
+    local bgB = 0.05 + theme.b * 0.04
+
     -- Shadow
     self:drawRect(px + 0.003*s, py - 0.003*s, pw, ph, SoilHUD.C_SHADOW)
 
-    -- Background
-    self:drawRect(px, py, pw, ph, SoilHUD.C_BG, alpha)
+    -- Background (tinted by color theme, alpha set by transparency level)
+    self:drawRect(px, py, pw, ph, {bgR, bgG, bgB, 1}, alpha)
 
     -- Title bar
     local titleH = SoilHUD.TITLE_H * s
@@ -653,7 +661,6 @@ function SoilHUD:drawPanel()
 
     -- ── Content ───────────────────────────────────────────
     local transparency = self.settings.hudTransparency or 3
-    if transparency <= 2 then setTextShadow(true) end
     setTextAlignment(RenderText.ALIGN_LEFT)
 
     local pad  = SoilHUD.PAD * s
@@ -831,7 +838,6 @@ function SoilHUD:drawPanel()
     end
 
     -- Reset text state
-    if transparency <= 2 then setTextShadow(false) end
     setTextBold(false)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(1, 1, 1, 1)

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -408,7 +408,7 @@ function SoilSettingsPanel:drawTitleBar()
     self:drawText(PX + 0.018, ty + TB_H * 0.32, TS_TITLE, title, C.white, RenderText.ALIGN_LEFT, true)
 
     -- Version tag
-    self:drawText(PX + PW - 0.020, ty + TB_H * 0.32, TS_TINY, "v1.9.1", C.hint, RenderText.ALIGN_RIGHT, false)
+    self:drawText(PX + PW - 0.020, ty + TB_H * 0.32, TS_TINY, "v1.9.2", C.hint, RenderText.ALIGN_RIGHT, false)
 
     -- [X] close button — right side
     local cbW = 0.038


### PR DESCRIPTION
## Summary

- **fix:** Remove `setTextShadow()` calls — function does not exist in FS25's Lua sandbox; caused a nil crash on every draw frame when transparency was set to Clear or Light
- **fix:** HUD background now shows a subtle tint from the selected color theme so transparency level changes are visually perceptible (pure black at any alpha level looked identical)

## Root cause

The original issue #187 report ("panel disappears") was caused by the `setTextShadow` nil crash aborting the draw method — the background rendered but all text was skipped. The alpha-floor fix in 1.9.1.0 helped aesthetics but didn't fix the crash.

## Test plan

- [ ] Cycle through all 5 transparency modes — no log errors, panel visible at each level
- [ ] Switch color theme — background tint should reflect the active theme
- [ ] Verify no regressions in HUD layout, nutrient bars, or field detection