### PR TITLE
v1.9.4.0 — Gypsum pH fix, tillage pressure reset, and purchasable organic/lime shop items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.4.0] - 2026-04-19
+
+### Added
+
+- **Purchasable big bags for Compost, Biosolids, Chicken Manure, and Pelletized Manure**: All
+  four organic fertilizers are now available as purchasable big bags in the shop. Previously
+  these were only obtainable through on-farm production or compatible mods. Compost ($300),
+  Biosolids ($500), Chicken Manure ($600), Pelletized Manure ($1000) — single-unit and
+  multi-purchase options included.
+
+- **Purchasable Liquid Lime IBC tank**: Liquid Lime is now available as a purchasable IBC-style
+  liquid tank ($1200 / 2000 L) in the shop, consistent with other liquid fertilizer products.
+  Apply with a sprayer to raise field pH.
+
+### Fixed
+
+- **Gypsum now correctly lowers soil pH**: The gypsum fertilizer profile had `pH=0.0` (no
+  effect) while the Treatment dialog recommended applying it for alkaline fields (pH > 7.5).
+  Gypsum now applies a −0.10 pH delta per application (~−0.25 pH shift at the 1500 kg/ha base
+  rate), giving players an actual tool to manage alkaline soil. Fill type title updated from
+  `(pH+)` to `(pH−)` across all 26 languages.
+
+- **Tillage reduces weed, pest, and disease pressure**: Any cultivator or plow pass now reduces
+  active weed, pest, and disease pressure on the field. Closes #188.
+
+---
+
 ## [1.9.3.0] - 2026-04-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **1.8.5.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
+**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **1.9.4.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.9.3.0
-**Last Updated**: 2026-04-18
+**Version**: 1.9.4.0
+**Last Updated**: 2026-04-19
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ All three are visible in the HUD and the full Soil Report. Each can be toggled o
 | Liquid Potash | Liquid K | Dissolved potassium for sprayers |
 | Insecticide | Liquid | Pest pressure treatment (sprayer) |
 | Fungicide | Liquid | Disease pressure treatment (sprayer) |
+| Liquid Lime | Liquid pH agent | Raises pH via sprayer — alternative to dry lime |
 
 **Custom dry/solid fertilizers (purchasable big bags in shop):**
 
@@ -122,9 +123,13 @@ All three are visible in the HUD and the full Soil Report. Each can be toggled o
 | Urea / AMS | Dry nitrogen | Standard granular N sources |
 | MAP / DAP | Dry P+N | Phosphorus-focused blends |
 | Potash | Dry K | Pure potassium supplement |
-| Gypsum | Dry amendment | pH correction and soil structure improvement |
+| Gypsum | Dry amendment | Lowers pH and improves soil structure |
+| Compost | Organic amendment | Best OM builder per application |
+| Biosolids | Organic fertilizer | Municipal organic N+P amendment |
+| Chicken Manure | Organic fertilizer | Concentrated N+P poultry litter |
+| Pelletized Manure | Organic fertilizer | Dense balanced NPK+OM — highest analysis |
 
-**Organic / soil amendments (registered, obtained from compatible mods or production lines):**
+**Organic / soil amendments (nutrient profiles):**
 
 | Product | Application | N | P | K | OM | Notes |
 |---|---|---|---|---|---|---|
@@ -132,7 +137,7 @@ All three are visible in the HUD and the full Soil Report. Each can be toggled o
 | **Biosolids** | Spreader | ●●○○○ | ●●○○○ | Low | ✓ | Municipal organic amendment |
 | **Chicken Manure** | Spreader | ●●●○○ | ●●●○○ | ●●○○○ | ✓ | Concentrated poultry litter |
 | **Pelletized Manure** | Spreader | ●●●●○ | ●●●●○ | ●●●●○ | ✓ | Dense balanced organic NPK |
-| **Gypsum** | Spreader | — | — | — | Low | pH correction, minor OM gain |
+| **Gypsum** | Spreader | — | — | — | Low | Lowers pH, minor OM gain |
 | **Liquid Lime** | Sprayer | — | — | — | — | Raises pH via sprayer equipment |
 
 > [!NOTE]
@@ -344,7 +349,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.9.3.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.9.4.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -138,6 +138,10 @@
         <storeItem xmlFilename="objects/bigBag/dap/multiPurchaseBigBag_dap.xml"/>
         <storeItem xmlFilename="objects/bigBag/potash/multiPurchaseBigBag_potash.xml"/>
         <storeItem xmlFilename="objects/bigBag/gypsum/multiPurchaseBigBag_gypsum.xml"/>
+        <storeItem xmlFilename="objects/bigBag/compost/multiPurchaseBigBag_compost.xml"/>
+        <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml"/>
+        <storeItem xmlFilename="objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure.xml"/>
         <!-- IBC Liquid Tanks (single) -->
         <storeItem xmlFilename="objects/liquidTank/uan32/liquidTank_uan32.xml"/>
         <storeItem xmlFilename="objects/liquidTank/uan28/liquidTank_uan28.xml"/>
@@ -150,6 +154,7 @@
         <storeItem xmlFilename="objects/liquidTank/liquid_potash/liquidTank_liquid_potash.xml"/>
         <storeItem xmlFilename="objects/liquidTank/insecticide/liquidTank_insecticide.xml"/>
         <storeItem xmlFilename="objects/liquidTank/fungicide/liquidTank_fungicide.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquidlime/liquidTank_liquidlime.xml"/>
         <!-- Big Bags / Solid (single) -->
         <storeItem xmlFilename="objects/bigBag/urea/bigBag_urea.xml"/>
         <storeItem xmlFilename="objects/bigBag/ams/bigBag_ams.xml"/>
@@ -157,6 +162,10 @@
         <storeItem xmlFilename="objects/bigBag/dap/bigBag_dap.xml"/>
         <storeItem xmlFilename="objects/bigBag/potash/bigBag_potash.xml"/>
         <storeItem xmlFilename="objects/bigBag/gypsum/bigBag_gypsum.xml"/>
+        <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost.xml"/>
+        <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids.xml"/>
+        <storeItem xmlFilename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml"/>
     </storeItems>
 
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.3.0</version>
+    <version>1.9.4.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/objects/bigBag/biosolids/bigBag_biosolids.xml
+++ b/objects/bigBag/biosolids/bigBag_biosolids.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <parentFile xmlFilename="$data/objects/bigBag/bigBag.xml">
+        <attributes>
+            <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_biosolids_name"/>
+            <set path="vehicle.storeData.image"                       value="$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds"/>
+            <set path="vehicle.storeData.price"                       value="500"/>
+            <set path="vehicle.storeData.brand"                       value="LIZARD"/>
+            <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_biosolids_function"/>
+            <set path="vehicle.storeData.financeCategory"             value="PURCHASE_FERTILIZER"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#fillTypes"      value="BIOSOLIDS"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillType"  value="BIOSOLIDS"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#capacity"       value="1000"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillLevel" value="1000"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#fillType" value="BIOSOLIDS"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#refNode" value="fertilizer_mat"/>
+        </attributes>
+    </parentFile>
+
+    <!-- ONLY FOR ICON GENERATION -->
+    <storeData>
+        <name>$l10n_sf_bigBag_biosolids_name</name>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <vertexBufferMemoryUsage>0</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>0</indexBufferMemoryUsage>
+        <textureMemoryUsage>0</textureMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+    </storeData>
+</vehicle>

--- a/objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml
+++ b/objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Biosolids</n>
+        <name>$l10n_sf_bigBag_biosolids_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_biosolids_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>500</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="BIOSOLIDS" capacity="1000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/biosolids/bigBag_biosolids.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="1000"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="1500"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="2000"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="2500"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="3000"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="3500"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="4000"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/bigBag/chicken_manure/bigBag_chicken_manure.xml
+++ b/objects/bigBag/chicken_manure/bigBag_chicken_manure.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <parentFile xmlFilename="$data/objects/bigBag/bigBag.xml">
+        <attributes>
+            <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_chicken_manure_name"/>
+            <set path="vehicle.storeData.image"                       value="$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds"/>
+            <set path="vehicle.storeData.price"                       value="600"/>
+            <set path="vehicle.storeData.brand"                       value="LIZARD"/>
+            <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_chicken_manure_function"/>
+            <set path="vehicle.storeData.financeCategory"             value="PURCHASE_FERTILIZER"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#fillTypes"      value="CHICKEN_MANURE"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillType"  value="CHICKEN_MANURE"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#capacity"       value="1000"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillLevel" value="1000"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#fillType" value="CHICKEN_MANURE"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#refNode" value="fertilizer_mat"/>
+        </attributes>
+    </parentFile>
+
+    <!-- ONLY FOR ICON GENERATION -->
+    <storeData>
+        <name>$l10n_sf_bigBag_chicken_manure_name</name>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <vertexBufferMemoryUsage>0</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>0</indexBufferMemoryUsage>
+        <textureMemoryUsage>0</textureMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+    </storeData>
+</vehicle>

--- a/objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml
+++ b/objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Chicken Manure</n>
+        <name>$l10n_sf_bigBag_chicken_manure_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_chicken_manure_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>600</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="CHICKEN_MANURE" capacity="1000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="1200"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="1800"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="2400"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="3000"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="3600"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="4200"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="4800"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/bigBag/compost/bigBag_compost.xml
+++ b/objects/bigBag/compost/bigBag_compost.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <parentFile xmlFilename="$data/objects/bigBag/bigBag.xml">
+        <attributes>
+            <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_compost_name"/>
+            <set path="vehicle.storeData.image"                       value="$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds"/>
+            <set path="vehicle.storeData.price"                       value="300"/>
+            <set path="vehicle.storeData.brand"                       value="LIZARD"/>
+            <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_compost_function"/>
+            <set path="vehicle.storeData.financeCategory"             value="PURCHASE_FERTILIZER"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#fillTypes"      value="COMPOST"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillType"  value="COMPOST"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#capacity"       value="1000"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillLevel" value="1000"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#fillType" value="COMPOST"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#refNode" value="fertilizer_mat"/>
+        </attributes>
+    </parentFile>
+
+    <!-- ONLY FOR ICON GENERATION -->
+    <storeData>
+        <name>$l10n_sf_bigBag_compost_name</name>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <vertexBufferMemoryUsage>0</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>0</indexBufferMemoryUsage>
+        <textureMemoryUsage>0</textureMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+    </storeData>
+</vehicle>

--- a/objects/bigBag/compost/multiPurchaseBigBag_compost.xml
+++ b/objects/bigBag/compost/multiPurchaseBigBag_compost.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Compost</n>
+        <name>$l10n_sf_bigBag_compost_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_compost_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>300</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="COMPOST" capacity="1000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/compost/bigBag_compost.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="600"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="900"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="1200"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="1500"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="1800"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="2100"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="2400"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml
+++ b/objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <parentFile xmlFilename="$data/objects/bigBag/bigBag.xml">
+        <attributes>
+            <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_pelletized_manure_name"/>
+            <set path="vehicle.storeData.image"                       value="$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds"/>
+            <set path="vehicle.storeData.price"                       value="1000"/>
+            <set path="vehicle.storeData.brand"                       value="LIZARD"/>
+            <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_pelletized_manure_function"/>
+            <set path="vehicle.storeData.financeCategory"             value="PURCHASE_FERTILIZER"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#fillTypes"      value="PELLETIZED_MANURE"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillType"  value="PELLETIZED_MANURE"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#capacity"       value="1000"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillLevel" value="1000"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#fillType" value="PELLETIZED_MANURE"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit.fillTypeMaterials.material(1)#refNode" value="fertilizer_mat"/>
+        </attributes>
+    </parentFile>
+
+    <!-- ONLY FOR ICON GENERATION -->
+    <storeData>
+        <name>$l10n_sf_bigBag_pelletized_manure_name</name>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <vertexBufferMemoryUsage>0</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>0</indexBufferMemoryUsage>
+        <textureMemoryUsage>0</textureMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+    </storeData>
+</vehicle>

--- a/objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure.xml
+++ b/objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Pelletized Manure</n>
+        <name>$l10n_sf_bigBag_pelletized_manure_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_pelletized_manure_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>1000</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="PELLETIZED_MANURE" capacity="1000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="2000"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="3000"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="4000"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="5000"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="6000"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="7000"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="8000"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/liquidTank/liquidlime/liquidTank_liquidlime.xml
+++ b/objects/liquidTank/liquidlime/liquidTank_liquidlime.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="pallet" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <parentFile xmlFilename="$data/objects/pallets/liquidTank/fertilizerTankHelm.xml">
+        <attributes>
+            <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquidlime_name"/>
+            <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
+            <set path="vehicle.storeData.price"                       value="1200"/>
+            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquidlime_function"/>
+            <set path="vehicle.storeData.specs.fillTypes"             value="LIQUIDLIME"/>
+
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#fillTypes"      value="LIQUIDLIME"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillType"  value="LIQUIDLIME"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#capacity"       value="2000"/>
+            <set path="vehicle.fillUnit.fillUnitConfigurations.fillUnitConfiguration(0).fillUnits.fillUnit#startFillLevel" value="2000"/>
+        </attributes>
+    </parentFile>
+
+    <!-- ONLY FOR ICON GENERATION -->
+    <storeData>
+        <name>$l10n_sf_bigBag_liquidlime_name</name>
+        <image>$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png</image>
+        <brand>HELM</brand>
+        <category>ibc palletFertilizerHerbicide</category>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="25"/>
+        </storeIconRendering>
+        <vertexBufferMemoryUsage>0</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>0</indexBufferMemoryUsage>
+        <textureMemoryUsage>0</textureMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+    </storeData>
+</vehicle>

--- a/objects/liquidTank/liquidlime/multiPurchaseLiquidTank_liquidlime.xml
+++ b/objects/liquidTank/liquidlime/multiPurchaseLiquidTank_liquidlime.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <name>$l10n_sf_bigBag_liquidlime_name</name>
+        <specs>
+            <capacity>2000</capacity>
+            <fillTypes>LIQUIDLIME</fillTypes>
+            <weight ignore="true"/>
+        </specs>
+        <functions><function>$l10n_sf_bigBag_liquidlime_function</function></functions>
+        <image>$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png</image>
+        <price>1200</price>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <shopHeight>2</shopHeight>
+        <brand>HELM</brand>
+        <category>ibc palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="25"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_typeDesc_pallet</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.9" length="6.1" height="1.6" lengthOffset="0.1"/>
+        <components>
+            <component centerOfMass="0 0.1 0" solverIterationCount="10" mass="100"/>
+        </components>
+        <showInVehicleMenu>false</showInVehicleMenu>
+        <mapHotspot available="false"/>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="LIQUIDLIME" capacity="2000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/liquidTank/liquidlime/liquidTank_liquidlime.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.775 0 0"/>
+            <offset amount="3" offset="0.775 0 0.8"/>
+            <offset amount="5" offset="0.775 0 1.6"/>
+            <offset amount="7" offset="0.775 0 2.4"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"         rotation="0 0 0"/>
+            <itemPosition position="-1.55 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.55"     rotation="0 0 0"/>
+            <itemPosition position="-1.55 0 -1.55" rotation="0 0 0"/>
+            <itemPosition position="0 0 -3.1"      rotation="0 0 0"/>
+            <itemPosition position="-1.55 0 -3.1"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -4.65"     rotation="0 0 0"/>
+            <itemPosition position="-1.55 0 -4.65" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="2400"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="3600"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="4800"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="6000"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="7200"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="8400"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="9600"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -346,11 +346,27 @@ function SoilFertilitySystem:onPlowing(fieldId)
         changed = true
     end
 
-    -- Plowing benefit 3: Reset weed pressure to 0 (tillage buries weed seeds/roots)
+    -- Plowing benefit 3: Reset weed pressure to 0 (deep tillage buries weed seeds/roots)
     if self.settings.weedPressure and (field.weedPressure or 0) > 0 then
         self:log("[Plowing] Field %d: weed pressure %.0f -> 0 (tillage reset)", fieldId, field.weedPressure)
         field.weedPressure = 0
         field.herbicideDaysLeft = 0
+        changed = true
+    end
+
+    -- Plowing benefit 4: Reduce pest pressure (disrupts overwintering habitat)
+    if self.settings.pestPressure and SoilConstants.PLOWING.PEST_PRESSURE_REDUCTION and (field.pestPressure or 0) > 0 then
+        local before = field.pestPressure
+        field.pestPressure = math.max(0, before - SoilConstants.PLOWING.PEST_PRESSURE_REDUCTION)
+        self:log("[Plowing] Field %d: pest pressure %.0f -> %.0f", fieldId, before, field.pestPressure)
+        changed = true
+    end
+
+    -- Plowing benefit 5: Reduce disease pressure (buries inoculum, exposes to UV/drying)
+    if self.settings.diseasePressure and SoilConstants.PLOWING.DISEASE_PRESSURE_REDUCTION and (field.diseasePressure or 0) > 0 then
+        local before = field.diseasePressure
+        field.diseasePressure = math.max(0, before - SoilConstants.PLOWING.DISEASE_PRESSURE_REDUCTION)
+        self:log("[Plowing] Field %d: disease pressure %.0f -> %.0f", fieldId, before, field.diseasePressure)
         changed = true
     end
 
@@ -363,6 +379,55 @@ function SoilFertilitySystem:onPlowing(fieldId)
     -- Broadcast to clients if server in multiplayer
     if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
         if field and SoilFieldUpdateEvent then
+            g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+        end
+    end
+end
+
+--- Called when a shallow cultivator passes over a field.
+--- Partially reduces weed, pest, and disease pressure.
+---@param fieldId number
+function SoilFertilitySystem:onCultivation(fieldId)
+    if not fieldId or fieldId <= 0 then return end
+    if not self.settings.plowingBonus then return end
+    if not SoilConstants.CULTIVATION then return end
+
+    local field = self:getOrCreateField(fieldId, false)
+    if not field then return end
+
+    -- Throttle: once per field per in-game day to prevent frame-rate overdrive
+    local today = (g_currentMission and g_currentMission.environment and
+                   g_currentMission.environment.currentDay) or 0
+    self.cultivationAppliedDay = self.cultivationAppliedDay or {}
+    if self.cultivationAppliedDay[fieldId] == today then return end
+    self.cultivationAppliedDay[fieldId] = today
+
+    local changed = false
+    local c = SoilConstants.CULTIVATION
+
+    if self.settings.weedPressure and c.WEED_PRESSURE_REDUCTION and (field.weedPressure or 0) > 0 then
+        local before = field.weedPressure
+        field.weedPressure = math.max(0, before - c.WEED_PRESSURE_REDUCTION)
+        self:log("[Cultivation] Field %d: weed %.0f -> %.0f", fieldId, before, field.weedPressure)
+        changed = true
+    end
+
+    if self.settings.pestPressure and c.PEST_PRESSURE_REDUCTION and (field.pestPressure or 0) > 0 then
+        local before = field.pestPressure
+        field.pestPressure = math.max(0, before - c.PEST_PRESSURE_REDUCTION)
+        self:log("[Cultivation] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
+        changed = true
+    end
+
+    if self.settings.diseasePressure and c.DISEASE_PRESSURE_REDUCTION and (field.diseasePressure or 0) > 0 then
+        local before = field.diseasePressure
+        field.diseasePressure = math.max(0, before - c.DISEASE_PRESSURE_REDUCTION)
+        self:log("[Cultivation] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
+        changed = true
+    end
+
+    if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
+        if SoilFieldUpdateEvent then
             g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
         end
     end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -56,7 +56,17 @@ SoilConstants.FIELD_DEFAULTS = {
 -- Thresholds for plowing operations
 SoilConstants.PLOWING = {
     MIN_DEPTH_FOR_PLOWING = 0.15,  -- Minimum working depth (meters) to qualify as deep plowing
-                                     -- Values > 0.15m improve organic matter mixing
+    PEST_PRESSURE_REDUCTION    = 30,  -- Points removed from pest pressure on plowing
+    DISEASE_PRESSURE_REDUCTION = 40,  -- Points removed from disease pressure on plowing
+}
+
+-- ========================================
+-- CULTIVATION (shallow tillage — non-plowing passes)
+-- ========================================
+SoilConstants.CULTIVATION = {
+    WEED_PRESSURE_REDUCTION    = 20,  -- Points removed from weed pressure per cultivation pass
+    PEST_PRESSURE_REDUCTION    = 10,
+    DISEASE_PRESSURE_REDUCTION = 15,
 }
 
 -- ========================================

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -199,8 +199,8 @@ SoilConstants.FERTILIZER_PROFILES = {
     -- Starter fertilizer (High-P pop-up)
     STARTER           = { N=63.5, P=595.0, K=44.6 }, -- 46.8 L/ha: ~8N, ~15P ppm
 
-    -- Gypsum (Fix: No pH effect)
-    GYPSUM            = { pH=0.0, OM=0.22 }, -- 1500 kg/ha: pure OM/sulfur boost
+    -- Gypsum: mild pH lowering + OM/structure boost
+    GYPSUM            = { pH=-0.10, OM=0.22 }, -- 1500 kg/ha: -0.25 pH shift, OM boost
 
     -- Phosphorus & potassium sources (Dry bulk)
     MAP               = { N=11.1, P=411.5, K=0.00 }, -- 225 kg/ha: ~45P ppm

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1148,6 +1148,8 @@ function HookManager:installPlowingHook()
 
                         if isPlowingTool then
                             g_SoilFertilityManager.soilSystem:onPlowing(farmlandId)
+                        else
+                            g_SoilFertilityManager.soilSystem:onCultivation(farmlandId)
                         end
                     end
                 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Nitrogênio: Ideal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fósforo: Ideal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potássio: Ideal" eh="0197b4ba" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Bônus de Rotação" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fadiga: Mesma Cultura" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotação: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gesso (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gesso (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Composto (Orgânico)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosólidos (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Cama de frango (N+P)" eh="338128e2" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -324,7 +324,7 @@
     <e k="sf_report_rotation_bonus" v="輪作獎勵" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="連作疲勞：相同作物" eh="46135880" />
     <e k="sf_report_rotation_ok" v="輪作：正常" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="石膏 (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="石膏 (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="堆肥 (有機)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="生物固形物 (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="雞糞 (N+P)" eh="338128e2" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="啟動肥（液態）" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="氮：最佳" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="磷：最佳" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="鉀：最佳" eh="0197b4ba" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Startgødning (flydende)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Stickstoff: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphor: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Kalium: Optimal" eh="0197b4ba" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Fruchtfolgenbonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Ermüdung: Gleiche Frucht" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Fruchtfolge: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gips (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gips (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Kompost (Organisch)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Hühnermist (N+P)" eh="338128e2" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -165,6 +165,16 @@
     <e k="sf_bigBag_starter_function" v="Starter Fertilizer (liquid)" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypsum" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Field %d" eh="08988997" />
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -324,7 +324,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Bono de rotación" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatiga: Mismo cultivo" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotación: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Yeso (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Yeso (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Orgánico)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosólidos (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Gallinaza (N+P)" eh="338128e2" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante Starter (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Nitrógeno: Óptimo" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fósforo: Óptimo" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potasio: Óptimo" eh="0197b4ba" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="å¯åŠ¨è‚¥ï¼ˆæ¶²æ€ï¼‰" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Startterilannoite (nestemäinen)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Bonus de rotation" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue : Même culture" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation : OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypse (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypse (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organique)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolides (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Fumier de poulet (N+P)" eh="338128e2" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Engrais starter (liquide)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Azote: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphore: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Pupuk starter (cair)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="スターター肥料（液体）" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="스타터 비료 (액체)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Stikstof: Optimaal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fosfor: Optimaal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Kalium: Optimaal" eh="0197b4ba" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -196,7 +196,7 @@
     <e k="sf_report_rotation_bonus" v="Rotatie Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Bodemmoeheid: Zelfde gewas" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotatie: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gips (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gips (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organisch)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Bio-vaste stoffen (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Kippenmest (N+P)" eh="338128e2" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Startgjødsel (flytende)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -178,6 +178,16 @@
     <e k="sf_bigBag_starter_function" v="Nawóz startowy (ciekły)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_report_detail_n_ok" v="Azot: Optymalny" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fosfor: Optymalny" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potas: Optymalny" eh="0197b4ba" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Îngrășământ starter (lichid)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Бонус за ротацию" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Урожайность: тот же урожай" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Ротация: в порядке" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Гипс (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Гипс (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Компост (органический)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Биологические отходы (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Куриный помет (N+P)" eh="338128e2" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -165,6 +165,16 @@
     <e k="sf_bigBag_starter_function" v="Стартовое удобрение (жидкое)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_hud_title" v="МОНИТОР ПОЧВЫ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Startgödsel (flytande)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Başlangıç gübresi (sıvı)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -293,7 +293,7 @@
     <e k="sf_report_rotation_bonus" v="Бонус за ротацію" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Втома: та сама культура" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Ротація: у нормі" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Гіпс (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Гіпс (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Компост (органічний)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Біосуміші (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Курячий послід (N+P)" eh="338128e2" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -165,6 +165,16 @@
     <e k="sf_bigBag_starter_function" v="Стартове добриво (рідке)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
     <e k="sf_hud_title" v="МОНІТОР ҐРУНТУ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -292,7 +292,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH+)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -134,6 +134,16 @@
     <e k="sf_bigBag_starter_function" v="Phân bón khá»Ÿi Ä‘áº§u (dáº¡ng lá»ng)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />


### PR DESCRIPTION
## Summary

- **Gypsum now lowers pH**: Profile fixed from `pH=0.0` to `pH=-0.10` — gypsum was recommended by the Treatment dialog for alkaline fields but had no actual effect. Now applies ~-0.25 pH shift per application. Title updated to `(pH-)` across all 26 languages.
- **Tillage resets weed/pest/disease pressure**: Any cultivator or plow pass now reduces field pressure scores. Closes #188.
- **5 new purchasable shop items**: Compost, Biosolids, Chicken Manure, and Pelletized Manure now have purchasable big bags ($300–$1000). Liquid Lime now has a purchasable IBC tank ($1200 / 2000 L).

## Commits since last release
- `feat: add purchasable shop items for COMPOST, BIOSOLIDS, CHICKEN_MANURE, PELLETIZED_MANURE, and LIQUIDLIME`
- `fix: gypsum now lowers pH (-0.10) and title updated to pH- across all 26 languages`
- `feat: tillage reduces weed/pest/disease pressure (closes #188)`