### PR TITLE
fix: PDA overlay coverage gaps and FPS throttle (v1.9.6.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.5.0</version>
+    <version>1.9.6.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -23,8 +23,9 @@ SoilMapOverlay.ALPHA          = 0.72
 
 -- Sampling constants
 SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 4500
-SoilMapOverlay.MAX_POINTS       = 20000  -- covers standard (24k needed) and 16x maps (25k needed); safe with affine transform fix
+SoilMapOverlay.MAX_POINTS       = 20000  -- fair per-field budget ensures all fields covered on any map size
 SoilMapOverlay.POLYGON_STEP     = 10     -- world-unit grid spacing for polygon sampling (meters)
+SoilMapOverlay.DRAW_THROTTLE_MS = 50     -- ~20fps cap for overlay draw (soil changes every 4.5s; 60fps redraws are pure waste)
 
 -- Status colors (match SoilHUD palette)
 SoilMapOverlay.C_POOR = {0.88, 0.25, 0.25}
@@ -75,6 +76,7 @@ function SoilMapOverlay.new(soilSystem, settings)
     self.samplePoints = {}
     self.displayValues = nil
     self.nextSampleUpdateTime = 0
+    self.lastDrawTime = 0
     self.isMapOpen = false
     self.isReady = false
 
@@ -315,9 +317,8 @@ function SoilMapOverlay:updateSamplePoints(force)
     end
 
     -- Fill each field polygon with a grid of coloured sample points.
-    -- We match fields to our soil data via farmland.id (the key fieldData uses).
-    -- getFieldFillPoints() handles the grid sampling and caching; it falls back to
-    -- a single centroid point for very small fields or when polygon data is absent.
+    -- Two-pass approach: collect valid fields first, then apply a fair per-field
+    -- point budget so no field is starved when MAX_POINTS is reached.
     local fields = g_fieldManager.fields
     if fields == nil then
         SoilLogger.info("SoilMapOverlay: g_fieldManager.fields is nil")
@@ -326,75 +327,87 @@ function SoilMapOverlay:updateSamplePoints(force)
 
     -- Scale sampling step proportional to terrain size so large maps
     -- (4x, 16x) get the same screen-pixel density as a standard 2048m map.
-    -- A 8192m map at step=10 would produce 16× more points and hit MAX_POINTS
-    -- after only a handful of fields, leaving the rest of the map empty.
     local terrainSize = (g_currentMission and g_currentMission.terrainSize) or 2048
     local scaledStep = SoilMapOverlay.POLYGON_STEP * math.max(1.0, terrainSize / 2048.0)
 
-    local totalPoints = 0
+    -- Pass 1: collect all fields that have soil data (cheap — no polygon math yet)
+    local validFields = {}
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
             if farmlandId and farmlandId > 0 then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
-                    local polyPts = self:getFieldFillPoints(fsField, scaledStep)
-                    -- Per-pixel path: when GRLE density map layers are available (layers 1-5),
-                    -- read the soil value at each sample point directly from the layer so that
-                    -- sprayed sub-areas show different colours from unsprayed areas.
-                    -- Falls back to per-field average for layers 6-9 or when layers are absent.
-                    local layerSystem = self.soilSystem and self.soilSystem.layerSystem
-                    local grleLayerName = layerSystem and layerSystem.available and LAYER_GRLE_NAME[layerIdx]
-                    if grleLayerName then
-                        -- GRLE per-pixel path: maps that ship custom density-map info layers
-                        for _, pt in ipairs(polyPts) do
-                            if totalPoints < SoilMapOverlay.MAX_POINTS then
-                                local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
-                                local r, g, b
-                                if val ~= nil then
-                                    r, g, b = self:valueToLayerColor(layerIdx, val)
-                                else
-                                    r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
-                                end
-                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                                totalPoints = totalPoints + 1
-                            end
-                        end
-                    elseif layerIdx >= 1 and layerIdx <= 5 then
-                        -- zoneData per-cell path: standard maps, layers 1-5 (N/P/K/pH/OM).
-                        -- Cells that have been sprayed show their local value; unvisited cells
-                        -- fall back to the field average so the map is always fully coloured.
-                        local fieldEntry = self.soilSystem.fieldData and self.soilSystem.fieldData[farmlandId]
-                        local zoneData = fieldEntry and fieldEntry.zoneData
-                        local zone = SoilConstants.ZONE
-                        for _, pt in ipairs(polyPts) do
-                            if totalPoints < SoilMapOverlay.MAX_POINTS then
-                                local r, g, b
-                                if zoneData then
-                                    local cx = math.floor(pt.x / zone.CELL_SIZE)
-                                    local cz = math.floor(pt.z / zone.CELL_SIZE)
-                                    local cell = zoneData[cx .. "_" .. cz]
-                                    if cell then
-                                        local val = getCellLayerValue(cell, layerIdx)
-                                        if val then r, g, b = self:valueToLayerColor(layerIdx, val) end
-                                    end
-                                end
-                                if not r then r, g, b = self:getLayerColor(layerIdx, info, farmlandId) end
-                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                                totalPoints = totalPoints + 1
-                            end
-                        end
-                    else
-                        -- Field-average path: layers 6-9 (urgency, weed, pest, disease)
-                        local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
-                        for _, pt in ipairs(polyPts) do
-                            if totalPoints < SoilMapOverlay.MAX_POINTS then
-                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                                totalPoints = totalPoints + 1
-                            end
-                        end
+                    table.insert(validFields, {fsField = fsField, farmlandId = farmlandId, info = info})
+                end
+            end
+        end
+    end
+
+    -- Fair per-field budget: every field gets an equal slice of MAX_POINTS.
+    -- This prevents early large fields from consuming all points and leaving
+    -- later fields (bottom of the map) completely uncoloured.
+    local fieldCount   = math.max(#validFields, 1)
+    local maxPerField  = math.ceil(SoilMapOverlay.MAX_POINTS / fieldCount)
+
+    -- Pass 2: fill polygons with the per-field cap applied
+    local totalPoints = 0
+    local layerSystem = self.soilSystem and self.soilSystem.layerSystem
+
+    for _, entry in ipairs(validFields) do
+        local fsField    = entry.fsField
+        local farmlandId = entry.farmlandId
+        local info       = entry.info
+
+        local polyPts = self:getFieldFillPoints(fsField, scaledStep)
+        local grleLayerName = layerSystem and layerSystem.available and LAYER_GRLE_NAME[layerIdx]
+        local fieldPts = 0
+
+        if grleLayerName then
+            -- GRLE per-pixel path
+            for _, pt in ipairs(polyPts) do
+                if fieldPts >= maxPerField then break end
+                local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
+                local r, g, b
+                if val ~= nil then
+                    r, g, b = self:valueToLayerColor(layerIdx, val)
+                else
+                    r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+                end
+                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                fieldPts  = fieldPts  + 1
+                totalPoints = totalPoints + 1
+            end
+        elseif layerIdx >= 1 and layerIdx <= 5 then
+            -- zoneData per-cell path: local sprayed values with field-average fallback
+            local fieldEntry = self.soilSystem.fieldData and self.soilSystem.fieldData[farmlandId]
+            local zoneData = fieldEntry and fieldEntry.zoneData
+            local zone = SoilConstants.ZONE
+            for _, pt in ipairs(polyPts) do
+                if fieldPts >= maxPerField then break end
+                local r, g, b
+                if zoneData then
+                    local cx = math.floor(pt.x / zone.CELL_SIZE)
+                    local cz = math.floor(pt.z / zone.CELL_SIZE)
+                    local cell = zoneData[cx .. "_" .. cz]
+                    if cell then
+                        local val = getCellLayerValue(cell, layerIdx)
+                        if val then r, g, b = self:valueToLayerColor(layerIdx, val) end
                     end
                 end
+                if not r then r, g, b = self:getLayerColor(layerIdx, info, farmlandId) end
+                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                fieldPts  = fieldPts  + 1
+                totalPoints = totalPoints + 1
+            end
+        else
+            -- Field-average path: layers 6-9 (urgency, weed, pest, disease)
+            local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+            for _, pt in ipairs(polyPts) do
+                if fieldPts >= maxPerField then break end
+                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                fieldPts  = fieldPts  + 1
+                totalPoints = totalPoints + 1
             end
         end
     end
@@ -410,6 +423,11 @@ end
 -- ── Draw (called by hook) ────────────────────────────────
 
 function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
+    -- Throttle to ~20fps: soil data changes every 4.5s; redrawing 60×/s is pure waste.
+    local now = (g_currentMission and g_currentMission.time) or g_time or 0
+    if now - self.lastDrawTime < SoilMapOverlay.DRAW_THROTTLE_MS then return end
+    self.lastDrawTime = now
+
     self:updateSamplePoints(false)
 
     if #self.samplePoints == 0 then return end


### PR DESCRIPTION
## Summary
- **Coverage fix**: switched from global first-come-first-served point cap to a fair per-field budget (`MAX_POINTS / fieldCount`). On maps with many fields, late fields were receiving zero sample points (appearing dark/uncolored). Every field now gets an equal slice of the budget.
- **FPS fix**: throttled `onDraw` to ~20fps (50ms minimum between draws). Soil data updates every 4.5s; redrawing 20k rects at 60fps was pure waste — this cuts GPU draw call volume by 3×.

## Test plan
- [ ] Open PDA soil overlay on a large map — all fields should be colored
- [ ] FPS should recover significantly compared to v1.9.5.0
- [ ] Layer switching and sidebar buttons still work
- [ ] No save migration needed