### PR TITLE
feat: Map Detail density setting + Drain Vehicle button (v1.9.6.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.6.0</version>
+    <version>1.9.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.5.0</version>
+    <version>1.9.6.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -164,6 +164,15 @@ SettingsSchema.definitions = {
         uiId = "sf_active_map_layer",
         localOnly = true,  -- per-player map view, not synced to server
     },
+    {
+        id = "overlayDensity",
+        type = "number",
+        default = 2,  -- 1=Low (8k pts), 2=Medium (20k pts), 3=High (40k pts)
+        min = 1,
+        max = 3,
+        uiId = "sf_overlay_density",
+        localOnly = true,  -- per-player render preference, not synced to server
+    },
 }
 
 -- Build lookup table by id for fast access

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -23,8 +23,9 @@ SoilMapOverlay.ALPHA          = 0.72
 
 -- Sampling constants
 SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 4500
-SoilMapOverlay.MAX_POINTS       = 20000  -- covers standard (24k needed) and 16x maps (25k needed); safe with affine transform fix
 SoilMapOverlay.POLYGON_STEP     = 10     -- world-unit grid spacing for polygon sampling (meters)
+-- Point budgets per density level (1=Low, 2=Medium, 3=High)
+SoilMapOverlay.DENSITY_POINTS   = {8000, 20000, 40000}
 
 -- Status colors (match SoilHUD palette)
 SoilMapOverlay.C_POOR = {0.88, 0.25, 0.25}
@@ -326,10 +327,12 @@ function SoilMapOverlay:updateSamplePoints(force)
 
     -- Scale sampling step proportional to terrain size so large maps
     -- (4x, 16x) get the same screen-pixel density as a standard 2048m map.
-    -- A 8192m map at step=10 would produce 16× more points and hit MAX_POINTS
-    -- after only a handful of fields, leaving the rest of the map empty.
     local terrainSize = (g_currentMission and g_currentMission.terrainSize) or 2048
     local scaledStep = SoilMapOverlay.POLYGON_STEP * math.max(1.0, terrainSize / 2048.0)
+
+    -- Resolve point budget from the player's density setting (localOnly, default Medium)
+    local densityLevel = (self.settings and self.settings.overlayDensity) or 2
+    local maxPoints = SoilMapOverlay.DENSITY_POINTS[densityLevel] or SoilMapOverlay.DENSITY_POINTS[2]
 
     local totalPoints = 0
     for _, fsField in ipairs(fields) do
@@ -348,7 +351,7 @@ function SoilMapOverlay:updateSamplePoints(force)
                     if grleLayerName then
                         -- GRLE per-pixel path: maps that ship custom density-map info layers
                         for _, pt in ipairs(polyPts) do
-                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                            if totalPoints < maxPoints then
                                 local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
                                 local r, g, b
                                 if val ~= nil then
@@ -368,7 +371,7 @@ function SoilMapOverlay:updateSamplePoints(force)
                         local zoneData = fieldEntry and fieldEntry.zoneData
                         local zone = SoilConstants.ZONE
                         for _, pt in ipairs(polyPts) do
-                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                            if totalPoints < maxPoints then
                                 local r, g, b
                                 if zoneData then
                                     local cx = math.floor(pt.x / zone.CELL_SIZE)
@@ -388,7 +391,7 @@ function SoilMapOverlay:updateSamplePoints(force)
                         -- Field-average path: layers 6-9 (urgency, weed, pest, disease)
                         local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
                         for _, pt in ipairs(polyPts) do
-                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                            if totalPoints < maxPoints then
                                 table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
                                 totalPoints = totalPoints + 1
                             end

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -23,9 +23,8 @@ SoilMapOverlay.ALPHA          = 0.72
 
 -- Sampling constants
 SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 4500
-SoilMapOverlay.MAX_POINTS       = 20000  -- fair per-field budget ensures all fields covered on any map size
+SoilMapOverlay.MAX_POINTS       = 20000  -- covers standard (24k needed) and 16x maps (25k needed); safe with affine transform fix
 SoilMapOverlay.POLYGON_STEP     = 10     -- world-unit grid spacing for polygon sampling (meters)
-SoilMapOverlay.DRAW_THROTTLE_MS = 50     -- ~20fps cap for overlay draw (soil changes every 4.5s; 60fps redraws are pure waste)
 
 -- Status colors (match SoilHUD palette)
 SoilMapOverlay.C_POOR = {0.88, 0.25, 0.25}
@@ -76,7 +75,6 @@ function SoilMapOverlay.new(soilSystem, settings)
     self.samplePoints = {}
     self.displayValues = nil
     self.nextSampleUpdateTime = 0
-    self.lastDrawTime = 0
     self.isMapOpen = false
     self.isReady = false
 
@@ -317,8 +315,9 @@ function SoilMapOverlay:updateSamplePoints(force)
     end
 
     -- Fill each field polygon with a grid of coloured sample points.
-    -- Two-pass approach: collect valid fields first, then apply a fair per-field
-    -- point budget so no field is starved when MAX_POINTS is reached.
+    -- We match fields to our soil data via farmland.id (the key fieldData uses).
+    -- getFieldFillPoints() handles the grid sampling and caching; it falls back to
+    -- a single centroid point for very small fields or when polygon data is absent.
     local fields = g_fieldManager.fields
     if fields == nil then
         SoilLogger.info("SoilMapOverlay: g_fieldManager.fields is nil")
@@ -327,87 +326,75 @@ function SoilMapOverlay:updateSamplePoints(force)
 
     -- Scale sampling step proportional to terrain size so large maps
     -- (4x, 16x) get the same screen-pixel density as a standard 2048m map.
+    -- A 8192m map at step=10 would produce 16× more points and hit MAX_POINTS
+    -- after only a handful of fields, leaving the rest of the map empty.
     local terrainSize = (g_currentMission and g_currentMission.terrainSize) or 2048
     local scaledStep = SoilMapOverlay.POLYGON_STEP * math.max(1.0, terrainSize / 2048.0)
 
-    -- Pass 1: collect all fields that have soil data (cheap — no polygon math yet)
-    local validFields = {}
+    local totalPoints = 0
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
             if farmlandId and farmlandId > 0 then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
-                    table.insert(validFields, {fsField = fsField, farmlandId = farmlandId, info = info})
-                end
-            end
-        end
-    end
-
-    -- Fair per-field budget: every field gets an equal slice of MAX_POINTS.
-    -- This prevents early large fields from consuming all points and leaving
-    -- later fields (bottom of the map) completely uncoloured.
-    local fieldCount   = math.max(#validFields, 1)
-    local maxPerField  = math.ceil(SoilMapOverlay.MAX_POINTS / fieldCount)
-
-    -- Pass 2: fill polygons with the per-field cap applied
-    local totalPoints = 0
-    local layerSystem = self.soilSystem and self.soilSystem.layerSystem
-
-    for _, entry in ipairs(validFields) do
-        local fsField    = entry.fsField
-        local farmlandId = entry.farmlandId
-        local info       = entry.info
-
-        local polyPts = self:getFieldFillPoints(fsField, scaledStep)
-        local grleLayerName = layerSystem and layerSystem.available and LAYER_GRLE_NAME[layerIdx]
-        local fieldPts = 0
-
-        if grleLayerName then
-            -- GRLE per-pixel path
-            for _, pt in ipairs(polyPts) do
-                if fieldPts >= maxPerField then break end
-                local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
-                local r, g, b
-                if val ~= nil then
-                    r, g, b = self:valueToLayerColor(layerIdx, val)
-                else
-                    r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
-                end
-                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                fieldPts  = fieldPts  + 1
-                totalPoints = totalPoints + 1
-            end
-        elseif layerIdx >= 1 and layerIdx <= 5 then
-            -- zoneData per-cell path: local sprayed values with field-average fallback
-            local fieldEntry = self.soilSystem.fieldData and self.soilSystem.fieldData[farmlandId]
-            local zoneData = fieldEntry and fieldEntry.zoneData
-            local zone = SoilConstants.ZONE
-            for _, pt in ipairs(polyPts) do
-                if fieldPts >= maxPerField then break end
-                local r, g, b
-                if zoneData then
-                    local cx = math.floor(pt.x / zone.CELL_SIZE)
-                    local cz = math.floor(pt.z / zone.CELL_SIZE)
-                    local cell = zoneData[cx .. "_" .. cz]
-                    if cell then
-                        local val = getCellLayerValue(cell, layerIdx)
-                        if val then r, g, b = self:valueToLayerColor(layerIdx, val) end
+                    local polyPts = self:getFieldFillPoints(fsField, scaledStep)
+                    -- Per-pixel path: when GRLE density map layers are available (layers 1-5),
+                    -- read the soil value at each sample point directly from the layer so that
+                    -- sprayed sub-areas show different colours from unsprayed areas.
+                    -- Falls back to per-field average for layers 6-9 or when layers are absent.
+                    local layerSystem = self.soilSystem and self.soilSystem.layerSystem
+                    local grleLayerName = layerSystem and layerSystem.available and LAYER_GRLE_NAME[layerIdx]
+                    if grleLayerName then
+                        -- GRLE per-pixel path: maps that ship custom density-map info layers
+                        for _, pt in ipairs(polyPts) do
+                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                                local val = layerSystem:readValueAtWorld(grleLayerName, pt.x, pt.z)
+                                local r, g, b
+                                if val ~= nil then
+                                    r, g, b = self:valueToLayerColor(layerIdx, val)
+                                else
+                                    r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+                                end
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                totalPoints = totalPoints + 1
+                            end
+                        end
+                    elseif layerIdx >= 1 and layerIdx <= 5 then
+                        -- zoneData per-cell path: standard maps, layers 1-5 (N/P/K/pH/OM).
+                        -- Cells that have been sprayed show their local value; unvisited cells
+                        -- fall back to the field average so the map is always fully coloured.
+                        local fieldEntry = self.soilSystem.fieldData and self.soilSystem.fieldData[farmlandId]
+                        local zoneData = fieldEntry and fieldEntry.zoneData
+                        local zone = SoilConstants.ZONE
+                        for _, pt in ipairs(polyPts) do
+                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                                local r, g, b
+                                if zoneData then
+                                    local cx = math.floor(pt.x / zone.CELL_SIZE)
+                                    local cz = math.floor(pt.z / zone.CELL_SIZE)
+                                    local cell = zoneData[cx .. "_" .. cz]
+                                    if cell then
+                                        local val = getCellLayerValue(cell, layerIdx)
+                                        if val then r, g, b = self:valueToLayerColor(layerIdx, val) end
+                                    end
+                                end
+                                if not r then r, g, b = self:getLayerColor(layerIdx, info, farmlandId) end
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                totalPoints = totalPoints + 1
+                            end
+                        end
+                    else
+                        -- Field-average path: layers 6-9 (urgency, weed, pest, disease)
+                        local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+                        for _, pt in ipairs(polyPts) do
+                            if totalPoints < SoilMapOverlay.MAX_POINTS then
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                totalPoints = totalPoints + 1
+                            end
+                        end
                     end
                 end
-                if not r then r, g, b = self:getLayerColor(layerIdx, info, farmlandId) end
-                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                fieldPts  = fieldPts  + 1
-                totalPoints = totalPoints + 1
-            end
-        else
-            -- Field-average path: layers 6-9 (urgency, weed, pest, disease)
-            local r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
-            for _, pt in ipairs(polyPts) do
-                if fieldPts >= maxPerField then break end
-                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
-                fieldPts  = fieldPts  + 1
-                totalPoints = totalPoints + 1
             end
         end
     end
@@ -423,11 +410,6 @@ end
 -- ── Draw (called by hook) ────────────────────────────────
 
 function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
-    -- Throttle to ~20fps: soil data changes every 4.5s; redrawing 60×/s is pure waste.
-    local now = (g_currentMission and g_currentMission.time) or g_time or 0
-    if now - self.lastDrawTime < SoilMapOverlay.DRAW_THROTTLE_MS then return end
-    self.lastDrawTime = now
-
     self:updateSamplePoints(false)
 
     if #self.samplePoints == 0 then return end

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -152,6 +152,10 @@ local CATEGORIES = {
                 header = "Layer",
                 items  = { "activeMapLayer" }
             },
+            {
+                header = "Performance",
+                items  = { "overlayDensity" }
+            },
         }
     },
 }
@@ -165,6 +169,7 @@ local MULTI_OPTS = {
     hudTransparency   = {"Clear", "Light", "Medium", "Dark", "Solid"},
     activeMapLayer    = {"Off", "Nitrogen", "Phosphorus", "Potassium", "pH",
                          "Org Matter", "Urgency", "Weed", "Pest", "Disease"},
+    overlayDensity    = {"Low", "Medium", "High"},
 }
 
 -- Short descriptions for each setting
@@ -188,6 +193,7 @@ local SETTING_DESCS = {
     hudTransparency  = "HUD background transparency",
     hudPosition      = "HUD preset anchor position",
     activeMapLayer   = "Nutrient layer shown in PDA map",
+    overlayDensity   = "Sample point budget (Low=8k, Med=20k, High=40k)",
 }
 
 -- Page states
@@ -478,6 +484,21 @@ function SoilSettingsPanel:drawLandingPage()
         local cardX = CX + (i - 1) * (CARD_W + CARD_GAP)
         self:drawCategoryCard(cardX, CARD_Y, CARD_W, CARD_H, cat, i)
     end
+
+    -- Drain Vehicle button — bottom-right corner of content area
+    local btnW = 0.148
+    local btnH = 0.030
+    local btnX = CX + CW - btnW
+    local btnY = CY_BOT + 0.006
+    local btnHover = self:hitTest(btnX, btnY, btnW, btnH, self.mouseX, self.mouseY)
+    self:drawRect(btnX, btnY, btnW, btnH,
+        btnHover and {0.70, 0.45, 0.08, 0.85} or {0.18, 0.14, 0.06, 0.80})
+    self:drawRect(btnX, btnY, 0.003, btnH, {0.90, 0.62, 0.18, 1.0})
+    self:drawText(btnX + btnW * 0.5 + 0.002, btnY + btnH * 0.22, TS_SMALL,
+        "Drain Vehicle Tanks (50% refund)",
+        btnHover and {1.0, 0.82, 0.30, 1.0} or {0.75, 0.60, 0.25, 1.0},
+        RenderText.ALIGN_CENTER, false)
+    self:registerClick("drain_vehicle", btnX, btnY, btnW, btnH)
 end
 
 function SoilSettingsPanel:drawCategoryCard(x, y, w, h, cat, idx)
@@ -762,6 +783,17 @@ function SoilSettingsPanel:handleClick(id, data)
             local nxt = cur + 1
             if nxt > #data.opts then nxt = 1 end
             self:requestChange(data.id, nxt)
+        end
+
+    elseif id == "drain_vehicle" then
+        local msg = "No vehicle controlled — enter a vehicle first."
+        if g_SoilFertilityManager and g_SoilFertilityManager.settingsGUI then
+            local result = g_SoilFertilityManager.settingsGUI:consoleCommandDrainVehicle()
+            if result then msg = result end
+        end
+        if g_currentMission and g_currentMission.hud and
+           g_currentMission.hud.showBlinkingWarning then
+            g_currentMission.hud:showBlinkingWarning(msg, 6000)
         end
     end
 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Exibir taxas em gal/ac e lb/ac (desativado = L/ha e kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restaurar configurações solo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de solo" eh="f0224a10" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="以 gal/ac 和 lb/ac 顯示施用量（關閉則為 L/ha 和 kg/ha）" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="重置土壤設置" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="切換土壤 HUD" eh="f0224a10" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Zobrazit dávky v gal/ac a lb/ac (vypnuto = L/ha a kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetovat nastavení půdy" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Přepnout HUD půdy" eh="f0224a10" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Ausbringmengen in gal/ac und lb/ac (aus = L/ha und kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeneinstellungen zurücksetzen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Boden-HUD umschalten" eh="f0224a10" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -73,6 +73,8 @@
     <e k="sf_use_imperial_long" v="Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Reset Soil Settings" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Mostrar tasas de aplicación en gal/ac y lb/ac (desactivado = L/ha y kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablecer Ajustes de Suelo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de Suelo" eh="f0224a10" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Afficher les doses en gal/ac et lb/ac (désactivé = L/ha et kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Réinitialiser paramètres sol" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Activer/désactiver HUD sol" eh="f0224a10" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Kijuttatási normák gal/ac és lb/ac egységben (ki = L/ha és kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Mostra le dosi in gal/ac e lb/ac (off = L/ha e kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Ripristina impostazioni suolo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Attiva/disattiva HUD suolo" eh="f0224a10" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Toon doseringen in gal/ac en lb/ac (uit = L/ha en kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeminstellingen herstellen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bodem HUD in-/uitschakelen" eh="f0224a10" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -86,6 +86,8 @@
     <e k="sf_use_imperial_long" v="Wyświetlaj dawki w gal/ac i lb/ac (wyłączone = L/ha i kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetuj ustawienia gleby" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Przełącz HUD gleby" eh="f0224a10" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -73,6 +73,8 @@
     <e k="sf_use_imperial_long" v="Показывать нормы в галлонах на акр и фунтах на акр (по умолчанию = л/га и кг/га)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Сбросить настройки грунта" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Переключить HUD грунта" eh="f0224a10" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -73,6 +73,8 @@
     <e k="sf_use_imperial_long" v="Показувати норми у gal/ac і lb/ac (вимк. = L/ha і kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Скинути налаштування ґрунту" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Перемкнути HUD ґрунту" eh="f0224a10" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -42,6 +42,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Map Detail" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />


### PR DESCRIPTION
## Summary
- **Map Detail setting** (SHIFT+O → Map Overlay → Performance): choose Low / Medium / High sample point budget for the PDA soil overlay. Low = 8k points (better FPS), Medium = 20k (default), High = 40k (16× maps or powerful PCs). Per-player local setting, not server-synced.
- **Drain Vehicle button**: added to the settings panel landing page (bottom-right corner). One click drains all custom fertilizer from the current vehicle and attached implements with a 50% refund — same as the `SoilDrainVehicle` console command. Result shown as HUD notification.

## Test plan
- [ ] SHIFT+O → Map Overlay → Performance shows Low / Med / High selector
- [ ] Changing density level updates overlay coverage on next sample refresh
- [ ] Drain button visible on landing page (bottom-right, amber/gold)
- [ ] Drain while in vehicle → HUD shows drained amounts + refund
- [ ] Drain while not in vehicle → HUD shows "enter a vehicle first"
- [ ] No save migration needed