### PR TITLE
v1.9.7.0 — sprayer visual effects, admin panel, crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.7.0] - 2026-04-19
+
+### Added
+
+- **Admin panel at SHIFT+O**: The SHIFT+O settings panel now opens to an admin landing page
+  listing every available console command with a brief description. The previous **Drain Vehicle**
+  button has been replaced by the **Admin** button that opens this panel — all drain and admin
+  operations are now accessible from one organised hub. Admin-only access in multiplayer is
+  enforced as before.
+
+### Fixed
+
+- **Liquid sprayer visual effects**: Custom liquid fertilizers (UAN-32, UAN-28, Anhydrous
+  Ammonia, Starter 10-34-0, Liquid Urea, Liquid AMS, Liquid MAP, Liquid DAP, Liquid Potash,
+  Insecticide, Fungicide, Liquid Lime) now correctly show spray visual effects and sounds on
+  any sprayer while active. The previous approach remapped fill types correctly at the Lua
+  level but the underlying `FertilizerMotionPathEffect` pipeline requires C++-registered motion
+  path data per fill type — silently producing no effect. The fix hooks `Sprayer.onUpdateTick`
+  to call `setEffectTypeInfo` + `startEffects` directly using the nearest vanilla fill type
+  as a proxy, bypassing the broken pipeline entirely.
+
+- **SoilSettingsPanel field position crash**: The field detection helper used `x, z = 0, 0`
+  as its default, causing `getFieldAtWorldPosition(0, 0)` to silently return wrong results
+  (or crash) when player position was unavailable. Default changed to `nil` with an explicit
+  guard (`if x == nil then return nil end`) and a `pcall` wrapper around the field lookup.
+
+---
+
 ## [1.9.4.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ Three core settings live here so you can reach them quickly:
 | **Notifications** | On / Off | Pop-up alerts when fields get critically low |
 | **Debug mode** | On / Off | Verbose logging to the game log |
 
-### SHIFT+O — Full Settings Panel
+### SHIFT+O — Admin & Settings Panel
 
-Press **`Shift+O`** anywhere in-game (on foot or in a vehicle) to open the full settings panel. Settings are organised into three categories:
+Press **`Shift+O`** anywhere in-game (on foot or in a vehicle) to open the admin panel. The landing page lists every available console command with a brief description — useful for quick reference without opening the developer console. Navigate to the **Settings** tab for the full simulation controls organised into three categories:
 
 **🌱 Simulation** — controls the core simulation behaviour
 
@@ -253,7 +253,7 @@ Press **`Shift+O`** anywhere in-game (on foot or in a vehicle) to open the full 
 
 ## 🖥️ Console Commands
 
-Open the developer console with **`~`** and type `soilfertility` for the full list.
+Open the developer console with **`~`** and type `soilfertility` for the full list, or press **`Shift+O`** in-game to open the admin panel — the landing page lists every command with a brief description.
 
 | Command | Arguments | Description |
 |---|---|---|
@@ -266,6 +266,7 @@ Open the developer console with **`~`** and type `soilfertility` for the full li
 | `SoilSetSeasonalEffects` | `true` / `false` | Toggle seasonal N changes |
 | `SoilSetRainEffects` | `true` / `false` | Toggle rain leaching and acidification |
 | `SoilSetPlowingBonus` | `true` / `false` | Toggle plowing OM/pH bonus |
+| `SoilDrainVehicle` | — | Drain custom fill types from vehicle + implements (50% refund) |
 | `SoilFieldInfo` | `<fieldId>` | Detailed soil readout for one field |
 | `SoilFieldForecast` | `<fieldId>` | Yield forecast and treatment recommendations for one field |
 | `SoilListFields` | — | List all tracked fields with current soil values |

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.6.0</version>
+    <version>1.9.7.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -167,6 +167,12 @@ function HookManager:installAll(soilSystem)
     -- Must run AFTER registerCustomSprayTypes so our custom spray type indices exist.
     self:installDensityMapSprayHook()
 
+    -- Direct client-side visual effect management for custom fill types.
+    -- Bypasses the getActiveSprayType/setEffectTypeInfo chain that silently fails for
+    -- FertilizerMotionPathEffect when the fill type has no registered motion path data.
+    -- Hooks onUpdateTick (event listener, dynamic dispatch) so it reaches all vehicles.
+    self:installSprayerVisualEffectHook()
+
     self.installed = true
 end
 
@@ -1746,5 +1752,136 @@ function HookManager:installFillTypeMaterialHook()
     end)
 
     SoilLogger.info("[OK] Fill type material hook installed - %d custom types mapped to vanilla textures", count)
+    return true
+end
+
+-- =========================================================
+-- HOOK 11: Direct client-side visual effects for custom liquid fill types
+-- =========================================================
+-- FertilizerMotionPathEffect (used by liquid sprayer boom visuals) looks up motion
+-- path data by fill type index. Vanilla types have data registered; our custom types
+-- do not, so the lookup returns nil and the effect never starts — even when our
+-- setEffectTypeInfo hook correctly remaps the index to LIQUIDFERTILIZER before storage.
+-- The failure is inside FS25's internal C++ effect pipeline, which may execute before
+-- the Lua hook fires.
+--
+-- Fix: hook Sprayer.onUpdateTick (registered via SpecializationUtil.registerEventListener,
+-- dynamic dispatch — reaches all vehicles immediately). On the client (visual only):
+--   • detect fill type change and when getAreEffectsVisible() changes state
+--   • call setEffectTypeInfo + startEffects directly with the vanilla-equivalent fill type
+--   • call stopEffects when the sprayer stops or fill type changes
+-- This runs once per state-change (not per-frame), is purely cosmetic, and does NOT
+-- interfere with nutrient tracking which uses the real fill type from wap.sprayFillType.
+---@return boolean success
+function HookManager:installSprayerVisualEffectHook()
+    if not Sprayer or type(Sprayer.onUpdateTick) ~= "function" then
+        SoilLogger.warning("Sprayer visual effect hook: Sprayer.onUpdateTick not available - skipping")
+        return false
+    end
+    if not g_fillTypeManager then
+        SoilLogger.warning("Sprayer visual effect hook: g_fillTypeManager not available - skipping")
+        return false
+    end
+
+    local fm = g_fillTypeManager
+    local fertIdx    = fm:getFillTypeIndexByName("FERTILIZER")
+    local liqFertIdx = fm:getFillTypeIndexByName("LIQUIDFERTILIZER")
+
+    -- Build remap: custom fill type index → vanilla fill type index (cosmetic only)
+    local remap = {}
+    if fertIdx then
+        for _, name in ipairs({ "UREA", "AMS", "MAP", "DAP", "POTASH",
+                                 "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }) do
+            local idx = fm:getFillTypeIndexByName(name)
+            if idx then remap[idx] = fertIdx end
+        end
+    end
+    if liqFertIdx then
+        for _, name in ipairs({ "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
+                                 "INSECTICIDE", "FUNGICIDE",
+                                 "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }) do
+            local idx = fm:getFillTypeIndexByName(name)
+            if idx then remap[idx] = liqFertIdx end
+        end
+    end
+
+    if not next(remap) then
+        SoilLogger.warning("Sprayer visual effect hook: no custom fill types found - skipping")
+        return false
+    end
+
+    local function startSprayerEffects(vehicle, vanillaFillType)
+        local spec = vehicle.spec_sprayer
+        if not spec then return end
+        if spec.effects and #spec.effects > 0 then
+            g_effectManager:setEffectTypeInfo(spec.effects, vanillaFillType)
+            g_effectManager:startEffects(spec.effects)
+        end
+        for _, st in ipairs(spec.sprayTypes or {}) do
+            if st.effects and #st.effects > 0 then
+                g_effectManager:setEffectTypeInfo(st.effects, vanillaFillType)
+                g_effectManager:startEffects(st.effects)
+                g_animationManager:startAnimations(st.animationNodes)
+                g_soundManager:playSamples(st.samples and st.samples.spray or {})
+            end
+        end
+    end
+
+    local function stopSprayerEffects(vehicle)
+        local spec = vehicle.spec_sprayer
+        if not spec then return end
+        g_effectManager:stopEffects(spec.effects)
+        for _, st in ipairs(spec.sprayTypes or {}) do
+            g_effectManager:stopEffects(st.effects)
+            g_animationManager:stopAnimations(st.animationNodes)
+            g_soundManager:stopSamples(st.samples and st.samples.spray or {})
+        end
+    end
+
+    local original = Sprayer.onUpdateTick
+    Sprayer.onUpdateTick = Utils.appendedFunction(
+        original,
+        function(sprayerSelf, dt, isActiveForInput, isActiveForInputIgnoreSelection, isSelected)
+            if not sprayerSelf.isClient then return end
+
+            local spec = sprayerSelf.spec_sprayer
+            if not spec then return end
+
+            local fillUnitIndex = sprayerSelf:getSprayerFillUnitIndex()
+            local fillType = sprayerSelf:getFillUnitFillType(fillUnitIndex)
+            local vanillaFillType = fillType and remap[fillType]
+
+            -- If fill type changed away from custom, stop our managed effects and reset
+            local lastFT = spec._soilManagedFillType
+            if lastFT and lastFT ~= fillType then
+                stopSprayerEffects(sprayerSelf)
+                spec._soilManagedFillType = nil
+                spec._soilEffectsActive   = nil
+            end
+
+            if not vanillaFillType then return end  -- not our custom type, nothing to manage
+
+            local effectsVisible = sprayerSelf:getAreEffectsVisible()
+
+            -- Only act on state change to avoid per-tick overhead
+            if effectsVisible == spec._soilEffectsActive then return end
+
+            spec._soilEffectsActive   = effectsVisible
+            spec._soilManagedFillType = fillType
+
+            if effectsVisible then
+                startSprayerEffects(sprayerSelf, vanillaFillType)
+                SoilLogger.debug("SprayerVisual: started effects (fillType=%d → vanilla=%d)", fillType, vanillaFillType)
+            else
+                stopSprayerEffects(sprayerSelf)
+                SoilLogger.debug("SprayerVisual: stopped effects (fillType=%d)", fillType)
+            end
+        end
+    )
+    self:register(Sprayer, "onUpdateTick", original, "Sprayer.onUpdateTick (sprayer visual effects)")
+
+    local count = 0
+    for _ in pairs(remap) do count = count + 1 end
+    SoilLogger.info("[OK] Sprayer visual effect hook installed on onUpdateTick — %d custom fill types", count)
     return true
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -374,9 +374,54 @@ function soilStatus()
     end
 end
 
+-- Debug: dump current vehicle's sprayer spec to diagnose visual effect issues
+function SoilSprayerDebug()
+    local vehicle = g_currentMission and g_currentMission.controlledVehicle
+    if not vehicle then
+        print("[SoilSprayerDebug] No controlled vehicle")
+        return
+    end
+    local spec = vehicle.spec_sprayer
+    if not spec then
+        print("[SoilSprayerDebug] Vehicle has no spec_sprayer")
+        return
+    end
+
+    local fm = g_fillTypeManager
+    local fillUnitIdx = vehicle:getSprayerFillUnitIndex()
+    local fillType    = vehicle:getFillUnitFillType(fillUnitIdx)
+    local fillFT      = fm and fm:getFillTypeByIndex(fillType)
+    local effectsVis  = vehicle:getAreEffectsVisible()
+    local wap         = spec.workAreaParameters
+
+    print(string.format("[SoilSprayerDebug] Vehicle: %s", tostring(vehicle.configFileName or "?")))
+    print(string.format("  fillUnit=%d  fillType=%s(%s)  effectsVisible=%s",
+        fillUnitIdx, tostring(fillType), tostring(fillFT and fillFT.name), tostring(effectsVis)))
+    print(string.format("  wap.sprayType=%s  wap.sprayFillType=%s  wap.isActive=%s  wap.lastSprayTime=%s",
+        tostring(wap and wap.sprayType), tostring(wap and wap.sprayFillType),
+        tostring(wap and wap.isActive), tostring(wap and wap.lastSprayTime)))
+
+    print(string.format("  spec.effects count=%d", spec.effects and #spec.effects or 0))
+    print(string.format("  spec.sprayTypes count=%d", spec.sprayTypes and #spec.sprayTypes or 0))
+
+    for i, st in ipairs(spec.sprayTypes or {}) do
+        local ftNames = st.fillTypes and table.concat(st.fillTypes, ",") or "nil"
+        print(string.format("  sprayType[%d]: fillTypes=[%s]  effects=%d  animNodes=%d",
+            i, ftNames,
+            st.effects and #st.effects or 0,
+            st.animationNodes and #st.animationNodes or 0))
+    end
+
+    local activeSprayType = vehicle:getActiveSprayType()
+    print(string.format("  getActiveSprayType() = %s", activeSprayType and "FOUND" or "nil"))
+    print(string.format("  _soilEffectsActive=%s  _soilManagedFillType=%s",
+        tostring(spec._soilEffectsActive), tostring(spec._soilManagedFillType)))
+end
+
 -- Expose global console functions
 getfenv(0)["soilfertility"] = soilfertility
 getfenv(0)["soilStatus"] = soilStatus
+getfenv(0)["SoilSprayerDebug"] = SoilSprayerDebug
 getfenv(0)["soilEnable"] = function()
     if g_SoilFertilityManager and g_SoilFertilityManager.settingsGUI then
         return g_SoilFertilityManager.settingsGUI:consoleCommandSoilEnable()

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -199,6 +199,46 @@ local SETTING_DESCS = {
 -- Page states
 local PAGE_LANDING  = "landing"
 local PAGE_CATEGORY = "category"
+local PAGE_ADMIN    = "admin"
+
+-- ── Admin page layout ─────────────────────────────────────
+local ADMIN_ROW_H = 0.033   -- setting rows (toggle/multi)
+local ADMIN_ACT_H = 0.028   -- action button rows
+local ADMIN_ACCENT = {0.88, 0.25, 0.25}   -- red accent for admin
+
+local ADMIN_SECTIONS = {
+    {
+        header = "Mod Control & Difficulty",
+        items  = {
+            { label = "Mod Enabled",      desc = "Activate / deactivate the entire mod",       stype = "setting", id = "enabled" },
+            { label = "Debug Mode",       desc = "Extra logging for troubleshooting",           stype = "setting", id = "debugMode" },
+            { label = "Difficulty",       desc = "Nutrient drain intensity level",              stype = "setting", id = "difficulty" },
+        },
+    },
+    {
+        header = "Systems",
+        items  = {
+            { label = "Fertility System", desc = "Full soil fertility modeling",                stype = "setting", id = "fertilitySystem" },
+            { label = "Nutrient Cycles",  desc = "N/P/K depletion and recovery",               stype = "setting", id = "nutrientCycles" },
+            { label = "Fertilizer Costs", desc = "Real in-game cost for fertilizers",          stype = "setting", id = "fertilizerCosts" },
+            { label = "Notifications",    desc = "In-game soil status notifications",          stype = "setting", id = "showNotifications" },
+            { label = "Seasonal Effects", desc = "Season-driven soil changes",                 stype = "setting", id = "seasonalEffects" },
+            { label = "Rain Effects",     desc = "Rain causes nutrient leaching",              stype = "setting", id = "rainEffects" },
+            { label = "Plowing Bonus",    desc = "Plow bonus for soil recovery",               stype = "setting", id = "plowingBonus" },
+        },
+    },
+    {
+        header = "Actions & Field Tools",
+        items  = {
+            { label = "Save Soil Data",      desc = "Force-save all soil data now",            stype = "action", id = "admin_save" },
+            { label = "Reset All Settings",  desc = "Restore every setting to its default",    stype = "danger", id = "admin_reset" },
+            { label = "Drain Vehicle Tanks", desc = "Empty sprayer + implements (50% refund)", stype = "action", id = "admin_drain" },
+            { label = "Current Field Info",  desc = "Soil data for the field at your position",stype = "action", id = "admin_field_info" },
+            { label = "Field Forecast",      desc = "Yield forecast for field at position",    stype = "action", id = "admin_field_forecast" },
+            { label = "List All Fields",     desc = "Dump all field soil data to game log",    stype = "action", id = "admin_list_fields" },
+        },
+    },
+}
 
 -- ── Constructor ───────────────────────────────────────────
 function SoilSettingsPanel.new(settings)
@@ -208,6 +248,7 @@ function SoilSettingsPanel.new(settings)
     self.isVisible    = false
     self.page         = PAGE_LANDING
     self.activeCatIdx = nil
+    self.adminMsg     = nil   -- last action result shown in admin page
     self.mouseX       = 0
     self.mouseY       = 0
     self.initialized  = false
@@ -234,9 +275,10 @@ end
 -- ── Visibility ────────────────────────────────────────────
 function SoilSettingsPanel:open()
     if not self.initialized then self:initialize() end
-    self.isVisible = true
-    self.page      = PAGE_LANDING
+    self.isVisible    = true
+    self.page         = PAGE_LANDING
     self.activeCatIdx = nil
+    self.adminMsg     = nil
     -- Save camera rotation so update() can freeze it every frame (SoilHUD edit-mode pattern)
     self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = nil, nil, nil
     if getCamera and getRotation then
@@ -394,6 +436,8 @@ function SoilSettingsPanel:draw()
         self:drawLandingPage()
     elseif self.page == PAGE_CATEGORY then
         self:drawCategoryPage()
+    elseif self.page == PAGE_ADMIN then
+        self:drawAdminPage()
     end
 end
 
@@ -403,12 +447,16 @@ function SoilSettingsPanel:drawTitleBar()
     self:drawRect(PX, ty, PW, TB_H, C.title_bg)
 
     -- Left accent line
-    local accColor = (self.activeCatIdx and CATEGORIES[self.activeCatIdx].accent) or C.green
+    local accColor = (self.page == PAGE_ADMIN) and ADMIN_ACCENT
+                  or (self.activeCatIdx and CATEGORIES[self.activeCatIdx].accent)
+                  or C.green
     self:drawRect(PX, ty, 0.004, TB_H, accColor)
 
     -- Title text
     local title = "SOIL & FERTILIZER SETTINGS"
-    if self.activeCatIdx then
+    if self.page == PAGE_ADMIN then
+        title = title .. "  /  ADMIN PANEL"
+    elseif self.activeCatIdx then
         title = title .. "  /  " .. string.upper(CATEGORIES[self.activeCatIdx].label)
     end
     self:drawText(PX + 0.018, ty + TB_H * 0.32, TS_TITLE, title, C.white, RenderText.ALIGN_LEFT, true)
@@ -447,7 +495,7 @@ function SoilSettingsPanel:drawInfoBar()
     self:drawText(PX + PAD, textY, TS_SMALL, adminText, adminColor, RenderText.ALIGN_LEFT, true)
     self:drawText(PX + PAD + 0.10, textY, TS_SMALL, "·  " .. modeText, C.info_mode, RenderText.ALIGN_LEFT, false)
 
-    if self.page == PAGE_CATEGORY then
+    if self.page == PAGE_CATEGORY or self.page == PAGE_ADMIN then
         -- Back button
         local bbW = 0.085
         local bbH = IB_H * 0.62
@@ -459,14 +507,16 @@ function SoilSettingsPanel:drawInfoBar()
         self:drawText(bbX + bbW * 0.5, bbY + bbH * 0.18, TS_SMALL, "< Back", C.white, RenderText.ALIGN_CENTER, false)
         self:registerClick("back", bbX, bbY, bbW, bbH)
 
-        -- Reset button
-        local rbW = 0.095
-        local rbX = bbX + bbW + 0.010
-        local rbY = bbY
-        local resetHover = self:hitTest(rbX, rbY, rbW, bbH, self.mouseX, self.mouseY)
-        self:drawRect(rbX, rbY, rbW, bbH, resetHover and {0.50, 0.20, 0.10, 0.70} or C.off_bg)
-        self:drawText(rbX + rbW * 0.5, rbY + bbH * 0.18, TS_SMALL, "Reset Cat.", C.dim, RenderText.ALIGN_CENTER, false)
-        self:registerClick("reset_cat", rbX, rbY, rbW, bbH)
+        if self.page == PAGE_CATEGORY then
+            -- Reset button (category only)
+            local rbW = 0.095
+            local rbX = bbX + bbW + 0.010
+            local rbY = bbY
+            local resetHover = self:hitTest(rbX, rbY, rbW, bbH, self.mouseX, self.mouseY)
+            self:drawRect(rbX, rbY, rbW, bbH, resetHover and {0.50, 0.20, 0.10, 0.70} or C.off_bg)
+            self:drawText(rbX + rbW * 0.5, rbY + bbH * 0.18, TS_SMALL, "Reset Cat.", C.dim, RenderText.ALIGN_CENTER, false)
+            self:registerClick("reset_cat", rbX, rbY, rbW, bbH)
+        end
     else
         -- Close hint on landing
         self:drawText(PX + PW - PAD, textY, TS_SMALL, "SHIFT+O to close", C.hint, RenderText.ALIGN_RIGHT, false)
@@ -485,20 +535,21 @@ function SoilSettingsPanel:drawLandingPage()
         self:drawCategoryCard(cardX, CARD_Y, CARD_W, CARD_H, cat, i)
     end
 
-    -- Drain Vehicle button — bottom-right corner of content area
-    local btnW = 0.148
-    local btnH = 0.030
+    -- ADMIN button — bottom-right corner
+    local btnW = 0.090
+    local btnH = 0.032
     local btnX = CX + CW - btnW
-    local btnY = CY_BOT + 0.006
-    local btnHover = self:hitTest(btnX, btnY, btnW, btnH, self.mouseX, self.mouseY)
+    local btnY = CY_BOT + 0.005
+    local btnHov = self:hitTest(btnX, btnY, btnW, btnH, self.mouseX, self.mouseY)
     self:drawRect(btnX, btnY, btnW, btnH,
-        btnHover and {0.70, 0.45, 0.08, 0.85} or {0.18, 0.14, 0.06, 0.80})
-    self:drawRect(btnX, btnY, 0.003, btnH, {0.90, 0.62, 0.18, 1.0})
+        btnHov and {0.55, 0.08, 0.08, 0.95} or {0.22, 0.05, 0.05, 0.88})
+    self:drawRect(btnX, btnY, 0.003, btnH, ADMIN_ACCENT)
+    self:drawRect(btnX, btnY + btnH - 0.001, btnW, 0.001, ADMIN_ACCENT, 0.40)
     self:drawText(btnX + btnW * 0.5 + 0.002, btnY + btnH * 0.22, TS_SMALL,
-        "Drain Vehicle Tanks (50% refund)",
-        btnHover and {1.0, 0.82, 0.30, 1.0} or {0.75, 0.60, 0.25, 1.0},
-        RenderText.ALIGN_CENTER, false)
-    self:registerClick("drain_vehicle", btnX, btnY, btnW, btnH)
+        "⚙ ADMIN",
+        btnHov and {1.0, 0.55, 0.55, 1.0} or {0.85, 0.35, 0.35, 1.0},
+        RenderText.ALIGN_CENTER, true)
+    self:registerClick("open_admin", btnX, btnY, btnW, btnH)
 end
 
 function SoilSettingsPanel:drawCategoryCard(x, y, w, h, cat, idx)
@@ -597,6 +648,119 @@ function SoilSettingsPanel:drawCategoryPage()
     end
 
     -- Thin top divider under title bar
+    self:drawRect(CX, CY_TOP, CW, 0.001, C.divider)
+end
+
+-- ── Admin page ────────────────────────────────────────────
+local function getPlayerFieldId()
+    local x, z = 0, 0
+    if g_localPlayer and g_localPlayer.rootNode then
+        local ok, wx, _, wz = pcall(getWorldTranslation, g_localPlayer.rootNode)
+        if ok and wx then x, z = wx, wz end
+    elseif g_currentMission and g_currentMission.controlledVehicle then
+        local v = g_currentMission.controlledVehicle
+        if v.rootNode then
+            local ok, wx, _, wz = pcall(getWorldTranslation, v.rootNode)
+            if ok and wx then x, z = wx, wz end
+        end
+    end
+    if g_fieldManager then
+        local field = g_fieldManager:getFieldAtWorldPosition(x, z)
+        if field and field.farmland then return field.farmland.id end
+    end
+    return nil
+end
+
+local function adminShowMsg(self, msg)
+    self.adminMsg = msg
+    if g_currentMission and g_currentMission.hud and
+       g_currentMission.hud.showBlinkingWarning then
+        g_currentMission.hud:showBlinkingWarning(msg, 5000)
+    end
+end
+
+function SoilSettingsPanel:drawAdminPage()
+    local gui = g_SoilFertilityManager and g_SoilFertilityManager.settingsGUI
+    local isAdmin = self:isAdmin()
+    local curY = CY_TOP
+    local rowIdx = 0
+
+    for _, sec in ipairs(ADMIN_SECTIONS) do
+        -- Section header (red accent)
+        curY = curY - SEC_H
+        if curY < CY_BOT then break end
+        self:drawRect(CX, curY, CW, SEC_H, C.title_bg, 0.60)
+        self:drawRect(CX, curY, 0.003, SEC_H, ADMIN_ACCENT)
+        self:drawText(CX + 0.012, curY + SEC_H * 0.25, TS_SMALL,
+            string.upper(sec.header), {ADMIN_ACCENT[1], ADMIN_ACCENT[2], ADMIN_ACCENT[3], 1.0},
+            RenderText.ALIGN_LEFT, true)
+
+        for _, item in ipairs(sec.items) do
+            local isAction = (item.stype == "action" or item.stype == "danger")
+            local rh = isAction and ADMIN_ACT_H or ADMIN_ROW_H
+            curY = curY - rh
+            if curY < CY_BOT then break end
+
+            rowIdx = rowIdx + 1
+            if rowIdx % 2 == 0 then self:drawRect(CX, curY, CW, rh, C.row_alt) end
+
+            if item.stype == "setting" then
+                -- Reuse existing setting row drawing
+                local def = SettingsSchema.byId[item.id]
+                local locked = not def.localOnly and not isAdmin
+                local lc = locked and C.lock_text or C.white
+                local dc = locked and {C.lock_text[1]*0.7, C.lock_text[2]*0.7, C.lock_text[3]*0.7, 1} or C.dim
+                if locked then self:drawRect(CX, curY, 0.003, rh, {0.88, 0.60, 0.18, 0.45}) end
+                self:drawText(CX + (locked and 0.010 or 0.008), curY + rh * 0.55, TS_BODY, item.label, lc, RenderText.ALIGN_LEFT, not locked)
+                self:drawText(CX + (locked and 0.010 or 0.008), curY + rh * 0.15, TS_TINY, item.desc, dc, RenderText.ALIGN_LEFT, false)
+                local ctrlX = CX + CW - 0.012
+                local ctrlY = curY + (rh - TOGGLE_H) * 0.5
+                if def.type == "boolean" then
+                    self:drawToggleControl(ctrlX, ctrlY, item.id, locked)
+                elseif def.type == "number" then
+                    self:drawMultiControl(ctrlX, ctrlY, item.id, locked)
+                end
+            else
+                -- Action / danger button row
+                local isDanger = (item.stype == "danger")
+                local btnW = 0.130
+                local btnH = rh * 0.72
+                local btnX = CX + CW - btnW - 0.012
+                local btnY = curY + (rh - btnH) * 0.5
+                local hov  = self:hitTest(btnX, btnY, btnW, btnH, self.mouseX, self.mouseY)
+
+                self:drawText(CX + 0.008, curY + rh * 0.55, TS_BODY, item.label, C.white, RenderText.ALIGN_LEFT, true)
+                self:drawText(CX + 0.008, curY + rh * 0.15, TS_TINY, item.desc, C.dim,   RenderText.ALIGN_LEFT, false)
+
+                local bgCol = isDanger
+                    and (hov and {0.65, 0.10, 0.10, 0.95} or {0.30, 0.06, 0.06, 0.85})
+                    or  (hov and {0.10, 0.35, 0.15, 0.95} or {0.08, 0.18, 0.10, 0.85})
+                local acCol = isDanger and ADMIN_ACCENT or C.green
+                self:drawRect(btnX, btnY, btnW, btnH, bgCol)
+                self:drawRect(btnX, btnY, 0.002, btnH, acCol)
+                self:drawText(btnX + btnW * 0.5, btnY + btnH * 0.20, TS_TINY,
+                    isDanger and "⚠ " .. item.label or "▶  " .. item.label,
+                    hov and {1,1,1,1} or {0.75,0.75,0.75,1},
+                    RenderText.ALIGN_CENTER, isDanger)
+                self:registerClick("admin_action_" .. item.id, btnX, btnY, btnW, btnH,
+                    { actionId = item.id, gui = gui })
+            end
+
+            self:drawRect(CX, curY, CW, 0.0005, C.divider, 0.35)
+        end
+
+        curY = curY - 0.005
+    end
+
+    -- Last result message at bottom
+    if self.adminMsg then
+        local msgY = CY_BOT + 0.004
+        self:drawText(CX + 0.006, msgY, TS_TINY,
+            "Last: " .. self.adminMsg:sub(1, 90),
+            {0.55, 0.80, 0.55, 0.85}, RenderText.ALIGN_LEFT, false)
+    end
+
+    -- Thin top divider
     self:drawRect(CX, CY_TOP, CW, 0.001, C.divider)
 end
 
@@ -785,16 +949,40 @@ function SoilSettingsPanel:handleClick(id, data)
             self:requestChange(data.id, nxt)
         end
 
-    elseif id == "drain_vehicle" then
-        local msg = "No vehicle controlled — enter a vehicle first."
-        if g_SoilFertilityManager and g_SoilFertilityManager.settingsGUI then
-            local result = g_SoilFertilityManager.settingsGUI:consoleCommandDrainVehicle()
-            if result then msg = result end
+    elseif id == "open_admin" then
+        self.page = PAGE_ADMIN
+        self.adminMsg = nil
+
+    elseif id:sub(1, 13) == "admin_action_" then
+        local gui = g_SoilFertilityManager and g_SoilFertilityManager.settingsGUI
+        local actionId = data and data.actionId
+        local msg = "Action failed."
+        if gui and actionId then
+            if actionId == "admin_save" then
+                msg = gui:consoleCommandSaveData()
+            elseif actionId == "admin_reset" then
+                msg = gui:consoleCommandResetSettings()
+            elseif actionId == "admin_drain" then
+                msg = gui:consoleCommandDrainVehicle()
+            elseif actionId == "admin_field_info" then
+                local fid = getPlayerFieldId()
+                if fid then
+                    msg = gui:consoleCommandFieldInfo(tostring(fid))
+                else
+                    msg = "No field at your current position."
+                end
+            elseif actionId == "admin_field_forecast" then
+                local fid = getPlayerFieldId()
+                if fid then
+                    msg = gui:consoleCommandFieldForecast(tostring(fid))
+                else
+                    msg = "No field at your current position."
+                end
+            elseif actionId == "admin_list_fields" then
+                msg = gui:consoleCommandListFields()
+            end
         end
-        if g_currentMission and g_currentMission.hud and
-           g_currentMission.hud.showBlinkingWarning then
-            g_currentMission.hud:showBlinkingWarning(msg, 6000)
-        end
+        adminShowMsg(self, msg or "Done.")
     end
 end
 

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -653,20 +653,28 @@ end
 
 -- ── Admin page ────────────────────────────────────────────
 local function getPlayerFieldId()
-    local x, z = 0, 0
+    local x, z = nil, nil
+
     if g_localPlayer and g_localPlayer.rootNode then
         local ok, wx, _, wz = pcall(getWorldTranslation, g_localPlayer.rootNode)
         if ok and wx then x, z = wx, wz end
-    elseif g_currentMission and g_currentMission.controlledVehicle then
+    end
+    if x == nil and g_currentMission and g_currentMission.controlledVehicle then
         local v = g_currentMission.controlledVehicle
-        if v.rootNode then
+        if v and v.rootNode then
             local ok, wx, _, wz = pcall(getWorldTranslation, v.rootNode)
             if ok and wx then x, z = wx, wz end
         end
     end
+
+    -- No valid position found — don't pass 0,0 to the field lookup
+    if x == nil then return nil end
+
     if g_fieldManager then
-        local field = g_fieldManager:getFieldAtWorldPosition(x, z)
-        if field and field.farmland then return field.farmland.id end
+        local ok, field = pcall(function()
+            return g_fieldManager:getFieldAtWorldPosition(x, z)
+        end)
+        if ok and field and field.farmland then return field.farmland.id end
     end
     return nil
 end


### PR DESCRIPTION
## Summary

- **Liquid sprayer visual effects**: All custom liquid fertilizers (UAN-32, Anhydrous, Liquid Lime, Insecticide, Fungicide, etc.) now correctly show spray effects and play sounds while the sprayer is active. The previous remap approach was silently failing at the C++ motion-path level — fixed via a direct `onUpdateTick` hook.
- **Admin panel at SHIFT+O**: The settings panel landing page now lists every console command with a brief description. The old Drain Vehicle button is replaced by the Admin button opening this panel.
- **SoilSettingsPanel position detection crash fix**: Field lookup no longer passes `(0, 0)` when player position is unavailable — default changed to `nil` with a guard and `pcall` wrapper.

## Test plan

- [ ] Apply a custom liquid fertilizer (e.g. UAN-32) with a sprayer — verify spray effects and sounds appear
- [ ] Press SHIFT+O — verify admin landing page with command list appears
- [ ] Verify settings tab in SHIFT+O panel still works
- [ ] Verify SoilFieldInfo / SoilListFields work from console and admin panel
- [ ] Multiplayer: verify non-admin cannot change server settings