### PR TITLE
Update fillTypes.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.7.1] - 2026-04-20
+
+### Fixed
+
+- **Unloading for spreaders**: Spraders can now unload custom fertilizers as big bags on site. But for sprayers is still in progress.
+
 ## [1.9.7.0] - 2026-04-19
 
 ### Added

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -11,9 +11,7 @@
             <economy pricePerLiter="1.60"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/uan32/bigBag_uan32.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/uan32/bigBag_uan32.xml" />
         </fillType>
 
         <fillType name="UAN28" title="$l10n_sf_uan28_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -21,9 +19,7 @@
             <economy pricePerLiter="1.50"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/uan28/bigBag_uan28.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/uan28/bigBag_uan28.xml" />
         </fillType>
 
         <fillType name="ANHYDROUS" title="$l10n_sf_anhydrous_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -31,9 +27,7 @@
             <economy pricePerLiter="1.85"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/anhydrous/bigBag_anhydrous.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/anhydrous/bigBag_anhydrous.xml" />
         </fillType>
 
         <fillType name="STARTER" title="$l10n_sf_starter_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -41,9 +35,7 @@
             <economy pricePerLiter="1.70"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/starter/bigBag_starter.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/starter/bigBag_starter.xml" />
         </fillType>
 
         <!-- ── SOLID GRANULAR SOURCES ─────────────────────────── -->
@@ -53,9 +45,7 @@
             <economy pricePerLiter="1.65"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <sprayType sprayTypeStr="SOLID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/urea/bigBag_urea.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/urea/bigBag_urea.xml" />
         </fillType>
 
         <fillType name="AMS" title="$l10n_sf_ams_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
@@ -63,9 +53,7 @@
             <economy pricePerLiter="1.40"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <sprayType sprayTypeStr="SOLID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
         </fillType>
 
         <fillType name="MAP" title="$l10n_sf_map_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
@@ -73,9 +61,7 @@
             <economy pricePerLiter="1.95"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <sprayType sprayTypeStr="SOLID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/map/bigBag_map.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/map/bigBag_map.xml" />
         </fillType>
 
         <fillType name="DAP" title="$l10n_sf_dap_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
@@ -83,9 +69,7 @@
             <economy pricePerLiter="1.75"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <sprayType sprayTypeStr="SOLID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/dap/bigBag_dap.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/dap/bigBag_dap.xml" />
         </fillType>
 
         <fillType name="POTASH" title="$l10n_sf_potash_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
@@ -93,9 +77,7 @@
             <economy pricePerLiter="1.80"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <sprayType sprayTypeStr="SOLID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/potash/bigBag_potash.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/potash/bigBag_potash.xml" />
         </fillType>
 
         <!-- ── CROP PROTECTION ────────────────────────────────── -->
@@ -105,9 +87,7 @@
             <economy pricePerLiter="1.20"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/insecticide/bigBag_insecticide.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/insecticide/bigBag_insecticide.xml" />
         </fillType>
 
         <fillType name="FUNGICIDE" title="$l10n_sf_fungicide_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -115,9 +95,7 @@
             <economy pricePerLiter="1.30"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/fungicide/bigBag_fungicide.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/fungicide/bigBag_fungicide.xml" />
         </fillType>
 
         <fillType name="LIQUID_UREA" title="$l10n_sf_liquid_urea_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -125,9 +103,7 @@
             <economy pricePerLiter="1.70"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/liquid_urea/bigBag_liquid_urea.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/liquid_urea/bigBag_liquid_urea.xml" />
         </fillType>
 
         <fillType name="LIQUID_AMS" title="$l10n_sf_liquid_ams_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -135,9 +111,7 @@
             <economy pricePerLiter="1.45"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/liquid_ams/bigBag_liquid_ams.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/liquid_ams/bigBag_liquid_ams.xml" />
         </fillType>
 
         <fillType name="LIQUID_MAP" title="$l10n_sf_liquid_map_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -145,9 +119,7 @@
             <economy pricePerLiter="2.00"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/liquid_map/bigBag_liquid_map.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/liquid_map/bigBag_liquid_map.xml" />
         </fillType>
 
         <fillType name="LIQUID_DAP" title="$l10n_sf_liquid_dap_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -155,9 +127,7 @@
             <economy pricePerLiter="1.80"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/liquid_dap/bigBag_liquid_dap.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/liquid_dap/bigBag_liquid_dap.xml" />
         </fillType>
 
         <fillType name="LIQUID_POTASH" title="$l10n_sf_liquid_potash_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">
@@ -165,9 +135,7 @@
             <economy pricePerLiter="1.85"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
             <sprayType sprayTypeStr="LIQUID"/>
-            <pallets>
-                <pallet filename="objects/bigBag/liquid_potash/bigBag_liquid_potash.xml" />
-            </pallets>
+            <pallet filename="objects/bigBag/liquid_potash/bigBag_liquid_potash.xml" />
         </fillType>
 
         <!-- ── ORGANIC / SOIL AMENDMENTS ──────────────────────── -->


### PR DESCRIPTION
## What Does This PR Do?

Hello dear creator! I like your mod and I made the code changes because I found that spreader and sprayer could not unload these fillTypes as pallets using the I key. After trying for some time, I determined the issue was with 'pallets' — each 'fillType' seems to be recognized by spreader/sprayer through 'pallet' instead of 'pallets'. After removing 'pallets', spreader can now unload the 'fillType' as a 'bigBag' pallet near vehicle by pressing I key.

Sprayer still cannot unload 'fillType' as pallets the same way. I would like to add custom parent LiquidTank for liquid pallet, and bigBagPallet for solid pallet, setup to support sprayer unload pallet as well, and also add textures for different products.

## Related Issue

Fixes #169 

## Type of Change

- [x] Bug fix
- [ ] New feature (crop, fertilizer, setting, UI)
- [x] Refactor / code quality
- [ ] Documentation / translations
- [ ] Build / tooling

## How Was This Tested?

- [x] Singleplayer — loaded a savegame, no errors in log.txt
- [ ] Multiplayer — tested as host and/or client
- [x] With Precision Farming active
- [ ] Relevant console commands ran (`SoilFieldInfo`, `SoilShowSettings`, etc.)

<!-- Describe what specifically you tested and any edge cases you checked -->

After removing "pallets", In Singleplay with PF mod, spreader with custom fertilizer can now unload as a "bigBag" pallet near vehicle by pressing I Key. But "liquidTank" still not working with sprayers.

## Checklist

- [x] I read `DEVELOPMENT.md` before writing code
- [x] I targeted the `development` branch (not `main`)
- [x] My change touches only what it needs to — no unrelated edits
- [x] If I added a setting: one entry in `SettingsSchema.lua` + `_short`/`_long` translations in `modDesc.xml` for all 10 languages
- [x] If I changed crop/fertilizer values: they're in `Constants.lua`, not hardcoded
- [x] If I changed behaviour: `CHANGELOG.md` has an entry under the correct version
- [x] No `assert()` calls — errors are handled gracefully with `pcall()`
- [x] No Lua 5.2+ syntax (`goto`, `continue`, `os.time()`, etc.)

## Screenshots / Log Output (if relevant)

<!-- Paste a log excerpt or screenshot if this fixes a visible bug or changes UI -->
