### PR TITLE
v1.9.9.3 — MP Stability & CropRotation Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.9.3] - 2026-04-24
+
+### Fixed
+
+- **#208 — Admin settings GUI not updating on dedicated server**: When an admin changed a setting, the broadcast excluded the sender's connection. The admin's own panel was never refreshed with the new value. The sender exclusion has been removed — all clients including the admin now receive the `SoilSettingSyncEvent` broadcast.
+
+- **#209 — Admin settings reset to defaults on dedicated server restart**: `settings:load()` was called during `SoilFertilityManager.new()`, before the savegame directory was set by the engine on dedicated servers. Settings always loaded from the wrong path and fell back to defaults. The load is now deferred to `deferredSoilSystemInit()` where `savegameDirectory` is guaranteed to be available.
+
+- **BUG-03 — `SoilFullSyncEvent` hardcoded settings list**: The MP full sync event enumerated 15 settings by name in a hardcoded block. Any new setting added to `SettingsSchema` would be silently absent from MP join syncs. Replaced with schema-driven iteration over `SettingsSchema.definitions` — new settings are now synced automatically. Wire format is unchanged for the existing 15 settings.
+
+- **BUG-05 — `VANILLA_SETTINGS` defined twice in `SoilSettingsUI`**: The list of 3 settings shown in the vanilla settings page was defined as a local variable twice — once before the callbacks (used by those functions) and once after a block of function definitions (the intended single definition, but unreachable as an upvalue). The duplicate was removed and the single declaration moved before all function definitions.
+
+- **#204 — Conflict with FS25_CropRotation**: When a crop was sown, `onSowing()` cleared `field.lastCrop = nil` to force a live `FieldState` detection in the HUD. However, `getFieldInfo()` already performs live `FieldState` detection regardless — the clearing was unnecessary. The side-effect was that `lastCrop` (previous season) and `lastCrop2` (season before) both reflected the same crop when the same crop was replanted, causing duplicate entries in the rotation history. Removed the `onSowing` clearing entirely; the sowing hook installation was also removed from `HookManager`.
+
+- **Zombie updaters in `hookInstaller` and batch dispatcher**: Both the deferred hook installer and the MP field batch dispatcher used `return true` / `return false` to signal completion. FS25's `addUpdateable` system ignores return values — updaters run forever unless `g_currentMission:removeUpdateable(self)` is called explicitly. Both updated to call `removeUpdateable` at the correct completion/cleanup points.
+
+---
+
 ## [1.9.9.1]  2026-04-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **1.9.4.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
+**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **1.9.9.3**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 1.9.9.1
-**Last Updated**: 2026-04-23
+**Version**: 1.9.9.3
+**Last Updated**: 2026-04-24
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.9.4.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 1.9.9.3
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.9.1</version>
+    <version>1.9.9.3</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -381,7 +381,8 @@ function SoilFertilityManager:deferredSoilSystemInit()
 
         update = function(self, dt)
             if self.installed then
-                return true  -- Remove updater - job done
+                g_currentMission:removeUpdateable(self)
+                return
             end
 
             self.attempts = self.attempts + 1
@@ -397,9 +398,9 @@ function SoilFertilityManager:deferredSoilSystemInit()
             if not missionReady then
                 if self.attempts >= self.maxAttempts then
                     SoilLogger.warning("Deferred init timeout: Mission not ready after %d attempts", self.attempts)
-                    return true  -- Give up and remove updater
+                    g_currentMission:removeUpdateable(self)
                 end
-                return false  -- Keep waiting
+                return
             end
 
             -- Guard 2: Field manager must be ready AND populated with at least one field.
@@ -409,9 +410,9 @@ function SoilFertilityManager:deferredSoilSystemInit()
             if not g_fieldManager or not g_fieldManager.fields or next(g_fieldManager.fields) == nil then
                 if self.attempts >= self.maxAttempts then
                     SoilLogger.warning("Deferred init timeout: FieldManager not populated after %d attempts", self.attempts)
-                    return true  -- Give up and remove updater
+                    g_currentMission:removeUpdateable(self)
                 end
-                return false  -- Keep waiting
+                return
             end
 
             -- Guard 3: FarmlandManager must be available for ownership hook installation.
@@ -420,13 +421,27 @@ function SoilFertilityManager:deferredSoilSystemInit()
             if not g_farmlandManager then
                 if self.attempts >= self.maxAttempts then
                     SoilLogger.warning("Deferred init timeout: FarmlandManager not available after %d attempts", self.attempts)
-                    return true  -- Give up and remove updater
+                    g_currentMission:removeUpdateable(self)
                 end
-                return false  -- Keep waiting
+                return
             end
 
             -- All guards passed - initialize soil system now
             SoilLogger.info("Game ready after %d update cycles - initializing soil system...", self.attempts)
+
+            -- Reload settings here: savegameDirectory is now guaranteed available.
+            -- The earlier load() in new() fires before savegameDirectory is set on
+            -- dedicated servers (Mission00.load timing), so it falls back to defaults.
+            -- This reload picks up the actual saved XML values.
+            self.sfm.settings:load()
+
+            -- Guard: if settings were saved with enabled=false, respect that.
+            if not self.sfm.settings.enabled then
+                SoilLogger.info("Mod disabled in settings — skipping soil system init")
+                self.installed = true
+                g_currentMission:removeUpdateable(self)
+                return
+            end
 
             local initSuccess, initError = pcall(function()
                 self.sfm.soilSystem:initialize()
@@ -448,7 +463,7 @@ function SoilFertilityManager:deferredSoilSystemInit()
             end
 
             self.installed = true
-            return true  -- Remove updater
+            g_currentMission:removeUpdateable(self)
         end
     }
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -281,19 +281,14 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
 end
 
 --- Hook delegate: called by HookManager when sowing/planting occurs on a field.
---- Clears the stale lastCrop so the HUD falls through to live FieldState detection
---- instead of showing the crop from the previous harvest (fix for issue #123).
+--- Called when a field is sown. Reserved for future sowing-time logic.
+--- NOTE: We previously cleared lastCrop here to force live HUD detection (#123),
+--- but that caused duplicate crop entries in history when the same crop is replanted
+--- (especially visible with FS25_CropRotation installed — issue #204).
+--- Live FieldState detection in getFieldInfo() works regardless of lastCrop, so
+--- the clearing was unnecessary and harmful to rotation history accuracy.
 ---@param fieldId number The field being sown
 function SoilFertilitySystem:onSowing(fieldId)
-    if not fieldId or fieldId <= 0 then return end
-    local field = self:getOrCreateField(fieldId, true)
-    if not field then return end
-    -- Clearing lastCrop here is safe: getFieldInfo() will immediately pick up the
-    -- live fruitTypeIndex from FieldState:update() once the crop is in the ground.
-    -- If FieldState somehow returns UNKNOWN in the first tick, we get "Fallow"
-    -- momentarily (correct — seeds just went in, nothing is growing yet).
-    field.lastCrop = nil
-    SoilLogger.debug("Sowing on field %d: cleared lastCrop for fresh HUD detection", fieldId)
 end
 
 --- Hook delegate: called by HookManager when plowing occurs

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -119,10 +119,6 @@ function HookManager:installAll(soilSystem)
     local weedControlOk = self:installWeederHook()
     if weedControlOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
-    -- Sowing / planting: clear stale lastCrop so HUD shows live crop (fix #123)
-    local sowingOk = self:installSowingHook()
-    if sowingOk then successCount = successCount + 1 else failCount = failCount + 1 end
-
     -- Patch vanilla fill units to accept custom fertilizer types
     local fillUnitOk = self:installFillUnitHook()
     if fillUnitOk then successCount = successCount + 1 else failCount = failCount + 1 end

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -318,22 +318,16 @@ end
 function SoilFullSyncEvent:readStream(streamId, connection)
     self.settings = {}
 
-    -- Read all settings
-    self.settings.enabled = streamReadBool(streamId)
-    self.settings.debugMode = streamReadBool(streamId)
-    self.settings.fertilitySystem = streamReadBool(streamId)
-    self.settings.nutrientCycles = streamReadBool(streamId)
-    self.settings.fertilizerCosts = streamReadBool(streamId)
-    self.settings.showNotifications = streamReadBool(streamId)
-    self.settings.seasonalEffects = streamReadBool(streamId)
-    self.settings.rainEffects = streamReadBool(streamId)
-    self.settings.plowingBonus = streamReadBool(streamId)
-    self.settings.weedPressure = streamReadBool(streamId)
-    self.settings.pestPressure = streamReadBool(streamId)
-    self.settings.diseasePressure = streamReadBool(streamId)
-    self.settings.difficulty = streamReadInt32(streamId)
-    self.settings.autoRateControl = streamReadBool(streamId)
-    self.settings.cropRotation = streamReadBool(streamId)
+    -- Read all non-local settings in schema order (matches writeStream iteration)
+    for _, def in ipairs(SettingsSchema.definitions) do
+        if not def.localOnly then
+            if def.type == "boolean" then
+                self.settings[def.id] = streamReadBool(streamId)
+            elseif def.type == "number" then
+                self.settings[def.id] = streamReadInt32(streamId)
+            end
+        end
+    end
 
     -- Read field data
     self.fieldData = {}
@@ -446,22 +440,16 @@ function SoilFullSyncEvent:readStream(streamId, connection)
 end
 
 function SoilFullSyncEvent:writeStream(streamId, connection)
-    -- Write all settings
-    streamWriteBool(streamId, self.settings.enabled)
-    streamWriteBool(streamId, self.settings.debugMode)
-    streamWriteBool(streamId, self.settings.fertilitySystem)
-    streamWriteBool(streamId, self.settings.nutrientCycles)
-    streamWriteBool(streamId, self.settings.fertilizerCosts)
-    streamWriteBool(streamId, self.settings.showNotifications)
-    streamWriteBool(streamId, self.settings.seasonalEffects)
-    streamWriteBool(streamId, self.settings.rainEffects)
-    streamWriteBool(streamId, self.settings.plowingBonus)
-    streamWriteBool(streamId, self.settings.weedPressure == true)
-    streamWriteBool(streamId, self.settings.pestPressure == true)
-    streamWriteBool(streamId, self.settings.diseasePressure == true)
-    streamWriteInt32(streamId, self.settings.difficulty)
-    streamWriteBool(streamId, self.settings.autoRateControl == true)
-    streamWriteBool(streamId, self.settings.cropRotation == true)
+    -- Write all non-local settings in schema order (matches readStream iteration)
+    for _, def in ipairs(SettingsSchema.definitions) do
+        if not def.localOnly then
+            if def.type == "boolean" then
+                streamWriteBool(streamId, self.settings[def.id] == true)
+            elseif def.type == "number" then
+                streamWriteInt32(streamId, self.settings[def.id] or def.default)
+            end
+        end
+    end
 
     -- Write field data
     local fieldCount = 0
@@ -513,23 +501,13 @@ function SoilFullSyncEvent:run(connection)
 
     SoilLogger.info("Client: Received full sync header from server (settings + %d legacy fields)", self:getFieldCount())
 
-    -- Apply all settings
+    -- Apply all non-local settings from schema (auto-covers any new settings)
     local settings = g_SoilFertilityManager.settings
-    settings.enabled          = self.settings.enabled
-    settings.debugMode        = self.settings.debugMode
-    settings.fertilitySystem  = self.settings.fertilitySystem
-    settings.nutrientCycles   = self.settings.nutrientCycles
-    settings.fertilizerCosts  = self.settings.fertilizerCosts
-    settings.showNotifications= self.settings.showNotifications
-    settings.seasonalEffects  = self.settings.seasonalEffects
-    settings.rainEffects      = self.settings.rainEffects
-    settings.plowingBonus     = self.settings.plowingBonus
-    settings.weedPressure     = self.settings.weedPressure
-    settings.pestPressure     = self.settings.pestPressure
-    settings.diseasePressure  = self.settings.diseasePressure
-    settings.difficulty       = self.settings.difficulty
-    settings.autoRateControl  = self.settings.autoRateControl
-    settings.cropRotation     = self.settings.cropRotation
+    for _, def in ipairs(SettingsSchema.definitions) do
+        if not def.localOnly then
+            settings[def.id] = self.settings[def.id]
+        end
+    end
 
     -- Legacy path: if the server sent field data inline (old server version),
     -- apply it directly so we stay backwards-compatible.

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -234,34 +234,66 @@ function SoilRequestFullSyncEvent:run(connection)
     local batchSize    = SoilConstants.NETWORK.FULL_SYNC_BATCH_SIZE
     local batchDelay   = SoilConstants.NETWORK.FULL_SYNC_BATCH_DELAY
     local totalBatches = math.ceil(#fieldIds / batchSize)
-    local batchIndex   = 1
 
-    -- Step 4: schedule each batch via a delayed callback so the engine loop
-    -- can process network I/O between batches (avoids the 3-minute hang).
-    local function sendNextBatch()
-        -- Guard: connection may have dropped between callbacks
-        if batchIndex > totalBatches then return end
+    -- Step 4: Use addUpdateable to drip-feed batches one per update tick,
+    -- throttled by batchDelay (ms). g_currentMission:addDelayedCallback() does
+    -- NOT exist in FS25 — addUpdateable is the correct deferred-work API.
+    local batchDispatcher = {
+        batchIndex  = 1,
+        timer       = 0,
+        batchSize   = batchSize,
+        batchDelay  = batchDelay,
+        totalBatches = totalBatches,
+        fieldIds    = fieldIds,
+        fieldData   = fieldData,
+        connection  = connection,
 
-        local startIdx = (batchIndex - 1) * batchSize + 1
-        local endIdx   = math.min(batchIndex * batchSize, #fieldIds)
-        local batch    = {}
-        for i = startIdx, endIdx do
-            local id = fieldIds[i]
-            batch[id] = fieldData[id]
+        update = function(self, dt)
+            -- Guard: connection may have dropped or all batches sent
+            if not self.connection or self.batchIndex > self.totalBatches then
+                g_currentMission:removeUpdateable(self)
+                return
+            end
+
+            -- Throttle: wait batchDelay ms between sends
+            self.timer = self.timer + dt
+            if self.timer < self.batchDelay then return end
+            self.timer = 0
+
+            local startIdx = (self.batchIndex - 1) * self.batchSize + 1
+            local endIdx   = math.min(self.batchIndex * self.batchSize, #self.fieldIds)
+            local batch    = {}
+            for i = startIdx, endIdx do
+                local id = self.fieldIds[i]
+                batch[id] = self.fieldData[id]
+            end
+
+            local isLast = (self.batchIndex == self.totalBatches)
+            self.connection:sendEvent(SoilFieldBatchSyncEvent.new(batch, isLast))
+
+            SoilLogger.info("Server: Field batch %d/%d sent (%d fields)",
+                self.batchIndex, self.totalBatches, endIdx - startIdx + 1)
+
+            self.batchIndex = self.batchIndex + 1
+
+            if isLast then
+                g_currentMission:removeUpdateable(self)
+            end
         end
+    }
 
-        local isLast = (batchIndex == totalBatches)
-        connection:sendEvent(SoilFieldBatchSyncEvent.new(batch, isLast))
-
-        SoilLogger.info("Server: Field batch %d/%d sent (%d fields)", batchIndex, totalBatches, endIdx - startIdx + 1)
-        batchIndex = batchIndex + 1
-
-        if not isLast then
-            g_currentMission:addDelayedCallback(sendNextBatch, batchDelay)
+    if g_currentMission and g_currentMission.addUpdateable then
+        g_currentMission:addUpdateable(batchDispatcher)
+        SoilLogger.info("Server: Batch dispatcher registered (%d batches of %d fields)", totalBatches, batchSize)
+    else
+        -- Fallback for edge cases: send everything at once (old blocking behaviour)
+        SoilLogger.warning("Server: addUpdateable unavailable — sending all %d fields synchronously", fieldCount)
+        local allBatch = {}
+        for _, id in ipairs(fieldIds) do
+            allBatch[id] = fieldData[id]
         end
+        connection:sendEvent(SoilFieldBatchSyncEvent.new(allBatch, true))
     end
-
-    g_currentMission:addDelayedCallback(sendNextBatch, batchDelay)
 end
 
 -- ========================================

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -94,12 +94,12 @@ function SoilSettingChangeEvent:run(connection)
             end
         end
 
-        -- Broadcast to all clients
+        -- Broadcast to ALL clients including the original sender.
+        -- On dedicated servers the admin is a client — excluding them (old behaviour)
+        -- meant their own panel never reflected the confirmed value (issue #208).
         if g_server then
             g_server:broadcastEvent(
-                SoilSettingSyncEvent.new(self.settingName, self.settingValue),
-                nil,  -- send to all
-                connection  -- except sender
+                SoilSettingSyncEvent.new(self.settingName, self.settingValue)
             )
         end
     end

--- a/src/settings/SoilSettingsUI.lua
+++ b/src/settings/SoilSettingsUI.lua
@@ -17,6 +17,10 @@ local SoilSettingsUI_mt = Class(SoilSettingsUI)
 -- Capture mod name at load time — g_currentModName is only valid during loading.
 local SF_MOD_NAME = g_currentModName
 
+-- The 3 settings injected into the vanilla settings page (Shift+Esc).
+-- Everything else lives in the custom SoilSettingsPanel (Shift+O).
+local VANILLA_SETTINGS = { "enabled", "showNotifications", "debugMode" }
+
 -- Resolve a translation key using the mod-scoped i18n instance.
 -- g_i18n is the base-game global and does not know about mod keys.
 local function tr(key, fallback)
@@ -109,7 +113,7 @@ function SoilSettingsUI:refreshUI()
     local frame = inGameMenu.pageSettings
     if not frame.soilFertilizer_initDone then return end
 
-    for _, id in ipairs({ "enabled", "showNotifications", "debugMode" }) do
+    for _, id in ipairs(VANILLA_SETTINGS) do
         local def = SettingsSchema.byId[id]
         if def then
             local element = frame["soilFertilizer_" .. def.uiId]
@@ -126,7 +130,7 @@ function SoilSettingsUI:updateAdminState(frame)
     if not frame.soilFertilizer_initDone then return end
     local isAdmin = self:isPlayerAdmin()
 
-    for _, id in ipairs({ "enabled", "showNotifications", "debugMode" }) do
+    for _, id in ipairs(VANILLA_SETTINGS) do
         local def = SettingsSchema.byId[id]
         if def then
             local element = frame["soilFertilizer_" .. def.uiId]
@@ -139,10 +143,6 @@ function SoilSettingsUI:updateAdminState(frame)
         end
     end
 end
-
--- The 3 settings we keep in the vanilla settings page.
--- Everything else lives in the custom SoilSettingsPanel (SHIFT+O).
-local VANILLA_SETTINGS = { "enabled", "showNotifications", "debugMode" }
 
 --- Called when InGameMenuSettingsFrame opens.
 --- Only injects the 3 core settings kept in the vanilla page.
@@ -203,7 +203,7 @@ end
 function SoilSettingsUI:updateGameSettings(frame)
     if not frame.soilFertilizer_initDone then return end
 
-    for _, id in ipairs({ "enabled", "showNotifications", "debugMode" }) do
+    for _, id in ipairs(VANILLA_SETTINGS) do
         local def = SettingsSchema.byId[id]
         if def then
             local element = frame["soilFertilizer_" .. def.uiId]
@@ -217,8 +217,8 @@ function SoilSettingsUI:updateGameSettings(frame)
     end
 end
 
--- Callbacks for the 3 vanilla settings only
-for _, id in ipairs({ "enabled", "showNotifications", "debugMode" }) do
+-- Callbacks for the vanilla settings only
+for _, id in ipairs(VANILLA_SETTINGS) do
     local def = SettingsSchema.byId[id]
     if def then
         SoilSettingsUI["on_" .. def.id .. "_Changed"] = function(self, state)


### PR DESCRIPTION
## Summary

- **#208** — Admin settings GUI not updating on dedi: removed sender exclusion from settings broadcast so all clients (including admin) receive the sync
- **#209** — Admin settings reset on dedi restart: deferred `settings:load()` to `deferredSoilSystemInit()` where `savegameDirectory` is guaranteed available
- **#204** — FS25_CropRotation conflict: removed `onSowing` lastCrop clearing — live FieldState detection doesn't need it; clearing caused duplicate crop history entries
- **BUG-03** — Schema-driven MP full sync: `SoilFullSyncEvent` now iterates `SettingsSchema.definitions` instead of a hardcoded 15-setting list — future settings sync automatically
- **BUG-05** — `VANILLA_SETTINGS` consolidated to single definition in `SoilSettingsUI`
- **Zombie updaters** — `hookInstaller` and batch dispatcher now call `removeUpdateable(self)` explicitly instead of relying on return values (which FS25 ignores)

## Test plan

- [ ] Singleplayer: harvest depletes, fertilize restores, save/load round-trips cleanly
- [ ] Dedicated server: settings persist after restart (`SoilShowSettings` matches after reboot)
- [ ] Dedicated server: admin changes a setting — admin's own panel refreshes
- [ ] Large map MP: client joins without freeze (batch sync working)
- [ ] With FS25_CropRotation: no duplicate crops in rotation history after replanting same crop
- [ ] MP join: all 15+ settings arrive correctly on client (schema-driven sync)