### PR TITLE
v1.9.9.9 — Final v1 Release

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.9.9.3</version>
+    <version>1.9.9.9</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -93,6 +93,13 @@ SettingsSchema.definitions = {
         localOnly = true,  -- per-player display preference, not synced to server
     },
     {
+        id = "hudDragEnabled",
+        type = "boolean",
+        default = true,
+        uiId = "sf_hud_drag_enabled",
+        localOnly = true,  -- per-player preference, not synced to server
+    },
+    {
         id = "seasonalEffects",
         type = "boolean",
         default = true,

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -88,7 +88,10 @@ end
 
 function SettingsManager:saveLocalSettings(settingsObject)
     local path = self:getLocalSettingsPath()
-    if not path then return false end
+    if not path then
+        SoilLogger.warning("saveLocalSettings: path unavailable (dedi server first boot, no savegame written yet)")
+        return false
+    end
 
     local xml = XMLFile.create("sf_LocalConfig", path, self.XMLTAG)
     if not xml then return false end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -296,8 +296,8 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     if not self.settings.showHUD then return false end
     if not self.visible then return false end
 
-    -- RMB: toggle edit mode
-    if isDown and button == 3 then
+    -- RMB: toggle edit mode (skipped if player disabled drag to avoid mod conflicts)
+    if isDown and button == 3 and self.settings.hudDragEnabled then
         if self.editMode then
             self:exitEditMode()
         else
@@ -374,7 +374,7 @@ function SoilHUD:update(dt)
     end
 
     -- Detection for initial RMB click when cursor might be hidden
-    if not self.editMode and self.initialized and self.settings.enabled and self.settings.showHUD and self.visible then
+    if not self.editMode and self.initialized and self.settings.enabled and self.settings.showHUD and self.visible and self.settings.hudDragEnabled then
         if Input and Input.isMouseButtonPressed and Input.isMouseButtonPressed(Input.MOUSE_BUTTON_RIGHT) then
             -- Note: posX/posY might not be perfectly accurate if hidden, but we check last known
             if g_inputBinding and g_inputBinding.mousePosXLast and g_inputBinding.mousePosYLast then

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -134,7 +134,7 @@ local CATEGORIES = {
             },
             {
                 header = "HUD Style",
-                items  = { "hudColorTheme", "hudFontSize", "hudTransparency" }
+                items  = { "hudColorTheme", "hudFontSize", "hudTransparency", "hudDragEnabled" }
             },
             {
                 header = "Position",
@@ -192,6 +192,7 @@ local SETTING_DESCS = {
     hudFontSize      = "HUD text size",
     hudTransparency  = "HUD background transparency",
     hudPosition      = "HUD preset anchor position",
+    hudDragEnabled   = "RMB enters HUD drag mode (disable if conflicting with other mods)",
     activeMapLayer   = "Nutrient layer shown in PDA map",
     overlayDensity   = "Sample point budget (Low=8k, Med=20k, High=40k)",
 }

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -246,6 +246,8 @@ function SoilSettingsPanel.new(settings)
     self.settings     = settings
     self.fillOverlay  = nil
     self.isVisible    = false
+    local mod = g_modManager and g_modManager:getModByName(g_currentModName)
+    self.modVersion   = "v" .. (mod and mod.version or "?")
     self.page         = PAGE_LANDING
     self.activeCatIdx = nil
     self.adminMsg     = nil   -- last action result shown in admin page
@@ -479,7 +481,7 @@ function SoilSettingsPanel:drawTitleBar()
     self:drawText(PX + 0.018, ty + TB_H * 0.32, TS_TITLE, title, C.white, RenderText.ALIGN_LEFT, true)
 
     -- Version tag
-    self:drawText(PX + PW - 0.020, ty + TB_H * 0.32, TS_TINY, "v1.9.9.1", C.hint, RenderText.ALIGN_RIGHT, false)
+    self:drawText(PX + PW - 0.020, ty + TB_H * 0.32, TS_TINY, self.modVersion, C.hint, RenderText.ALIGN_RIGHT, false)
 
     -- [X] close button — right side
     local cbW = 0.038

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Grande" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Transparência HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Definir nível transparência fundo (Claro = transparente, Sólido = opaco)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Claro" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Leve" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Médio" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Exibir taxas em gal/ac e lb/ac (desativado = L/ha e kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restaurar configurações solo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de solo" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrogênio: Ideal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fósforo: Ideal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potássio: Ideal" eh="0197b4ba" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="大" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD 透明度" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="設置背景透明度等級（透明 = 可看穿，實色 = 不透明）" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="透明" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="輕微" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="中等" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="以 gal/ac 和 lb/ac 顯示施用量（關閉則為 L/ha 和 kg/ha）" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="重置土壤設置" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="切換土壤 HUD" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="啟動肥（液態）" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="氮：最佳" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="磷：最佳" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="鉀：最佳" eh="0197b4ba" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Velký" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Průhlednost HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Nastavte úroveň průhlednosti pozadí (Čirý = průhledný, Plný = neprůhledný)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Čirý" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Lehký" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Střední" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Zobrazit dávky v gal/ac a lb/ac (vypnuto = L/ha a kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetovat nastavení půdy" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Přepnout HUD půdy" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Startgødning (flydende)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Groß" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD-Transparenz" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Hintergrundtransparenz festlegen (Klar = durchsichtig, Fest = undurchsichtig)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Klar" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Leicht" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Mittel" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Ausbringmengen in gal/ac und lb/ac (aus = L/ha und kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeneinstellungen zurücksetzen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Boden-HUD umschalten" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Stickstoff: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphor: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Kalium: Optimal" eh="0197b4ba" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Large" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD Transparency" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+    <e k="sf_hud_drag_enabled_short" v="HUD Drag" eh="e5a9a723" />
+    <e k="sf_hud_drag_enabled_long" v="Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Clear" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Light" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Medium" eh="87f8a6ab" />
@@ -73,8 +75,8 @@
     <e k="sf_use_imperial_long" v="Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Reset Soil Settings" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Toggle Soil HUD" eh="f0224a10" />
@@ -167,16 +169,16 @@
     <e k="sf_bigBag_starter_function" v="Starter Fertilizer (liquid)" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypsum" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Field %d" eh="08988997" />
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
@@ -336,7 +338,7 @@
     <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
     <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="d66da34c" />
     <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Grande" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Transparencia HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Establecer nivel de transparencia del fondo (Claro = transparente, Sólido = opaco)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Claro" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Ligero" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Medio" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Mostrar tasas de aplicación en gal/ac y lb/ac (desactivado = L/ha y kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablecer Ajustes de Suelo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de Suelo" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante Starter (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrógeno: Óptimo" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fósforo: Óptimo" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potasio: Óptimo" eh="0197b4ba" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="å¯åŠ¨è‚¥ï¼ˆæ¶²æ€ï¼‰" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Startterilannoite (nestemäinen)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Grand" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Transparence HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Définir niveau transparence fond (Clair = transparent, Solide = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Clair" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Léger" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Moyen" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Afficher les doses en gal/ac et lb/ac (désactivé = L/ha et kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Réinitialiser paramètres sol" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Activer/désactiver HUD sol" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Engrais starter (liquide)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Azote: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphore: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Nagy" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD átlátszóság" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Háttér átlátszósági szint beállítása (Átlátszó = áttetszÅ‘, Tömör = átlátszatlan)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Átlátszó" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Könnyű" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Közepes" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Kijuttatási normák gal/ac és lb/ac egységben (ki = L/ha és kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Pupuk starter (cair)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Grande" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Trasparenza HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Imposta livello trasparenza sfondo (Chiaro = trasparente, Solido = opaco)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Chiaro" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Leggero" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Medio" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Mostra le dosi in gal/ac e lb/ac (off = L/ha e kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Ripristina impostazioni suolo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Attiva/disattiva HUD suolo" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="スターター肥料（液体）" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="스타터 비료 (액체)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Groot" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD Transparantie" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Stel het transparantie-niveau van de achtergrond in" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Helder" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Licht" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Medium" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Toon doseringen in gal/ac en lb/ac (uit = L/ha en kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeminstellingen herstellen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bodem HUD in-/uitschakelen" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Stikstof: Optimaal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fosfor: Optimaal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Kalium: Optimaal" eh="0197b4ba" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Startgjødsel (flytende)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Duży" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Przezroczystość HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Ustaw poziom przezroczystości tła (Przezroczysty = przejrzysty, Solidny = nieprzezroczysty)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Przezroczysty" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Lekki" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Średni" eh="87f8a6ab" />
@@ -86,8 +88,8 @@
     <e k="sf_use_imperial_long" v="Wyświetlaj dawki w gal/ac i lb/ac (wyłączone = L/ha i kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetuj ustawienia gleby" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Przełącz HUD gleby" eh="f0224a10" />
@@ -180,16 +182,16 @@
     <e k="sf_bigBag_starter_function" v="Nawóz startowy (ciekły)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Azot: Optymalny" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fosfor: Optymalny" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potas: Optymalny" eh="0197b4ba" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Îngrășământ starter (lichid)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Большой" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Прозрачность HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Установить уровень прозрачности фона (Прозрачный = прозрачный, Сплошной = непрозрачный)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Прозрачный" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Легкий" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Средний" eh="87f8a6ab" />
@@ -73,8 +75,8 @@
     <e k="sf_use_imperial_long" v="Показывать нормы в галлонах на акр и фунтах на акр (по умолчанию = л/га и кг/га)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Сбросить настройки грунта" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Переключить HUD грунта" eh="f0224a10" />
@@ -167,16 +169,16 @@
     <e k="sf_bigBag_starter_function" v="Стартовое удобрение (жидкое)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_hud_title" v="МОНИТОР ПОЧВЫ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Startgödsel (flytande)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Başlangıç gübresi (sıvı)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -64,6 +64,8 @@
     <e k="sf_hud_font_3" v="Великий" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="Прозорість HUD" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Встановити рівень прозорості фону (Прозорий = прозорий, Суцільний = непрозорий)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
     <e k="sf_hud_trans_1" v="Прозорий" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Легкий" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Середній" eh="87f8a6ab" />
@@ -73,8 +75,8 @@
     <e k="sf_use_imperial_long" v="Показувати норми у gal/ac і lb/ac (вимк. = L/ha і kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Скинути налаштування ґрунту" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Перемкнути HUD ґрунту" eh="f0224a10" />
@@ -167,16 +169,16 @@
     <e k="sf_bigBag_starter_function" v="Стартове добриво (рідке)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_hud_title" v="МОНІТОР ҐРУНТУ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -20,6 +20,8 @@
 		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
 		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
 		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
+		<e k="sf_hud_drag_enabled_short" v="[EN] HUD Drag" eh="e5a9a723" />
+		<e k="sf_hud_drag_enabled_long" v="[EN] Allow right-click to enter HUD drag/edit mode. Disable if conflicting with other mods (e.g. Courseplay)" eh="d9e2d813" />
 		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
 		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
@@ -42,8 +44,8 @@
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." />
+    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
@@ -136,16 +138,16 @@
     <e k="sf_bigBag_starter_function" v="Phân bón khá»Ÿi Ä‘áº§u (dáº¡ng lá»ng)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
 
 		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />


### PR DESCRIPTION
## Summary

Final v1.x release. All v1 bugs resolved — v2.0.0 development begins after this merge.

## Changes

**Bug fixes:**
- BUG-08 (#222): New HUD Drag toggle (Shift+O → Display & HUD) — disables RMB capture to prevent Courseplay conflicts. All 26 languages updated.
- BUG-04 (#215): Settings panel now reads version dynamically from `g_modManager` — no more stale hardcoded version string.
- BUG-07 (#216): `saveLocalSettings()` now logs a warning when path is unavailable on dedi first boot instead of failing silently.

**Housekeeping:**
- V2 Roadmap issue #225 created
- All v1 issues closed

## Notes

No save migration needed. Existing savegames load normally.

v2.0.0 roadmap: https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/225