### PR TITLE
fix: include PNG textures in build — bigBag diffuse maps were excluded

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,8 +57,8 @@ MOD_DIR = os.getcwd()
 ZIP_PATH = os.path.join(os.path.dirname(MOD_DIR), os.path.basename(MOD_DIR) + ".zip")
 
 EXCLUDE_DIRS  = {".git", ".claude", "__MACOSX"}
-EXCLUDE_EXTS  = {".sh", ".py", ".md", ".DS_Store", ".zip", ".png", ".txt"}
-EXCLUDE_FILES = {".gitignore"}
+EXCLUDE_EXTS  = {".sh", ".py", ".md", ".DS_Store", ".zip", ".txt"}
+EXCLUDE_FILES = {".gitignore", "icon_source.png"}
 
 with zipfile.ZipFile(ZIP_PATH, "w", zipfile.ZIP_DEFLATED) as zf:
     for root, dirs, files in os.walk(MOD_DIR):


### PR DESCRIPTION
## Summary
- Fixes missing bigBag diffuse map PNG textures that were excluded from the build output

## Changes
- Single commit: `b423bda` — ensures PNG texture files are included when building the mod zip

## Test plan
- [ ] Build zip and verify bigBag diffuse map textures are present in the archive