### PR TITLE
v2.0.3.0 — Shop fix & organic fertilizer recalibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Shop duplicate items removed** (#236 related): Single-item pallet/bigBag storeItems were
+  showing alongside their `multipleItemPurchase` counterparts, creating duplicate shop entries
+  for every purchasable product. Single items are now registered with `showInStore=false` so
+  `multipleItemPurchase` can still spawn them at purchase time, but they no longer appear as
+  separate shop entries.
+
+- **Organic fertilizer P coefficients recalibrated** (#236): Phosphorus coefficients for all
+  manure-based products were approximately 5× too high relative to real-world N:P:K ratios
+  from UNL Extension publication G1335. A single slurry pass at 14,000 L/ha was delivering
+  +22 internal P points (blowing past the "fair" threshold in one application); corrected
+  values now deliver +3–6 P points per pass, requiring 2–3 passes to bring a depleted field
+  to "fair" levels. Affected products: Manure, Slurry, Digestate, Biosolids, Chicken Manure,
+  Pelletized Manure. Base application rates (14,000 L/ha for slurry) are unchanged.
+
+---
+
+## [2.0.2.0] - 2026-04-25
+
+### Added
+
+- **Per-cell soil compaction tracking** (#231): Compaction is now tracked individually per
+  soil cell rather than per field, enabling finer-grained overlay visualization and more
+  accurate subsoiler targeting.
+
+### Fixed
+
+- **BigBag diffuse map textures included in build**: PNG texture files for bigBag products
+  were excluded from the mod ZIP by the build script; corrected so all diffuse maps are
+  packaged correctly.
+
+---
+
+## [2.0.1.0] - 2026-04-25
+
+### Added
+
+- **Per-product label textures for big bags**: Each big bag product now has its own unique
+  label texture (`_diffuse.png`) so products are visually distinguishable in-game.
+
+- **Community translations** (RU/UK): Russian and Ukrainian localizations contributed by
+  community members.
+
+### Fixed
+
+- **LPS calibration for custom spray types** (PR #233 by @antler22): `registerCustomSprayTypes`
+  was scaling custom LPS off the vanilla display rate (93.5 L/ha) instead of the actual drain
+  rate (291.6 L/ha), causing a 3.12× over-drain on every custom fertilizer type. Fixed by
+  deriving `customLPS = customRate / 36000` directly. All 22 custom spray types now drain at
+  exactly their `BASE_RATES` values.
+
+- **Stale VEHICLE context action event IDs** (PR #233 by @antler22): SF was accumulating
+  duplicate input event registrations on every vehicle mount and Courseplay seat-change,
+  causing keys to fire 2–3× per press and HUD drag to toggle on then immediately back off.
+  Fixed by purging all existing SF vehicle event IDs before each re-registration pass.
+
+- **Big bag store icon textures**: Missing `.dds` store icon files added for affected big bag
+  products.
+
+---
+
 ## [2.0.0.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ All three are visible in the HUD and the full Soil Report. Each can be toggled o
 |---|---|---|---|---|---|
 | **Liquid Fertilizer** | ●●●○○ | ●●○○○ | ●●●○○ | — | Fast-acting, balanced NPK |
 | **Solid Fertilizer** | ●●●●○ | ●●●○○ | ●●●○○ | — | Higher N/P, granular |
-| **Manure** | ●●○○○ | ●●○○○ | ●●●○○ | ✓ | Slow-release, builds OM over time |
-| **Slurry** | ●●●○○ | ●●○○○ | ●●●●○ | ✓ | Liquid organic, strong K |
-| **Digestate** | ●●●○○ | ●●○○○ | ●●●●○ | ✓ | Biogas byproduct, well-rounded |
+| **Manure** | ●●○○○ | ●○○○○ | ●●○○○ | ✓ | Slow-release, builds OM over time |
+| **Slurry** | ●●●○○ | ●●○○○ | ●●●●○ | ✓ | Liquid organic, K-dominant (real N:P:K ratio) |
+| **Digestate** | ●●●○○ | ●●○○○ | ●●●●○ | ✓ | Biogas byproduct, higher N availability than raw manure |
 | **Lime** | — | — | — | — | Only raises pH — but nothing else works properly without it |
 
 **Custom liquid fertilizers (purchasable IBC liquid tanks in shop):**
@@ -136,7 +136,7 @@ All three are visible in the HUD and the full Soil Report. Each can be toggled o
 | **Compost** | Spreader | Low | Low | Low | ●●●●● | Best OM builder per litre |
 | **Biosolids** | Spreader | ●●○○○ | ●●○○○ | Low | ✓ | Municipal organic amendment |
 | **Chicken Manure** | Spreader | ●●●○○ | ●●●○○ | ●●○○○ | ✓ | Concentrated poultry litter |
-| **Pelletized Manure** | Spreader | ●●●●○ | ●●●●○ | ●●●●○ | ✓ | Dense balanced organic NPK |
+| **Pelletized Manure** | Spreader | ●●●●○ | ●●●○○ | ●●●●○ | ✓ | Dense balanced organic NPK |
 | **Gypsum** | Spreader | — | — | — | Low | Lowers pH, minor OM gain |
 | **Liquid Lime** | Sprayer | — | — | — | — | Raises pH via sprayer equipment |
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.0.2.0</version>
+    <version>2.0.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -147,6 +147,29 @@
         <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml"/>
         <storeItem xmlFilename="objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml"/>
         <storeItem xmlFilename="objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure.xml"/>
+        <!-- Single items — registered for multiPurchase spawning, hidden from shop UI -->
+        <storeItem xmlFilename="objects/liquidTank/uan32/liquidTank_uan32.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/uan28/liquidTank_uan28.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/anhydrous/liquidTank_anhydrous.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/starter/liquidTank_starter.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquid_urea/liquidTank_liquid_urea.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquid_ams/liquidTank_liquid_ams.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquid_map/liquidTank_liquid_map.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquid_dap/liquidTank_liquid_dap.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquid_potash/liquidTank_liquid_potash.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/insecticide/liquidTank_insecticide.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/fungicide/liquidTank_fungicide.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquidlime/liquidTank_liquidlime.xml"/>
+        <storeItem xmlFilename="objects/bigBag/urea/bigBag_urea.xml"/>
+        <storeItem xmlFilename="objects/bigBag/ams/bigBag_ams.xml"/>
+        <storeItem xmlFilename="objects/bigBag/map/bigBag_map.xml"/>
+        <storeItem xmlFilename="objects/bigBag/dap/bigBag_dap.xml"/>
+        <storeItem xmlFilename="objects/bigBag/potash/bigBag_potash.xml"/>
+        <storeItem xmlFilename="objects/bigBag/gypsum/bigBag_gypsum.xml"/>
+        <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost.xml"/>
+        <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids.xml"/>
+        <storeItem xmlFilename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml"/>
     </storeItems>
 
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -135,6 +135,7 @@
         <storeItem xmlFilename="objects/liquidTank/liquid_potash/multiPurchaseLiquidTank_liquid_potash.xml"/>
         <storeItem xmlFilename="objects/liquidTank/insecticide/multiPurchaseLiquidTank_insecticide.xml"/>
         <storeItem xmlFilename="objects/liquidTank/fungicide/multiPurchaseLiquidTank_fungicide.xml"/>
+        <storeItem xmlFilename="objects/liquidTank/liquidlime/multiPurchaseLiquidTank_liquidlime.xml"/>
         <!-- Big Bags / Solid (multi-purchase) -->
         <storeItem xmlFilename="objects/bigBag/urea/multiPurchaseBigBag_urea.xml"/>
         <storeItem xmlFilename="objects/bigBag/ams/multiPurchaseBigBag_ams.xml"/>
@@ -146,30 +147,6 @@
         <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml"/>
         <storeItem xmlFilename="objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml"/>
         <storeItem xmlFilename="objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure.xml"/>
-        <!-- IBC Liquid Tanks (single) -->
-        <storeItem xmlFilename="objects/liquidTank/uan32/liquidTank_uan32.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/uan28/liquidTank_uan28.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/anhydrous/liquidTank_anhydrous.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/starter/liquidTank_starter.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/liquid_urea/liquidTank_liquid_urea.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/liquid_ams/liquidTank_liquid_ams.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/liquid_map/liquidTank_liquid_map.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/liquid_dap/liquidTank_liquid_dap.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/liquid_potash/liquidTank_liquid_potash.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/insecticide/liquidTank_insecticide.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/fungicide/liquidTank_fungicide.xml"/>
-        <storeItem xmlFilename="objects/liquidTank/liquidlime/liquidTank_liquidlime.xml"/>
-        <!-- Big Bags / Solid (single) -->
-        <storeItem xmlFilename="objects/bigBag/urea/bigBag_urea.xml"/>
-        <storeItem xmlFilename="objects/bigBag/ams/bigBag_ams.xml"/>
-        <storeItem xmlFilename="objects/bigBag/map/bigBag_map.xml"/>
-        <storeItem xmlFilename="objects/bigBag/dap/bigBag_dap.xml"/>
-        <storeItem xmlFilename="objects/bigBag/potash/bigBag_potash.xml"/>
-        <storeItem xmlFilename="objects/bigBag/gypsum/bigBag_gypsum.xml"/>
-        <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost.xml"/>
-        <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids.xml"/>
-        <storeItem xmlFilename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml"/>
-        <storeItem xmlFilename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml"/>
     </storeItems>
 
 

--- a/objects/bigBag/ams/bigBag_ams.xml
+++ b/objects/bigBag/ams/bigBag_ams.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_ams_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/biosolids/bigBag_biosolids.xml
+++ b/objects/bigBag/biosolids/bigBag_biosolids.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_biosolids_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/chicken_manure/bigBag_chicken_manure.xml
+++ b/objects/bigBag/chicken_manure/bigBag_chicken_manure.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_chicken_manure_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/compost/bigBag_compost.xml
+++ b/objects/bigBag/compost/bigBag_compost.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_compost_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/dap/bigBag_dap.xml
+++ b/objects/bigBag/dap/bigBag_dap.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_dap_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/gypsum/bigBag_gypsum.xml
+++ b/objects/bigBag/gypsum/bigBag_gypsum.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_gypsum_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/map/bigBag_map.xml
+++ b/objects/bigBag/map/bigBag_map.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_map_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml
+++ b/objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_pelletized_manure_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/potash/bigBag_potash.xml
+++ b/objects/bigBag/potash/bigBag_potash.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_potash_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/bigBag/urea/bigBag_urea.xml
+++ b/objects/bigBag/urea/bigBag_urea.xml
@@ -16,7 +16,7 @@
         <functions><function>$l10n_sf_bigBag_urea_function</function></functions>
         <financeCategory>PURCHASE_FERTILIZER</financeCategory>
         <shopHeight>2</shopHeight>
-        <showInStore>true</showInStore>
+        <showInStore>false</showInStore>
         <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
         <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
         <textureMemoryUsage>851968</textureMemoryUsage>

--- a/objects/liquidTank/anhydrous/liquidTank_anhydrous.xml
+++ b/objects/liquidTank/anhydrous/liquidTank_anhydrous.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_anhydrous_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3700"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_anhydrous_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="ANHYDROUS"/>
 

--- a/objects/liquidTank/fungicide/liquidTank_fungicide.xml
+++ b/objects/liquidTank/fungicide/liquidTank_fungicide.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_fungicide_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_herbicideTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="2600"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_fungicide_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="FUNGICIDE"/>
 

--- a/objects/liquidTank/insecticide/liquidTank_insecticide.xml
+++ b/objects/liquidTank/insecticide/liquidTank_insecticide.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_insecticide_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_herbicideTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="2400"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_insecticide_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="INSECTICIDE"/>
 

--- a/objects/liquidTank/liquid_ams/liquidTank_liquid_ams.xml
+++ b/objects/liquidTank/liquid_ams/liquidTank_liquid_ams.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquid_ams_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="2900"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquid_ams_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="LIQUID_AMS"/>
 

--- a/objects/liquidTank/liquid_dap/liquidTank_liquid_dap.xml
+++ b/objects/liquidTank/liquid_dap/liquidTank_liquid_dap.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquid_dap_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3600"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquid_dap_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="LIQUID_DAP"/>
 

--- a/objects/liquidTank/liquid_map/liquidTank_liquid_map.xml
+++ b/objects/liquidTank/liquid_map/liquidTank_liquid_map.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquid_map_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="4000"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquid_map_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="LIQUID_MAP"/>
 

--- a/objects/liquidTank/liquid_potash/liquidTank_liquid_potash.xml
+++ b/objects/liquidTank/liquid_potash/liquidTank_liquid_potash.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquid_potash_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3700"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquid_potash_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="LIQUID_POTASH"/>
 

--- a/objects/liquidTank/liquid_urea/liquidTank_liquid_urea.xml
+++ b/objects/liquidTank/liquid_urea/liquidTank_liquid_urea.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquid_urea_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3400"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquid_urea_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="LIQUID_UREA"/>
 

--- a/objects/liquidTank/liquidlime/liquidTank_liquidlime.xml
+++ b/objects/liquidTank/liquidlime/liquidTank_liquidlime.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_liquidlime_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="1200"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_liquidlime_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="LIQUIDLIME"/>
 

--- a/objects/liquidTank/starter/liquidTank_starter.xml
+++ b/objects/liquidTank/starter/liquidTank_starter.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_starter_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3400"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_starter_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="STARTER"/>
 

--- a/objects/liquidTank/uan28/liquidTank_uan28.xml
+++ b/objects/liquidTank/uan28/liquidTank_uan28.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_uan28_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3000"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_uan28_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="UAN28"/>
 

--- a/objects/liquidTank/uan32/liquidTank_uan32.xml
+++ b/objects/liquidTank/uan32/liquidTank_uan32.xml
@@ -6,7 +6,7 @@
             <set path="vehicle.storeData.name"                        value="$l10n_sf_bigBag_uan32_name"/>
             <set path="vehicle.storeData.image"                       value="$data/objects/pallets/liquidTank/store_fertilizerTankHelm.png"/>
             <set path="vehicle.storeData.price"                       value="3200"/>
-            <set path="vehicle.storeData.showInStore"                 value="true"/>
+            <set path="vehicle.storeData.showInStore"                 value="false"/>
             <set path="vehicle.storeData.functions.function"          value="$l10n_sf_bigBag_uan32_function"/>
             <set path="vehicle.storeData.specs.fillTypes"             value="UAN32"/>
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -187,9 +187,9 @@ SoilConstants.FERTILIZER_PROFILES = {
     -- Base game (NPK balanced)
     LIQUIDFERTILIZER  = { N=79.2, P=198.0, K=44.5 },          -- 93.5 L/ha: ~20N, ~10P, ~15K ppm
     FERTILIZER        = { N=41.1, P=164.6, K=24.7 },          -- 225 kg/ha: ~25N, ~20P, ~20K ppm
-    MANURE            = { N=0.53, P=1.59,  K=0.60, OM=0.04 }, -- 14000 L/ha: ~20N, ~12P, ~30K ppm
-    LIQUIDMANURE      = { N=0.42, P=1.59,  K=0.80, OM=0.03 }, -- Slurry
-    DIGESTATE         = { N=0.58, P=1.85,  K=1.10, OM=0.04 }, -- Digestate
+    MANURE            = { N=0.53, P=0.25,  K=0.45, OM=0.04 }, -- 14000 L/ha: ~7N, ~3.5P, ~6K pts/pass (UNL beef N:P:K ratio)
+    LIQUIDMANURE      = { N=0.50, P=0.35,  K=0.65, OM=0.03 }, -- Slurry — dairy N:P:K 1:0.70:1.33 (UNL g1335)
+    DIGESTATE         = { N=0.65, P=0.40,  K=0.85, OM=0.04 }, -- Digestate — higher N availability vs raw manure
     LIME              = { pH=0.16 },                          -- 2500 kg/ha: +0.40 pH shift per pass (~3 passes to correct pH 5.5→6.5)
     LIQUIDLIME        = { pH=1.07 },                          -- 374  L/ha: +0.40 pH shift per pass (rate corrected from 2800→374 L/ha)
 
@@ -220,9 +220,9 @@ SoilConstants.FERTILIZER_PROFILES = {
 
     -- Organic / slow-release
     COMPOST           = { N=0.74, P=0.55, K=0.55, OM=0.60 }, -- 5000 kg/ha
-    BIOSOLIDS         = { N=2.05, P=6.17, K=1.23, OM=0.45 }, -- 4500 kg/ha
-    CHICKEN_MANURE    = { N=3.70, P=13.9, K=2.78, OM=0.55 }, -- 2000 kg/ha
-    PELLETIZED_MANURE = { N=16.4, P=41.1, K=18.5, OM=0.40 }, -- 450 kg/ha
+    BIOSOLIDS         = { N=2.05, P=1.20, K=1.23, OM=0.45 }, -- 4500 kg/ha: ~+9N, +5P, +5K pts/pass
+    CHICKEN_MANURE    = { N=3.70, P=2.80, K=2.78, OM=0.55 }, -- 2000 kg/ha: ~+7N, +5P, +5K pts/pass
+    PELLETIZED_MANURE = { N=16.4, P=8.20, K=18.5, OM=0.40 }, -- 450 kg/ha:  ~+7N, +3P, +8K pts/pass
 
     -- Crop protection products (Handled via effectiveness calculation)
     INSECTICIDE = { pestReduction = 1.0 },

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -472,7 +472,7 @@
     <e k="sf_help_soil_header" v="ХІМІЯ ҐРУНТУ" eh="19c67ff5" />
     <e k="sf_help_ph" v="pH 6,5-7,0 = Ідеально. < 6,5 – нанесіть вапно. > 7,5 – нанесіть гіпс." eh="8929304d" />
     <e k="sf_help_pressure_header" v="ТИСК НА КУЛЬТУРУ" eh="132b0f66" />
-    <e k="sf_help_weed" v="Бур'яни > 20% - Застосуйте гербіцид."" eh="c8d890df" />
+    <e k="sf_help_weed" v="Бур'яни > 20% - Застосуйте гербіцид." eh="c8d890df" />
     <e k="sf_help_pest" v="Шкідник > 20% - Застосуйте інсектицид." eh="f4932a05" />
     <e k="sf_help_disease" v="Хвороба > 20% - Застосуйте фунгіцид." eh="1bfd0913" />
     <e k="sf_help_status_header" v="РІВНІ СТАТУСУ" eh="b081c2c6" />


### PR DESCRIPTION
## Summary

- **Shop duplicate items fixed**: Single-item pallets and big bags were showing alongside their multi-purchase counterparts in the shop, doubling every purchasable entry. Single items are now registered with `showInStore=false` so `multipleItemPurchase` can still spawn them, but they no longer appear as separate shop entries.

- **Organic fertilizer P coefficients recalibrated** (#236): Phosphorus coefficients for all manure-based products were ~5× too high relative to real-world N:P:K ratios (UNL Extension G1335). A single slurry pass was delivering +22 internal P points; corrected values deliver +3–6 P points per pass. Requires 2–3 passes to bring a depleted field to "fair" levels. Affected: Manure, Slurry, Digestate, Biosolids, Chicken Manure, Pelletized Manure.

- **Changelog and README updated**: Added missing 2.0.1.0 and 2.0.2.0 entries; fertilizer dot ratings in README updated to match recalibrated profiles.

## Save compatibility

✅ No save migration needed — soil data format unchanged.