### PR TITLE
feat: complete Danish translation by @DJWestDK

### DIFF
--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -9,105 +9,104 @@
     <e k="sf_diff_long" v="Sværhedsgrad for jordstyring" eh="d6f4560c" />
     <e k="sf_auto_rate_short" v="Automatisk hastighedskontrol" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerer automatisk gødningsraten baseret på markens behov" eh="a9ca9f6b" />
-		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
-		<e k="sf_hud_theme_2" v="[EN] Blue" eh="9594eec9" />
-		<e k="sf_hud_theme_3" v="[EN] Amber" eh="88068e33" />
-		<e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
-		<e k="sf_hud_font_size_short" v="[EN] HUD Font Size" eh="fd6ca64a" />
-		<e k="sf_hud_font_size_long" v="[EN] Adjust text size for better readability" eh="c338854f" />
-		<e k="sf_hud_font_1" v="[EN] Small" eh="2660064e" />
-		<e k="sf_hud_font_2" v="[EN] Medium" eh="87f8a6ab" />
-		<e k="sf_hud_font_3" v="[EN] Large" eh="3a69b34c" />
-		<e k="sf_hud_transparency_short" v="[EN] HUD Transparency" eh="e8a009e4" />
-		<e k="sf_hud_transparency_long" v="[EN] Set background transparency level (Clear = see-through, Solid = opaque)" eh="152e390a" />
-		<e k="sf_hud_trans_1" v="[EN] Clear" eh="dc30bc0c" />
-		<e k="sf_hud_trans_2" v="[EN] Light" eh="9914a0ce" />
-		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
-		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
-		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_theme_1" v="Grøn" eh="d382816a" />
+    <e k="sf_hud_theme_2" v="Blå" eh="9594eec9" />
+    <e k="sf_hud_theme_3" v="Rav" eh="88068e33" />
+    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_font_size_short" v="HUD-skriftstørrelse" eh="fd6ca64a" />
+    <e k="sf_hud_font_size_long" v="Juster tekststørrelsen for bedre læsbarhed" eh="c338854f" />
+    <e k="sf_hud_font_1" v="Lille" eh="2660064e" />
+    <e k="sf_hud_font_2" v="Mellem" eh="87f8a6ab" />
+    <e k="sf_hud_font_3" v="Stor" eh="3a69b34c" />
+    <e k="sf_hud_transparency_short" v="HUD-gennemsigtighed" eh="e8a009e4" />
+    <e k="sf_hud_transparency_long" v="Angiv baggrundens gennemsigtighedsniveau (Klar = gennemsigtig, Solid = uigennemsigtig)" eh="152e390a" />
+    <e k="sf_hud_trans_1" v="Klar" eh="dc30bc0c" />
+    <e k="sf_hud_trans_2" v="Lys" eh="9914a0ce" />
+    <e k="sf_hud_trans_3" v="Mellem" eh="87f8a6ab" />
+    <e k="sf_hud_trans_4" v="Mørk" eh="a18366b2" />
+    <e k="sf_hud_trans_5" v="Solid" eh="e41480b6" />
+    <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="Mark %d" eh="08988997" />
+    <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="Brak" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="Ukrudt" eh="324181de" />
+    <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />
+    <e k="sf_hud_disease" v="Sygdom" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="(beskyttet)" eh="8273211e" />
+    <e k="sf_hud_yield" v="Udbytte" eh="97345487" />
+    <e k="sf_hud_estYield" v="Est. udbytte" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
-		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
-		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
-		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
-		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
-		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
-		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
-		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
+    <e k="sf_hud_hint_edit" v="Træk: flyt   Hjørne: ændr størrelse   HMK: færdig" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="HMK: flyt/ændr størrelse" eh="afc8f13b" />
+    <e k="sf_use_imperial_short" v="Imperiale enheder" eh="ff2701ad" />
+    <e k="sf_use_imperial_long" v="Vis udbringningsrater i gal/ac og lb/ac (fra = L/ha og kg/ha)" eh="17efa489" />
+    <e k="sf_active_map_layer_short" v="Aktivt kortlag" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="Næringsstoflag vist som overlejring på PDA-kortet" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Kortdetalje" />
+    <e k="sf_overlay_density_long" v="Prøvepunktsbudget for PDA-jordoverlejringen. Lav = bedre FPS, Høj = bedre dækning på store kort." />
+    <e k="input_SF_OPEN_SETTINGS" v="Åbn jordindstillinger" eh="2e31c0dd" />
+    <e k="sf_reset" v="Nulstil jordindstillinger" eh="467bc2f5" />
+    <e k="input_SF_TOGGLE_HUD" v="Slå jord-HUD til/fra" eh="f0224a10" />
+    <e k="input_SF_SOIL_REPORT" v="Jordrapport" eh="c33180ef" />
+    <e k="input_SF_RATE_UP" v="Øg gødningsrate" eh="6e601ef5" />
+    <e k="input_SF_RATE_DOWN" v="Sænk gødningsrate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Skift automatisk hastighed" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
-		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
-		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
-		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
-		<e k="sf_report_back" v="[EN] Back" eh="0557fa92" />
-		<e k="sf_report_difficulty" v="[EN] Difficulty:" eh="3abaf54f" />
-		<e k="sf_report_col_field" v="[EN] Field" eh="6f16a5f8" />
-		<e k="sf_report_col_last_crop" v="[EN] Last Crop" eh="ff41e5eb" />
-		<e k="sf_report_col_fert" v="[EN] Fert?" eh="9e6d0eb4" />
-		<e k="sf_report_no_data" v="[EN] No soil data available. Walk onto a field to start tracking." eh="1528a4cb" />
-		<e k="sf_report_prev" v="[EN] Prev" eh="14230d11" />
-		<e k="sf_report_next" v="[EN] Next" eh="10ac3d04" />
-		<e k="sf_report_yes" v="[EN] YES" eh="7469a286" />
-		<e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
-		<e k="sf_report_none" v="[EN] None" eh="6adf97f8" />
-		<e k="sf_report_rec_n_poor" v="[EN] Needs Nitrogen" eh="5dca0711" />
-		<e k="sf_report_rec_n_fair" v="[EN] Low Nitrogen" eh="35ad072d" />
-		<e k="sf_report_rec_p_poor" v="[EN] Needs Phosphorus" eh="e8fa326f" />
-		<e k="sf_report_rec_p_fair" v="[EN] Low Phosphorus" eh="077e12cf" />
-		<e k="sf_report_rec_k_poor" v="[EN] Needs Potassium" eh="f23194e0" />
-		<e k="sf_report_rec_k_fair" v="[EN] Low Potassium" eh="2006c0a2" />
-		<e k="sf_report_rec_ph_adjust" v="[EN] Adjust pH" eh="84f6bbbc" />
-		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
-		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
-		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
-		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
-		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
-		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
-		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
-		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
-		<e k="sf_starter_title" v="[EN] Starter Fertilizer 10-34-0 (P)" eh="8c1a1ddc" />
-		<e k="sf_urea_title" v="[EN] Urea 46-0-0 (N)" eh="659b3097" />
-		<e k="sf_ams_title" v="[EN] Ammonium Sulfate 21-0-0 (N)" eh="033d1845" />
-		<e k="sf_map_title" v="[EN] MAP Fertilizer 11-52-0 (P)" eh="31aa2534" />
-		<e k="sf_dap_title" v="[EN] DAP Fertilizer 18-46-0 (P)" eh="5030a80a" />
-		<e k="sf_potash_title" v="[EN] Potash 0-0-60 (K)" eh="8db6c54c" />
-		<e k="sf_liquid_urea_title" v="[EN] Liquid Urea (N)" eh="7fee4f12" />
-		<e k="sf_liquid_ams_title" v="[EN] Liquid Ammonium Sulfate (N)" eh="0daf3a6f" />
-		<e k="sf_liquid_map_title" v="[EN] Liquid MAP (P)" eh="3ce7c8c9" />
-		<e k="sf_liquid_dap_title" v="[EN] Liquid DAP (P)" eh="86bd893e" />
-		<e k="sf_liquid_potash_title" v="[EN] Liquid Potash (K)" eh="72ac9fd3" />
-		<e k="sf_insecticide_title" v="[EN] Insecticide" eh="5650eeef" />
-		<e k="sf_fungicide_title" v="[EN] Fungicide" eh="e8512698" />
-		<e k="sf_report_page_info" v="[EN] Fields %d-%d of %d  |  Page %d of %d" eh="8db851d1" />
-    <e k="sf_bigBag_uan32_name" v="Big Bag UAN 32-0-0" eh="7bdc4d9d" />
+    <e k="input_SF_CYCLE_MAP_LAYER" v="Skift jordkortlag" eh="8e4a716c" />
+    <e k="input_SF_SOIL_PDA" v="Åbn jord-PDA" eh="7d70f7b4" />
+    <e k="sf_report_title" v="Jord- og gødningsrapport" eh="a76f8218" />
+    <e k="sf_report_fields_tracked" v="Sporede marker:" eh="7b1e59b8" />
+    <e k="sf_report_need_fert" v="Mangler gødning:" eh="110b60f2" />
+    <e k="sf_report_farm_health" v="Gårdens sundhed:" eh="a5330ade" />
+    <e k="sf_report_back" v="Tilbage" eh="0557fa92" />
+    <e k="sf_report_difficulty" v="Sværhedsgrad:" eh="3abaf54f" />
+    <e k="sf_report_col_field" v="Mark" eh="6f16a5f8" />
+    <e k="sf_report_col_last_crop" v="Sidste afgrøde" eh="ff41e5eb" />
+    <e k="sf_report_col_fert" v="Gødn.?" eh="9e6d0eb4" />
+    <e k="sf_report_no_data" v="Ingen jorddata tilgængelig. Gå ud på en mark for at begynde registrering." eh="1528a4cb" />
+    <e k="sf_report_prev" v="Forrige" eh="14230d11" />
+    <e k="sf_report_next" v="Næste" eh="10ac3d04" />
+    <e k="sf_report_yes" v="JA" eh="7469a286" />
+    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_none" v="Ingen" eh="6adf97f8" />
+    <e k="sf_report_rec_n_poor" v="Mangler kvælstof" eh="5dca0711" />
+    <e k="sf_report_rec_n_fair" v="Lavt kvælstofniveau" eh="35ad072d" />
+    <e k="sf_report_rec_p_poor" v="Mangler fosfor" eh="e8fa326f" />
+    <e k="sf_report_rec_p_fair" v="Lavt fosforniveau" eh="077e12cf" />
+    <e k="sf_report_rec_k_poor" v="Mangler kalium" eh="f23194e0" />
+    <e k="sf_report_rec_k_fair" v="Lavt kaliumniveau" eh="2006c0a2" />
+    <e k="sf_report_rec_ph_adjust" v="Juster pH" eh="84f6bbbc" />
+    <e k="sf_report_rec_ph_monitor" v="Overvåg pH" eh="6dfcded4" />
+    <e k="sf_report_rec_om_increase" v="Øg organisk materiale" eh="c2a930af" />
+    <e k="sf_report_rec_om_maintain" v="Vedligehold organisk materiale" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="Skadedyrsrisiko" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="Sygdomsrisiko" eh="e7655847" />
+    <e k="sf_report_rec_needs" v="Behov:" eh="3e6d95cf" />
+    <e k="sf_report_rec_optimal" v="Jordsundhed: Optimal" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="God" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="Rimelig" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="Dårlig" eh="0e94d017" />
+    <e k="sf_uan32_title" v="UAN 32 Gødning (N)" eh="90913bb8" />
+    <e k="sf_uan28_title" v="UAN 28 Gødning (N)" eh="9d902cd7" />
+    <e k="sf_anhydrous_title" v="Vandfri ammoniak (N)" eh="3fc85c02" />
+    <e k="sf_starter_title" v="Startgødning 10-34-0 (P)" eh="8c1a1ddc" />
+    <e k="sf_urea_title" v="Urea 46-0-0 (N)" eh="659b3097" />
+    <e k="sf_ams_title" v="Ammoniumsulfat 21-0-0 (N)" eh="033d1845" />
+    <e k="sf_map_title" v="MAP-gødning 11-52-0 (P)" eh="31aa2534" />
+    <e k="sf_dap_title" v="DAP-gødning 18-46-0 (P)" eh="5030a80a" />
+    <e k="sf_potash_title" v="Kaliumklorid 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_liquid_urea_title" v="Flydende urea (N)" eh="7fee4f12" />
+    <e k="sf_liquid_ams_title" v="Flydende ammoniumsulfat (N)" eh="0daf3a6f" />
+    <e k="sf_liquid_map_title" v="Flydende MAP (P)" eh="3ce7c8c9" />
+    <e k="sf_liquid_dap_title" v="Flydende DAP (P)" eh="86bd893e" />
+    <e k="sf_liquid_potash_title" v="Flydende kaliumklorid (K)" eh="72ac9fd3" />
+    <e k="sf_insecticide_title" v="Insekticid" eh="5650eeef" />
+    <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
+    <e k="sf_report_page_info" v="Marker %d-%d af %d  |  Side %d af %d" eh="8db851d1" />
+    <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
     <e k="sf_bigBag_uan32_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
-    <e k="sf_bigBag_uan28_name" v="Big Bag UAN 28-0-0" eh="997781d5" />
+    <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
     <e k="sf_bigBag_uan28_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
-    <e k="sf_bigBag_anhydrous_name" v="Big Bag Vandfri Ammoniak 82-0-0" eh="44914201" />
+    <e k="sf_bigBag_anhydrous_name" v="IBC Vandfri Ammoniak 82-0-0" eh="fb09e6ce" />
     <e k="sf_bigBag_anhydrous_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Kvælstofgødning (tør)" eh="63efea20" />
@@ -119,371 +118,362 @@
     <e k="sf_bigBag_dap_function" v="Fosfatgødning (tør)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgødning (tør)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
-		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
-		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
-		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
-		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
-		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
-    <e k="sf_bigBag_starter_name" v="Big Bag Startgødning 10-34-0" eh="953fd6c0" />
-    <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
-    <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_liquid_urea_name" v="IBC Flydende Urea" eh="c40b906f" />
+    <e k="sf_bigBag_liquid_urea_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_name" v="IBC Flydende AMS" eh="32e6c8bb" />
+    <e k="sf_bigBag_liquid_ams_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_map_name" v="IBC Flydende MAP" eh="4628addb" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosfatgødning (flydende)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_name" v="IBC Flydende DAP" eh="82fb3c06" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgødning (flydende)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_potash_name" v="IBC Flydende Kaliumklorid" eh="7176856d" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgødning (flydende)" eh="52169d4a" />
+    <e k="sf_bigBag_starter_name" v="IBC Startgødning 10-34-0" eh="62b13bd1" />
+    <e k="sf_bigBag_insecticide_name" v="IBC Insekticid" eh="c8f0aabb" />
+    <e k="sf_bigBag_insecticide_function" v="Insekticid (flydende)" eh="09580f6b" />
+    <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
+    <e k="sf_bigBag_fungicide_function" v="Fungicid (flydende)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Startgødning (flydende)" eh="2c36ea57" />
-		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
-		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
-
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
-		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
-		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
-		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
-		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
-		<e k="sf_seasonal_effects_long" v="[EN] Enable/disable seasonal impact on soil nutrients (spring growth boost, fall slowdown)" eh="3eea94c7" />
-		<e k="sf_rain_effects_short" v="[EN] Rain Effects" eh="a2a1758b" />
-		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
-		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
-		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
-		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
-		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
-		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
-		<e k="sf_nutrients_long" v="[EN] Enable/disable realistic nutrient depletion and replenishment" eh="dbe9c8ff" />
-		<e k="sf_difficulty_short" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="sf_difficulty_long" v="[EN] Set difficulty level: Simple, Realistic, Hardcore" eh="cfb758a4" />
-		<e k="sf_diff_1" v="[EN] Simple" eh="1fbb1e39" />
-		<e k="sf_diff_2" v="[EN] Realistic" eh="408c999f" />
-		<e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
-		<e k="sf_ui_soilReport_syncing" v="[EN] Syncing soil data..." eh="03f01c4d" />
-		<e k="sf_ui_soilReport_syncTimeout" v="[EN] Could not load field ownership. Please close and reopen the report." eh="9f699982" />
-		<e k="sf_fertilizer_cost_short" v="[EN] Fertilizer Costs" eh="6870d88b" />
-		<e k="sf_fertilizer_cost_long" v="[EN] Enable/disable realistic fertilizer purchase costs" eh="12b03fbb" />
-		<e k="sf_notifications_short" v="[EN] Notifications" eh="a274f4d4" />
-		<e k="sf_notifications_long" v="[EN] Enable/disable soil and fertilizer notifications" eh="9a872f8f" />
-		<e k="sf_show_hud_short" v="[EN] Show HUD" eh="c94fd4d7" />
-		<e k="sf_show_hud_long" v="[EN] Show/hide the soil info HUD overlay (F8 to toggle temporarily)" eh="4e2e11b6" />
-		<e k="sf_hud_position_short" v="[EN] HUD Position" eh="5ac371f2" />
-		<e k="sf_hud_position_long" v="[EN] Choose where the soil info HUD appears on screen" eh="d7b9c109" />
-		<e k="sf_hud_pos_1" v="[EN] Top Right" eh="5f9f6784" />
-		<e k="sf_hud_pos_2" v="[EN] Top Left" eh="ac71274a" />
-		<e k="sf_hud_pos_3" v="[EN] Bottom Right" eh="4d297f5d" />
-		<e k="sf_hud_pos_4" v="[EN] Bottom Left" eh="7eb55425" />
-		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
-		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
-		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
-		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
-		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
-		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
-		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
-		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
-		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
-		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
-		<e k="helpLine_sf_ov_p1_intro_title" v="[EN] Per-Field Soil Tracking" eh="8fe3248d" />
-		<e k="helpLine_sf_ov_p1_intro_text" v="[EN] Every field independently tracks five properties: Nitrogen (N), Phosphorus (P), Potassium (K), Organic Matter (OM), and pH. Values are saved with your savegame and persist across sessions." eh="c30216e6" />
-		<e k="helpLine_sf_ov_p1_flow_title" v="[EN] The Nutrient Cycle" eh="15b0d408" />
-		<e k="helpLine_sf_ov_p1_flow_text" v="[EN] Crops remove nutrients at harvest. Fertilizer, manure, slurry, and lime restore them. The mod tracks a realistic nutrient budget - what crops take out, you must put back." eh="418041f0" />
-		<e k="helpLine_sf_ov_p2_title" v="[EN] Environmental Effects" eh="e139e84f" />
-		<e k="helpLine_sf_ov_p2_rain_title" v="[EN] Rain and Leaching" eh="33e0d8ea" />
-		<e k="helpLine_sf_ov_p2_rain_text" v="[EN] Rain leaches Nitrogen most heavily, then Potassium, then Phosphorus. It also slowly acidifies pH over time. Rain effects can be toggled off in Settings." eh="91e39cc6" />
-		<e k="helpLine_sf_ov_p2_season_title" v="[EN] Seasons and Fallow Recovery" eh="ad2009c8" />
-		<e k="helpLine_sf_ov_p2_season_text" v="[EN] Spring adds +0.03 N per day (biological activity). Fall removes 0.02 N per day. Fields left unplanted for more than 7 days slowly recover all nutrients on their own." eh="e5ebb3b2" />
-		<e k="helpLine_sf_gs_p1_title" v="[EN] Your First Steps" eh="bdd0e0a7" />
-		<e k="helpLine_sf_gs_p1_hud_title" v="[EN] Open the HUD (J key)" eh="e1bdea72" />
-		<e k="helpLine_sf_gs_p1_hud_text" v="[EN] Press J to toggle the live soil overlay. It shows N, P, K, pH, and OM for the field you are standing in. Good / Fair / Poor status labels tell you what needs attention at a glance." eh="53cef520" />
-		<e k="helpLine_sf_gs_p1_report_title" v="[EN] Open the Soil Report (K key)" eh="e71446cd" />
-		<e k="helpLine_sf_gs_p1_report_text" v="[EN] Press K to open the full farm soil report. Every field is listed with color-coded nutrient status, sorted by urgency. Click the arrow on any row for a detailed view with recommendations." eh="9a0d32a6" />
-		<e k="helpLine_sf_gs_p2_title" v="[EN] Fertilize and Harvest" eh="1a52ac04" />
-		<e k="helpLine_sf_gs_p2_fert_title" v="[EN] Fertilizing Fields" eh="ea52ec26" />
-		<e k="helpLine_sf_gs_p2_fert_text" v="[EN] Apply fertilizer with any standard sprayer or spreader. The mod recognizes all base-game types plus 9 custom types (UAN-32, MAP, Potash, etc.). Each type restores different nutrients - see the Fertilizers category for full profiles." eh="fe906e29" />
-		<e k="helpLine_sf_gs_p2_harvest_title" v="[EN] Harvest Depletion" eh="a67b6cb5" />
-		<e k="helpLine_sf_gs_p2_harvest_text" v="[EN] Every harvest removes nutrients from the field. Demanding crops (potato, sugar beet, soybean) deplete significantly more than light feeders (barley, oats). Re-check the HUD or soil report after each harvest cycle." eh="63f90ed4" />
-		<e k="helpLine_sf_gs_p3_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
-		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
-		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
-		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
-		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
-		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
-		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
-		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
-		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
-		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
-		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
-		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
-		<e k="helpLine_sf_nu_p3_om_text" v="[EN] Builds very slowly and is not depleted by harvest. Poor: below 2.5. Good: above 4.0. Raise with: manure, slurry, digestate, compost, biosolids, chicken litter, pelletized manure, or by chopping straw back into the field." eh="f9a02359" />
-		<e k="helpLine_sf_nu_p3_fallow_title" v="[EN] Fallow Recovery" eh="14133b0b" />
-		<e k="helpLine_sf_nu_p3_fallow_text" v="[EN] A field left unplanted for 7+ days slowly recovers nutrients. Per day: N +0.07, P +0.03, K +0.05, OM +0.01. Crop rotation and periods of rest still have real value in this mod." eh="81fa82b3" />
-		<e k="helpLine_sf_fe_p1_title" v="[EN] Base Game Types" eh="fd941c0d" />
-		<e k="helpLine_sf_fe_p1_base_title" v="[EN] Liquid, Solid, Manure and Slurry" eh="4668dca7" />
-		<e k="helpLine_sf_fe_p1_base_text" v="[EN] Liquid Fertilizer adds balanced N+P+K. Solid Fertilizer is higher in N and P. Manure and Slurry add N, P, K, and Organic Matter. Digestate (biogas byproduct) is high in K and also adds OM. All applied with standard equipment." eh="64069a56" />
-		<e k="helpLine_sf_fe_p1_lime_title" v="[EN] Lime and pH Correction" eh="8933cce1" />
-		<e k="helpLine_sf_fe_p1_lime_text" v="[EN] Lime is the only base-game pH correction - it does not add nutrients. Custom types Liquid Lime and Gypsum also raise pH (Gypsum adds minor OM too). Apply when pH drops below 6.0 to keep crops in their optimal range." eh="833a967f" />
-		<e k="helpLine_sf_fe_p2_title" v="[EN] Custom Nitrogen and PK Sources" eh="1021f8c9" />
-		<e k="helpLine_sf_fe_p2_n_title" v="[EN] Nitrogen Sources (custom big bags)" eh="9dfe5a5a" />
-		<e k="helpLine_sf_fe_p2_n_text" v="[EN] UAN-32 (32-0-0) and UAN-28 (28-0-0) are liquid nitrogen solutions. Anhydrous Ammonia (82-0-0) is the highest-N product per litre. Urea (46-0-0) and AMS (21-0-0-24S) are dry granular. All are N only - no effect on P, K, or pH." eh="6a100c25" />
-		<e k="helpLine_sf_fe_p2_pk_title" v="[EN] Phosphorus and Potassium Sources" eh="a2d4091b" />
-		<e k="helpLine_sf_fe_p2_pk_text" v="[EN] MAP (11-52-0): highest P per litre. DAP (18-46-0): high P with some N. Potash (0-0-60): pure K. Starter (10-34-0): high-P in-furrow product with balanced N+K. All available as purchasable big bags in the shop." eh="75a86964" />
-		<e k="helpLine_sf_fe_p3_title" v="[EN] Organic Products and Burn Risk" eh="7ab807d1" />
-		<e k="helpLine_sf_fe_p3_organic_title" v="[EN] Organic and Slow-Release Products" eh="0199e6be" />
-		<e k="helpLine_sf_fe_p3_organic_text" v="[EN] Compost is the strongest OM builder (+0.12 per 1,000 L). Biosolids and Chicken Litter add N, P, and OM. Pelletized Manure is a concentrated balanced organic. All are custom fill types available when compatible equipment mods are installed." eh="3d16e4ee" />
-		<e k="helpLine_sf_fe_p3_burn_title" v="[EN] Overapplication Burn Risk" eh="e986cc54" />
-		<e k="helpLine_sf_fe_p3_burn_text" v="[EN] Applying above 1.25x the base rate risks fertilizer burn (-0.15 pH and -5 N). At 1.50x or higher, burn is guaranteed every pass (-0.30 pH and -12 N). Use SF Rate Up / Rate Down keys in the vehicle to control the application rate." eh="7bccc46a" />
-		<e k="helpLine_sf_hu_p1_title" v="[EN] The Soil HUD" eh="6522879b" />
-		<e k="helpLine_sf_hu_p1_toggle_title" v="[EN] Toggling the HUD (J key)" eh="402283ba" />
-		<e k="helpLine_sf_hu_p1_toggle_text" v="[EN] Press J to show or hide the live soil overlay. It detects the field you are on and shows N, P, K, pH, and OM. When Weed, Pest, or Disease settings are enabled, those rows appear at the bottom of the panel." eh="3dcb9bfe" />
-		<e k="helpLine_sf_hu_p1_status_title" v="[EN] Reading the Status" eh="291c3aac" />
-		<e k="helpLine_sf_hu_p1_status_text" v="[EN] Each nutrient shows Good (no action needed), Fair (consider treating soon), or Poor (action needed - yield affected). The overall badge in the title bar reflects the worst value across all tracked dimensions including weed, pest, and disease." eh="3b8c2c6e" />
-		<e k="helpLine_sf_hu_p2_title" v="[EN] Field Health Pressures" eh="b4d35b30" />
-		<e k="helpLine_sf_hu_p2_press_title" v="[EN] Weed, Pest and Disease" eh="0a3fae00" />
-		<e k="helpLine_sf_hu_p2_press_text" v="[EN] Three pressure scores (0 to 100) track biological threats per field. Left unchecked they reduce yield at harvest: Weed up to -30%, Pest -20%, Disease -25%. HUD rows W, I, and D show color-coded severity: green (low), yellow (moderate), red (high)." eh="3fc3c400" />
-		<e k="helpLine_sf_hu_p2_treat_title" v="[EN] Treating Pressure" eh="cb24bf50" />
-		<e k="helpLine_sf_hu_p2_treat_text" v="[EN] Herbicide reduces weed pressure - any tillage also resets it to zero. Insecticide reduces pest pressure by 25 pts and suppresses regrowth for 10 days. Fungicide reduces disease by 20 pts and suppresses for 12 days. Each system can be toggled off in Settings." eh="4d65bdec" />
-		<e k="helpLine_sf_hu_p3_title" v="[EN] The Soil Report" eh="35fcce6c" />
-		<e k="helpLine_sf_hu_p3_open_title" v="[EN] Opening the Report (K key)" eh="62e3f629" />
-		<e k="helpLine_sf_hu_p3_open_text" v="[EN] Press K to open the full farm soil report. The summary bar shows total fields tracked, how many need fertilizer, and a weighted Farm Health percentage. Fields are sorted by urgency - worst condition first." eh="38a5bd2e" />
-		<e k="helpLine_sf_hu_p3_detail_title" v="[EN] Field Detail and Recommendations" eh="c99d2b89" />
-		<e k="helpLine_sf_hu_p3_detail_text" v="[EN] Click the arrow on any row to open that field's detail view: nutrient values, pressure levels, a yield penalty forecast, and a bulleted recommendation list telling you exactly what to apply. Press Back or Escape to return to the table." eh="38dd2c6d" />
-		<e k="helpLine_sf_se_p1_title" v="[EN] Simulation Settings" eh="cbf13e3c" />
-		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
-		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
-		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
-		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
-		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
-		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
-		<e k="helpLine_sf_se_p2_rate_title" v="[EN] Sprayer Rate Control" eh="5ecdfa23" />
-		<e k="helpLine_sf_se_p2_rate_text" v="[EN] While in a sprayer or spreader, use SF Rate Up (]) and SF Rate Down ([) to adjust the application rate from 0.10x to 2.00x. Toggle Auto-Rate Control (Shift+L) to let the mod automatically target optimal nutrient levels and avoid burn risk." eh="dd385e39" />
-		<e k="helpLine_sf_mp_p1_title" v="[EN] How Multiplayer Works" eh="8a4ce30e" />
-		<e k="helpLine_sf_mp_p1_auth_title" v="[EN] Server-Authoritative Simulation" eh="8d324792" />
-		<e k="helpLine_sf_mp_p1_auth_text" v="[EN] All soil simulation runs on the server. Clients receive full field data and settings on join, with automatic retry if the server is still loading. HUD display settings (position, theme, size) are per-player and are never synced to the server." eh="db72a3f9" />
-		<e k="helpLine_sf_mp_p1_ded_title" v="[EN] Dedicated Servers" eh="4d3a45ba" />
-		<e k="helpLine_sf_mp_p1_ded_text" v="[EN] Dedicated servers run the full simulation without any HUD or GUI overhead - this is expected and normal. Use console commands (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) to manage and verify settings on a dedicated server." eh="3df784d6" />
-		<e k="helpLine_sf_mp_p2_title" v="[EN] PrecisionFarming Compatibility" eh="3647a30c" />
-		<e k="helpLine_sf_mp_p2_compat_title" v="[EN] Running Both Mods Together" eh="bc5325f5" />
-		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
-		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
-		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
-		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
-		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
-		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
-		<e k="sf_map_layer_k" v="[EN] Potassium" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
-		<e k="sf_map_layer_om" v="[EN] Organic Matter" eh="6305f4bb" />
-		<e k="sf_map_layer_urgency" v="[EN] Field Urgency" eh="419ea5af" />
-		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
-		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
-		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
-		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
-		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
-		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />
-		<e k="sf_map_sidebar_label" v="[EN] Active Layer" eh="f8a2c198" />
-		<e k="sf_map_sidebar_tooltip" v="[EN] Select which soil nutrient to display on the map" eh="eb926e9a" />
-		<e k="sf_map_overlay_low" v="[EN] Low" eh="28d0edd0" />
-		<e k="sf_map_overlay_med" v="[EN] Med" eh="248c9511" />
-		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
-
-    <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
-    <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
-    <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
-    <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
-    <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
-		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
-		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
-		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
+    <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
+    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tør)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Kompost" />
+    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør)" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolider" />
+    <e k="sf_bigBag_biosolids_function" v="Organisk gødning (tør)" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsemøg" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organisk gødning (tør)" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelleteret Gødning" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gødning (tør)" />
+    <e k="sf_bigBag_liquidlime_name" v="Flydende Kalktank" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-hævende middel (flydende)" />
+    <e k="sf_section" v="Jord &amp; Gødning" eh="d30a22a9" />
+    <e k="sf_enabled_short" v="Aktiver mod" eh="cf7fea13" />
+    <e k="sf_enabled_long" v="Aktiver eller deaktiver jord- og gødningsmoddet" eh="e377fd59" />
+    <e k="sf_debug_short" v="DEBUG-tilstand" eh="2ddcdc76" />
+    <e k="sf_debug_long" v="Aktiver/deaktiver fejlfiningstilstand (ekstra logning)" eh="f6f20240" />
+    <e k="sf_seasonal_effects_short" v="Sæsoneffekter" eh="c16ea608" />
+    <e k="sf_seasonal_effects_long" v="Aktiver/deaktiver sæsonmæssig påvirkning af jordnæringsstoffer (forårsvækst, efterårsstagnation)" eh="3eea94c7" />
+    <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
+    <e k="sf_rain_effects_long" v="Aktiver/deaktiver regnens påvirkning af jord (næringsstofudvaskning, pH-ændringer)" eh="de3b14b9" />
+    <e k="sf_plowing_bonus_short" v="Pløjebonus" eh="541ec752" />
+    <e k="sf_plowing_bonus_long" v="Aktiver/deaktiver pløjningens fordele for jordfrugtbarhed (forbedret kvælstof og organisk materiale)" eh="fe701c1c" />
+    <e k="sf_weed_pressure_short" v="Ukrudtstryk" eh="53f8b936" />
+    <e k="sf_weed_pressure_long" v="Aktiver/deaktiver dynamisk ukrudtsvækst og udbyttepåvirkning" eh="ac99a865" />
+    <e k="sf_pest_pressure_short" v="Skadedyrstryk" eh="18a7c2be" />
+    <e k="sf_pest_pressure_long" v="Aktiver/deaktiver insekt- og skadedyrsangrebssystem" eh="2ba11abc" />
+    <e k="sf_disease_pressure_short" v="Sygdomstryk" eh="2b805cc9" />
+    <e k="sf_disease_pressure_long" v="Aktiver/deaktiver svampe- og afgrødesygdomssystem" eh="9080edbc" />
+    <e k="sf_fertility_short" v="Frugtbarhedssystem" eh="f7e27d58" />
+    <e k="sf_fertility_long" v="Aktiver/deaktiver dynamisk jordfrugtbarhedssystem" eh="ea074366" />
+    <e k="sf_nutrients_short" v="Næringsstofcyklusser" eh="ffab595d" />
+    <e k="sf_nutrients_long" v="Aktiver/deaktiver realistisk næringsstofudtømning og -genopfyldning" eh="dbe9c8ff" />
+    <e k="sf_difficulty_short" v="Sværhedsgrad" eh="7b29ca96" />
+    <e k="sf_difficulty_long" v="Angiv sværhedsgrad: Simpel, Realistisk, Hardcore" eh="cfb758a4" />
+    <e k="sf_diff_1" v="Simpel" eh="1fbb1e39" />
+    <e k="sf_diff_2" v="Realistisk" eh="408c999f" />
+    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_ui_soilReport_syncing" v="Synkroniserer jorddata..." eh="03f01c4d" />
+    <e k="sf_ui_soilReport_syncTimeout" v="Kunne ikke indlæse markejerskab. Luk og genåbn rapporten." eh="9f699982" />
+    <e k="sf_fertilizer_cost_short" v="Gødningsomkostninger" eh="6870d88b" />
+    <e k="sf_fertilizer_cost_long" v="Aktiver/deaktiver realistiske gødningsindkøbsomkostninger" eh="12b03fbb" />
+    <e k="sf_notifications_short" v="Notifikationer" eh="a274f4d4" />
+    <e k="sf_notifications_long" v="Aktiver/deaktiver jord- og gødningsnotifikationer" eh="9a872f8f" />
+    <e k="sf_show_hud_short" v="Vis HUD" eh="c94fd4d7" />
+    <e k="sf_show_hud_long" v="Vis/skjul jord-HUD-overlejringen (F8 for midlertidigt skift)" eh="4e2e11b6" />
+    <e k="sf_hud_position_short" v="HUD-position" eh="5ac371f2" />
+    <e k="sf_hud_position_long" v="Vælg hvor jord-HUD'et vises på skærmen" eh="d7b9c109" />
+    <e k="sf_hud_pos_1" v="Øverst til højre" eh="5f9f6784" />
+    <e k="sf_hud_pos_2" v="Øverst til venstre" eh="ac71274a" />
+    <e k="sf_hud_pos_3" v="Nederst til højre" eh="4d297f5d" />
+    <e k="sf_hud_pos_4" v="Nederst til venstre" eh="7eb55425" />
+    <e k="sf_hud_pos_5" v="Midten til højre" eh="d7afdc5a" />
+    <e k="sf_hud_pos_6" v="Brugerdefineret" eh="90589c47" />
+    <e k="sf_hud_color_theme_short" v="HUD-farvetema" eh="4a73f95b" />
+    <e k="sf_hud_color_theme_long" v="Vælg farvepalette til jorddatavisning" eh="3218bca6" />
+    <e k="sf_report_detail_n_ok" v="Kvælstof: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="Fosfor: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="Kalium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="Overvåg" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="Juster" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="Vedligehold" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="Forøg" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="Lav" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="Moderat" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="Høj" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="Baseret på N/P/K vs. optimal grænse" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="Udbytte ~-%d%%" eh="d64d5d59" />
+    <e k="helpLine_sf_cat_overview" v="Oversigt" eh="3b878279" />
+    <e k="helpLine_sf_cat_started" v="Kom godt i gang" eh="bf647454" />
+    <e k="helpLine_sf_cat_nutrients" v="Jordnæringsstoffer" eh="64377acf" />
+    <e k="helpLine_sf_cat_fertilizers" v="Gødningstyper" eh="754d59bd" />
+    <e k="helpLine_sf_cat_hud" v="HUD &amp; Jordrapport" eh="9b9888b9" />
+    <e k="helpLine_sf_cat_settings" v="Indstillinger" eh="f4f70727" />
+    <e k="helpLine_sf_cat_multiplayer" v="Multiplayer" eh="901a7320" />
+    <e k="helpLine_sf_ov_p1_title" v="Hvad gør moddet?" eh="46cbb25b" />
+    <e k="helpLine_sf_ov_p1_intro_title" v="Markbaseret jordregistrering" eh="8fe3248d" />
+    <e k="helpLine_sf_ov_p1_intro_text" v="Hver mark registrerer uafhængigt fem egenskaber: Kvælstof (N), Fosfor (P), Kalium (K), Organisk materiale (OM) og pH. Værdierne gemmes med din gemte spil og bevares på tværs af sessioner." eh="c30216e6" />
+    <e k="helpLine_sf_ov_p1_flow_title" v="Næringsstofcyklussen" eh="15b0d408" />
+    <e k="helpLine_sf_ov_p1_flow_text" v="Afgrøder fjerner næringsstoffer ved høst. Gødning, gylle og kalk genetablerer dem. Moddet sporer et realistisk næringsstofbudget - det afgrøderne tager, skal du sætte tilbage." eh="418041f0" />
+    <e k="helpLine_sf_ov_p2_title" v="Miljøeffekter" eh="e139e84f" />
+    <e k="helpLine_sf_ov_p2_rain_title" v="Regn og udvaskning" eh="33e0d8ea" />
+    <e k="helpLine_sf_ov_p2_rain_text" v="Regn udvasker kvælstof mest, derefter kalium og fosfor. Det forsurer også langsomt pH over tid. Regneffekter kan slås fra i indstillingerne." eh="91e39cc6" />
+    <e k="helpLine_sf_ov_p2_season_title" v="Sæsoner og brakgenopretning" eh="ad2009c8" />
+    <e k="helpLine_sf_ov_p2_season_text" v="Forår tilføjer +0,03 N pr. dag (biologisk aktivitet). Efterår fjerner 0,02 N pr. dag. Marker efterladt ubeplantede i mere end 7 dage genopretter langsomt alle næringsstoffer på egen hånd." eh="e5ebb3b2" />
+    <e k="helpLine_sf_gs_p1_title" v="Dine første skridt" eh="bdd0e0a7" />
+    <e k="helpLine_sf_gs_p1_hud_title" v="Åbn HUD (J-tast)" eh="e1bdea72" />
+    <e k="helpLine_sf_gs_p1_hud_text" v="Tryk J for at slå jordoverlejringen til. Den viser N, P, K, pH og OM for den mark du står på. God / Rimelig / Dårlig statusindikatorer viser hvad der kræver opmærksomhed med det samme." eh="53cef520" />
+    <e k="helpLine_sf_gs_p1_report_title" v="Åbn jordrapporten (K-tast)" eh="e71446cd" />
+    <e k="helpLine_sf_gs_p1_report_text" v="Tryk K for at åbne den fulde gårdsjordrapport. Alle marker er listet med farvekodet næringsstofstatus, sorteret efter hastende behov. Klik på pilen på en række for en detaljeret visning med anbefalinger." eh="9a0d32a6" />
+    <e k="helpLine_sf_gs_p2_title" v="Gødsk og høst" eh="1a52ac04" />
+    <e k="helpLine_sf_gs_p2_fert_title" v="Gødskning af marker" eh="ea52ec26" />
+    <e k="helpLine_sf_gs_p2_fert_text" v="Påfør gødning med en hvilken som helst standard-sprøjte eller spreder. Moddet genkender alle basisspilstyper plus 9 brugerdefinerede typer (UAN-32, MAP, Kaliumklorid osv.). Hver type genopretter forskellige næringsstoffer." eh="fe906e29" />
+    <e k="helpLine_sf_gs_p2_harvest_title" v="Næringsstofudtømning ved høst" eh="a67b6cb5" />
+    <e k="helpLine_sf_gs_p2_harvest_text" v="Hver høst fjerner næringsstoffer fra marken. Krævende afgrøder (kartofler, sukkerroer, sojabønner) udtømmer væsentligt mere end lette afgrøder (byg, havre). Tjek HUD eller jordrapporten efter hver høstcyklus." eh="63f90ed4" />
+    <e k="helpLine_sf_gs_p3_title" v="Sværhedsgrad" eh="7b29ca96" />
+    <e k="helpLine_sf_gs_p3_levels_title" v="Tre sværhedsgrader" eh="52611188" />
+    <e k="helpLine_sf_gs_p3_levels_text" v="Simpel (0,7x): 30% mindre udtømning - god for nye spillere. Realistisk (1,0x): balanceret, kalibreret til virkelige landbrugsrater. Hardcore (1,5x): 50% mere udtømning - intens jordforvaltning påkrævet." eh="f4f1ea30" />
+    <e k="helpLine_sf_gs_p3_access_title" v="Ændring af indstillinger" eh="b421c88f" />
+    <e k="helpLine_sf_gs_p3_access_text" v="Åbn indstillinger via ESC &gt; Indstillinger &gt; Jord &amp; Gødning. I multiplayer kan kun serveradministratoren ændre simuleringsindstillinger. Alle HUD-visningsindstillinger er pr. spiller og deles ikke." eh="f36a5639" />
+    <e k="helpLine_sf_nu_p1_title" v="Kvælstof og fosfor" eh="27d37372" />
+    <e k="helpLine_sf_nu_p1_n_title" v="Kvælstof (N) - Skala 0 til 100" eh="10a358f4" />
+    <e k="helpLine_sf_nu_p1_n_text" v="Det mest mobile næringsstof - udtømmes hurtigst og udvaskes kraftigt i regn. Dårlig: under 30. God: over 50. Hæv med: flydende gødning, UAN-32, UAN-28, vandfri ammoniak, urea, AMS, gylle eller ajle." eh="58d62253" />
+    <e k="helpLine_sf_nu_p1_p_title" v="Fosfor (P) - Skala 0 til 100" eh="979bba64" />
+    <e k="helpLine_sf_nu_p1_p_text" v="Binder sig tæt til jord og udvaskes meget langsomt. Udtømmes primært ved høst. Raps har det højeste P-behov. Dårlig: under 25. God: over 45. Hæv med: MAP, DAP, startgødning eller flydende gødning." eh="92c5ac66" />
+    <e k="helpLine_sf_nu_p2_title" v="Kalium og pH" eh="6bd92f25" />
+    <e k="helpLine_sf_nu_p2_k_title" v="Kalium (K) - Skala 0 til 100" eh="2a16e8bc" />
+    <e k="helpLine_sf_nu_p2_k_text" v="Kritisk for rod- og knoldafgrøder. Kartofler og sukkerroer udtømmer K kraftigt ved hver høst. Udvaskes moderat i regn. Dårlig: under 20. God: over 40. Hæv med: kaliumklorid (0-0-60), ajle, digestat eller flydende gødning." eh="7230fee4" />
+    <e k="helpLine_sf_nu_p2_ph_title" v="pH - Skala 5,0 til 7,5" eh="944beca2" />
+    <e k="helpLine_sf_nu_p2_ph_text" v="De fleste afgrøder trives ved pH 6,5 til 7,0. Regn forsurer langsomt jord over tid. pH genopretter sig ikke af sig selv - kun kalk eller flydende kalk hæver den. Dårlig: under 5,5. Anvend kalk hvis pH falder inden næste plantning." eh="08e0aefd" />
+    <e k="helpLine_sf_nu_p3_title" v="Organisk materiale" eh="6305f4bb" />
+    <e k="helpLine_sf_nu_p3_om_title" v="Organisk materiale (OM) - Skala 0 til 10" eh="58f490f3" />
+    <e k="helpLine_sf_nu_p3_om_text" v="Opbygges meget langsomt og udtømmes ikke ved høst. Dårlig: under 2,5. God: over 4,0. Hæv med: gylle, ajle, digestat, kompost, biosolider, hønsemøg, pelleteret gødning, eller ved at hakke halm tilbage i marken." eh="f9a02359" />
+    <e k="helpLine_sf_nu_p3_fallow_title" v="Brakgenopretning" eh="14133b0b" />
+    <e k="helpLine_sf_nu_p3_fallow_text" v="En mark efterladt ubeplanted i 7+ dage genopretter langsomt næringsstoffer. Pr. dag: N +0,07, P +0,03, K +0,05, OM +0,01. Sædskifte og hvileperioder har stadig reel værdi i dette modd." eh="81fa82b3" />
+    <e k="helpLine_sf_fe_p1_title" v="Basisspilstyper" eh="fd941c0d" />
+    <e k="helpLine_sf_fe_p1_base_title" v="Flydende, fast, gylle og ajle" eh="4668dca7" />
+    <e k="helpLine_sf_fe_p1_base_text" v="Flydende gødning tilføjer afbalanceret N+P+K. Fast gødning er højere i N og P. Gylle og ajle tilføjer N, P, K og organisk materiale. Digestat (biogasbiprodukt) er rigt på K og tilføjer også OM. Alt anvendes med standardudstyr." eh="64069a56" />
+    <e k="helpLine_sf_fe_p1_lime_title" v="Kalk og pH-korrektion" eh="8933cce1" />
+    <e k="helpLine_sf_fe_p1_lime_text" v="Kalk er den eneste basisspils pH-korrektion - den tilføjer ikke næringsstoffer. Flydende Kalk og Gips hæver også pH (Gips tilføjer også lidt OM). Anvend når pH falder under 6,0." eh="833a967f" />
+    <e k="helpLine_sf_fe_p2_title" v="Brugerdefinerede kvælstof- og PK-kilder" eh="1021f8c9" />
+    <e k="helpLine_sf_fe_p2_n_title" v="Kvælstofkilder (brugerdefinerede storsække)" eh="9dfe5a5a" />
+    <e k="helpLine_sf_fe_p2_n_text" v="UAN-32 (32-0-0) og UAN-28 (28-0-0) er flydende kvælstofopløsninger. Vandfri ammoniak (82-0-0) er det højeste-N-produkt pr. liter. Urea (46-0-0) og AMS (21-0-0-24S) er tør granulat. Alle er kun N." eh="6a100c25" />
+    <e k="helpLine_sf_fe_p2_pk_title" v="Fosfor- og kaliumkilder" eh="a2d4091b" />
+    <e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0): højeste P pr. liter. DAP (18-46-0): høj P med noget N. Kaliumklorid (0-0-60): rent K. Startgødning (10-34-0): høj-P nedfældningsprodukt med afbalanceret N+K. Alle tilgængelige som storsække i butikken." eh="75a86964" />
+    <e k="helpLine_sf_fe_p3_title" v="Organiske produkter og forbrændingsrisiko" eh="7ab807d1" />
+    <e k="helpLine_sf_fe_p3_organic_title" v="Organiske og langsomt frigivende produkter" eh="0199e6be" />
+    <e k="helpLine_sf_fe_p3_organic_text" v="Kompost er den stærkeste OM-opbygger (+0,12 pr. 1.000 L). Biosolider og hønsemøg tilføjer N, P og OM. Pelleteret gødning er en koncentreret afbalanceret organisk gødning." eh="3d16e4ee" />
+    <e k="helpLine_sf_fe_p3_burn_title" v="Overudbringningsforbrændingsrisiko" eh="e986cc54" />
+    <e k="helpLine_sf_fe_p3_burn_text" v="Påføring over 1,25x basisraten risikerer gødningsforbrænding (-0,15 pH og -5 N). Ved 1,50x eller højere er forbrænding garanteret (-0,30 pH og -12 N). Brug SF Rate Op / Rate Ned-tasterne til at kontrollere udbringningsraten." eh="7bccc46a" />
+    <e k="helpLine_sf_hu_p1_title" v="Jord-HUD'et" eh="6522879b" />
+    <e k="helpLine_sf_hu_p1_toggle_title" v="Slå HUD til/fra (J-tast)" eh="402283ba" />
+    <e k="helpLine_sf_hu_p1_toggle_text" v="Tryk J for at vise eller skjule jordoverlejringen. Den registrerer den mark du er på og viser N, P, K, pH og OM. Når Ukrudt-, Skadedyrs- eller Sygdomsindstillinger er aktiveret, vises disse rækker nederst i panelet." eh="3dcb9bfe" />
+    <e k="helpLine_sf_hu_p1_status_title" v="Aflæsning af status" eh="291c3aac" />
+    <e k="helpLine_sf_hu_p1_status_text" v="Hvert næringsstof viser God (ingen handling nødvendig), Rimelig (overvej behandling snart) eller Dårlig (handling nødvendig). Det overordnede mærke i titellinjen afspejler den dårligste værdi på tværs af alle sporede dimensioner." eh="3b8c2c6e" />
+    <e k="helpLine_sf_hu_p2_title" v="Marksundhedstryk" eh="b4d35b30" />
+    <e k="helpLine_sf_hu_p2_press_title" v="Ukrudt, skadedyr og sygdom" eh="0a3fae00" />
+    <e k="helpLine_sf_hu_p2_press_text" v="Tre trykscorer (0 til 100) sporer biologiske trusler pr. mark. Ukontrolleret reducerer de udbyttet ved høst: Ukrudt op til -30%, Skadedyr -20%, Sygdom -25%. HUD-rækker U, I og S viser farvekodet alvorlighed: grøn (lav), gul (moderat), rød (høj)." eh="3fc3c400" />
+    <e k="helpLine_sf_hu_p2_treat_title" v="Behandling af tryk" eh="cb24bf50" />
+    <e k="helpLine_sf_hu_p2_treat_text" v="Herbicid reducerer ukrudtstryk - enhver jordbehandling nulstiller det også. Insekticid reducerer skadedyrstryk med 25 point og undertrykker genvækst i 10 dage. Fungicid reducerer sygdom med 20 point og undertrykker i 12 dage." eh="4d65bdec" />
+    <e k="helpLine_sf_hu_p3_title" v="Jordrapporten" eh="35fcce6c" />
+    <e k="helpLine_sf_hu_p3_open_title" v="Åbning af rapporten (K-tast)" eh="62e3f629" />
+    <e k="helpLine_sf_hu_p3_open_text" v="Tryk K for at åbne den fulde gårdsjordrapport. Resumélinjen viser totale sporede marker, hvor mange der mangler gødning og en vægtet Gårdsundhedsprocent. Marker er sorteret efter hastende behov." eh="38a5bd2e" />
+    <e k="helpLine_sf_hu_p3_detail_title" v="Markdetaljer og anbefalinger" eh="c99d2b89" />
+    <e k="helpLine_sf_hu_p3_detail_text" v="Klik på pilen på en række for at åbne markens detaljerede visning: næringsstofværdier, tryksniveauer, en udbyttetabsprognose og anbefalinger. Tryk Tilbage eller Escape for at vende tilbage til tabellen." eh="38dd2c6d" />
+    <e k="helpLine_sf_se_p1_title" v="Simuleringsindstillinger" eh="cbf13e3c" />
+    <e k="helpLine_sf_se_p1_server_title" v="Serverindstillinger (kun administrator i multiplayer)" eh="49f37ed7" />
+    <e k="helpLine_sf_se_p1_server_text" v="Frugtbarhedssystem, næringsstofcyklusser, sæsoneffekter, regneffekter, pløjebonus, ukrudt-/skadedyrs-/sygdomstryk, gødningsomkostninger, notifikationer, sædskifte og automatisk hastighedskontrol. I multiplayer kan kun serveradministratoren ændre disse." eh="abca5e43" />
+    <e k="helpLine_sf_se_p1_diff_title" v="Sværhedsgrad" eh="7b29ca96" />
+    <e k="helpLine_sf_se_p1_diff_text" v="Simpel (0,7x) reducerer udtømning med 30% for en afslappet oplevelse. Realistisk (1,0x) er den balancerede standard. Hardcore (1,5x) øger udtømning med 50% for intens jordforvaltning. Tilgås via ESC &gt; Indstillinger &gt; Jord &amp; Gødning." eh="740a3a4e" />
+    <e k="helpLine_sf_se_p2_title" v="HUD og hastighedskontrol" eh="399f4910" />
+    <e k="helpLine_sf_se_p2_hud_title" v="HUD-indstillinger pr. spiller" eh="0df76500" />
+    <e k="helpLine_sf_se_p2_hud_text" v="Hver spiller styrer sit eget HUD. Muligheder: Vis HUD (til/fra), Position (5 forudindstillinger + træk), Farvetema (Grøn / Blå / Rav / Mono), Skriftstørrelse (Lille / Mellem / Stor), Gennemsigtighed (25% til 100%), Imperiale enheder (til/fra)." eh="f3934884" />
+    <e k="helpLine_sf_se_p2_rate_title" v="Sprøjtehastighedskontrol" eh="5ecdfa23" />
+    <e k="helpLine_sf_se_p2_rate_text" v="Mens du er i en sprøjte eller spreder, brug SF Rate Op (]) og SF Rate Ned ([) til at justere udbringningsraten fra 0,10x til 2,00x. Slå automatisk hastighedskontrol til (Skift+L) for at lade moddet sigte mod optimale næringsstofniveauer." eh="dd385e39" />
+    <e k="helpLine_sf_mp_p1_title" v="Sådan fungerer multiplayer" eh="8a4ce30e" />
+    <e k="helpLine_sf_mp_p1_auth_title" v="Serverautoritativ simulering" eh="8d324792" />
+    <e k="helpLine_sf_mp_p1_auth_text" v="Al jordsimulering kører på serveren. Klienter modtager fulde markdata og indstillinger ved tilmelding. HUD-visningsindstillinger (position, tema, størrelse) er pr. spiller og synkroniseres aldrig til serveren." eh="db72a3f9" />
+    <e k="helpLine_sf_mp_p1_ded_title" v="Dedikerede servere" eh="4d3a45ba" />
+    <e k="helpLine_sf_mp_p1_ded_text" v="Dedikerede servere kører den fulde simulering uden HUD- eller GUI-overhead. Brug konsolkommandoer (soilStatus, SoilSetDifficulty, SoilShowSettings osv.) til at administrere indstillinger på en dedikeret server." eh="3df784d6" />
+    <e k="helpLine_sf_mp_p2_title" v="PrecisionFarming-kompatibilitet" eh="3647a30c" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="Kørsel af begge modd samtidigt" eh="bc5325f5" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="Begge modd kører fuldt uafhængigt og er fuldt kompatible. Et gødningsgennemkørsel opdaterer begge på samme tid. PF's jordszoner og SoilFertilizer's N/P/K-værdier bruger forskellige modeller og vil ikke være identiske." eh="5c9f8ada" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="Praktisk arbejdsgang" eh="b6f73f04" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="Brug PrecisionFarming til at se hvor i en mark der kræver opmærksomhed. Brug SoilFertilizer's HUD og jordrapport til at se hvilket næringsstof der skal påføres. Ét gennemkørsel tilfredsstiller begge modd simultant." eh="cde2c27c" />
+    <e k="sf_crop_rotation_short" v="Sædskifte" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="Aktiver/deaktiver sædskiftebonus og monoafgrødetræthed (bælgplantsekvenser genopretter kvælstof; samme afgrøde i på hinanden følgende sæsoner øger udtømning)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="Sædskiftebonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="Træthed: Samme afgrøde" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="Sædskifte: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="Gips (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="Kompost (organisk)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="Biosolider (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="Hønsemøg (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="Pelleteret gødning (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="Flydende kalk (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="Sædskifte" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="Sædskiftebonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="Dyrkning af en bælgplante (sojabønner, ærter, bønner) efter en ikke-bælgplante giver et gratis kvælstofboost hver forår i 3 dage." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="Afgrødetræthed" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="Plantning af samme afgrøde to sæsoner i træk øger næringsstofudtrækning med 15%. Roter afgrøder for at undgå jordtræthed." eh="1613f3c6" />
+    <e k="sf_map_layer_off" v="Jordkort: Fra" eh="3e654ade" />
+    <e k="sf_map_layer_n" v="Kvælstof" eh="1e9ef3ba" />
+    <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_om" v="Organisk materiale" eh="6305f4bb" />
+    <e k="sf_map_layer_urgency" v="Markhastegrad" eh="419ea5af" />
+    <e k="sf_map_layer_weed" v="Ukrudtstryk" eh="53f8b936" />
+    <e k="sf_map_layer_pest" v="Skadedyrstryk" eh="18a7c2be" />
+    <e k="sf_map_layer_disease" v="Sygdomstryk" eh="2b805cc9" />
+    <e k="sf_map_overlay_cycle" v="Skift+M: Skift jordlag" eh="032fdac7" />
+    <e k="sf_map_page_title" v="Jordlag" eh="04a675fb" />
+    <e k="sf_map_sidebar_header" v="Jordkortlag" eh="81332549" />
+    <e k="sf_map_sidebar_label" v="Aktivt lag" eh="f8a2c198" />
+    <e k="sf_map_sidebar_tooltip" v="Vælg hvilket jordnæringsstof der vises på kortet" eh="eb926e9a" />
+    <e k="sf_map_overlay_low" v="Lav" eh="28d0edd0" />
+    <e k="sf_map_overlay_med" v="Mid" eh="248c9511" />
+    <e k="sf_map_overlay_high" v="Høj" eh="655d20c1" />
+    <e k="sf_pda_screen_title" v="Jord &amp; Gødning" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="Jordkort" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="Marker" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="Behandlingsplan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="Gårdsoversigt" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="Sporede marker" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="Ejede marker" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="Gns. næringsstoffer" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="Kvælstof (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="Fosfor (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="Kalium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="pH-niveau" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="Organisk materiale" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="Afgrødetryk" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="Ukrudt" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="Skadedyr" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="Sygdom" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="Kræver opmærksomhed" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="Mangler gødning" eh="fa9ded5e" />
+    <e k="sf_pda_total_urgent_label" v="I alt kræver opmærksomhed" eh="b3ce2db9" />
+    <e k="sf_pda_no_data_left" v="Ingen markdata endnu." eh="ba71c6b1" />
+    <e k="sf_pda_map_section_title" v="Jordkortlag" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="Aktivt lag" eh="f8a2c198" />
+    <e k="sf_pda_map_layer_off_desc" v="Intet jordlag aktivt. Vælg venligst et lag at vise." eh="3bd7e65a" />
+    <e k="sf_pda_map_layer_n_desc" v="Kvælstofindhold på tværs af alle marker. Grøn = god, rød = udtømt." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="Fosforindhold på tværs af alle marker. Grøn = god, rød = udtømt." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="Kaliumindhold på tværs af alle marker. Grøn = god, rød = udtømt." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="Jordens pH-niveau. Optimalt interval er 6,5-7,0 (grøn)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="Organisk materialeindhold. Højere er bedre for langsigtet frugtbarhed." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="Kombineret behandlingshastegrad. Rød = kræver øjeblikkelig opmærksomhed." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="Ukrudtstrykniveau. Rød = høj infestation, anvend herbicid." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="Skadedyrstrykniveau. Rød = høj infestation, anvend insekticid." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="Sygdomstrykniveau. Rød = aktivt udbrud, anvend fungicid." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="Kortforklaring" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="God" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="Rimelig" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="Dårlig / Lav" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="Lav" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="Mellem" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="Høj" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="Overskud" eh="d1d25b9f" />
+    <e k="sf_pda_map_instructions" v="Tryk Skift+M i spillet for at skifte jordkortlag." eh="b13603aa" />
+    <e k="sf_pda_map_open_btn" v="Åbn jordkort" eh="0901ae30" />
+    <e k="sf_pda_map_unavailable" v="Kortforhåndsvisning utilgængelig" eh="00000000" />
+    <e k="sf_map_health_overall" v="Gennemsnitlig jordsundhed" eh="5533cbe3" />
+    <e k="sf_map_btn_report" v="Åbn gårdsoversigt" eh="6f0800e8" />
+    <e k="sf_map_btn_help" v="Udviklernote (VIRKER IKKE ENDNU)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Skift lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver lag" eh="8e75dec5" />
     <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
-    <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
+    <e k="sf_help_title" v="Jordens hurtige reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="NÆRINGSSTOFFER" eh="9aeb39bf" />
+    <e k="sf_help_n" v="N  (Kvælstof)     - Udtømmes hurtigt. Anvend UAN, Urea eller Gylle." eh="f2d0c792" />
+    <e k="sf_help_p" v="P  (Fosfor)       - Langtidsvirkende. Anvend MAP eller DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="K  (Kalium)       - Anvend Kaliumklorid. Vigtigt for rødder." eh="e0217634" />
+    <e k="sf_help_om" v="OM (Org. mat.)    - Opbygges langsomt. Pløj gylle/kompost ned." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="JORDKEMI" eh="19c67ff5" />
+    <e k="sf_help_ph" v="pH  6,5-7,0 = Ideelt.  &lt; 6,5 anvend Kalk.  &gt; 7,5 anvend Gips." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="AFGRØDETRYK" eh="132b0f66" />
+    <e k="sf_help_weed" v="Ukrudt  &gt; 20% - Anvend Herbicid." eh="c8d890df" />
+    <e k="sf_help_pest" v="Skadedyr &gt; 20% - Anvend Insekticid." eh="f4932a05" />
+    <e k="sf_help_disease" v="Sygdom  &gt; 20% - Anvend Fungicid." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="STATUSNIVEAUER" eh="b081c2c6" />
+    <e k="sf_help_good" v="God - Ingen handling nødvendig." eh="03910bec" />
+    <e k="sf_help_fair" v="Rimelig - Overvåg / forebyggende eftergødskning." eh="2922eb1c" />
+    <e k="sf_help_poor" v="Dårlig - Øjeblikkelig behandling påkrævet." eh="b287d206" />
+    <e k="sf_pda_fields_section_title" v="Alle marker" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="Mark" eh="6f16a5f8" />
     <e k="sf_pda_col_n" v="N%" eh="30740562" />
     <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
-		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
-		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
+    <e k="sf_pda_filter_all" v="Filter: Alle marker" eh="a46a8cb2" />
+    <e k="sf_pda_filter_owned" v="Filter: Kun ejede" eh="258cb971" />
     <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
     <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
-    <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
-    <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
-		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
-		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
-		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
-		<e k="sf_treat_section_prot" v="[EN] Crop Protection" eh="bd3fe9cd" />
-		<e k="sf_treat_hint" v="[EN] Refer to the 'Products' section of the shop for specialized fertilizers." eh="540bff4d" />
-		<e k="sf_treat_action_optimal" v="[EN] Optimal - No action needed." eh="4501a96b" />
-		<e k="sf_treat_action_lime" v="[EN] Apply LIME or LIQUID LIME to raise pH." eh="d1420b97" />
-		<e k="sf_treat_action_gypsum" v="[EN] Apply GYPSUM to lower pH / improve structure." eh="4cb3f0dc" />
-		<e k="sf_treat_action_om_low" v="[EN] Plow in MANURE, COMPOST, or chop straw." eh="33ec544c" />
-		<e k="sf_treat_action_om_fair" v="[EN] Monitor. Maintain organic inputs." eh="ae3af748" />
-		<e k="sf_treat_action_n_poor" v="[EN] Apply UAN32, UREA, or ANHYDROUS." eh="ebc225b0" />
-		<e k="sf_treat_action_n_fair" v="[EN] Apply AMS or STARTER fertilizer." eh="dc8fbeba" />
-		<e k="sf_treat_action_p_poor" v="[EN] Apply MAP or DAP (Phosphorus)." eh="ec2d9afa" />
-		<e k="sf_treat_action_p_fair" v="[EN] Apply blended FERTILIZER." eh="6f802546" />
-		<e k="sf_treat_action_k_poor" v="[EN] Apply POTASH (Potassium)." eh="bb2960f3" />
-		<e k="sf_treat_action_k_fair" v="[EN] Apply blended FERTILIZER." eh="6f802546" />
-		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
-		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
-		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
+    <e k="sf_pda_no_fields" v="Ingen markdata registreret endnu." eh="72265670" />
+    <e k="sf_pda_status_good" v="God" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="Rimelig" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="Dårlig" eh="0e94d017" />
+    <e k="sf_pda_treatment_section_title" v="Behandlingsplan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="Hastegrad" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="Behov" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="Alle marker er i god stand." eh="fa985166" />
+    <e k="sf_pda_need_n" v="Kvælstof" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="pH-justering" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="Herbicid" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="Insekticid" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="Fungicid" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="Flere" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="Mindre" eh="6fed0c37" />
+    <e k="sf_detail_title" v="Markdetalje" eh="03b5acd7" />
+    <e k="sf_detail_close" v="Luk" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="Mark #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="Hastegrad:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="Jordnæringsstoffer" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="Afgrødetryk" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="Afgrødehistorik" eh="54c27499" />
+    <e k="sf_detail_n_label" v="Kvælstof (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="Fosfor (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="Kalium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="pH-niveau" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="Organisk materiale" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="Ukrudtstryk" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="Skadedyrstryk" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="Sygdomstryk" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="Sidste afgrøde" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="Sædskiftestatus" eh="83f7f522" />
+    <e k="sf_treat_title" v="Behandlingsrecept" eh="0ccc3ee5" />
+    <e k="sf_treat_section_soil" v="Jordforbedring" eh="09e016e4" />
+    <e k="sf_treat_section_fert" v="Næringsstofpåføring" eh="76521e8e" />
+    <e k="sf_treat_section_prot" v="Afgrødebeskyttelse" eh="bd3fe9cd" />
+    <e k="sf_treat_hint" v="Se 'Produkter'-sektionen i butikken for specialiserede gødningstyper." eh="540bff4d" />
+    <e k="sf_treat_action_optimal" v="Optimal - ingen handling nødvendig." eh="4501a96b" />
+    <e k="sf_treat_action_lime" v="Anvend KALK eller FLYDENDE KALK for at hæve pH." eh="d1420b97" />
+    <e k="sf_treat_action_gypsum" v="Anvend GIPS for at sænke pH / forbedre struktur." eh="4cb3f0dc" />
+    <e k="sf_treat_action_om_low" v="Pløj GYLLE, KOMPOST ned eller hak halm." eh="33ec544c" />
+    <e k="sf_treat_action_om_fair" v="Overvåg. Vedligehold organiske inputs." eh="ae3af748" />
+    <e k="sf_treat_action_n_poor" v="Anvend UAN32, UREA eller VANDFRI AMMONIAK." eh="ebc225b0" />
+    <e k="sf_treat_action_n_fair" v="Anvend AMS eller STARTGØDNING." eh="dc8fbeba" />
+    <e k="sf_treat_action_p_poor" v="Anvend MAP eller DAP (Fosfor)." eh="ec2d9afa" />
+    <e k="sf_treat_action_p_fair" v="Anvend blandet GØDNING." eh="6f802546" />
+    <e k="sf_treat_action_k_poor" v="Anvend KALIUMKLORID (Kalium)." eh="bb2960f3" />
+    <e k="sf_treat_action_k_fair" v="Anvend blandet GØDNING." eh="6f802546" />
+    <e k="sf_treat_action_weed" v="Anvend HERBICID øjeblikkeligt." eh="625551c5" />
+    <e k="sf_treat_action_pest" v="Anvend INSEKTICID øjeblikkeligt." eh="f4db9a03" />
+    <e k="sf_treat_action_disease" v="Anvend FUNGICID øjeblikkeligt." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_bonus" v="Bælgplantebonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="Træthed (x1,15 udtømning)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="Ingen data tilgængelig." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="Ingen registreret" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Udviklernote" eh="5320d63f" />
     <e k="sf_pda_help_github" v="DIN FEEDBACK BETYDER NOGET! Hvis du støder på fejl, har forslag til nye funktioner eller ønsker at bidrage til koden, kan du besøge projektet på GitHub. Du kan åbne et Issue eller en Pull Request til enhver tid for at hjælpe med at gøre denne mod bedre for alle. Tak for testningen!" eh="3a10b023" />
-		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
-    <e k="sf_pda_help_text" v="Hej, det er mig, udvikleren! Som du kan se, er denne side stadig meget under opbygning. Kortlagene er i øjeblikket kun visuelle forhåndsvisninger (ikke-funktionelle til valg), og mange UI-elementer mangler stadig deres endelige finish." eh="58e05bdf" />
+    <e k="sf_pda_help_note" v="Bemærk: Jordlagsfanen på kortsiden VIRKER IKKE. Jeg er bekendt med problemet og arbejder på en løsning. (hvilket kan tage noget tid)" eh="2d8f5dc7" />
+    <e k="sf_pda_help_text" v="Hej, det er mig, udvikleren! Jeg har flyttet jordkortlagene til det native PDA-kort (ESC &gt; Kort) for en mere gnidningsfri oplevelse. Du kan nu vælge lag direkte fra sidebjælken. PDA-siden er stadig ved at blive poleret, så hold dig opdateret!" eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Klik på et felt for at hoppe til det på kortet" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
-    <e k="sf_pda_total_urgent_label" v="I alt kræver opmærksomhed" eh="b3ce2db9" />
+    <e k="sf_pda_map_native_hint" v="Jordlagsvisualiseringen er flyttet! Du kan nu tilgå og skifte alle jordlag direkte fra det native PDA-kortes sidebjælke (ESC &gt; Kort). Se efter kategorien 'Jordlag' i sidebjælkens prikker." eh="87f73b10" />
     <e k="sf_pda_treatment_hint" v="Felterne opført til højre kræver behandling. Klik på en række for at se anbefalede inputs og estimerede mængder." eh="5748d316" />
     </elements>
 </l10n>


### PR DESCRIPTION
## Summary

Full native Danish translation contributed by **@DJWestDK** (LastLight from the Hedeholm server).

Replaces all remaining `[EN]` placeholder strings with native Danish — covers HUD themes, font size options, transparency levels, HUD labels (JORDMONITOR, Mark, Brak, Ukrudt, Skadedyr, Sygdom…), imperial units toggle, map overlay settings, and all input action labels.

Thank you @DJWestDK! 🇩🇰