### PR TITLE
fix: large map support (64x) — field scan, MP broadcast, overlay budget

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.0.4.0</version>
+    <version>2.0.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -667,7 +667,7 @@ function SoilFertilitySystem:scanFields()
         return false
     end
     local fields = g_fieldManager.fields
-    for _, field in ipairs(fields) do
+    for _, field in pairs(fields) do
         if field and type(field) == "table" then
             local actualFieldId = field.farmland and field.farmland.id
 
@@ -715,16 +715,72 @@ function SoilFertilitySystem:broadcastAllFieldData()
     if not g_server then return end
     if not g_currentMission then return end
     if not (g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer) then return end
-    if not SoilFieldUpdateEvent then return end
+    if not SoilFieldBatchSyncEvent then return end
 
-    local count = 0
-    for fieldId, field in pairs(self.fieldData) do
-        g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
-        count = count + 1
+    local fieldIds = {}
+    for fieldId in pairs(self.fieldData) do
+        table.insert(fieldIds, fieldId)
     end
+    local fieldCount = #fieldIds
+    if fieldCount == 0 then return end
 
-    if count > 0 then
-        self:info("Broadcast initial field data for %d fields to all clients", count)
+    local batchSize  = SoilConstants.NETWORK.FULL_SYNC_BATCH_SIZE
+    local batchDelay = SoilConstants.NETWORK.FULL_SYNC_BATCH_DELAY
+    local totalBatches = math.ceil(fieldCount / batchSize)
+    local fieldData = self.fieldData
+
+    if g_dedicatedServer then
+        -- Dedicated server: send all batches synchronously (no live rendering pressure)
+        self:info("Broadcasting %d fields to all clients in %d synchronous batches", fieldCount, totalBatches)
+        for batchIndex = 1, totalBatches do
+            local startIdx = (batchIndex - 1) * batchSize + 1
+            local endIdx   = math.min(batchIndex * batchSize, fieldCount)
+            local batch = {}
+            for i = startIdx, endIdx do
+                local id = fieldIds[i]
+                batch[id] = fieldData[id]
+            end
+            local isLast = (batchIndex == totalBatches)
+            g_server:broadcastEvent(SoilFieldBatchSyncEvent.new(batch, isLast))
+        end
+    else
+        -- Listen server: drip-feed batches across frames to avoid a single-frame spike
+        self:info("Broadcasting %d fields to all clients in %d batched frames", fieldCount, totalBatches)
+        local batchDispatcher = {
+            batchIndex   = 1,
+            totalBatches = totalBatches,
+            batchSize    = batchSize,
+            batchDelay   = batchDelay,
+            timer        = 0,
+            fieldIds     = fieldIds,
+            fieldData    = fieldData,
+            update = function(self, dt)
+                if self.batchIndex > self.totalBatches then
+                    g_currentMission:removeUpdateable(self)
+                    return
+                end
+                self.timer = self.timer + dt
+                if self.timer < self.batchDelay then return end
+                self.timer = 0
+                local startIdx = (self.batchIndex - 1) * self.batchSize + 1
+                local endIdx   = math.min(self.batchIndex * self.batchSize, #self.fieldIds)
+                local batch = {}
+                for i = startIdx, endIdx do
+                    local id = self.fieldIds[i]
+                    batch[id] = self.fieldData[id]
+                end
+                local isLast = (self.batchIndex == self.totalBatches)
+                g_server:broadcastEvent(SoilFieldBatchSyncEvent.new(batch, isLast))
+                self.batchIndex = self.batchIndex + 1
+                if self.batchIndex > self.totalBatches then
+                    g_currentMission:removeUpdateable(self)
+                end
+            end,
+            delete = function(self)
+                g_currentMission:removeUpdateable(self)
+            end
+        }
+        g_currentMission:addUpdateable(batchDispatcher)
     end
 end
 
@@ -1708,7 +1764,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId)
     local cropName = nil
     if g_fieldManager and g_fieldManager.fields then
         local fsField = nil
-        for _, f in ipairs(g_fieldManager.fields) do
+        for _, f in pairs(g_fieldManager.fields) do
             if f and f.farmland and f.farmland.id == fieldId then
                 fsField = f
                 break
@@ -2046,7 +2102,7 @@ function SoilFertilitySystem:listAllFields()
 
     if g_fieldManager and g_fieldManager.fields then
         SoilLogger.info("Fields in FieldManager:")
-        for _, field in ipairs(g_fieldManager.fields) do
+        for _, field in pairs(g_fieldManager.fields) do
             -- NOTE: field.fieldId / field.id / field.index are all nil in FS25.
             -- The correct identifier is field.farmland.id (farmland-based ID system).
             local fieldIdStr = tostring(field.farmland and field.farmland.id or "?")

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -24,7 +24,10 @@ SoilMapOverlay.ALPHA          = 0.72
 -- Sampling constants
 SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 4500
 SoilMapOverlay.POLYGON_STEP     = 10     -- world-unit grid spacing for polygon sampling (meters)
--- Point budgets per density level (1=Low, 2=Medium, 3=High)
+-- Point budgets per density level (1=Low, 2=Medium, 3=High).
+-- These are the BASE values for a standard 2048m map. At runtime the budget is
+-- scaled up proportionally with terrain size so large maps (4x, 16x, 64x) get the
+-- same visual coverage density without hitting the cap mid-field-list.
 SoilMapOverlay.DENSITY_POINTS   = {8000, 20000, 40000}
 
 -- Status colors (match SoilHUD palette)
@@ -328,16 +331,20 @@ function SoilMapOverlay:updateSamplePoints(force)
     end
 
     -- Scale sampling step proportional to terrain size so large maps
-    -- (4x, 16x) get the same screen-pixel density as a standard 2048m map.
+    -- (4x, 16x, 64x) get the same screen-pixel density as a standard 2048m map.
     local terrainSize = (g_currentMission and g_currentMission.terrainSize) or 2048
-    local scaledStep = SoilMapOverlay.POLYGON_STEP * math.max(1.0, terrainSize / 2048.0)
+    local mapScale    = math.max(1.0, terrainSize / 2048.0)
+    local scaledStep  = SoilMapOverlay.POLYGON_STEP * mapScale
 
-    -- Resolve point budget from the player's density setting (localOnly, default Medium)
+    -- Resolve point budget from the player's density setting (localOnly, default Medium).
+    -- Scale the budget proportionally with map area (mapScale²) so large maps don't exhaust
+    -- the cap before all fields are drawn — a 4x map needs ~16x the points of a standard map.
     local densityLevel = (self.settings and self.settings.overlayDensity) or 2
-    local maxPoints = SoilMapOverlay.DENSITY_POINTS[densityLevel] or SoilMapOverlay.DENSITY_POINTS[2]
+    local basePoints   = SoilMapOverlay.DENSITY_POINTS[densityLevel] or SoilMapOverlay.DENSITY_POINTS[2]
+    local maxPoints    = math.floor(basePoints * mapScale * mapScale)
 
     local totalPoints = 0
-    for _, fsField in ipairs(fields) do
+    for _, fsField in pairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
             if farmlandId and farmlandId > 0 then


### PR DESCRIPTION
## Summary

- **Fields missing on large maps**: `ipairs` was used on `g_fieldManager.fields` in 3 places — it stops at the first nil index, silently skipping any fields beyond a gap in the array. Common on 64x maps where field indices are non-sequential. Changed to `pairs` everywhere.
- **MP broadcast flooding**: `broadcastAllFieldData` was sending all field events in a single frame with no throttle. On a 64x map with 300+ fields this floods the socket buffer. Now uses `SoilFieldBatchSyncEvent` (32 fields / 50ms) matching the existing join-sync path.
- **Overlay not coloring all fields**: The `maxPoints` sample budget was a flat number regardless of map size. On a 64x map (8× linear scale = 64× area) the budget was exhausted before all fields got color. Budget now scales with `mapScale²` so coverage is consistent across all map sizes.

## Root cause (reported by Discord user karlos, 64x map MP)
> "Bodenebenen nicht richtig angezeigt / ein paar Felder fehlen bei der Berechnung"
> (Soil levels not displayed correctly / some fields missing from the calculation)

## Test plan
- [ ] Standard 2048m map — soil data scans all fields, overlay colors all fields
- [ ] 4x map (4096m) — same, no fields skipped, overlay fills fully
- [ ] MP listen server — joining client receives all field data without frame spike
- [ ] MP dedicated server — same, synchronous batch path