### PR TITLE
v2.0.6.0 — RMB cursor fix, MP weed HUD sync, replenishment rate setting

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.0.5.0</version>
+    <version>2.0.6.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -552,6 +552,10 @@ end
 -- Input callback for HUD drag toggle (SF_HUD_DRAG, default RMB)
 function SoilFertilityManager:onHUDDragInput()
     if not self.soilHUD then return end
+    -- Don't steal RMB when HUD is hidden or mod is disabled — prevents mouse cursor
+    -- appearing on RMB vehicle actions (e.g. direction change) after implement cycling.
+    if not self.soilHUD.visible then return end
+    if not (self.settings and self.settings.showHUD and self.settings.enabled) then return end
     if self.soilHUD.editMode then
         self.soilHUD:exitEditMode()
     else

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -919,7 +919,15 @@ function SoilFertilitySystem:updateDailySoil()
     local seasonal = SoilConstants.SEASONAL_EFFECTS
     local phNorm = SoilConstants.PH_NORMALIZATION
 
+    local isMP = g_server and g_currentMission and g_currentMission.missionDynamicInfo and
+                 g_currentMission.missionDynamicInfo.isMultiplayer and SoilFieldUpdateEvent
+    local changedFields = isMP and {} or nil
+
     for fieldId, field in pairs(self.fieldData) do
+        local prevWeed    = field.weedPressure    or 0
+        local prevPest    = field.pestPressure    or 0
+        local prevDisease = field.diseasePressure or 0
+
         -- Clear fertilizer and coverage buffers daily
         field.nutrientBuffer    = {}
         field.coveredCells      = {}
@@ -1184,6 +1192,25 @@ function SoilFertilitySystem:updateDailySoil()
                 end
             end
         end
+
+        -- Track changed fields for MP broadcast (only if pressure values changed)
+        if changedFields then
+            if math.abs((field.weedPressure    or 0) - prevWeed)    > 0.01 or
+               math.abs((field.pestPressure    or 0) - prevPest)    > 0.01 or
+               math.abs((field.diseasePressure or 0) - prevDisease) > 0.01 then
+                changedFields[fieldId] = field
+            end
+        end
+    end
+
+    -- Broadcast pressure changes to clients (dedicated server / MP only)
+    if changedFields and next(changedFields) then
+        local count = 0
+        for fieldId, field in pairs(changedFields) do
+            g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+            count = count + 1
+        end
+        self:log("Daily broadcast: %d field(s) with pressure changes synced to clients", count)
     end
 
     -- Track season for spring-transition detection (crop rotation bonus)
@@ -1397,7 +1424,9 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
 
     else
         -- 2. Apply standard nutrients (scaled by the liters applied this frame)
-        local factor = (liters / 1000) / areaInHa
+        local rrIdx  = self.settings.replenishmentRate or 3
+        local rrMult = SoilConstants.DIFFICULTY.REPLENISHMENT_MULTIPLIERS[rrIdx] or 1.0
+        local factor = (liters / 1000) / areaInHa * rrMult
 
         -- Capture before-values for diagnostic logging (debug mode only).
         local dbgN0, dbgP0, dbgK0, dbgPH0 = field.nitrogen, field.phosphorus, field.potassium, field.pH

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -30,6 +30,14 @@ SoilConstants.DIFFICULTY = {
         [1] = 0.7,   -- Simple
         [2] = 1.0,   -- Realistic
         [3] = 1.5,   -- Hardcore
+    },
+    -- Fertilizer replenishment speed (applied to nutrient gain per litre)
+    REPLENISHMENT_MULTIPLIERS = {
+        [1] = 0.25,  -- Very Slow
+        [2] = 0.50,  -- Slow
+        [3] = 1.00,  -- Normal (default)
+        [4] = 1.50,  -- Fast
+        [5] = 2.00,  -- Very Fast
     }
 }
 

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -143,6 +143,14 @@ SettingsSchema.definitions = {
         uiId = "sf_diff",
     },
     {
+        id = "replenishmentRate",
+        type = "number",
+        default = 3,
+        min = 1,
+        max = 5,
+        uiId = "sf_rr",
+    },
+    {
         id = "useImperialUnits",
         type = "boolean",
         default = true,

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -110,7 +110,7 @@ local CATEGORIES = {
             },
             {
                 header = "Difficulty",
-                items  = { "difficulty" }
+                items  = { "difficulty", "replenishmentRate" }
             },
             {
                 header = "Environment",
@@ -163,6 +163,7 @@ local CATEGORIES = {
 -- ── Multi-option labels ────────────────────────────────────
 local MULTI_OPTS = {
     difficulty        = {"Simple", "Realistic", "Hardcore"},
+    replenishmentRate = {"Very Slow (0.25x)", "Slow (0.5x)", "Normal (1.0x)", "Fast (1.5x)", "Very Fast (2.0x)"},
     hudPosition       = {"Top Right", "Top Left", "Bot Right", "Bot Left", "Ctr Right", "Custom"},
     hudColorTheme     = {"Green", "Blue", "Amber", "Mono"},
     hudFontSize       = {"Small", "Medium", "Large"},
@@ -179,7 +180,8 @@ local SETTING_DESCS = {
     fertilizerCosts  = "Real in-game cost for fertilizers",
     cropRotation     = "Rotation benefits and penalties",
     autoRateControl  = "Smart sprayer application rates",
-    difficulty       = "Nutrient drain intensity level",
+    difficulty         = "Nutrient drain intensity level",
+    replenishmentRate  = "Fertilizer nutrient restoration speed",
     seasonalEffects  = "Season-driven soil changes",
     rainEffects      = "Rain causes nutrient leaching",
     plowingBonus     = "Plow bonus for soil recovery",
@@ -211,9 +213,10 @@ local ADMIN_SECTIONS = {
     {
         header = "Mod Control & Difficulty",
         items  = {
-            { label = "Mod Enabled",      desc = "Activate / deactivate the entire mod",       stype = "setting", id = "enabled" },
-            { label = "Debug Mode",       desc = "Extra logging for troubleshooting",           stype = "setting", id = "debugMode" },
-            { label = "Difficulty",       desc = "Nutrient drain intensity level",              stype = "setting", id = "difficulty" },
+            { label = "Mod Enabled",         desc = "Activate / deactivate the entire mod",            stype = "setting", id = "enabled" },
+            { label = "Debug Mode",          desc = "Extra logging for troubleshooting",               stype = "setting", id = "debugMode" },
+            { label = "Difficulty",          desc = "Nutrient drain intensity level",                  stype = "setting", id = "difficulty" },
+            { label = "Replenishment Rate",  desc = "Fertilizer nutrient restoration speed",           stype = "setting", id = "replenishmentRate" },
         },
     },
     {

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Ativar/desativar sistema de infestação de insetos e pragas" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Pressão de Doenças" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Ativar/desativar sistema de doenças fúngicas e de culturas" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Sistema Fertilidade" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Ativar/desativar sistema dinâmico de fertilidade do solo" eh="ea074366" />
     <e k="sf_nutrients_short" v="Ciclos Nutrientes" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificuldade" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nível de dificuldade de gestão do solo" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Controle automático de taxa" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automaticamente a taxa de aplicação com base nas necessidades do campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restaurar configurações solo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de solo" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Relatório Solo" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Aumentar taxa de fertilizante" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Reduzir taxa de fertilizante" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="Pressão de Ervas Daninhas" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="Pressão de Pragas" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="Pressão de Doenças" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="Shift+M: Ciclar Camada de Solo" eh="032fdac7" />
 		<e k="sf_map_page_title" v="Camadas de Solo" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="Camada do Mapa de Solo" eh="81332549" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="啟用/禁用昆蟲和病蟲害侵襲系統" eh="2ba11abc" />
     <e k="sf_disease_pressure_short" v="疾病壓力" eh="2b805cc9" />
     <e k="sf_disease_pressure_long" v="啟用/禁用真菌和作物疾病系統" eh="9080edbc" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="肥力系統" eh="f7e27d58" />
     <e k="sf_fertility_long" v="啟用/禁用動態土壤肥力系統" eh="ea074366" />
     <e k="sf_nutrients_short" v="養分循環" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="單色" eh="5d9b47bd" />
     <e k="sf_diff_short" v="難度" eh="7b29ca96" />
     <e k="sf_diff_long" v="土壤管理難度等級" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="自動施用量控制" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="根據田地需求自動調整肥料施用量" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="綠色" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="重置土壤設置" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="切換土壤 HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="土壤報告" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="增加肥料施用量" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="減少肥料施用量" eh="30712026" />
@@ -362,7 +364,7 @@
     <e k="sf_map_layer_weed" v="雜草壓力" eh="53f8b936" />
     <e k="sf_map_layer_pest" v="害蟲壓力" eh="18a7c2be" />
     <e k="sf_map_layer_disease" v="疾病壓力" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
     <e k="sf_map_overlay_cycle" v="Shift+M: 切換土壤圖層" eh="032fdac7" />
     <e k="sf_map_page_title" v="土壤圖層" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="土壤地圖圖層" eh="81332549" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Systém Úrodnosti" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Povolit/zakázat dynamický systém úrodnosti půdy" eh="ea074366" />
     <e k="sf_nutrients_short" v="Nutriční Cykly" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Obtížnost" eh="7b29ca96" />
     <e k="sf_diff_long" v="Úroveň obtížnosti správy půdy" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatické řízení dávky" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automaticky upravuje dávku hnojiva podle potřeb pole" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Zelený" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetovat nastavení půdy" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Přepnout HUD půdy" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Zpráva o půdě" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Zvýšit dávku hnojiva" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Snížit dávku hnojiva" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Sværhedsgrad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Sværhedsgrad for jordstyring" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatisk hastighedskontrol" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerer automatisk gødningsraten baseret på markens behov" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grøn" eh="d382816a" />
@@ -42,11 +44,12 @@
     <e k="sf_use_imperial_long" v="Vis udbringningsrater i gal/ac og lb/ac (fra = L/ha og kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Aktivt kortlag" eh="1861765f" />
     <e k="sf_active_map_layer_long" v="Næringsstoflag vist som overlejring på PDA-kortet" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Kortdetalje" />
-    <e k="sf_overlay_density_long" v="Prøvepunktsbudget for PDA-jordoverlejringen. Lav = bedre FPS, Høj = bedre dækning på store kort." />
+    <e k="sf_overlay_density_short" v="Kortdetalje" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Prøvepunktsbudget for PDA-jordoverlejringen. Lav = bedre FPS, Høj = bedre dækning på store kort." eh="89215ce5" />
     <e k="input_SF_OPEN_SETTINGS" v="Åbn jordindstillinger" eh="2e31c0dd" />
     <e k="sf_reset" v="Nulstil jordindstillinger" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Slå jord-HUD til/fra" eh="f0224a10" />
+		<e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Jordrapport" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Øg gødningsrate" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Sænk gødningsrate" eh="30712026" />
@@ -136,16 +139,16 @@
     <e k="sf_bigBag_starter_function" v="Startgødning (flydende)" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tør)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Kompost" />
-    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør)" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolider" />
-    <e k="sf_bigBag_biosolids_function" v="Organisk gødning (tør)" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsemøg" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organisk gødning (tør)" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelleteret Gødning" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gødning (tør)" />
-    <e k="sf_bigBag_liquidlime_name" v="Flydende Kalktank" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-hævende middel (flydende)" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolider" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Organisk gødning (tør)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsemøg" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organisk gødning (tør)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelleteret Gødning" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gødning (tør)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Flydende Kalktank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-hævende middel (flydende)" eh="7a118b6d" />
     <e k="sf_section" v="Jord &amp; Gødning" eh="d30a22a9" />
     <e k="sf_enabled_short" v="Aktiver mod" eh="cf7fea13" />
     <e k="sf_enabled_long" v="Aktiver eller deaktiver jord- og gødningsmoddet" eh="e377fd59" />
@@ -163,6 +166,8 @@
     <e k="sf_pest_pressure_long" v="Aktiver/deaktiver insekt- og skadedyrsangrebssystem" eh="2ba11abc" />
     <e k="sf_disease_pressure_short" v="Sygdomstryk" eh="2b805cc9" />
     <e k="sf_disease_pressure_long" v="Aktiver/deaktiver svampe- og afgrødesygdomssystem" eh="9080edbc" />
+		<e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+		<e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Frugtbarhedssystem" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Aktiver/deaktiver dynamisk jordfrugtbarhedssystem" eh="ea074366" />
     <e k="sf_nutrients_short" v="Næringsstofcyklusser" eh="ffab595d" />
@@ -325,6 +330,7 @@
     <e k="sf_map_layer_weed" v="Ukrudtstryk" eh="53f8b936" />
     <e k="sf_map_layer_pest" v="Skadedyrstryk" eh="18a7c2be" />
     <e k="sf_map_layer_disease" v="Sygdomstryk" eh="2b805cc9" />
+		<e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
     <e k="sf_map_overlay_cycle" v="Skift+M: Skift jordlag" eh="032fdac7" />
     <e k="sf_map_page_title" v="Jordlag" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Jordkortlag" eh="81332549" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Insekten- und Schädlingbefallssystem ein-/ausschalten" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Krankheitsdruck" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Pilz- und Pflanzenkrankheitssystem ein-/ausschalten" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Fruchtbarkeitssystem" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Dynamisches Bodenfruchtbarkeitssystem ein-/ausschalten" eh="ea074366" />
     <e k="sf_nutrients_short" v="Nährstoffkreisläufe" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Schwierigkeit" eh="7b29ca96" />
     <e k="sf_diff_long" v="Schwierigkeitsgrad der Bodenverwaltung" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatische Ratensteuerung" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Passt die Düngerrate automatisch an den Bedarf des Feldes an" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grün" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeneinstellungen zurücksetzen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Boden-HUD umschalten" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Bodenbericht" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Düngerrate erhöhen" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Düngerrate verringern" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="Unkrautdruck" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="Schädlingdruck" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="Krankheitsdruck" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="Umschalt+M: Bodenebene wechseln" eh="032fdac7" />
 		<e k="sf_map_page_title" v="Bodenebenen" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="Bodenkartenebene" eh="81332549" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificultad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nivel de dificultad de gestión del suelo" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Control de tasa automático" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automáticamente la tasa de aplicación según las necesidades del campo" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="2ba11abc" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="2b805cc9" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="9080edbc" />
-    <e k="sf_compaction_short" v="Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Fertility System" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Enable/disable dynamic soil fertility system" eh="ea074366" />
     <e k="sf_nutrients_short" v="Nutrient Cycles" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficulty" eh="7b29ca96" />
     <e k="sf_diff_long" v="Soil management difficulty level" eh="d6f4560c" />
+    <e k="sf_rr_short" v="Replenishment Rate" eh="b363b336" />
+    <e k="sf_rr_long" v="How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Auto Rate Control" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatically adjusts fertilizer application rate based on field needs" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Green" eh="d382816a" />
@@ -80,7 +82,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Reset Soil Settings" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Soil Report" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Increase Fertilizer Rate" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Decrease Fertilizer Rate" eh="30712026" />
@@ -362,7 +364,7 @@
     <e k="sf_map_layer_weed" v="Weed Pressure" eh="53f8b936" />
     <e k="sf_map_layer_pest" v="Pest Pressure" eh="18a7c2be" />
     <e k="sf_map_layer_disease" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="Compaction" eh="19cf3ee7" />
     <e k="sf_map_overlay_cycle" v="Shift+M: Cycle Soil Layer" eh="032fdac7" />
     <e k="sf_map_page_title" v="Soil Layers" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Soil Map Layer" eh="81332549" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Activar/desactivar el sistema de infestación de insectos y plagas" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Presión de Enfermedades" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Activar/desactivar el sistema de enfermedades fúngicas y de cultivos" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Sistema de Fertilidad" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Activar/desactivar el sistema dinámico de fertilidad del suelo" eh="ea074366" />
     <e k="sf_nutrients_short" v="Ciclos de Nutrientes" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificultad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nivel de dificultad de la gestión del suelo" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Control de Tasa Automático" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automáticamente la tasa de aplicación de fertilizante según las necesidades del campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablecer Ajustes de Suelo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de Suelo" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Informe de Suelo" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Aumentar Tasa de Fertilizante" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Disminuir Tasa de Fertilizante" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="Presión de Maleza" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="Presión de Plagas" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="Presión de Enfermedades" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="Mayús+M: Cambiar capa de suelo" eh="032fdac7" />
 		<e k="sf_map_page_title" v="Capas de suelo" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="Capa del mapa de suelo" eh="81332549" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="å•è‰²" eh="5d9b47bd" />
     <e k="sf_diff_short" v="难度" eh="7b29ca96" />
     <e k="sf_diff_long" v="åœŸå£¤ç®¡ç†éš¾åº¦ç­‰çº§" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="è‡ªåŠ¨æ–½ç”¨é‡æŽ§åˆ¶" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="æ ¹æ®ç”°åœ°éœ€æ±‚è‡ªåŠ¨è°ƒæ•´è‚¥æ–™æ–½ç”¨é‡" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Vaikeus" eh="7b29ca96" />
     <e k="sf_diff_long" v="Maaperänhallinnan vaikeustaso" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automaattinen annostelun hallinta" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Säätää lannoitteen levitysmäärän automaattisesti pellon tarpeiden mukaan" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficulté" eh="7b29ca96" />
     <e k="sf_diff_long" v="Niveau de difficulté de gestion du sol" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Contrôle automatique du débit" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajuste automatiquement le taux d'application selon les besoins du champ" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Vert" eh="d382816a" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="Pression des adventices" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="Pression des ravageurs" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="Pression des maladies" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="Maj+M : Faire défiler les couches" eh="032fdac7" />
 		<e k="sf_map_page_title" v="Couches de sol" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="Couche de carte de sol" eh="81332549" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Termékenységi Rendszer" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Dinamikus talajtermékenységi rendszer engedélyezése/tiltása" eh="ea074366" />
     <e k="sf_nutrients_short" v="Tápanyagciklusok" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Nehézség" eh="7b29ca96" />
     <e k="sf_diff_long" v="Talajkezelés nehézségi szintje" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatikus adagolás vezérlés" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatikusan állítja be a műtrágya kijuttatási arányát a terület igényei alapján" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Zöld" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Talajjelentés" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Műtrágya arány növelése" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Műtrágya arány csökkentése" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Kesulitan" eh="7b29ca96" />
     <e k="sf_diff_long" v="Tingkat kesulitan manajemen tanah" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Kontrol laju otomatis" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Secara otomatis menyesuaikan laju aplikasi pupuk berdasarkan kebutuhan lahan" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Sistema Fertilità" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Attiva/disattiva sistema dinamico fertilità del suolo" eh="ea074366" />
     <e k="sf_nutrients_short" v="Cicli Nutrienti" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficoltà" eh="7b29ca96" />
     <e k="sf_diff_long" v="Livello di difficoltà della gestione del suolo" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Controllo automatico della velocità" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Regola automaticamente il tasso di applicazione in base alle esigenze del campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Ripristina impostazioni suolo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Attiva/disattiva HUD suolo" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Rapporto Suolo" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Aumenta dose fertilizzante" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Riduci dose fertilizzante" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="モノ" eh="5d9b47bd" />
     <e k="sf_diff_short" v="難易度" eh="7b29ca96" />
     <e k="sf_diff_long" v="åœŸå£Œç®¡ç†ã®é›£æ˜“åº¦ãƒ¬ãƒ™ãƒ«" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="自動レート制御" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="åœƒå ´ã®çŠ¶æ…‹ã«åŸºã¥ã„ã¦è‚¥æ–™æ•£å¸ƒé‡ã‚’è‡ªå‹•èª¿æ•´ã—ã¾ã™" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="단색" eh="5d9b47bd" />
     <e k="sf_diff_short" v="ë‚œì´ë„" eh="7b29ca96" />
     <e k="sf_diff_long" v="í† ì–‘ ê´€ë¦¬ ë‚œì´ë„ ìˆ˜ì¤€" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="ìžë™ ì‚´í¬ëŸ‰ ì¡°ì ˆ" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="í† ì–‘ ìƒíƒœì— ë”°ë¼ ë¹„ë£Œ ì‚´í¬ëŸ‰ì„ ìžë™ìœ¼ë¡œ ì¡°ì •í•©ë‹ˆë‹¤" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="In-/uitschakelen van insecten- en plagendruksysteem" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Ziekte druk" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="In-/uitschakelen van schimmel- en gewasziektesysteem" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Vruchtbaarheidssysteem" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Dynamisch bodemvruchtbaarheidssysteem in-/uitschakelen" eh="ea074366" />
     <e k="sf_nutrients_short" v="Voedingsstoffencycli" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Moeilijkheid" eh="7b29ca96" />
     <e k="sf_diff_long" v="Moeilijkheidsgraad bodembeheer" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatische snelheidscontrole" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Past automatisch de bemestingssnelheid aan op basis van veldbehoeften" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Groen" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeminstellingen herstellen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bodem HUD in-/uitschakelen" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Bodemrapport" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Meststofdosering verhogen" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Meststofdosering verlagen" eh="30712026" />
@@ -331,7 +333,7 @@
     <e k="sf_map_layer_weed" v="Onkruiddruk" eh="53f8b936" />
     <e k="sf_map_layer_pest" v="Plagendruk" eh="18a7c2be" />
     <e k="sf_map_layer_disease" v="Ziektedruk" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
     <e k="sf_map_overlay_cycle" v="Shift+M: Wissel bodemlaag" eh="032fdac7" />
     <e k="sf_map_page_title" v="Bodemlagen" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Bodemkaartlaag" eh="81332549" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Vanskelighet" eh="7b29ca96" />
     <e k="sf_diff_long" v="Vanskelighetsgrad for jordforvaltning" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatisk ratekontroll" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerer automatisk gjødslingsraten basert på jordbehov" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="System Żyzności" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Włącz/wyłącz dynamiczny system żyzności gleby" eh="ea074366" />
     <e k="sf_nutrients_short" v="Cykle Składników" eh="ffab595d" />
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Trudność" eh="7b29ca96" />
     <e k="sf_diff_long" v="Poziom trudności zarządzania glebą" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatyczna kontrola dawki" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatycznie dostosowuje dawkę nawożenia do potrzeb pola" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Zielony" eh="d382816a" />
@@ -93,7 +95,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetuj ustawienia gleby" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Przełącz HUD gleby" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Raport Gleby" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Zwiększ dawkę nawozu" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Zmniejsz dawkę nawozu" eh="30712026" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificuldade" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nível de dificuldade de gestão do solo" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Controlo automático de taxa" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automaticamente a taxa de aplicação com base nas necessidades do campo" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificultate" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nivelul de dificultate al managementului solului" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Control automat al ratei" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajustează automat rata de aplicare în funcție de nevoile câmpului" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Моно" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Сложность" eh="7b29ca96" />
     <e k="sf_diff_long" v="Уровень сложности управления почвой" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Автоматическое управление нормой" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Автоматически регулирует норму внесения удобрений в зависимости от потребностей поля" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Зеленый" eh="d382816a" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Svårighetsgrad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Svårighetsgrad för markförvaltning" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Automatisk hastighetskontroll" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerar automatiskt gödslingshastigheten baserat på fältets behov" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Zorluk" eh="7b29ca96" />
     <e k="sf_diff_long" v="Toprak yönetimi zorluk seviyesi" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Otomatik doz kontrolü" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Tarla ihtiyaçlarına göre gübre uygulama oranını otomatik olarak ayarlar" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -53,6 +53,8 @@
     <e k="sf_hud_color_4" v="Моно" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Складність" eh="7b29ca96" />
     <e k="sf_diff_long" v="Рівень складності управління ґрунтом" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Автоматичне керування нормою" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Автоматично регулює норму внесення добрив залежно від потреб поля" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Зелений" eh="d382816a" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -7,6 +7,8 @@
     <e k="sf_hud_color_4" v="Đơn sắc" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Äá»™ khó" eh="7b29ca96" />
     <e k="sf_diff_long" v="Mức độ khó của quản lý đất" eh="d6f4560c" />
+		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
+		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
     <e k="sf_auto_rate_short" v="Äiá»u khiá»ƒn tá»‘c Ä‘á»™ tá»± Ä‘á»™ng" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Tá»± Ä‘á»™ng Ä‘iá»u chá»‰nh lÆ°á»£ng phân bón dá»±a trên nhu cáº§u cá»§a thá»­a ruá»™ng" eh="a9ca9f6b" />
 		<e k="sf_hud_theme_1" v="[EN] Green" eh="d382816a" />
@@ -47,7 +49,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
 		<e k="input_SF_SOIL_REPORT" v="[EN] Soil Report" eh="c33180ef" />
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
@@ -165,8 +167,8 @@
     <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="00000000" />
-    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="00000000" />
+    <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
+    <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
 		<e k="sf_fertility_long" v="[EN] Enable/disable dynamic soil fertility system" eh="ea074366" />
 		<e k="sf_nutrients_short" v="[EN] Nutrient Cycles" eh="ffab595d" />
@@ -328,7 +330,7 @@
 		<e k="sf_map_layer_weed" v="[EN] Weed Pressure" eh="53f8b936" />
 		<e k="sf_map_layer_pest" v="[EN] Pest Pressure" eh="18a7c2be" />
 		<e k="sf_map_layer_disease" v="[EN] Disease Pressure" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
 		<e k="sf_map_overlay_cycle" v="[EN] Shift+M: Cycle Soil Layer" eh="032fdac7" />
 		<e k="sf_map_page_title" v="[EN] Soil Layers" eh="04a675fb" />
 		<e k="sf_map_sidebar_header" v="[EN] Soil Map Layer" eh="81332549" />


### PR DESCRIPTION
## Summary

- **Fix #242**: RMB no longer shows mouse cursor when Soil HUD is hidden — `onHUDDragInput` now guards on `visible` and `showHUD` flags before entering edit mode
- **Fix #248**: Weed/pest/disease pressure now syncs to clients on dedicated servers — daily update broadcasts `SoilFieldUpdateEvent` for any field where pressure values changed
- **Fix #244**: Confirmed fixed in v2.0.4.0 (tank drain `lastSpeed == nil` guard); closed issue
- **Feat #236**: New **Replenishment Rate** server setting (0.25x–2.0x, default 1.0x) — controls how quickly fertilizer restores field nutrients, complementary to existing Difficulty depletion multiplier; accessible via Settings Panel → Simulation → Difficulty section
- **i18n**: New `sf_rr_short` / `sf_rr_long` keys propagated to all 26 language files via lang_sync

## Test plan
- [ ] Verify RMB with HUD hidden (J) no longer shows cursor in vehicle
- [ ] Verify RMB after pressing G (implement cycle) still doesn't show cursor when HUD is off
- [ ] On dedicated server: verify weed pressure HUD updates each in-game day without spraying
- [ ] Test Replenishment Rate slider at Very Slow (0.25x) — verify fields need more passes to reach Fair
- [ ] Test at Very Fast (2.0x) — verify one pass fully saturates a depleted field
- [ ] Confirm setting is admin-only in MP and syncs to clients