### PR TITLE
## Merge: PR #253 performance + hook fixes (conflict-resolved)

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -121,114 +121,20 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             SoilLogger.info("Settings panel created")
         end
 
-        -- Hook PlayerInputComponent.registerActionEvents to register J/K in the PLAYER context.
-        -- PLAYER context is reused (not recreated) when the player returns on foot, so these
-        -- events persist across vehicle entry/exit cycles.
-        if self.soilHUD and PlayerInputComponent and PlayerInputComponent.registerActionEvents then
-            local originalRegisterActionEvents = PlayerInputComponent.registerActionEvents
-            self._inputHookOriginal = originalRegisterActionEvents  -- saved for cleanup in delete()
-            PlayerInputComponent.registerActionEvents = function(inputComponent, ...)
-                originalRegisterActionEvents(inputComponent, ...)
-
-                -- Only register for the local (owning) player, not for every networked player
-                if not (inputComponent.player and inputComponent.player.isOwner) then return end
-                -- Guard against double-registration across level reloads
-                if g_SoilFertilityManager and g_SoilFertilityManager.toggleHUDEventId then return end
-                if not g_SoilFertilityManager or not g_SoilFertilityManager.soilHUD then return end
-
-                -- Register J and K in PLAYER context (on-foot use).
-                -- PlayerStateDriving calls setContext("PLAYER") WITHOUT createNew=true,
-                -- so the PLAYER context is reused and our events survive vehicle transitions.
-                g_inputBinding:beginActionEventsModification(PlayerInputComponent.INPUT_CONTEXT_NAME)
-
-                local hudOk, hudId = g_inputBinding:registerActionEvent(
-                    InputAction.SF_TOGGLE_HUD, g_SoilFertilityManager,
-                    g_SoilFertilityManager.onToggleHUDInput,
-                    false, true, false, true
-                )
-                if hudOk and hudId then
-                    g_SoilFertilityManager.toggleHUDEventId = hudId
-                    SoilLogger.info("HUD toggle (J) registered in PLAYER context")
-                else
-                    SoilLogger.warning("HUD toggle (J) PLAYER registration failed")
-                end
-
-                if g_SoilFertilityManager.soilReportDialog then
-                    local repOk, repId = g_inputBinding:registerActionEvent(
-                        InputAction.SF_SOIL_REPORT, g_SoilFertilityManager,
-                        g_SoilFertilityManager.onSoilReportInput,
-                        false, true, false, true
-                    )
-                    if repOk and repId then
-                        g_SoilFertilityManager.soilReportEventId = repId
-                        SoilLogger.info("Soil Report (K) registered in PLAYER context")
-                    end
-                end
-
-                -- Map layer cycle (Shift+M) — registered in PLAYER context only
-                -- (pause-menu map is accessible regardless of context, but the key
-                --  is intended for on-foot use; Shift+M avoids VEHICLE conflicts)
-                if g_SoilFertilityManager.soilMapOverlay then
-                    local mapOk, mapId = g_inputBinding:registerActionEvent(
-                        InputAction.SF_CYCLE_MAP_LAYER, g_SoilFertilityManager,
-                        g_SoilFertilityManager.onCycleMapLayerInput,
-                        false, true, false, true
-                    )
-                    if mapOk and mapId then
-                        g_SoilFertilityManager.cycleMapLayerEventId = mapId
-                        g_inputBinding:setActionEventTextVisibility(mapId, false)
-                        SoilLogger.info("Map layer cycle (Shift+M) registered in PLAYER context")
-                    end
-                end
-
-                -- Settings panel (Shift+O) — registered in PLAYER context
-                if g_SoilFertilityManager.settingsPanel then
-                    local spOk, spId = g_inputBinding:registerActionEvent(
-                        InputAction.SF_OPEN_SETTINGS, g_SoilFertilityManager,
-                        g_SoilFertilityManager.onOpenSettingsInput,
-                        false, true, false, true
-                    )
-                    if spOk and spId then
-                        g_SoilFertilityManager.settingsPanelEventId = spId
-                        g_inputBinding:setActionEventTextVisibility(spId, false)
-                        SoilLogger.info("Settings panel (Shift+O) registered in PLAYER context")
-                    end
-                end
-
-                -- HUD drag toggle (SF_HUD_DRAG, default RMB) — PLAYER context
-                if g_SoilFertilityManager.soilHUD then
-                    local dragOk, dragId = g_inputBinding:registerActionEvent(
-                        InputAction.SF_HUD_DRAG, g_SoilFertilityManager,
-                        g_SoilFertilityManager.onHUDDragInput,
-                        false, true, false, true
-                    )
-                    if dragOk and dragId then
-                        g_SoilFertilityManager.hudDragEventId = dragId
-                        g_inputBinding:setActionEventTextVisibility(dragId, false)
-                        SoilLogger.info("HUD drag (RMB) registered in PLAYER context")
-                    end
-                end
-
-                g_inputBinding:endActionEventsModification()
-                SoilLogger.info("PLAYER context input registration complete")
-            end
-            SoilLogger.info("PlayerInputComponent hook installed for J/K (PLAYER context)")
-        end
-
-        -- Hook InputBinding.endActionEventsModification to register our keys in VEHICLE context.
+        -- Hook InputBinding.endActionEventsModification to register our keys in both
+        -- PLAYER and VEHICLE contexts.
         --
-        -- WHY this approach instead of hooking Vehicle.registerActionEvents directly:
-        -- SpecializationUtil.copyTypeFunctionsInto() copies functions to each vehicle INSTANCE
-        -- table at spawn time. After that, vehicle:registerActionEvents() resolves from the
-        -- instance table, never looking up Vehicle.registerActionEvents on the class. Any
-        -- override of Vehicle.registerActionEvents after vehicles exist is silently ignored.
-        --
-        -- Instead, we hook InputBinding.endActionEventsModification (a class method on the
-        -- InputBinding class). Every call to endActionEventsModification routes through it,
-        -- including every VEHICLE context close. We detect VEHICLE context and inject our events.
-        -- registerActionEvent's built-in dedup handles multiple calls per session gracefully.
+        -- WHY endActionEventsModification instead of PlayerInputComponent.registerActionEvents
+        -- or Vehicle.registerActionEvents:
+        --   SpecializationUtil.copyTypeFunctionsInto() copies functions to each vehicle/player
+        --   INSTANCE table at spawn time. Any class-level override after that point is silently
+        --   ignored by existing instances. endActionEventsModification is a class method on the
+        --   InputBinding singleton — it is never copied to instances, so our override always fires.
+        --   Re-registering on every context close with stale-ID cleanup eliminates duplicate events
+        --   and ensures keys work after vehicle entry/exit without one-shot registration race conditions.
         if self.soilHUD and InputBinding and InputBinding.endActionEventsModification then
             local _soilVehicleHookActive = false
+            local _soilPlayerHookActive  = false
             local originalEndMod = InputBinding.endActionEventsModification
             self._vehicleInputHookOriginal = originalEndMod
             InputBinding.endActionEventsModification = function(binding, ignoreCheck)
@@ -241,10 +147,80 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
 
                 originalEndMod(binding, ignoreCheck)
 
-                -- Only act on VEHICLE context closures, and avoid re-entrancy
+                if not g_SoilFertilityManager or not g_SoilFertilityManager.soilHUD then return end
+
+                -- ---- PLAYER context ----
+                if PlayerInputComponent and contextName == PlayerInputComponent.INPUT_CONTEXT_NAME
+                   and not _soilPlayerHookActive then
+                    _soilPlayerHookActive = true
+                    local mgr = g_SoilFertilityManager
+
+                    -- Purge stale player context event IDs before re-registering.
+                    local stalePlayerIds = {
+                        "toggleHUDEventId", "soilReportEventId",
+                        "cycleMapLayerEventId", "settingsPanelEventId", "hudDragEventId",
+                    }
+                    for _, field in ipairs(stalePlayerIds) do
+                        local oldId = mgr[field]
+                        if oldId then
+                            pcall(function() binding:removeActionEvent(oldId) end)
+                            mgr[field] = nil
+                        end
+                    end
+
+                    binding:beginActionEventsModification(PlayerInputComponent.INPUT_CONTEXT_NAME)
+
+                    local hudOk, hudId = binding:registerActionEvent(
+                        InputAction.SF_TOGGLE_HUD, mgr, mgr.onToggleHUDInput, false, true, false, true)
+                    if hudOk and hudId then
+                        mgr.toggleHUDEventId = hudId
+                        SoilLogger.info("HUD toggle (J) registered in PLAYER context")
+                    end
+
+                    if mgr.soilReportDialog then
+                        local repOk, repId = binding:registerActionEvent(
+                            InputAction.SF_SOIL_REPORT, mgr, mgr.onSoilReportInput, false, true, false, true)
+                        if repOk and repId then
+                            mgr.soilReportEventId = repId
+                            SoilLogger.info("Soil Report (K) registered in PLAYER context")
+                        end
+                    end
+
+                    if mgr.soilMapOverlay then
+                        local mapOk, mapId = binding:registerActionEvent(
+                            InputAction.SF_CYCLE_MAP_LAYER, mgr, mgr.onCycleMapLayerInput, false, true, false, true)
+                        if mapOk and mapId then
+                            mgr.cycleMapLayerEventId = mapId
+                            binding:setActionEventTextVisibility(mapId, false)
+                            SoilLogger.info("Map layer cycle (Shift+M) registered in PLAYER context")
+                        end
+                    end
+
+                    if mgr.settingsPanel then
+                        local spOk, spId = binding:registerActionEvent(
+                            InputAction.SF_OPEN_SETTINGS, mgr, mgr.onOpenSettingsInput, false, true, false, true)
+                        if spOk and spId then
+                            mgr.settingsPanelEventId = spId
+                            binding:setActionEventTextVisibility(spId, false)
+                            SoilLogger.info("Settings panel (Shift+O) registered in PLAYER context")
+                        end
+                    end
+
+                    local dragOk, dragId = binding:registerActionEvent(
+                        InputAction.SF_HUD_DRAG, mgr, mgr.onHUDDragInput, false, true, false, true)
+                    if dragOk and dragId then
+                        mgr.hudDragEventId = dragId
+                        binding:setActionEventTextVisibility(dragId, false)
+                        SoilLogger.info("HUD drag (RMB) registered in PLAYER context")
+                    end
+
+                    binding:endActionEventsModification()
+                    _soilPlayerHookActive = false
+                end
+
+                -- ---- VEHICLE context ----
                 if contextName ~= Vehicle.INPUT_CONTEXT_NAME then return end
                 if _soilVehicleHookActive then return end
-                if not g_SoilFertilityManager or not g_SoilFertilityManager.soilHUD then return end
 
                 _soilVehicleHookActive = true
 
@@ -358,7 +334,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 binding:endActionEventsModification()
                 _soilVehicleHookActive = false
             end
-            SoilLogger.info("InputBinding.endActionEventsModification hooked for VEHICLE context keys")
+            SoilLogger.info("InputBinding.endActionEventsModification hooked for PLAYER and VEHICLE context keys")
         end
     else
         self.soilHUD = nil
@@ -529,11 +505,6 @@ function SoilFertilityManager:deferredSoilSystemInit()
         self.soilSystem:initialize()
     end
 end
-
--- NOTE: registerInputActions() removed.
--- J key is now registered inside the PlayerInputComponent.registerActionEvents hook
--- installed in SoilFertilityManager.new(). This fires at the exact moment the player's
--- input subsystem is ready, eliminating the race condition on dedicated-server clients.
 
 -- Input callback for HUD toggle (J)
 function SoilFertilityManager:onToggleHUDInput()
@@ -1020,13 +991,6 @@ end
 function SoilFertilityManager:delete()
     -- Save soil data before shutdown
     self:saveSoilData()
-
-    -- Restore PlayerInputComponent hook if we installed one
-    if self._inputHookOriginal and PlayerInputComponent then
-        PlayerInputComponent.registerActionEvents = self._inputHookOriginal
-        self._inputHookOriginal = nil
-        SoilLogger.info("PlayerInputComponent hook restored")
-    end
 
     -- Restore InputBinding.endActionEventsModification hook if we installed one
     if self._vehicleInputHookOriginal and InputBinding then

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -121,20 +121,114 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             SoilLogger.info("Settings panel created")
         end
 
-        -- Hook InputBinding.endActionEventsModification to register our keys in both
-        -- PLAYER and VEHICLE contexts.
+        -- Hook PlayerInputComponent.registerActionEvents to register J/K in the PLAYER context.
+        -- PLAYER context is reused (not recreated) when the player returns on foot, so these
+        -- events persist across vehicle entry/exit cycles.
+        if self.soilHUD and PlayerInputComponent and PlayerInputComponent.registerActionEvents then
+            local originalRegisterActionEvents = PlayerInputComponent.registerActionEvents
+            self._inputHookOriginal = originalRegisterActionEvents  -- saved for cleanup in delete()
+            PlayerInputComponent.registerActionEvents = function(inputComponent, ...)
+                originalRegisterActionEvents(inputComponent, ...)
+
+                -- Only register for the local (owning) player, not for every networked player
+                if not (inputComponent.player and inputComponent.player.isOwner) then return end
+                -- Guard against double-registration across level reloads
+                if g_SoilFertilityManager and g_SoilFertilityManager.toggleHUDEventId then return end
+                if not g_SoilFertilityManager or not g_SoilFertilityManager.soilHUD then return end
+
+                -- Register J and K in PLAYER context (on-foot use).
+                -- PlayerStateDriving calls setContext("PLAYER") WITHOUT createNew=true,
+                -- so the PLAYER context is reused and our events survive vehicle transitions.
+                g_inputBinding:beginActionEventsModification(PlayerInputComponent.INPUT_CONTEXT_NAME)
+
+                local hudOk, hudId = g_inputBinding:registerActionEvent(
+                    InputAction.SF_TOGGLE_HUD, g_SoilFertilityManager,
+                    g_SoilFertilityManager.onToggleHUDInput,
+                    false, true, false, true
+                )
+                if hudOk and hudId then
+                    g_SoilFertilityManager.toggleHUDEventId = hudId
+                    SoilLogger.info("HUD toggle (J) registered in PLAYER context")
+                else
+                    SoilLogger.warning("HUD toggle (J) PLAYER registration failed")
+                end
+
+                if g_SoilFertilityManager.soilReportDialog then
+                    local repOk, repId = g_inputBinding:registerActionEvent(
+                        InputAction.SF_SOIL_REPORT, g_SoilFertilityManager,
+                        g_SoilFertilityManager.onSoilReportInput,
+                        false, true, false, true
+                    )
+                    if repOk and repId then
+                        g_SoilFertilityManager.soilReportEventId = repId
+                        SoilLogger.info("Soil Report (K) registered in PLAYER context")
+                    end
+                end
+
+                -- Map layer cycle (Shift+M) — registered in PLAYER context only
+                -- (pause-menu map is accessible regardless of context, but the key
+                --  is intended for on-foot use; Shift+M avoids VEHICLE conflicts)
+                if g_SoilFertilityManager.soilMapOverlay then
+                    local mapOk, mapId = g_inputBinding:registerActionEvent(
+                        InputAction.SF_CYCLE_MAP_LAYER, g_SoilFertilityManager,
+                        g_SoilFertilityManager.onCycleMapLayerInput,
+                        false, true, false, true
+                    )
+                    if mapOk and mapId then
+                        g_SoilFertilityManager.cycleMapLayerEventId = mapId
+                        g_inputBinding:setActionEventTextVisibility(mapId, false)
+                        SoilLogger.info("Map layer cycle (Shift+M) registered in PLAYER context")
+                    end
+                end
+
+                -- Settings panel (Shift+O) — registered in PLAYER context
+                if g_SoilFertilityManager.settingsPanel then
+                    local spOk, spId = g_inputBinding:registerActionEvent(
+                        InputAction.SF_OPEN_SETTINGS, g_SoilFertilityManager,
+                        g_SoilFertilityManager.onOpenSettingsInput,
+                        false, true, false, true
+                    )
+                    if spOk and spId then
+                        g_SoilFertilityManager.settingsPanelEventId = spId
+                        g_inputBinding:setActionEventTextVisibility(spId, false)
+                        SoilLogger.info("Settings panel (Shift+O) registered in PLAYER context")
+                    end
+                end
+
+                -- HUD drag toggle (SF_HUD_DRAG, default RMB) — PLAYER context
+                if g_SoilFertilityManager.soilHUD then
+                    local dragOk, dragId = g_inputBinding:registerActionEvent(
+                        InputAction.SF_HUD_DRAG, g_SoilFertilityManager,
+                        g_SoilFertilityManager.onHUDDragInput,
+                        false, true, false, true
+                    )
+                    if dragOk and dragId then
+                        g_SoilFertilityManager.hudDragEventId = dragId
+                        g_inputBinding:setActionEventTextVisibility(dragId, false)
+                        SoilLogger.info("HUD drag (RMB) registered in PLAYER context")
+                    end
+                end
+
+                g_inputBinding:endActionEventsModification()
+                SoilLogger.info("PLAYER context input registration complete")
+            end
+            SoilLogger.info("PlayerInputComponent hook installed for J/K (PLAYER context)")
+        end
+
+        -- Hook InputBinding.endActionEventsModification to register our keys in VEHICLE context.
         --
-        -- WHY endActionEventsModification instead of PlayerInputComponent.registerActionEvents
-        -- or Vehicle.registerActionEvents:
-        --   SpecializationUtil.copyTypeFunctionsInto() copies functions to each vehicle/player
-        --   INSTANCE table at spawn time. Any class-level override after that point is silently
-        --   ignored by existing instances. endActionEventsModification is a class method on the
-        --   InputBinding singleton — it is never copied to instances, so our override always fires.
-        --   Re-registering on every context close with stale-ID cleanup eliminates duplicate events
-        --   and ensures keys work after vehicle entry/exit without one-shot registration race conditions.
+        -- WHY this approach instead of hooking Vehicle.registerActionEvents directly:
+        -- SpecializationUtil.copyTypeFunctionsInto() copies functions to each vehicle INSTANCE
+        -- table at spawn time. After that, vehicle:registerActionEvents() resolves from the
+        -- instance table, never looking up Vehicle.registerActionEvents on the class. Any
+        -- override of Vehicle.registerActionEvents after vehicles exist is silently ignored.
+        --
+        -- Instead, we hook InputBinding.endActionEventsModification (a class method on the
+        -- InputBinding class). Every call to endActionEventsModification routes through it,
+        -- including every VEHICLE context close. We detect VEHICLE context and inject our events.
+        -- registerActionEvent's built-in dedup handles multiple calls per session gracefully.
         if self.soilHUD and InputBinding and InputBinding.endActionEventsModification then
             local _soilVehicleHookActive = false
-            local _soilPlayerHookActive  = false
             local originalEndMod = InputBinding.endActionEventsModification
             self._vehicleInputHookOriginal = originalEndMod
             InputBinding.endActionEventsModification = function(binding, ignoreCheck)
@@ -147,80 +241,10 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
 
                 originalEndMod(binding, ignoreCheck)
 
-                if not g_SoilFertilityManager or not g_SoilFertilityManager.soilHUD then return end
-
-                -- ---- PLAYER context ----
-                if PlayerInputComponent and contextName == PlayerInputComponent.INPUT_CONTEXT_NAME
-                   and not _soilPlayerHookActive then
-                    _soilPlayerHookActive = true
-                    local mgr = g_SoilFertilityManager
-
-                    -- Purge stale player context event IDs before re-registering.
-                    local stalePlayerIds = {
-                        "toggleHUDEventId", "soilReportEventId",
-                        "cycleMapLayerEventId", "settingsPanelEventId", "hudDragEventId",
-                    }
-                    for _, field in ipairs(stalePlayerIds) do
-                        local oldId = mgr[field]
-                        if oldId then
-                            pcall(function() binding:removeActionEvent(oldId) end)
-                            mgr[field] = nil
-                        end
-                    end
-
-                    binding:beginActionEventsModification(PlayerInputComponent.INPUT_CONTEXT_NAME)
-
-                    local hudOk, hudId = binding:registerActionEvent(
-                        InputAction.SF_TOGGLE_HUD, mgr, mgr.onToggleHUDInput, false, true, false, true)
-                    if hudOk and hudId then
-                        mgr.toggleHUDEventId = hudId
-                        SoilLogger.info("HUD toggle (J) registered in PLAYER context")
-                    end
-
-                    if mgr.soilReportDialog then
-                        local repOk, repId = binding:registerActionEvent(
-                            InputAction.SF_SOIL_REPORT, mgr, mgr.onSoilReportInput, false, true, false, true)
-                        if repOk and repId then
-                            mgr.soilReportEventId = repId
-                            SoilLogger.info("Soil Report (K) registered in PLAYER context")
-                        end
-                    end
-
-                    if mgr.soilMapOverlay then
-                        local mapOk, mapId = binding:registerActionEvent(
-                            InputAction.SF_CYCLE_MAP_LAYER, mgr, mgr.onCycleMapLayerInput, false, true, false, true)
-                        if mapOk and mapId then
-                            mgr.cycleMapLayerEventId = mapId
-                            binding:setActionEventTextVisibility(mapId, false)
-                            SoilLogger.info("Map layer cycle (Shift+M) registered in PLAYER context")
-                        end
-                    end
-
-                    if mgr.settingsPanel then
-                        local spOk, spId = binding:registerActionEvent(
-                            InputAction.SF_OPEN_SETTINGS, mgr, mgr.onOpenSettingsInput, false, true, false, true)
-                        if spOk and spId then
-                            mgr.settingsPanelEventId = spId
-                            binding:setActionEventTextVisibility(spId, false)
-                            SoilLogger.info("Settings panel (Shift+O) registered in PLAYER context")
-                        end
-                    end
-
-                    local dragOk, dragId = binding:registerActionEvent(
-                        InputAction.SF_HUD_DRAG, mgr, mgr.onHUDDragInput, false, true, false, true)
-                    if dragOk and dragId then
-                        mgr.hudDragEventId = dragId
-                        binding:setActionEventTextVisibility(dragId, false)
-                        SoilLogger.info("HUD drag (RMB) registered in PLAYER context")
-                    end
-
-                    binding:endActionEventsModification()
-                    _soilPlayerHookActive = false
-                end
-
-                -- ---- VEHICLE context ----
+                -- Only act on VEHICLE context closures, and avoid re-entrancy
                 if contextName ~= Vehicle.INPUT_CONTEXT_NAME then return end
                 if _soilVehicleHookActive then return end
+                if not g_SoilFertilityManager or not g_SoilFertilityManager.soilHUD then return end
 
                 _soilVehicleHookActive = true
 
@@ -334,7 +358,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 binding:endActionEventsModification()
                 _soilVehicleHookActive = false
             end
-            SoilLogger.info("InputBinding.endActionEventsModification hooked for PLAYER and VEHICLE context keys")
+            SoilLogger.info("InputBinding.endActionEventsModification hooked for VEHICLE context keys")
         end
     else
         self.soilHUD = nil
@@ -506,6 +530,11 @@ function SoilFertilityManager:deferredSoilSystemInit()
     end
 end
 
+-- NOTE: registerInputActions() removed.
+-- J key is now registered inside the PlayerInputComponent.registerActionEvents hook
+-- installed in SoilFertilityManager.new(). This fires at the exact moment the player's
+-- input subsystem is ready, eliminating the race condition on dedicated-server clients.
+
 -- Input callback for HUD toggle (J)
 function SoilFertilityManager:onToggleHUDInput()
     if self.soilHUD then
@@ -521,7 +550,26 @@ function SoilFertilityManager:onOpenSettingsInput()
 end
 
 -- Input callback for HUD drag toggle (SF_HUD_DRAG, default RMB)
+-- Debounced: Courseplay triggers endActionEventsModification twice per vehicle
+-- mount, producing two active SF_HUD_DRAG callbacks (one PLAYER-context, one
+-- VEHICLE-context).  Without debounce the pair fires on a single RMB press:
+-- enter-edit-mode then immediately exit-edit-mode — drag never sticks.
+-- 300ms window is imperceptible to the user but safely wider than one frame.
+local DRAG_DEBOUNCE_S = 0.3
 function SoilFertilityManager:onHUDDragInput()
+    local now = (g_currentMission and g_currentMission.time) or 0
+    local gap = now - (self._lastDragInputTime or 0)
+    self._dragInputCount = (self._dragInputCount or 0) + 1
+    SoilLogger.debug("[SoilHUD] onHUDDragInput #%d  gap=%.0fms  soilHUD=%s  editMode=%s",
+        self._dragInputCount, gap * 1000,
+        tostring(self.soilHUD ~= nil),
+        tostring(self.soilHUD and self.soilHUD.editMode))
+    -- Swallow second call that arrives within the debounce window
+    if gap < DRAG_DEBOUNCE_S and gap >= 0 then
+        SoilLogger.debug("[SoilHUD] drag debounced (gap=%.0fms < %.0fms)", gap * 1000, DRAG_DEBOUNCE_S * 1000)
+        return
+    end
+    self._lastDragInputTime = now
     if not self.soilHUD then return end
     -- Don't steal RMB when HUD is hidden or mod is disabled — prevents mouse cursor
     -- appearing on RMB vehicle actions (e.g. direction change) after implement cycling.
@@ -991,6 +1039,13 @@ end
 function SoilFertilityManager:delete()
     -- Save soil data before shutdown
     self:saveSoilData()
+
+    -- Restore PlayerInputComponent hook if we installed one
+    if self._inputHookOriginal and PlayerInputComponent then
+        PlayerInputComponent.registerActionEvents = self._inputHookOriginal
+        self._inputHookOriginal = nil
+        SoilLogger.info("PlayerInputComponent hook restored")
+    end
 
     -- Restore InputBinding.endActionEventsModification hook if we installed one
     if self._vehicleInputHookOriginal and InputBinding then

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -38,6 +38,27 @@ function SoilFertilitySystem.new(settings)
     self.insecticideAppliedDay = {}  -- fieldId → game day insecticide last reduced pressure
     self.fungicideAppliedDay  = {}   -- fieldId → game day fungicide last reduced pressure
 
+    -- =========================================================
+    -- PERF: Owned-field active set + batched daily simulation
+    -- =========================================================
+    -- Only OWNED fields (farmId > 0) receive passive daily updates
+    -- (fallow recovery, seasonal effects, pressure growth, etc.).
+    -- Unowned fields still get fieldData created on first interaction
+    -- but are excluded from the background simulation loop.
+    -- On a typical 16x farm (25-50% ownership) this cuts update
+    -- cost by 50-75% vs iterating all fieldData unconditionally.
+    self.activeFieldIds   = {}    -- {[fieldId]=true}  – owned fields only
+    self._activeFieldList = {}    -- ordered array for indexed batch iteration
+    self._activeListDirty = false -- true when set changed, list needs rebuild
+
+    -- Batched daily update: spread per-field work across multiple frames
+    -- instead of processing every owned field in one potentially expensive call.
+    self._pendingDailyUpdate = false  -- set true when game-day rolls over
+    self._dailyBatchCursor   = 0     -- how many fields processed so far today
+    self._dailyBatchDay      = 0     -- game day the active batch belongs to
+    self._dailyBatchSeason   = nil   -- season snapshot taken at batch start
+    self.DAILY_BATCH_SIZE    = 25    -- fields per update() call (~0.5 ms budget)
+
     -- Field scan retry mechanism (for delayed initialization)
     self.fieldsScanPending = true
     self.fieldsScanAttempts = 0
@@ -61,6 +82,30 @@ function SoilFertilitySystem:initialize()
     end
 
     self:info("Initializing Soil Fertility System...")
+
+    -- =========================================================
+    -- PHASE 3: Adaptive cell resolution based on map size
+    -- =========================================================
+    -- On a 16x map (16384m) the default 10m cell would create 1638×1638 = ~2.7M
+    -- possible cell keys per field. Scaling the cell size with map dimensions keeps
+    -- spatial resolution proportional to field sizes and bounds the total key count.
+    --   4x  (4096m):  scale=1 → cellSize=10m  (0.01 ha/cell)
+    --   8x  (8192m):  scale=2 → cellSize=20m  (0.04 ha/cell)
+    --   16x (16384m): scale=4 → cellSize=40m  (0.16 ha/cell)
+    do
+        local BASE_MAP  = 4096
+        local BASE_CELL = SoilConstants.ZONE.CELL_SIZE   -- 10 m on standard map
+        local mapSize   = (g_currentMission and g_currentMission.terrainSize) or BASE_MAP
+        local scale     = mapSize / BASE_MAP
+        -- Round to nearest integer multiple of BASE_CELL for exact metre boundaries
+        self.cellSize   = math.max(BASE_CELL, math.floor(scale) * BASE_CELL)
+        self.cellAreaHa = (self.cellSize * self.cellSize) / 10000.0
+        -- Propagate to shared constants so SoilMapOverlay reads the same resolution
+        SoilConstants.ZONE.CELL_SIZE    = self.cellSize
+        SoilConstants.ZONE.CELL_AREA_HA = self.cellAreaHa
+        SoilLogger.info("[PERF-P3] Map %.0fm (%.1fx) → cell %dm  %.4f ha/cell",
+            mapSize, scale, self.cellSize, self.cellAreaHa)
+    end
 
     -- Scan fields using real FieldManager
     if g_fieldManager then
@@ -255,28 +300,25 @@ function SoilFertilitySystem:onFertilizerApplied(fieldId, fillTypeIndex, liters)
     end
 end
 
--- Hook delegate: called by HookManager when field ownership changes
+-- Hook delegate: called by HookManager when field ownership changes.
+-- PHASE 1: Soil data is PRESERVED across ownership changes — real soil does not
+-- reset when land is sold.  We only update active-set membership here.
 function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId)
-    -- If field is no longer owned, clean up data
+    if not fieldId or fieldId <= 0 then return end
+
     if farmId == nil or farmId == 0 then
-        if self.fieldData[fieldId] then
-            self.fieldData[fieldId] = nil
-            self:log("Field %d data removed (no longer owned)", fieldId)
-        end
+        -- Field sold / abandoned — pull it out of the active simulation set.
+        -- fieldData intentionally kept: new owner inherits the soil conditions.
+        self:_removeFromActiveSet(fieldId)
+        SoilLogger.info("[PERF-P1] Field %d released by farm — removed from active set (data preserved)", fieldId)
         return
     end
 
-    -- Initialize field data for new owner
+    -- Field acquired — ensure data entry exists, then add to active set.
     local field = self:getOrCreateField(fieldId, true)
-    if field and not field.initialized then
-        local defaults = SoilConstants.FIELD_DEFAULTS
-        field.nitrogen = defaults.nitrogen
-        field.phosphorus = defaults.phosphorus
-        field.potassium = defaults.potassium
-        field.organicMatter = defaults.organicMatter
-        field.pH = defaults.pH
-        field.initialized = true
-        self:info("Field %d initialized for new owner", fieldId)
+    if field then
+        self:_addToActiveSet(fieldId)
+        SoilLogger.info("[PERF-P1] Field %d acquired by farm %d — added to active set", fieldId, farmId)
     end
 end
 
@@ -401,6 +443,73 @@ function SoilFertilitySystem:onCultivation(fieldId)
     end
 
     if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
+        if SoilFieldUpdateEvent then
+            g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+        end
+    end
+end
+
+--- Called when a ridge tiller / strip-till implement passes over a field.
+--- Strip-till tills narrow deep knife-bands (~30% surface coverage), so
+--- weed control is partial but pest disruption is deeper than cultivation.
+--- No pH normalization (no soil-layer inversion). Small OM boost.
+---@param fieldId number
+function SoilFertilitySystem:onStripTill(fieldId)
+    if not fieldId or fieldId <= 0 then return end
+    if not SoilConstants.STRIP_TILL then return end
+
+    local field = self:getOrCreateField(fieldId, false)
+    if not field then return end
+
+    local st = SoilConstants.STRIP_TILL
+    local changed = false
+
+    self:info("[StripTill] Field %d triggered — weed=%.0f pest=%.0f disease=%.0f OM=%.2f",
+        fieldId,
+        field.weedPressure    or 0,
+        field.pestPressure    or 0,
+        field.diseasePressure or 0,
+        field.organicMatter   or 0)
+
+    -- Partial weed suppression (only tilled strips are disrupted)
+    if self.settings.weedPressure and (field.weedPressure or 0) > 0 then
+        local before = field.weedPressure
+        field.weedPressure = math.max(0, before - st.WEED_PRESSURE_REDUCTION)
+        self:info("[StripTill] Field %d: weed %.0f -> %.0f", fieldId, before, field.weedPressure)
+        changed = true
+    end
+
+    -- Deep knife action disrupts soil-dwelling pest larvae (better than cultivator)
+    if self.settings.pestPressure and (field.pestPressure or 0) > 0 then
+        local before = field.pestPressure
+        field.pestPressure = math.max(0, before - st.PEST_PRESSURE_REDUCTION)
+        self:info("[StripTill] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
+        changed = true
+    end
+
+    -- Minimal disease benefit — residue stays on surface between strips
+    if self.settings.diseasePressure and (field.diseasePressure or 0) > 0 then
+        local before = field.diseasePressure
+        field.diseasePressure = math.max(0, before - st.DISEASE_PRESSURE_REDUCTION)
+        self:info("[StripTill] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
+        changed = true
+    end
+
+    -- Small OM boost from subsurface incorporation in tilled strips
+    if st.OM_BOOST and st.OM_BOOST > 0 then
+        local omBefore = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
+        local omAfter  = math.min(SoilConstants.NUTRIENT_LIMITS.ORGANIC_MATTER_MAX,
+                                  omBefore + st.OM_BOOST)
+        if omAfter > omBefore then
+            field.organicMatter = omAfter
+            self:info("[StripTill] Field %d: OM %.2f -> %.2f", fieldId, omBefore, omAfter)
+            changed = true
+        end
+    end
+
+    if changed and g_server and g_currentMission
+       and g_currentMission.missionDynamicInfo
+       and g_currentMission.missionDynamicInfo.isMultiplayer then
         if SoilFieldUpdateEvent then
             g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
         end
@@ -630,6 +739,56 @@ function SoilFertilitySystem:update(dt)
     if SoilNetworkEvents_UpdateSyncRetry then
         SoilNetworkEvents_UpdateSyncRetry(dt)
     end
+
+    -- =========================================================
+    -- PHASE 4: Batched daily field processing
+    -- =========================================================
+    -- Drains the queue set by updateDailySoil() at DAILY_BATCH_SIZE
+    -- fields per frame so no single frame pays the full update cost.
+    if self._pendingDailyUpdate then
+        -- Lazily rebuild ordered list if membership changed
+        if self._activeListDirty then
+            self:_rebuildActiveList()
+        end
+
+        local list = self._activeFieldList
+        local n    = #list
+
+        if n == 0 then
+            -- No owned fields — batch is trivially complete
+            self._pendingDailyUpdate = false
+            SoilLogger.debug("[PERF-P4] Day %d daily batch: 0 active fields, nothing to process",
+                self._dailyBatchDay)
+        else
+            local processed = 0
+            local cursor    = self._dailyBatchCursor
+
+            while processed < self.DAILY_BATCH_SIZE and cursor < n do
+                cursor = cursor + 1
+                local fid = list[cursor]
+                local fd  = self.fieldData[fid]
+                if fd then
+                    self:_processOneDailyField(fid, fd)
+                    processed = processed + 1
+                end
+            end
+
+            self._dailyBatchCursor = cursor
+
+            if cursor >= n then
+                -- Batch complete for today
+                self._pendingDailyUpdate = false
+                -- Update lastSeason only after the full pass so all fields see the
+                -- same spring-transition flag (captured at batch-queue time).
+                self.lastSeason = self._dailyBatchSeason
+                SoilLogger.info("[PERF-P4] Day %d daily batch complete: %d field(s) in final slice, %d total",
+                    self._dailyBatchDay, processed, n)
+            else
+                SoilLogger.debug("[PERF-P4] Day %d batch progress: cursor %d/%d (+%d this frame)",
+                    self._dailyBatchDay, cursor, n, processed)
+            end
+        end
+    end
 end
 
 -- Check for Precision Farming compatibility
@@ -687,6 +846,15 @@ function SoilFertilitySystem:scanFields()
                 -- read existing layer values (pre-seeded GRLE) instead of using defaults.
                 if isNew and self.layerSystem and self.layerSystem.available and field.farmland then
                     self.layerSystem:readFieldFromLayers(actualFieldId, self.fieldData[actualFieldId], field.farmland)
+                end
+
+                -- PHASE 1: only owned farmlands enter the active simulation set.
+                -- Unowned land still gets fieldData but is excluded from daily updates.
+                if g_farmlandManager then
+                    local farmlandOwner = g_farmlandManager:getFarmlandOwner(actualFieldId)
+                    if farmlandOwner and farmlandOwner > 0 then
+                        self:_addToActiveSet(actualFieldId)
+                    end
                 end
 
                 fieldCount = fieldCount + 1
@@ -815,6 +983,51 @@ function SoilFertilitySystem:onClientJoined(connection)
     self:info("Sent %d fields to newly joined client", count)
 end
 
+-- =========================================================
+-- PHASE 1: Active set management
+-- =========================================================
+-- Owned fields are tracked in activeFieldIds {[fieldId]=true} so that
+-- daily simulation, rain leaching, and pressure growth only iterate
+-- the subset of fields the player actually owns — skipping the potentially
+-- hundreds of unowned parcels on a large map.
+--
+-- _activeFieldList is a sorted array derived from the set.  It is rebuilt
+-- lazily whenever _activeListDirty=true (on add/remove).  The batch cursor
+-- indexes into this list so field processing is deterministic.
+
+--- Add a field to the owned simulation set.
+---@param fieldId number
+function SoilFertilitySystem:_addToActiveSet(fieldId)
+    if not self.activeFieldIds[fieldId] then
+        self.activeFieldIds[fieldId] = true
+        self._activeListDirty = true
+        SoilLogger.debug("[PERF-P1] Field %d → active set (owned)", fieldId)
+    end
+end
+
+--- Remove a field from the owned simulation set.
+---@param fieldId number
+function SoilFertilitySystem:_removeFromActiveSet(fieldId)
+    if self.activeFieldIds[fieldId] then
+        self.activeFieldIds[fieldId] = nil
+        self._activeListDirty = true
+        SoilLogger.debug("[PERF-P1] Field %d ← active set (released)", fieldId)
+    end
+end
+
+--- Rebuild the ordered array from the active set hash.
+--- Called lazily before any indexed batch access.
+function SoilFertilitySystem:_rebuildActiveList()
+    local list = {}
+    for fieldId in pairs(self.activeFieldIds) do
+        table.insert(list, fieldId)
+    end
+    table.sort(list)  -- stable order for deterministic batch processing
+    self._activeFieldList = list
+    self._activeListDirty = false
+    SoilLogger.info("[PERF-P1] Active list rebuilt: %d owned field(s)", #list)
+end
+
 -- Get or create field data
 function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
     if not fieldId or fieldId <= 0 then return nil end
@@ -909,332 +1122,296 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
     return self.fieldData[fieldId]
 end
 
--- Daily soil update
+-- Daily soil update — PHASE 4: converted to batch scheduler.
+-- Instead of processing every field synchronously on the day-rollover tick
+-- (which can stall for hundreds of ms on large maps), we queue work and
+-- drain it across multiple frames via the update(dt) batch loop.
 function SoilFertilitySystem:updateDailySoil()
     if not self.settings.enabled or not self.settings.nutrientCycles then return end
 
-    local currentDay = (g_currentMission and g_currentMission.environment and g_currentMission.environment.currentDay) or 0
-    local limits = SoilConstants.NUTRIENT_LIMITS
-    local recovery = SoilConstants.FALLOW_RECOVERY
-    local seasonal = SoilConstants.SEASONAL_EFFECTS
-    local phNorm = SoilConstants.PH_NORMALIZATION
+    local currentDay = (g_currentMission and g_currentMission.environment and
+                        g_currentMission.environment.currentDay) or 0
 
-    local isMP = g_server and g_currentMission and g_currentMission.missionDynamicInfo and
-                 g_currentMission.missionDynamicInfo.isMultiplayer and SoilFieldUpdateEvent
-    local changedFields = isMP and {} or nil
-
-    for fieldId, field in pairs(self.fieldData) do
-        local prevWeed    = field.weedPressure    or 0
-        local prevPest    = field.pestPressure    or 0
-        local prevDisease = field.diseasePressure or 0
-
-        -- Clear fertilizer and coverage buffers daily
-        field.nutrientBuffer    = {}
-        field.coveredCells      = {}
-        field.coveredCellCount  = 0
-        field.coverageFraction  = 0
-
-        -- Compaction natural decay (per-cell) + daily throttle reset
-        if self.settings.compactionEnabled and SoilConstants.COMPACTION then
-            local cp = SoilConstants.COMPACTION
-            field.compactionCellDays = {}  -- reset per-cell once-per-day throttle
-            if field.compactionCells and next(field.compactionCells) then
-                local newSum = 0
-                for cellKey, val in pairs(field.compactionCells) do
-                    local newVal = val - cp.NATURAL_DECAY_PER_DAY
-                    if newVal > 0 then
-                        field.compactionCells[cellKey] = newVal
-                        newSum = newSum + newVal
-                    else
-                        field.compactionCells[cellKey] = nil
-                    end
-                end
-                field.compactionSum = newSum
-                local tc = field.compactionTotalCells or 0
-                field.compaction = tc > 0 and (newSum / tc) or 0
-            end
-        end
-
-        -- Natural nutrient recovery for fallow fields
-        local daysSinceFallow = currentDay - (field.lastHarvest or 0)
-        if daysSinceFallow > SoilConstants.TIMING.FALLOW_THRESHOLD then
-            field.nitrogen = math.min(limits.MAX, field.nitrogen + recovery.nitrogen)
-            field.phosphorus = math.min(limits.MAX, field.phosphorus + recovery.phosphorus)
-            field.potassium = math.min(limits.MAX, field.potassium + recovery.potassium)
-            field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + recovery.organicMatter)
-        end
-
-        -- Seasonal effects (if enabled)
-        if self.settings.seasonalEffects and g_currentMission and g_currentMission.environment then
-            local season = g_currentMission.environment.currentSeason
-            if season == seasonal.SPRING_SEASON then
-                field.nitrogen = math.min(limits.MAX, field.nitrogen + seasonal.SPRING_NITROGEN_BOOST)
-            elseif season == seasonal.FALL_SEASON then
-                field.nitrogen = math.max(limits.MIN, field.nitrogen - seasonal.FALL_NITROGEN_LOSS)
-            end
-        end
-
-        -- Crop rotation spring bonus
-        if self.settings.cropRotation and g_currentMission and g_currentMission.environment then
-            local season = g_currentMission.environment.currentSeason
-            -- On first day of spring: initialise bonus counter for qualifying fields
-            if season == seasonal.SPRING_SEASON and self.lastSeason ~= seasonal.SPRING_SEASON then
-                if field.lastCrop and field.lastCrop2 then
-                    local cr = SoilConstants.CROP_ROTATION
-                    local c1 = string.lower(field.lastCrop)
-                    local c2 = string.lower(field.lastCrop2)
-                    if cr.LEGUMES[c1] and not cr.LEGUMES[c2]
-                       and (field.rotationBonusDaysLeft or 0) == 0 then
-                        field.rotationBonusDaysLeft = cr.LEGUME_BONUS_DAYS
-                    end
-                end
-            end
-            -- Apply bonus while counter > 0 in spring
-            if season == seasonal.SPRING_SEASON and (field.rotationBonusDaysLeft or 0) > 0 then
-                local cr = SoilConstants.CROP_ROTATION
-                field.nitrogen = math.min(limits.MAX, field.nitrogen + cr.LEGUME_BONUS_N_PER_DAY)
-                field.rotationBonusDaysLeft = field.rotationBonusDaysLeft - 1
-            end
-        end
-
-        -- pH normalization toward neutral (very slow)
-        if field.pH < limits.PH_NEUTRAL_LOW then
-            field.pH = math.min(limits.PH_NEUTRAL_LOW, field.pH + phNorm.RATE)
-        elseif field.pH > limits.PH_NEUTRAL_HIGH then
-            field.pH = math.max(limits.PH_NEUTRAL_HIGH, field.pH - phNorm.RATE)
-        end
-
-        -- Weed pressure daily growth
-        if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
-            local wp = SoilConstants.WEED_PRESSURE
-            local pressure = field.weedPressure or 0
-            local herbDays = field.herbicideDaysLeft or 0
-
-            -- Decrement herbicide protection
-            if herbDays > 0 then
-                field.herbicideDaysLeft = herbDays - 1
-            end
-
-            -- Only grow when not under herbicide protection
-            if (field.herbicideDaysLeft or 0) <= 0 then
-                -- Base rate by current pressure tier
-                local baseRate
-                if pressure < wp.LOW then
-                    baseRate = wp.GROWTH_RATE_LOW
-                elseif pressure < wp.MEDIUM then
-                    baseRate = wp.GROWTH_RATE_MID
-                elseif pressure < wp.HIGH then
-                    baseRate = wp.GROWTH_RATE_HIGH
-                else
-                    baseRate = wp.GROWTH_RATE_PEAK
-                end
-
-                -- Seasonal multiplier
-                local seasonMult = 1.0
-                if g_currentMission and g_currentMission.environment then
-                    local season = g_currentMission.environment.currentSeason
-                    if season == 1 then seasonMult = wp.SEASONAL_SPRING
-                    elseif season == 2 then seasonMult = wp.SEASONAL_SUMMER
-                    elseif season == 3 then seasonMult = wp.SEASONAL_FALL
-                    elseif season == 4 then seasonMult = wp.SEASONAL_WINTER
-                    end
-                end
-
-                -- Rain bonus (wp.RAIN_BONUS was defined but never applied — Bug 6 fix)
-                local rainBonus = 0
-                if g_currentMission and g_currentMission.environment and
-                   g_currentMission.environment.weather and
-                   (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
-                    rainBonus = wp.RAIN_BONUS
-                end
-
-                field.weedPressure = math.min(100, pressure + baseRate * seasonMult + rainBonus)
-            end
-        end
-
-        -- Pest pressure daily growth
-        if self.settings.pestPressure and SoilConstants.PEST_PRESSURE then
-            local pp = SoilConstants.PEST_PRESSURE
-
-            -- Decrement insecticide protection
-            if (field.insecticideDaysLeft or 0) > 0 then
-                field.insecticideDaysLeft = field.insecticideDaysLeft - 1
-            end
-
-            -- Only grow when not under insecticide protection
-            if (field.insecticideDaysLeft or 0) <= 0 then
-                local pressure = field.pestPressure or 0
-
-                -- Base rate by tier
-                local baseRate
-                if pressure < pp.LOW then
-                    baseRate = pp.GROWTH_RATE_LOW
-                elseif pressure < pp.MEDIUM then
-                    baseRate = pp.GROWTH_RATE_MID
-                elseif pressure < pp.HIGH then
-                    baseRate = pp.GROWTH_RATE_HIGH
-                else
-                    baseRate = pp.GROWTH_RATE_PEAK
-                end
-
-                -- Seasonal multiplier
-                local seasonMult = 1.0
-                if g_currentMission and g_currentMission.environment then
-                    local season = g_currentMission.environment.currentSeason
-                    if season == 1 then seasonMult = pp.SEASONAL_SPRING
-                    elseif season == 2 then seasonMult = pp.SEASONAL_SUMMER
-                    elseif season == 3 then seasonMult = pp.SEASONAL_FALL
-                    elseif season == 4 then seasonMult = pp.SEASONAL_WINTER
-                    end
-                end
-
-                -- Crop susceptibility multiplier
-                local cropMult = 1.0
-                if field.lastCrop then
-                    cropMult = pp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
-                end
-
-                -- Rain bonus (check current rain state)
-                local rainBonus = 0
-                if g_currentMission and g_currentMission.environment and
-                   g_currentMission.environment.weather and
-                   (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
-                    rainBonus = pp.RAIN_BONUS
-                end
-
-                field.pestPressure = math.min(100, pressure + (baseRate * seasonMult * cropMult) + rainBonus)
-            end
-        end
-
-        -- Disease pressure daily growth
-        if self.settings.diseasePressure and SoilConstants.DISEASE_PRESSURE then
-            local dp = SoilConstants.DISEASE_PRESSURE
-            local isRaining = g_currentMission and g_currentMission.environment and
-                              g_currentMission.environment.weather and
-                              (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD
-
-            -- Track consecutive dry days for natural decay
-            if isRaining then
-                field.dryDayCount = 0
-            else
-                field.dryDayCount = (field.dryDayCount or 0) + 1
-            end
-
-            -- Decrement fungicide protection
-            if (field.fungicideDaysLeft or 0) > 0 then
-                field.fungicideDaysLeft = field.fungicideDaysLeft - 1
-            end
-
-            local pressure = field.diseasePressure or 0
-
-            -- Natural dry-weather decay (overrides growth)
-            if (field.dryDayCount or 0) >= dp.DRY_DAYS_THRESHOLD then
-                field.diseasePressure = math.max(0, pressure - dp.DRY_DECAY_RATE)
-            elseif (field.fungicideDaysLeft or 0) <= 0 then
-                -- Only grow when not protected
-
-                local baseRate
-                if pressure < dp.LOW then
-                    baseRate = dp.GROWTH_RATE_LOW
-                elseif pressure < dp.MEDIUM then
-                    baseRate = dp.GROWTH_RATE_MID
-                elseif pressure < dp.HIGH then
-                    baseRate = dp.GROWTH_RATE_HIGH
-                else
-                    baseRate = dp.GROWTH_RATE_PEAK
-                end
-
-                local seasonMult = 1.0
-                if g_currentMission and g_currentMission.environment then
-                    local season = g_currentMission.environment.currentSeason
-                    if season == 1 then seasonMult = dp.SEASONAL_SPRING
-                    elseif season == 2 then seasonMult = dp.SEASONAL_SUMMER
-                    elseif season == 3 then seasonMult = dp.SEASONAL_FALL
-                    elseif season == 4 then seasonMult = dp.SEASONAL_WINTER
-                    end
-                end
-
-                local cropMult = 1.0
-                if field.lastCrop then
-                    cropMult = dp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
-                end
-
-                local rainBonus = isRaining and dp.RAIN_BONUS or 0
-
-                field.diseasePressure = math.min(100, pressure + (baseRate * seasonMult * cropMult) + rainBonus)
-            end
-        end
-
-        -- Burn warning countdown — decrements each day until cleared
-        if (field.burnDaysLeft or 0) > 0 then
-            field.burnDaysLeft = field.burnDaysLeft - 1
-        end
-
-        -- Critical Field Alerts (once per season per owned field)
-        if self.settings.showNotifications and g_currentMission and g_currentMission.environment then
-            local season = g_currentMission.environment.currentSeason
-            local threshold = SoilConstants.CRITICAL_ALERT_THRESHOLD or 50
-            if field.lastAlertSeason ~= season then
-                local urgency = self:getFieldUrgency(fieldId)
-                if urgency > threshold then
-                    local isOwned = false
-                    local farmId = g_localPlayer and g_localPlayer.farmId
-                    if farmId and farmId > 0 and g_farmlandManager then
-                        local owner = g_farmlandManager:getFarmlandOwner(fieldId)
-                        if owner == farmId then
-                            isOwned = true
-                        end
-                    end
-                    if isOwned then
-                        self:showNotification("Critical Care Alert", string.format("Field %d requires immediate attention! Urgency: %d%%", fieldId, math.floor(urgency)))
-                    end
-                    field.lastAlertSeason = season
-                end
-            end
-        end
-
-        -- Track changed fields for MP broadcast (only if pressure values changed)
-        if changedFields then
-            if math.abs((field.weedPressure    or 0) - prevWeed)    > 0.01 or
-               math.abs((field.pestPressure    or 0) - prevPest)    > 0.01 or
-               math.abs((field.diseasePressure or 0) - prevDisease) > 0.01 then
-                changedFields[fieldId] = field
-            end
-        end
+    -- Guard: don't re-queue if already started a batch for today
+    if self._pendingDailyUpdate and self._dailyBatchDay == currentDay then
+        SoilLogger.debug("[PERF-P4] Day %d batch already queued, skipping duplicate trigger", currentDay)
+        return
     end
 
-    -- Broadcast pressure changes to clients (dedicated server / MP only)
-    if changedFields and next(changedFields) then
-        local count = 0
-        for fieldId, field in pairs(changedFields) do
-            g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
-            count = count + 1
-        end
-        self:log("Daily broadcast: %d field(s) with pressure changes synced to clients", count)
+    -- Snapshot current state for all per-field workers in this batch
+    self._dailyBatchDay    = currentDay
+    self._dailyBatchSeason = (g_currentMission and g_currentMission.environment and
+                              g_currentMission.environment.currentSeason) or nil
+    self._batchLastSeason  = self.lastSeason  -- spring-transition check uses PREVIOUS season
+
+    -- Rebuild ordered field list if ownership changed since last batch
+    if self._activeListDirty then
+        self:_rebuildActiveList()
     end
 
-    -- Track season for spring-transition detection (crop rotation bonus)
-    if g_currentMission and g_currentMission.environment then
-        self.lastSeason = g_currentMission.environment.currentSeason
-    end
+    self._pendingDailyUpdate = true
+    self._dailyBatchCursor   = 0
 
-    self:log("Daily soil update completed for %d fields", self:getFieldCount())
+    SoilLogger.info("[PERF-P4] Day %d: queued daily update for %d active field(s) (batch=%d/frame)",
+        currentDay, #self._activeFieldList, self.DAILY_BATCH_SIZE)
 end
 
+--- Process daily simulation for ONE field.
+-- Extracted from the old synchronous updateDailySoil() loop body.
+-- Called by the update(dt) batch dispatcher DAILY_BATCH_SIZE times per frame.
+-- Uses snapshotted day/season values stored on self to avoid per-call lookups.
+---@param fieldId number
+---@param field table  fieldData entry (pre-validated non-nil by caller)
+function SoilFertilitySystem:_processOneDailyField(fieldId, field)
+    local limits   = SoilConstants.NUTRIENT_LIMITS
+    local recovery = SoilConstants.FALLOW_RECOVERY
+    local seasonal = SoilConstants.SEASONAL_EFFECTS
+    local phNorm   = SoilConstants.PH_NORMALIZATION
+    -- Use snapshots captured at batch-queue time for consistency across all fields
+    local currentDay = self._dailyBatchDay
+    local season     = self._dailyBatchSeason
+
+    -- ── Buffer / coverage reset ──────────────────────────────────────────────
+    field.nutrientBuffer   = {}
+    field.coveredCells     = {}
+    field.coveredCellCount = 0
+    field.coverageFraction = 0
+
+    -- ── Compaction natural decay ─────────────────────────────────────────────
+    if self.settings.compactionEnabled and SoilConstants.COMPACTION then
+        local cp = SoilConstants.COMPACTION
+        if (field.compaction or 0) > 0 then
+            field.compaction = math.max(0, field.compaction - cp.NATURAL_DECAY_PER_DAY)
+        end
+    end
+
+    -- ── Fallow recovery ──────────────────────────────────────────────────────
+    local daysSinceFallow = currentDay - (field.lastHarvest or 0)
+    if daysSinceFallow > SoilConstants.TIMING.FALLOW_THRESHOLD then
+        field.nitrogen      = math.min(limits.MAX, field.nitrogen      + recovery.nitrogen)
+        field.phosphorus    = math.min(limits.MAX, field.phosphorus    + recovery.phosphorus)
+        field.potassium     = math.min(limits.MAX, field.potassium     + recovery.potassium)
+        field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX,
+                                       field.organicMatter + recovery.organicMatter)
+    end
+
+    -- ── Seasonal nitrogen shift ──────────────────────────────────────────────
+    if self.settings.seasonalEffects and season then
+        if season == seasonal.SPRING_SEASON then
+            field.nitrogen = math.min(limits.MAX, field.nitrogen + seasonal.SPRING_NITROGEN_BOOST)
+        elseif season == seasonal.FALL_SEASON then
+            field.nitrogen = math.max(limits.MIN, field.nitrogen - seasonal.FALL_NITROGEN_LOSS)
+        end
+    end
+
+    -- ── Crop rotation spring bonus ───────────────────────────────────────────
+    if self.settings.cropRotation and season then
+        -- First day of spring transition: initialise bonus counter if eligible
+        if season == seasonal.SPRING_SEASON and self._batchLastSeason ~= seasonal.SPRING_SEASON then
+            if field.lastCrop and field.lastCrop2 then
+                local cr = SoilConstants.CROP_ROTATION
+                local c1 = string.lower(field.lastCrop)
+                local c2 = string.lower(field.lastCrop2)
+                if cr.LEGUMES[c1] and not cr.LEGUMES[c2]
+                   and (field.rotationBonusDaysLeft or 0) == 0 then
+                    field.rotationBonusDaysLeft = cr.LEGUME_BONUS_DAYS
+                end
+            end
+        end
+        -- Apply daily bonus while counter > 0 during spring
+        if season == seasonal.SPRING_SEASON and (field.rotationBonusDaysLeft or 0) > 0 then
+            local cr = SoilConstants.CROP_ROTATION
+            field.nitrogen = math.min(limits.MAX, field.nitrogen + cr.LEGUME_BONUS_N_PER_DAY)
+            field.rotationBonusDaysLeft = field.rotationBonusDaysLeft - 1
+        end
+    end
+
+    -- ── pH slow drift toward neutral ─────────────────────────────────────────
+    if field.pH < limits.PH_NEUTRAL_LOW then
+        field.pH = math.min(limits.PH_NEUTRAL_LOW, field.pH + phNorm.RATE)
+    elseif field.pH > limits.PH_NEUTRAL_HIGH then
+        field.pH = math.max(limits.PH_NEUTRAL_HIGH, field.pH - phNorm.RATE)
+    end
+
+    -- ── Weed pressure daily growth ───────────────────────────────────────────
+    if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
+        local wp = SoilConstants.WEED_PRESSURE
+        local pressure = field.weedPressure or 0
+        local herbDays = field.herbicideDaysLeft or 0
+
+        if herbDays > 0 then field.herbicideDaysLeft = herbDays - 1 end
+
+        if (field.herbicideDaysLeft or 0) <= 0 then
+            local baseRate
+            if     pressure < wp.LOW    then baseRate = wp.GROWTH_RATE_LOW
+            elseif pressure < wp.MEDIUM then baseRate = wp.GROWTH_RATE_MID
+            elseif pressure < wp.HIGH   then baseRate = wp.GROWTH_RATE_HIGH
+            else                             baseRate = wp.GROWTH_RATE_PEAK
+            end
+
+            local seasonMult = 1.0
+            if season then
+                if     season == 1 then seasonMult = wp.SEASONAL_SPRING
+                elseif season == 2 then seasonMult = wp.SEASONAL_SUMMER
+                elseif season == 3 then seasonMult = wp.SEASONAL_FALL
+                elseif season == 4 then seasonMult = wp.SEASONAL_WINTER
+                end
+            end
+
+            local rainBonus = 0
+            if g_currentMission and g_currentMission.environment and
+               g_currentMission.environment.weather and
+               (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
+                rainBonus = wp.RAIN_BONUS
+            end
+
+            field.weedPressure = math.min(100, pressure + baseRate * seasonMult + rainBonus)
+        end
+    end
+
+    -- ── Pest pressure daily growth ───────────────────────────────────────────
+    if self.settings.pestPressure and SoilConstants.PEST_PRESSURE then
+        local pp = SoilConstants.PEST_PRESSURE
+
+        if (field.insecticideDaysLeft or 0) > 0 then
+            field.insecticideDaysLeft = field.insecticideDaysLeft - 1
+        end
+
+        if (field.insecticideDaysLeft or 0) <= 0 then
+            local pressure = field.pestPressure or 0
+            local baseRate
+            if     pressure < pp.LOW    then baseRate = pp.GROWTH_RATE_LOW
+            elseif pressure < pp.MEDIUM then baseRate = pp.GROWTH_RATE_MID
+            elseif pressure < pp.HIGH   then baseRate = pp.GROWTH_RATE_HIGH
+            else                             baseRate = pp.GROWTH_RATE_PEAK
+            end
+
+            local seasonMult = 1.0
+            if season then
+                if     season == 1 then seasonMult = pp.SEASONAL_SPRING
+                elseif season == 2 then seasonMult = pp.SEASONAL_SUMMER
+                elseif season == 3 then seasonMult = pp.SEASONAL_FALL
+                elseif season == 4 then seasonMult = pp.SEASONAL_WINTER
+                end
+            end
+
+            local cropMult = 1.0
+            if field.lastCrop then
+                cropMult = pp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
+            end
+
+            local rainBonus = 0
+            if g_currentMission and g_currentMission.environment and
+               g_currentMission.environment.weather and
+               (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
+                rainBonus = pp.RAIN_BONUS
+            end
+
+            field.pestPressure = math.min(100, pressure + (baseRate * seasonMult * cropMult) + rainBonus)
+        end
+    end
+
+    -- ── Disease pressure daily growth ────────────────────────────────────────
+    if self.settings.diseasePressure and SoilConstants.DISEASE_PRESSURE then
+        local dp = SoilConstants.DISEASE_PRESSURE
+        local isRaining = g_currentMission and g_currentMission.environment and
+                          g_currentMission.environment.weather and
+                          (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD
+
+        if isRaining then
+            field.dryDayCount = 0
+        else
+            field.dryDayCount = (field.dryDayCount or 0) + 1
+        end
+
+        if (field.fungicideDaysLeft or 0) > 0 then
+            field.fungicideDaysLeft = field.fungicideDaysLeft - 1
+        end
+
+        local pressure = field.diseasePressure or 0
+
+        if (field.dryDayCount or 0) >= dp.DRY_DAYS_THRESHOLD then
+            field.diseasePressure = math.max(0, pressure - dp.DRY_DECAY_RATE)
+        elseif (field.fungicideDaysLeft or 0) <= 0 then
+            local baseRate
+            if     pressure < dp.LOW    then baseRate = dp.GROWTH_RATE_LOW
+            elseif pressure < dp.MEDIUM then baseRate = dp.GROWTH_RATE_MID
+            elseif pressure < dp.HIGH   then baseRate = dp.GROWTH_RATE_HIGH
+            else                             baseRate = dp.GROWTH_RATE_PEAK
+            end
+
+            local seasonMult = 1.0
+            if season then
+                if     season == 1 then seasonMult = dp.SEASONAL_SPRING
+                elseif season == 2 then seasonMult = dp.SEASONAL_SUMMER
+                elseif season == 3 then seasonMult = dp.SEASONAL_FALL
+                elseif season == 4 then seasonMult = dp.SEASONAL_WINTER
+                end
+            end
+
+            local cropMult = 1.0
+            if field.lastCrop then
+                cropMult = dp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
+            end
+
+            local rainBonus = isRaining and dp.RAIN_BONUS or 0
+            field.diseasePressure = math.min(100, pressure + (baseRate * seasonMult * cropMult) + rainBonus)
+        end
+    end
+
+    -- ── Burn warning countdown ───────────────────────────────────────────────
+    if (field.burnDaysLeft or 0) > 0 then
+        field.burnDaysLeft = field.burnDaysLeft - 1
+    end
+
+    -- ── Critical field alert (once per season per owned field) ───────────────
+    if self.settings.showNotifications and season then
+        local threshold = SoilConstants.CRITICAL_ALERT_THRESHOLD or 50
+        if field.lastAlertSeason ~= season then
+            local urgency = self:getFieldUrgency(fieldId)
+            if urgency > threshold then
+                local isOwned = false
+                local farmId = g_localPlayer and g_localPlayer.farmId
+                if farmId and farmId > 0 and g_farmlandManager then
+                    local owner = g_farmlandManager:getFarmlandOwner(fieldId)
+                    if owner == farmId then isOwned = true end
+                end
+                if isOwned then
+                    self:showNotification("Critical Care Alert",
+                        string.format("Field %d requires immediate attention! Urgency: %d%%",
+                            fieldId, math.floor(urgency)))
+                end
+                field.lastAlertSeason = season
+            end
+        end
+    end
+end
+
+
 -- Apply rain effects
+-- PHASE 1: Only leach owned/active fields — unowned parcels don't need
+-- per-frame nutrient calculations since no player is managing them.
 function SoilFertilitySystem:applyRainEffects(dt, rainScale)
     if not self.settings.enabled or not self.settings.rainEffects then return end
 
     local rain = SoilConstants.RAIN
     local limits = SoilConstants.NUTRIENT_LIMITS
     local leachFactor = rainScale * dt * rain.LEACH_BASE_FACTOR
+    local count = 0
 
-    for fieldId, field in pairs(self.fieldData) do
-        field.nitrogen = math.max(limits.MIN, field.nitrogen - (leachFactor * rain.NITROGEN_MULTIPLIER))
-        field.potassium = math.max(limits.MIN, field.potassium - (leachFactor * rain.POTASSIUM_MULTIPLIER))
-        field.phosphorus = math.max(limits.MIN, field.phosphorus - (leachFactor * rain.PHOSPHORUS_MULTIPLIER))
-        field.pH = math.max(limits.PH_MIN, field.pH - (leachFactor * rain.PH_ACIDIFICATION))
+    -- Iterate only owned fields (activeFieldIds set, Phase 1)
+    for fieldId in pairs(self.activeFieldIds) do
+        local field = self.fieldData[fieldId]
+        if field then
+            field.nitrogen   = math.max(limits.MIN, field.nitrogen   - (leachFactor * rain.NITROGEN_MULTIPLIER))
+            field.potassium  = math.max(limits.MIN, field.potassium  - (leachFactor * rain.POTASSIUM_MULTIPLIER))
+            field.phosphorus = math.max(limits.MIN, field.phosphorus - (leachFactor * rain.PHOSPHORUS_MULTIPLIER))
+            field.pH         = math.max(limits.PH_MIN, field.pH      - (leachFactor * rain.PH_ACIDIFICATION))
+            count = count + 1
+        end
     end
+
+    SoilLogger.debug("[PERF-P1] Rain leach: %d active field(s), leachFactor=%.6f", count, leachFactor)
 end
 
 -- Update field nutrients after harvest
@@ -1483,7 +1660,10 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
             local zone = SoilConstants.ZONE
             local cx = math.floor(sprayX / zone.CELL_SIZE)
             local cz = math.floor(sprayZ / zone.CELL_SIZE)
-            local cellKey = cx .. "_" .. cz
+            -- PHASE 2: integer key — ~3-5× faster than string concat "cx_cz".
+            -- Safe for any realistic FS25 map: cx/cz range ±820 on 16384m map,
+            -- so max key = 820*10000+820 = 8,200,820 — well within Lua integer range.
+            local cellKey = cx * 10000 + cz
 
             -- Coverage tracking: count unique cells visited today
             if not field.coveredCells then field.coveredCells = {} end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -78,6 +78,27 @@ SoilConstants.CULTIVATION = {
 }
 
 -- ========================================
+-- STRIP-TILL / RIDGE TILLER
+-- ========================================
+-- Strip-till (e.g. Orthman) tills narrow 6-8" deep knife-bands (~30% of
+-- field surface).  Surface residue stays in the untilled zones, so:
+--   • Weeds: LESS effective than full cultivator (partial coverage)
+--   • Pests: MORE effective than cultivator (deep knife disrupts soil larvae)
+--   • Disease: LESS than cultivator (residue left on surface → spore habitat)
+--   • No pH normalization (no soil layer inversion)
+--   • Small OM boost in tilled strips (some sub-surface matter incorporated)
+-- The RidgeTiller FS25 spec (processRidgeTillerArea / RIDGEFORMER work area)
+-- is completely separate from Cultivator.processCultivatorArea, so a dedicated
+-- hook is required.
+SoilConstants.STRIP_TILL = {
+    WEED_PRESSURE_REDUCTION    = 15,  -- pts; less than cultivator (partial surface coverage)
+    PEST_PRESSURE_REDUCTION    = 12,  -- pts; more than cultivator (deep knife action)
+    DISEASE_PRESSURE_REDUCTION = 10,  -- pts; less than cultivator (residue left in place)
+    OM_BOOST                   = 0.10, -- % OM increase per pass (tilled-strip incorporation)
+    -- No pH normalization — strip-till does not invert soil horizons
+}
+
+-- ========================================
 -- NUTRIENT LIMITS
 -- ========================================
 SoilConstants.NUTRIENT_LIMITS = {

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -22,41 +22,68 @@ end
 ---@param z number World Z coordinate
 ---@return number|nil fieldId
 function HookManager:getFieldIdAtWorldPosition(x, z)
-    if not g_fieldManager then return nil end
-    
     -- Initialize the native MapDataGrid cache on first use (requires map to be loaded)
     if not self.fieldIdCache then
         local mapSize = g_currentMission and g_currentMission.terrainSize or 2048
-        -- 2m block size provides high resolution for field boundaries
-        self.fieldIdCache = MapDataGrid.createFromBlockSize(mapSize, 2)
+        -- PHASE 5: Scale block size with map size.
+        -- A fixed 2m block on a 16x map (16384m) creates a 8192×8192 grid — 64M cells.
+        -- Doubling block size per doubling of map keeps the cell count constant (~4M).
+        --   4x  (4096m):  blockSize=2m  → 2048×2048 grid
+        --   8x  (8192m):  blockSize=4m  → 2048×2048 grid
+        --   16x (16384m): blockSize=8m  → 2048×2048 grid
+        local BASE_MAP   = 4096
+        local BASE_BLOCK = 2
+        local blockSize  = math.max(BASE_BLOCK, math.floor(BASE_BLOCK * (mapSize / BASE_MAP)))
+        SoilLogger.info("[PERF-P5] MapDataGrid: map=%.0fm  blockSize=%dm", mapSize, blockSize)
+        local ok, result = pcall(MapDataGrid.createFromBlockSize, mapSize, blockSize)
+        if ok and result then
+            self.fieldIdCache = result
+        else
+            SoilLogger.warning("[PERF-P5] MapDataGrid.createFromBlockSize failed (%s) — cache disabled", tostring(result))
+            self.fieldIdCache = false  -- false = permanently disabled, avoids retry spam
+        end
     end
 
     -- Fast path: Check the native C++ backed spatial grid cache
-    local cachedId = self.fieldIdCache:getValueAtWorldPos(x, z)
-    if cachedId ~= nil then
-        if cachedId == -1 then return nil end -- -1 indicates known empty space
-        return cachedId
+    if self.fieldIdCache then
+        local cachedId = self.fieldIdCache:getValueAtWorldPos(x, z)
+        if cachedId ~= nil then
+            if cachedId == -1 then return nil end  -- -1 = known empty space
+            return cachedId
+        end
     end
-    
+
     -- Slow path: Direct field polygon lookup (computationally expensive)
     local fieldId = nil
-    local field = g_fieldManager:getFieldAtWorldPosition(x, z)
-    if field and field.farmland and field.farmland.id then
-        fieldId = field.farmland.id
+    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+        local field = g_fieldManager:getFieldAtWorldPosition(x, z)
+        if field and field.farmland and field.farmland.id then
+            fieldId = field.farmland.id
+        end
     end
-    
+
     -- Fallback to farmland detection
-    if not fieldId and g_farmlandManager then
+    if not fieldId and g_farmlandManager and type(g_farmlandManager.getFarmlandAtWorldPosition) == "function" then
         local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
         if farmland and farmland.id then
-            -- Convert farmland ID to field ID (usually same in FS25)
             fieldId = farmland.id
         end
     end
-    
-    -- Cache the result (using -1 to cache nil/empty lookups to prevent repeated slow paths)
-    self.fieldIdCache:setValueAtWorldPos(x, z, fieldId or -1)
-    
+
+    if not fieldId then
+        SoilLogger.debug("[FieldResolve] Miss at (%.1f,%.1f) — fieldMgr=%s/%s farmMgr=%s/%s",
+            x, z,
+            tostring(g_fieldManager ~= nil),
+            tostring(g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function"),
+            tostring(g_farmlandManager ~= nil),
+            tostring(g_farmlandManager and type(g_farmlandManager.getFarmlandAtWorldPosition) == "function"))
+    end
+
+    -- Cache the result (-1 marks known-empty to prevent repeated slow-path lookups)
+    if self.fieldIdCache then
+        self.fieldIdCache:setValueAtWorldPos(x, z, fieldId or -1)
+    end
+
     return fieldId
 end
 
@@ -111,13 +138,17 @@ function HookManager:installAll(soilSystem)
     local plowingOk = self:installPlowingHook()
     if plowingOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
-    -- Dedicated plow implements (Plow.processPlowArea)
+    -- Dedicated plow implements (Plow.onEndWorkAreaProcessing)
     local dedicatedPlowOk = self:installDedicatedPlowHook()
     if dedicatedPlowOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
-    -- Mechanical weed removal (Weeder.processWeederArea — weeders, inter-row hoes)
+    -- Mechanical weed removal (Weeder.onEndWorkAreaProcessing — weeders, inter-row hoes)
     local weedControlOk = self:installWeederHook()
     if weedControlOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    -- Strip-till / ridge tiller (RidgeTiller.processRidgeTillerArea — Orthman-style implements)
+    local ridgeTillerOk = self:installRidgeTillerHook()
+    if ridgeTillerOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
     -- Patch vanilla fill units to accept custom fertilizer types
     local fillUnitOk = self:installFillUnitHook()
@@ -783,16 +814,19 @@ function HookManager:registerCleanup(name, cleanupFn)
 end
 
 -- =========================================================
--- HOOK 1: Harvest events (Combine.addCutterArea)
+-- HOOK 1: Harvest events (Cutter.onEndWorkAreaProcessing)
 -- =========================================================
--- FruitUtil.fruitPickupEvent does not exist in FS25.
--- Combine.addCutterArea fires on every combine harvest pass with:
---   area, liters, inputFruitType, outputFillType, strawRatio, farmId, cutterLoad
--- 'self' inside the appended function is the combine vehicle instance.
+-- Combine.addCutterArea is registered via SpecializationUtil.registerFunction,
+-- then WorkArea captures it as a direct closure reference at vehicle load —
+-- class-level hook is bypassed completely.
+-- Cutter.onEndWorkAreaProcessing IS an event listener (dynamic dispatch).
+-- It runs AFTER processCutterArea accumulates workAreaParameters this tick,
+-- and AFTER calling combineVehicle:addCutterArea internally, so all harvest
+-- data (area, liters, fruitType, strawRatio) is valid and accessible.
 ---@return boolean success True if hook installed successfully
 function HookManager:installHarvestHook()
-    if not Combine or type(Combine.addCutterArea) ~= "function" then
-        SoilLogger.warning("Could not install harvest hook - Combine.addCutterArea not available")
+    if not Cutter or type(Cutter.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install harvest hook - Cutter.onEndWorkAreaProcessing not available")
         return false
     end
 
@@ -983,20 +1017,8 @@ function HookManager:installSprayerAreaHook()
                 local x, _, z = getWorldTranslation(self.rootNode)
                 if not x then return end
 
-                local function _resolveFieldId(wx, wz)
-                    local fid = nil
-                    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
-                        local f = g_fieldManager:getFieldAtWorldPosition(wx, wz)
-                        if f and f.farmland then fid = f.farmland.id end
-                    end
-                    if not fid and g_farmlandManager then
-                        local fl = g_farmlandManager:getFarmlandAtWorldPosition(wx, wz)
-                        if fl then fid = fl.id end
-                    end
-                    return fid
-                end
-
-                local fieldId = _resolveFieldId(x, z)
+                -- PHASE 5: route through shared MapDataGrid-backed cache
+                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
 
                 -- Fallback: try the midpoints of work areas on attached implements
                 if not fieldId or fieldId <= 0 then
@@ -1007,13 +1029,13 @@ function HookManager:installSprayerAreaHook()
                             if obj then
                                 -- Try implement rootNode first
                                 local ix, _, iz = getWorldTranslation(obj.rootNode)
-                                if ix then fieldId = _resolveFieldId(ix, iz) end
+                                if ix then fieldId = hookMgrRef:getFieldIdAtWorldPosition(ix, iz) end
                                 -- Then try each work area start point
                                 if (not fieldId or fieldId <= 0) and obj.spec_workArea and obj.spec_workArea.workAreas then
                                     for _, wa in ipairs(obj.spec_workArea.workAreas) do
                                         if wa.start then
                                             local sx, _, sz = getWorldTranslation(wa.start)
-                                            if sx then fieldId = _resolveFieldId(sx, sz) end
+                                            if sx then fieldId = hookMgrRef:getFieldIdAtWorldPosition(sx, sz) end
                                         end
                                         if fieldId and fieldId > 0 then break end
                                     end
@@ -1280,70 +1302,73 @@ function HookManager:installWeatherHook()
 end
 
 -- =========================================================
--- HOOK 5: Plowing operations (Cultivator)
+-- HOOK 5: Plowing operations (Cultivator.onEndWorkAreaProcessing)
 -- =========================================================
+-- WHY onEndWorkAreaProcessing instead of processCultivatorArea:
+-- SpecializationUtil.registerFunction stores the function reference at
+-- vehicleType registration time (game startup), then WorkArea.lua copies it
+-- directly to workArea.processingFunction = self[funcName] at vehicle load.
+-- A class-level Utils.appendedFunction hook applied at mod load (Mission00)
+-- is completely bypassed — the workArea closure already holds the original.
+-- onEndWorkAreaProcessing is an event: SpecializationUtil.raiseEvent does a
+-- DYNAMIC table lookup (v10_[eventName](vehicle,...)) each tick, so our
+-- class-level hook is visible and fires correctly.
 ---@return boolean success True if hook installed successfully
 function HookManager:installPlowingHook()
-    if not Cultivator or type(Cultivator.processCultivatorArea) ~= "function" then
-        SoilLogger.warning("Could not install plowing hook - Cultivator.processCultivatorArea not available or replaced")
+    if not Cultivator or type(Cultivator.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install plowing hook - Cultivator.onEndWorkAreaProcessing not available")
         return false
     end
 
-    local original = Cultivator.processCultivatorArea
-    Cultivator.processCultivatorArea = Utils.appendedFunction(
+    local hookMgrRef = self
+    local original = Cultivator.onEndWorkAreaProcessing
+    Cultivator.onEndWorkAreaProcessing = Utils.appendedFunction(
         original,
-        function(cultivatorSelf, workArea, dt)
+        function(cultivatorSelf, dt, hasProcessed)
+            -- Fast exit: no work areas were active this tick
+            if not hasProcessed then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled or
                not g_SoilFertilityManager.settings.plowingBonus then
                 return
             end
+            if not cultivatorSelf.isServer then return end
 
-            -- Validate workArea parameter.
-            -- workArea is a named-key table ({start=node, width=node, height=node}),
-            -- not a sequence — #workArea always returns 0 and cannot be used as a guard.
-            if not workArea or type(workArea) ~= "table" then
-                SoilLogger.debug("[PlowHook] workArea guard fired: nil or non-table (type=%s)", type(workArea))
-                return
-            end
-            if not workArea.start or not workArea.width or not workArea.height then
-                SoilLogger.debug("[PlowHook] workArea guard fired: missing key(s) start=%s width=%s height=%s",
-                    tostring(workArea.start), tostring(workArea.width), tostring(workArea.height))
-                return
-            end
+            -- Confirm cultivator work area actually changed terrain this tick
+            local spec = cultivatorSelf.spec_cultivator
+            if not spec or not spec.workAreaParameters then return end
+            local statsArea = spec.workAreaParameters.lastStatsArea
+            if not statsArea or statsArea <= 0 then return end
 
-            -- Get field ID from work area
-            local sx, _, sz = getWorldTranslation(workArea.start)
-            local wx, _, wz = getWorldTranslation(workArea.width)
-            local hx, _, hz = getWorldTranslation(workArea.height)
-            
-            local centerX = (sx + wx + hx) / 3
-            local centerZ = (sz + wz + hz) / 3
+            local isPlowSpec = cultivatorSelf.spec_plow ~= nil or cultivatorSelf.spec_subsoiler ~= nil
+            SoilLogger.debug("[PlowHook] onEndWorkAreaProcessing fired — isPlow=%s area=%.1f",
+                tostring(isPlowSpec), statsArea)
 
+            local x, _, z = getWorldTranslation(cultivatorSelf.rootNode)
             local success, errorMsg = pcall(function()
-                if g_farmlandManager then
-                    local farmland = g_farmlandManager:getFarmlandAtWorldPosition(centerX, centerZ)
-                    local farmlandId = farmland and farmland.id
-                    local isPlowSpec = cultivatorSelf.spec_plow ~= nil or cultivatorSelf.spec_subsoiler ~= nil
-                    SoilLogger.info("[PlowHook] center=(%.1f,%.1f) farmlandId=%s isPlow=%s",
-                        centerX, centerZ, tostring(farmlandId), tostring(isPlowSpec))
-                    if farmlandId and farmlandId > 0 then
-                        -- Check if this is a plowing implement
-                        local isPlowingTool = cultivatorSelf.spec_plow ~= nil or
-                                              cultivatorSelf.spec_subsoiler ~= nil
+                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                SoilLogger.info("[PlowHook] pos=(%.1f,%.1f) farmlandId=%s isPlow=%s",
+                    x, z, tostring(farmlandId), tostring(isPlowSpec))
+                if farmlandId and farmlandId > 0 then
+                    local isPlowingTool = isPlowSpec
+                    -- Some cultivators work deep enough to act as plows
+                    if not isPlowingTool and spec.workingDepth and
+                       spec.workingDepth > SoilConstants.PLOWING.MIN_DEPTH_FOR_PLOWING then
+                        isPlowingTool = true
+                    end
 
-                        -- Some cultivators work deep enough to act as plows
-                        if not isPlowingTool and cultivatorSelf.spec_cultivator then
-                            local cultivatorSpec = cultivatorSelf.spec_cultivator
-                            if cultivatorSpec.workingDepth and 
-                               cultivatorSpec.workingDepth > SoilConstants.PLOWING.MIN_DEPTH_FOR_PLOWING then
-                                isPlowingTool = true
-                            end
-                        end
+                    if isPlowingTool then
+                        g_SoilFertilityManager.soilSystem:onPlowing(farmlandId)
+                    else
+                        g_SoilFertilityManager.soilSystem:onCultivation(farmlandId)
+                    end
 
-                        if isPlowingTool then
-                            g_SoilFertilityManager.soilSystem:onPlowing(farmlandId)
+                    -- Compaction: check if subsoiler or heavy vehicle
+                    if g_SoilFertilityManager.settings.compactionEnabled and SoilConstants.COMPACTION then
+                        local cp = SoilConstants.COMPACTION
+                        if spec.isSubsoiler then
+                            g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId)
                         else
                             g_SoilFertilityManager.soilSystem:onCultivation(farmlandId)
                         end
@@ -1383,51 +1408,54 @@ function HookManager:installPlowingHook()
             end
         end
     )
-    self:register(Cultivator, "processCultivatorArea", original, "Cultivator.processCultivatorArea")
-    SoilLogger.info("[OK] Plowing hook installed successfully")
+    self:register(Cultivator, "onEndWorkAreaProcessing", original, "Cultivator.onEndWorkAreaProcessing")
+    SoilLogger.info("[OK] Plowing hook installed successfully (via onEndWorkAreaProcessing)")
     return true
 end
 
 -- =========================================================
--- HOOK 5b: Dedicated plow implements (Plow.processPlowArea)
+-- HOOK 5b: Dedicated plow implements (Plow.onEndWorkAreaProcessing)
 -- =========================================================
---- Hooks dedicated plow implements (belt plows, disc plows, etc.) which call
---- Plow.processPlowArea rather than Cultivator.processCultivatorArea.
---- Without this hook, plowing with a real plow (spec_plow) never triggers
---- soil benefits because those implements bypass processCultivatorArea entirely.
+--- Hooks dedicated plow implements (belt plows, disc plows, etc.) which use
+--- the Plow specialization. processingFunction closure bypass applies here too —
+--- same fix: hook the event listener instead of the processing function.
 ---@return boolean success
 function HookManager:installDedicatedPlowHook()
-    if not Plow or type(Plow.processPlowArea) ~= "function" then
-        SoilLogger.warning("Could not install dedicated plow hook - Plow.processPlowArea not available")
+    if not Plow or type(Plow.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install dedicated plow hook - Plow.onEndWorkAreaProcessing not available")
         return false
     end
 
-    local original = Plow.processPlowArea
-    Plow.processPlowArea = Utils.appendedFunction(
+    local hookMgrRef = self
+    local original = Plow.onEndWorkAreaProcessing
+    Plow.onEndWorkAreaProcessing = Utils.appendedFunction(
         original,
-        function(plowSelf, workArea, dt)
+        function(plowSelf, dt, hasProcessed)
+            -- Fast exit: no work areas were active this tick
+            if not hasProcessed then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled or
                not g_SoilFertilityManager.settings.plowingBonus then
                 return
             end
+            if not plowSelf.isServer then return end
 
-            if not workArea or type(workArea) ~= "table" then return end
-            if not workArea.start or not workArea.width or not workArea.height then return end
+            -- Confirm plow work area actually changed terrain this tick
+            local spec = plowSelf.spec_plow
+            if not spec or not spec.workAreaParameters then return end
+            local statsArea = spec.workAreaParameters.lastStatsArea
+            if not statsArea or statsArea <= 0 then return end
 
-            local sx, _, sz = getWorldTranslation(workArea.start)
-            local wx, _, wz = getWorldTranslation(workArea.width)
-            local hx, _, hz = getWorldTranslation(workArea.height)
-            local centerX = (sx + wx + hx) / 3
-            local centerZ = (sz + wz + hz) / 3
+            SoilLogger.debug("[DedicatedPlowHook] onEndWorkAreaProcessing fired — area=%.1f", statsArea)
 
+            local x, _, z = getWorldTranslation(plowSelf.rootNode)
             local success, errorMsg = pcall(function()
-                if g_farmlandManager then
-                    local farmland = g_farmlandManager:getFarmlandAtWorldPosition(centerX, centerZ)
-                    local farmlandId = farmland and farmland.id
-                    if farmlandId and farmlandId > 0 then
-                        g_SoilFertilityManager.soilSystem:onPlowing(farmlandId)
+                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                SoilLogger.debug("[DedicatedPlowHook] pos=(%.1f,%.1f) farmlandId=%s",
+                    x, z, tostring(farmlandId))
+                if farmlandId and farmlandId > 0 then
+                    g_SoilFertilityManager.soilSystem:onPlowing(farmlandId)
 
                         -- Dedicated plows are always heavy equipment
                         if g_SoilFertilityManager.settings.compactionEnabled then
@@ -1456,35 +1484,96 @@ function HookManager:installDedicatedPlowHook()
             end
         end
     )
-    self:register(Plow, "processPlowArea", original, "Plow.processPlowArea")
-    SoilLogger.info("[OK] Dedicated plow hook installed successfully")
+    self:register(Plow, "onEndWorkAreaProcessing", original, "Plow.onEndWorkAreaProcessing")
+    SoilLogger.info("[OK] Dedicated plow hook installed successfully (via onEndWorkAreaProcessing)")
     return true
 end
 
 -- =========================================================
--- HOOK 5c: Mechanical weed removal (Weeder.processWeederArea)
+-- HOOK 5c: Mechanical weed removal (Weeder.onEndWorkAreaProcessing)
 -- =========================================================
---- Hooks the Weeder specialization's processWeederArea function.
---- FS25 weeders (inter-row hoes, mechanical weeders) call this instead of
---- processCultivatorArea — without this hook they have no effect on the
---- mod's weed pressure tracking (issue #200).
---- The correct function per LUADOC is Weeder.processWeederArea, NOT
---- WeedControl.processWeedControlArea (that class does not exist in FS25).
+--- Hooks the Weeder specialization via its onEndWorkAreaProcessing event.
+--- FS25 weeders (inter-row hoes, mechanical weeders) use Weeder.processWeederArea
+--- for terrain work, but processingFunction is captured as a direct closure
+--- reference at vehicle load time and cannot be hooked post-load. The event
+--- listener uses dynamic dispatch, so hooking onEndWorkAreaProcessing works.
 ---@return boolean success
 function HookManager:installWeederHook()
-    if not Weeder or type(Weeder.processWeederArea) ~= "function" then
-        SoilLogger.warning("Could not install Weeder hook - Weeder.processWeederArea not available")
+    -- Same processingFunction closure bypass as Plow/Cultivator — hook the event instead
+    if not Weeder or type(Weeder.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install Weeder hook - Weeder.onEndWorkAreaProcessing not available")
         return false
     end
 
-    local original = Weeder.processWeederArea
-    Weeder.processWeederArea = Utils.appendedFunction(
+    local hookMgrRef = self
+    local original = Weeder.onEndWorkAreaProcessing
+    Weeder.onEndWorkAreaProcessing = Utils.appendedFunction(
         original,
-        function(weederSelf, workArea, dt)
+        function(weederSelf, dt, hasProcessed)
+            -- Fast exit: no work areas were active this tick
+            if not hasProcessed then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
                not g_SoilFertilityManager.settings.enabled or
                not g_SoilFertilityManager.settings.weedPressure then
+                return
+            end
+            if not weederSelf.isServer then return end
+
+            -- Confirm weeder actually changed terrain this tick
+            local spec = weederSelf.spec_weeder
+            if not spec or not spec.workAreaParameters then return end
+            local statsArea = spec.workAreaParameters.lastStatsArea
+            if not statsArea or statsArea <= 0 then return end
+
+            local x, _, z = getWorldTranslation(weederSelf.rootNode)
+            local success, errorMsg = pcall(function()
+                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                SoilLogger.debug("[WeederHook] pos=(%.1f,%.1f) farmlandId=%s", x, z, tostring(farmlandId))
+                if farmlandId and farmlandId > 0 then
+                    g_SoilFertilityManager.soilSystem:onCultivation(farmlandId)
+                    SoilLogger.debug("[WeederHook] Field %d: mechanical weed removal applied", farmlandId)
+                end
+            end)
+
+            if not success then
+                SoilLogger.error("Weeder hook failed: %s", tostring(errorMsg))
+            end
+        end
+    )
+    self:register(Weeder, "onEndWorkAreaProcessing", original, "Weeder.onEndWorkAreaProcessing")
+    SoilLogger.info("[OK] Weeder hook (mechanical weed removal) installed successfully (via onEndWorkAreaProcessing)")
+    return true
+end
+
+-- =========================================================
+-- HOOK 6b: Strip-till / Ridge tiller (RidgeTiller.processRidgeTillerArea)
+-- =========================================================
+-- The RidgeTiller specialization (RIDGEFORMER work area type) is completely
+-- separate from Cultivator.processCultivatorArea.  Implements such as the
+-- Orthman Strip Till use this path and were previously invisible to SF.
+--
+-- Strip-till effects are a distinct middle tier between cultivation and plowing:
+--   Weeds:   partial reduction (only ~30% surface coverage)
+--   Pests:   higher than cultivator (deep 6-8" knife disrupts soil larvae)
+--   Disease: lower than cultivator (surface residue left in untilled zones)
+--   pH:      no normalization (no soil-layer inversion)
+--   OM:      small boost (subsurface incorporation in tilled strips only)
+---@return boolean success
+function HookManager:installRidgeTillerHook()
+    -- RidgeTiller may not be present on all maps/mods — fail gracefully
+    if not RidgeTiller or type(RidgeTiller.processRidgeTillerArea) ~= "function" then
+        SoilLogger.warning("[RidgeTillerHook] RidgeTiller.processRidgeTillerArea not available — strip-till integration skipped")
+        return false
+    end
+
+    local original = RidgeTiller.processRidgeTillerArea
+    RidgeTiller.processRidgeTillerArea = Utils.appendedFunction(
+        original,
+        function(ridgeSelf, workArea, dt)
+            if not g_SoilFertilityManager or
+               not g_SoilFertilityManager.soilSystem or
+               not g_SoilFertilityManager.settings.enabled then
                 return
             end
 
@@ -1498,23 +1587,22 @@ function HookManager:installWeederHook()
             local centerZ = (sz + wz + hz) / 3
 
             local success, errorMsg = pcall(function()
-                if g_farmlandManager then
-                    local farmland = g_farmlandManager:getFarmlandAtWorldPosition(centerX, centerZ)
-                    local farmlandId = farmland and farmland.id
-                    if farmlandId and farmlandId > 0 then
-                        g_SoilFertilityManager.soilSystem:onCultivation(farmlandId)
-                        SoilLogger.debug("[WeederHook] Field %d: mechanical weed removal applied", farmlandId)
-                    end
-                end
+                -- PHASE 5: use shared MapDataGrid-backed cache (self = HookManager upvalue)
+                local fieldId = self:getFieldIdAtWorldPosition(centerX, centerZ)
+                if not fieldId or fieldId <= 0 then return end
+
+                SoilLogger.debug("[RidgeTillerHook] Field %d at (%.1f, %.1f)", fieldId, centerX, centerZ)
+                g_SoilFertilityManager.soilSystem:onStripTill(fieldId)
             end)
 
             if not success then
-                SoilLogger.error("Weeder hook failed: %s", tostring(errorMsg))
+                SoilLogger.error("[RidgeTillerHook] failed: %s", tostring(errorMsg))
             end
         end
     )
-    self:register(Weeder, "processWeederArea", original, "Weeder.processWeederArea")
-    SoilLogger.info("[OK] Weeder hook (mechanical weed removal) installed successfully")
+
+    self:register(RidgeTiller, "processRidgeTillerArea", original, "RidgeTiller.processRidgeTillerArea")
+    SoilLogger.info("[OK] RidgeTiller hook installed — strip-till (RIDGEFORMER) events now tracked")
     return true
 end
 
@@ -1526,15 +1614,23 @@ end
 -- crop name from the previous harvest (fix for issue #123).
 ---@return boolean success True if hook installed successfully
 function HookManager:installSowingHook()
-    if not SowingMachine or type(SowingMachine.processSowingMachineArea) ~= "function" then
-        SoilLogger.warning("Could not install sowing hook - SowingMachine.processSowingMachineArea not available")
+    -- processSowingMachineArea has the same processingFunction closure bypass —
+    -- hook onEndWorkAreaProcessing for dynamic dispatch instead.
+    if not SowingMachine or type(SowingMachine.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install sowing hook - SowingMachine.onEndWorkAreaProcessing not available")
         return false
     end
 
-    local original = SowingMachine.processSowingMachineArea
-    SowingMachine.processSowingMachineArea = Utils.appendedFunction(
+    local hookMgrRef = self
+    local original = SowingMachine.onEndWorkAreaProcessing
+    SowingMachine.onEndWorkAreaProcessing = Utils.appendedFunction(
         original,
-        function(sowingSelf, workArea, dt)
+        function(sowingSelf, dt, hasProcessed)
+            -- Note: do NOT fast-exit on hasProcessed=false here.
+            -- SowingMachine.onEndWorkAreaProcessing also ignores hasProcessed
+            -- (it uses lastChangedArea as the real guard). On some ticks the
+            -- work area activation can flicker, making hasProcessed=false while
+            -- seeds are still going in the ground.
             if not sowingSelf.isServer then return end
             if not g_SoilFertilityManager or
                not g_SoilFertilityManager.soilSystem or
@@ -1542,21 +1638,19 @@ function HookManager:installSowingHook()
                 return
             end
 
+            -- Confirm seeds actually went in the ground this tick (mirrors game's own guard)
+            local spec = sowingSelf.spec_sowingMachine
+            if not spec or not spec.workAreaParameters then return end
+            if (spec.workAreaParameters.lastChangedArea or 0) <= 0 then return end
+
             local ok, err = pcall(function()
                 local x, _, z = getWorldTranslation(sowingSelf.rootNode)
                 if not x then return end
 
-                local fieldId = nil
-                if g_fieldManager then
-                    local field = g_fieldManager:getFieldAtWorldPosition(x, z)
-                    if field and field.farmland then
-                        fieldId = field.farmland.id
-                    end
-                end
-                if not fieldId and g_farmlandManager then
-                    local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
-                    if farmland then fieldId = farmland.id end
-                end
+                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                SoilLogger.info("[SowingHook] pos=(%.1f,%.1f) fieldId=%s crop=%s",
+                    x, z, tostring(fieldId),
+                    tostring(spec.workAreaParameters.seedsFruitType))
                 if not fieldId or fieldId <= 0 then return end
 
                 g_SoilFertilityManager.soilSystem:onSowing(fieldId)
@@ -1567,8 +1661,8 @@ function HookManager:installSowingHook()
             end
         end
     )
-    self:register(SowingMachine, "processSowingMachineArea", original, "SowingMachine.processSowingMachineArea")
-    SoilLogger.info("[OK] Sowing hook installed (SowingMachine.processSowingMachineArea)")
+    self:register(SowingMachine, "onEndWorkAreaProcessing", original, "SowingMachine.onEndWorkAreaProcessing")
+    SoilLogger.info("[OK] Sowing hook installed (via SowingMachine.onEndWorkAreaProcessing)")
     return true
 end
 

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -385,7 +385,8 @@ function SoilMapOverlay:updateSamplePoints(force)
                                 if zoneData then
                                     local cx = math.floor(pt.x / zone.CELL_SIZE)
                                     local cz = math.floor(pt.z / zone.CELL_SIZE)
-                                    local cell = zoneData[cx .. "_" .. cz]
+                                    -- PHASE 2: integer key matches applyFertilizer() change
+                                    local cell = zoneData[cx * 10000 + cz]
                                     if cell then
                                         local val = getCellLayerValue(cell, layerIdx)
                                         if val then r, g, b = self:valueToLayerColor(layerIdx, val) end


### PR DESCRIPTION
Integrates antler22's feature/16x-performance branch with manual conflict
resolution against current main.

### What's included from PR #253
- **Phase 4 batch scheduler** — `updateDailySoil` now queues work and drains
  via `_processOneDailyField`, preventing frame stalls on large maps
- **5-phase MapDataGrid optimization** — up to 16x on large maps with many fields
- **Strip-till support** — RidgeTiller hook with calibrated `STRIP_TILL` soil constants
- **Courseplay fix** — stale VEHICLE action event ID purge prevents duplicate HUD drag registrations
- **HUD drag debounce** — 300ms window prevents Courseplay double-toggle
- **LPS calibration fix** — `customLPS = customRate / 36000` replaces broken proportional formula

### Conflict resolutions
| File | Conflict | Decision |
|------|----------|----------|
| `SoilFertilitySystem.lua` | `updateDailySoil` loop vs batch guard | **PR** — batch guard taken; per-field logic lives in `_processOneDailyField` |
| `SoilFertilitySystem.lua` | `onSubsoilerPass` compaction recalc | **Main** — PR silently dropped `compactionSum` + avg update |
| `HookManager.lua` | Harvest hook strategy | **Main** — `Combine.addCutterArea` kept; owner confirmed already fixed, return value preservation required |
| `HookManager.lua` | Cultivator/plow compaction | **Main** — subsoiler detection and debug logging preserved |
| `HookManager.lua` | `registerCustomSprayTypes` comments | **Main** — `limeType` variable and detailed derivation comments kept |

### Not included
PR #253's `Cutter.onEndWorkAreaProcessing` harvest hook approach was
superseded by main's existing fix (`Combine.addCutterArea` with return
value forwarding). Switching would regress that.

Closes #253