### PR TITLE
feat: mower hook — forage crop (grass/alfalfa) nutrient tracking

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -304,11 +304,15 @@ function SoilFertilitySystem:onMow(fieldId, fruitTypeIndex, areaHa)
         return
     end
 
-    -- Look up forage-specific rates first, then per-crop, then default
-    local name = string.lower(fruitDesc.name or "unknown")
-    local rates = SoilConstants.CROP_EXTRACTION[name]
-        or SoilConstants.CROP_EXTRACTION_FORAGE
-        or SoilConstants.CROP_EXTRACTION_DEFAULT
+    -- Mowing ALWAYS uses CROP_EXTRACTION_FORAGE, never the per-crop grain rates.
+    -- Reason: CROP_EXTRACTION rates are calibrated for harvested grain volume/density
+    -- (threshed yield, e.g. wheat at 0.39 L/sqm). The Mower spec cuts whole-plant
+    -- biomass (e.g. wheat windrow at 3.8 L/sqm) — a completely different density.
+    -- Using grain rates with windrow-equivalent area would over-extract by ~10x.
+    -- CROP_EXTRACTION_FORAGE is calibrated for cut green biomass at MOWER_HA_FACTOR.
+    -- This also prevents "mowing wheat before harvest depletes N faster than combining"
+    -- scenarios that would confuse players (TisonK's review note on PR #265).
+    local rates = SoilConstants.CROP_EXTRACTION_FORAGE or SoilConstants.CROP_EXTRACTION_DEFAULT
 
     local diffMult = SoilConstants.DIFFICULTY.MULTIPLIERS[self.settings.difficulty] or 1.0
     local haFactor = SoilConstants.MOWER_HA_FACTOR or 6.0

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -280,6 +280,61 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
 end
 
 --- Hook delegate: called by HookManager when fertilizer applied
+--- Hook delegate: called by HookManager when a mower/swather cuts forage crops.
+--- Handles nutrient depletion for crops that are CUT but not direct-threshed:
+--- grass, alfalfa, clover, mowed triticale, etc.
+--- Uses area-based depletion (not liter-based) since no yield liters are produced
+--- at mow time — the cut material is left as a windrow for later pickup.
+---@param fieldId    number Field/farmland ID
+---@param fruitTypeIndex number FS25 fruit type index
+---@param areaHa     number Area mowed this tick in hectares
+function SoilFertilitySystem:onMow(fieldId, fruitTypeIndex, areaHa)
+    if not self.settings.enabled or not self.settings.nutrientCycles then return end
+    if not areaHa or areaHa <= 0 then return end
+
+    local field = self:getOrCreateField(fieldId, true)
+    if not field then
+        self:warning("onMow: field %d not found", fieldId)
+        return
+    end
+
+    local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    if not fruitDesc then
+        self:warning("onMow: fruit type %d not found", fruitTypeIndex)
+        return
+    end
+
+    -- Look up forage-specific rates first, then per-crop, then default
+    local name = string.lower(fruitDesc.name or "unknown")
+    local rates = SoilConstants.CROP_EXTRACTION[name]
+        or SoilConstants.CROP_EXTRACTION_FORAGE
+        or SoilConstants.CROP_EXTRACTION_DEFAULT
+
+    local diffMult = SoilConstants.DIFFICULTY.MULTIPLIERS[self.settings.difficulty] or 1.0
+    local haFactor = SoilConstants.MOWER_HA_FACTOR or 6.0
+    local factor   = areaHa * haFactor * diffMult
+
+    local limits = SoilConstants.NUTRIENT_LIMITS
+    field.nitrogen   = math.max(limits.MIN, field.nitrogen   - rates.N * factor)
+    field.phosphorus = math.max(limits.MIN, field.phosphorus - rates.P * factor)
+    field.potassium  = math.max(limits.MIN, field.potassium  - rates.K * factor)
+
+    field.lastCrop    = fruitDesc.name
+    field.lastHarvest = (g_currentMission and g_currentMission.environment
+                         and g_currentMission.environment.currentDay) or 0
+
+    SoilLogger.debug("Mow: Field %d, %s, %.5f ha — N:%.1f P:%.1f K:%.1f",
+        fieldId, fruitDesc.name, areaHa, field.nitrogen, field.phosphorus, field.potassium)
+
+    -- Broadcast field update to clients in multiplayer
+    if g_server and g_currentMission and g_currentMission.missionDynamicInfo
+        and g_currentMission.missionDynamicInfo.isMultiplayer then
+        if SoilFieldUpdateEvent then
+            g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+        end
+    end
+end
+
 --- Restores soil nutrients based on fertilizer type
 ---@param fieldId number The field being fertilized
 ---@param fillTypeIndex number FS25 fill type index for fertilizer

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -205,6 +205,19 @@ SoilConstants.CROP_EXTRACTION = {
 -- Default extraction for unknown crops (average cereal)
 SoilConstants.CROP_EXTRACTION_DEFAULT = { N=2.10, P=0.90, K=1.70 }
 
+-- Forage extraction rates for mowed crops (grass, alfalfa, clover, etc.)
+-- These crops are not in CROP_EXTRACTION because they are not direct-threshed;
+-- their nutrient removal is triggered by the Mower hook (area-based, not liter-based).
+-- Calibrated per MOWER_HA_FACTOR unit: mowing 1 ha of grass removes ~8 N-units
+-- (~57% of a 1-ha wheat harvest), reflecting a single cutting in a multi-cut season.
+SoilConstants.CROP_EXTRACTION_FORAGE = { N=1.40, P=0.55, K=1.80 }
+
+-- Mower area calibration factor.
+-- Formula: depletion = rates[nutrient] * areaHa * MOWER_HA_FACTOR * difficultyMult
+-- At factor=6.0, grass/alfalfa: N=8.4, P=3.3, K=10.8 units depleted per ha per cut.
+-- Compare: wheat harvest 1ha at 7000L → N=14.7, P=6.3, K=11.9. Forage ~57% of grain.
+SoilConstants.MOWER_HA_FACTOR = 6.0
+
 -- ========================================
 -- FERTILIZER PROFILES (per 1,000 liters applied)
 -- ========================================

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -118,9 +118,13 @@ function HookManager:installAll(soilSystem)
 
     SoilLogger.info("Installing event hooks...")
 
-    -- Harvest hook (FruitUtil)
+    -- Harvest hook: direct-cut combines and forage harvesters (Cutter spec)
     local harvestOk = self:installHarvestHook()
     if harvestOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    -- Mower hook: forage crops cut to windrow (grass, alfalfa, clover, mowed triticale…)
+    local mowerOk = self:installMowerHook()
+    if mowerOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
     -- Fertilizer application hook (covers ALL sprayers + spreaders via Sprayer specialization)
     local sprayerAreaOk = self:installSprayerAreaHook()
@@ -906,6 +910,81 @@ function HookManager:installHarvestHook()
     end
 
     SoilLogger.info("[OK] Harvest hook installed (Combine.addCutterArea) — %d existing combines patched", patched)
+    return true
+end
+
+-- =========================================================
+-- HOOK 1b: Mower / Swather (forage crops cut to windrow)
+-- =========================================================
+-- Hooks Mower.onEndWorkAreaProcessing to capture nutrient depletion for crops
+-- that are CUT but not direct-threshed: grass, alfalfa, clover, mowed triticale, etc.
+--
+-- Why not the Cutter hook?
+--   Cutter.processCutterArea only reads the STANDING-CROP density map — it returns
+--   0 area for windrow-pickup passes, so Cutter.onEndWorkAreaProcessing never fires
+--   for mowed-crop scenarios.
+--
+-- Area source:
+--   spec_mower.workAreaParameters.lastStatsArea  — density-map pixels cut this tick
+--   MathUtil.areaToHa(pixels, getFruitPixelsToSqm()) converts to hectares.
+--
+-- Depletion is area-based (not liter-based) via SoilFertilitySystem:onMow().
+-- SoilConstants.MOWER_HA_FACTOR calibrates per-ha depletion relative to grain crops.
+---@return boolean success True if hook installed successfully
+function HookManager:installMowerHook()
+    if not Mower or type(Mower.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("[MowerHook] Mower.onEndWorkAreaProcessing not available — forage crop tracking skipped")
+        return false
+    end
+
+    local hookMgrRef = self
+    local original   = Mower.onEndWorkAreaProcessing
+    Mower.onEndWorkAreaProcessing = Utils.appendedFunction(
+        original,
+        function(mowerSelf, dt, hasProcessed)
+            if not mowerSelf.isServer then return end
+            if not g_SoilFertilityManager
+               or not g_SoilFertilityManager.soilSystem
+               or not g_SoilFertilityManager.settings.enabled
+               or not g_SoilFertilityManager.settings.nutrientCycles then
+                return
+            end
+
+            local spec = mowerSelf.spec_mower
+            if not spec or not spec.workAreaParameters then return end
+
+            -- lastStatsArea: density-map pixels processed this tick (same unit as Cutter's lastArea)
+            local area = spec.workAreaParameters.lastStatsArea or 0
+            if area <= 0 then return end
+
+            local fruitType = spec.workAreaParameters.lastInputFruitType
+            if not fruitType or fruitType <= 0 then return end
+
+            local success, errorMsg = pcall(function()
+                local x, _, z = getWorldTranslation(mowerSelf.rootNode)
+                if not x then return end
+
+                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                if not fieldId or fieldId <= 0 then return end
+
+                -- Convert density-map pixels → hectares using same formula as Mower.lua's
+                -- internal MathUtil.areaToHa(lastStatsArea, getFruitPixelsToSqm()) call
+                local areaHa = MathUtil.areaToHa(area, getFruitPixelsToSqm())
+                if areaHa <= 0 then return end
+
+                SoilLogger.debug("[MowerHook] Field %d, Crop %d, area=%.1f px (%.5f ha)",
+                    fieldId, fruitType, area, areaHa)
+                g_SoilFertilityManager.soilSystem:onMow(fieldId, fruitType, areaHa)
+            end)
+
+            if not success then
+                SoilLogger.error("[MowerHook] failed: %s", tostring(errorMsg))
+            end
+        end
+    )
+
+    self:register(Mower, "onEndWorkAreaProcessing", original, "Mower.onEndWorkAreaProcessing")
+    SoilLogger.info("[OK] Mower hook installed (Mower.onEndWorkAreaProcessing) — forage crop nutrient tracking active")
     return true
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -926,7 +926,7 @@ end
 --
 -- Area source:
 --   spec_mower.workAreaParameters.lastStatsArea  — density-map pixels cut this tick
---   MathUtil.areaToHa(pixels, getFruitPixelsToSqm()) converts to hectares.
+--   MathUtil.areaToHa(pixels, g_currentMission:getFruitPixelsToSqm()) converts to hectares.
 --
 -- Depletion is area-based (not liter-based) via SoilFertilitySystem:onMow().
 -- SoilConstants.MOWER_HA_FACTOR calibrates per-ha depletion relative to grain crops.
@@ -967,9 +967,11 @@ function HookManager:installMowerHook()
                 local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
                 if not fieldId or fieldId <= 0 then return end
 
-                -- Convert density-map pixels → hectares using same formula as Mower.lua's
-                -- internal MathUtil.areaToHa(lastStatsArea, getFruitPixelsToSqm()) call
-                local areaHa = MathUtil.areaToHa(area, getFruitPixelsToSqm())
+                -- Convert density-map pixels → hectares.
+                -- getFruitPixelsToSqm() is a method on g_currentMission, NOT a global.
+                -- Mower.lua itself calls g_currentMission:getFruitPixelsToSqm() internally.
+                if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
+                local areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
                 if areaHa <= 0 then return end
 
                 SoilLogger.debug("[MowerHook] Field %d, Crop %d, area=%.1f px (%.5f ha)",


### PR DESCRIPTION
## Summary

Adds `installMowerHook()` on `Mower.onEndWorkAreaProcessing` so mowing grass, alfalfa, clover, and other forage crops removes N/P/K from the field. Previously, only direct-threshed crops (combine → Cutter path) triggered nutrient depletion — any field used exclusively for hay/silage would never deplete regardless of how many times it was cut.

### Why `Mower` and not `Cutter`
`Cutter.processCutterArea` reads only the standing-crop density map and returns 0 area for windrow-pickup passes. `Mower.onEndWorkAreaProcessing` fires for all disc mowers, drum mowers, and swathers (any implement using the Mower specialization).

### Approach
Uses area-based depletion via a new `SoilFertilitySystem:onMow(fieldId, fruitTypeIndex, areaHa)` method, since no yield liters are produced at mow time. Area comes from `spec_mower.workAreaParameters.lastStatsArea` (density-map pixels), converted to ha via `MathUtil.areaToHa + getFruitPixelsToSqm()` — the same call Mower.lua itself uses internally.

### Calibration
`MOWER_HA_FACTOR = 6.0` → mowing 1 ha of grass depletes ~8.4 N-units (~57% of a 1-ha wheat harvest). Grass is typically cut 3-4 times per season, so cumulative depletion per season is comparable to or exceeds a grain crop. `CROP_EXTRACTION_FORAGE = {N=1.40, P=0.55, K=1.80}` applies to grass, alfalfa, and any forage crop not listed in `CROP_EXTRACTION`.

### Files changed
| File | Change |
|---|---|
| `src/hooks/HookManager.lua` | `installMowerHook()` added; wired into `installAll()` as Hook 1b |
| `src/SoilFertilitySystem.lua` | `onMow(fieldId, fruitTypeIndex, areaHa)` added after `onHarvest` |
| `src/config/Constants.lua` | `CROP_EXTRACTION_FORAGE` and `MOWER_HA_FACTOR` added after `CROP_EXTRACTION_DEFAULT` |

## Test plan
- [ ] Mow a grass field; confirm `[MowerHook]` debug log fires and N/P/K values drop
- [ ] Verify no depletion occurs when no fruit type is detected (non-crop area)
- [ ] Confirm the hook fails gracefully (warning, returns false) if `Mower.onEndWorkAreaProcessing` is unavailable
- [ ] Multiplayer: confirm `SoilFieldUpdateEvent` broadcasts to clients after mow