### PR TITLE
fix: save/load fertilizer loss + per-crop nutrient targets (issues #258 #261)

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2130,12 +2130,22 @@ function SoilFertilitySystem:getFieldInfo(fieldId)
         end
     end
 
+    -- Resolve per-crop nutrient targets (nil when no crop planted)
+    local cropTargets = nil
+    if cropName and cropName ~= "" then
+        local targets = SoilConstants.CROP_NUTRIENT_TARGETS
+        if targets then
+            cropTargets = targets[string.lower(cropName)] or targets.default
+        end
+    end
+
     return {
         fieldId = fieldId,
         fieldArea = field.fieldArea or 1.0,
         nitrogen = { value = math.floor(field.nitrogen), status = nutrientStatus(field.nitrogen, "nitrogen") },
         phosphorus = { value = math.floor(field.phosphorus), status = nutrientStatus(field.phosphorus, "phosphorus") },
         potassium = { value = math.floor(field.potassium), status = nutrientStatus(field.potassium, "potassium") },
+        cropTargets = cropTargets,
         organicMatter = field.organicMatter,
         pH = field.pH,
         lastCrop = cropName,

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -21,6 +21,9 @@ function SoilFertilitySystem.new(settings)
     self.isInitialized = false
     self.lastUpdateDay = 0
     self.hookManager = HookManager.new()
+    -- Install early so custom fill types are in supportedFillTypes before Mission00.load
+    -- restores vehicle fill levels from the savegame (fixes fertilizer disappearing on reload).
+    self.hookManager:installFillUnitHookEarly()
     self.layerSystem = SoilLayerSystem and SoilLayerSystem.new() or nil
 
     -- Per-day flag table for fertilizer application notifications (fieldId → game day last shown)

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -349,6 +349,33 @@ SoilConstants.STATUS_THRESHOLDS = {
 }
 
 -- ========================================
+-- CROP NUTRIENT TARGETS (per-crop min / optimal, internal 0-100 scale)
+-- ========================================
+-- min = minimum for acceptable growth (below = crop-specific deficiency)
+-- opt = optimal level for full yield (at/above = no yield penalty)
+-- Legumes (soybean, peas, beans) have low N targets — they fix atmospheric N.
+-- Root crops (potato, sugarbeet) have very high K targets — they partition K into tubers.
+-- Fallback "default" is used for unrecognised crops.
+SoilConstants.CROP_NUTRIENT_TARGETS = {
+    wheat      = { N = { min = 35, opt = 55 }, P = { min = 25, opt = 40 }, K = { min = 25, opt = 40 } },
+    barley     = { N = { min = 25, opt = 45 }, P = { min = 20, opt = 35 }, K = { min = 20, opt = 35 } },
+    maize      = { N = { min = 40, opt = 60 }, P = { min = 25, opt = 40 }, K = { min = 30, opt = 45 } },
+    canola     = { N = { min = 45, opt = 65 }, P = { min = 30, opt = 45 }, K = { min = 30, opt = 45 } },
+    soybean    = { N = { min = 15, opt = 30 }, P = { min = 30, opt = 50 }, K = { min = 35, opt = 55 } },
+    sunflower  = { N = { min = 35, opt = 55 }, P = { min = 25, opt = 40 }, K = { min = 35, opt = 55 } },
+    potato     = { N = { min = 45, opt = 65 }, P = { min = 35, opt = 55 }, K = { min = 60, opt = 80 } },
+    sugarbeet  = { N = { min = 45, opt = 65 }, P = { min = 35, opt = 55 }, K = { min = 65, opt = 85 } },
+    oat        = { N = { min = 25, opt = 45 }, P = { min = 20, opt = 35 }, K = { min = 20, opt = 35 } },
+    oats       = { N = { min = 25, opt = 45 }, P = { min = 20, opt = 35 }, K = { min = 20, opt = 35 } },
+    rye        = { N = { min = 25, opt = 45 }, P = { min = 20, opt = 35 }, K = { min = 20, opt = 35 } },
+    triticale  = { N = { min = 35, opt = 55 }, P = { min = 25, opt = 40 }, K = { min = 25, opt = 40 } },
+    sorghum    = { N = { min = 30, opt = 50 }, P = { min = 20, opt = 35 }, K = { min = 25, opt = 40 } },
+    peas       = { N = { min = 15, opt = 30 }, P = { min = 25, opt = 45 }, K = { min = 30, opt = 50 } },
+    beans      = { N = { min = 15, opt = 30 }, P = { min = 25, opt = 45 }, K = { min = 30, opt = 50 } },
+    default    = { N = { min = 30, opt = 50 }, P = { min = 25, opt = 40 }, K = { min = 20, opt = 40 } },
+}
+
+-- ========================================
 -- PPM DISPLAY SCALE
 -- ========================================
 -- Converts the internal 0-100 nutrient scale to soil-test PPM values for

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1737,6 +1737,59 @@ function HookManager:installSowingHook()
 end
 
 -- =========================================================
+-- HOOK 7a: Early FillUnit.onPostLoad hook (installed before vehicles load)
+-- =========================================================
+-- Must run as prependedFunction so custom types are in supportedFillTypes BEFORE
+-- vanilla's onPostLoad restores the saved fill level.  Called from
+-- SoilFertilitySystem.new() so it is installed inside Mission00.load (prepend),
+-- guaranteeing it fires for every vehicle the game loads from the savegame.
+function HookManager:installFillUnitHookEarly()
+    if self._fillUnitOnPostLoadHooked then return true end
+    if not FillUnit or type(FillUnit.onPostLoad) ~= "function" then
+        SoilLogger.warning("FillUnit early hook: FillUnit.onPostLoad not available - skipping")
+        return false
+    end
+
+    local solidNames  = {"UREA", "AMS", "MAP", "DAP", "POTASH",
+                          "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM"}
+    local liquidNames = {"UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "INSECTICIDE", "FUNGICIDE",
+                         "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH"}
+
+    local original = FillUnit.onPostLoad
+    FillUnit.onPostLoad = Utils.prependedFunction(original, function(vehicleSelf)
+        local fm = g_fillTypeManager
+        if not fm then return end
+        local fertIdx    = fm:getFillTypeIndexByName("FERTILIZER")
+        local liqFertIdx = fm:getFillTypeIndexByName("LIQUIDFERTILIZER")
+        local spec = vehicleSelf.spec_fillUnit
+        if not spec or not spec.fillUnits then return end
+        for _, fu in pairs(spec.fillUnits) do
+            if fu.supportedFillTypes then
+                local addSolid  = fertIdx    and fu.supportedFillTypes[fertIdx]
+                local addLiquid = liqFertIdx and fu.supportedFillTypes[liqFertIdx]
+                if addSolid then
+                    for _, name in ipairs(solidNames) do
+                        local idx = fm:getFillTypeIndexByName(name)
+                        if idx then fu.supportedFillTypes[idx] = true end
+                    end
+                end
+                if addLiquid then
+                    for _, name in ipairs(liquidNames) do
+                        local idx = fm:getFillTypeIndexByName(name)
+                        if idx then fu.supportedFillTypes[idx] = true end
+                    end
+                end
+            end
+        end
+    end)
+
+    self:register(FillUnit, "onPostLoad", original, "FillUnit.onPostLoad (early)")
+    self._fillUnitOnPostLoadHooked = true
+    SoilLogger.info("[OK] FillUnit early hook installed - custom fill types injected before vanilla save restore")
+    return true
+end
+
+-- =========================================================
 -- HOOK 7: Patch vehicle fill units to accept custom types
 -- =========================================================
 -- Vanilla spreaders/sprayers have fillUnit#fillTypes="FERTILIZER" or "LIQUIDFERTILIZER".
@@ -1813,15 +1866,24 @@ function HookManager:installFillUnitHook()
         end
     end
 
-    local original = FillUnit.onPostLoad
-    FillUnit.onPostLoad = Utils.appendedFunction(
-        original,
-        function(vehicleSelf, savegame)
-            patchVehicleFillUnits(vehicleSelf)
-        end
-    )
-    self:register(FillUnit, "onPostLoad", original, "FillUnit.onPostLoad")
-    SoilLogger.info("[OK] FillUnit hook installed - custom types injected into compatible vehicles")
+    -- Only hook FillUnit.onPostLoad if the early hook wasn't already installed.
+    -- installFillUnitHookEarly() runs before vehicles load (from SoilFertilitySystem.new),
+    -- which is the only way to ensure custom types are in supportedFillTypes BEFORE
+    -- vanilla's onPostLoad tries to restore the saved fill level.
+    if not self._fillUnitOnPostLoadHooked then
+        local original = FillUnit.onPostLoad
+        FillUnit.onPostLoad = Utils.prependedFunction(
+            original,
+            function(vehicleSelf, savegame)
+                patchVehicleFillUnits(vehicleSelf)
+            end
+        )
+        self:register(FillUnit, "onPostLoad", original, "FillUnit.onPostLoad")
+        self._fillUnitOnPostLoadHooked = true
+        SoilLogger.info("[OK] FillUnit hook installed - custom types injected into compatible vehicles")
+    else
+        SoilLogger.info("[OK] FillUnit.onPostLoad already hooked by early install - skipping duplicate")
+    end
 
     -- Build customToBase: custom fill type index → vanilla base type index.
     -- Used by getFillUnitSupportsFillType hook below.

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -215,13 +215,14 @@ function SoilFieldDetailDialog:_populateData()
         end
     end
 
-    -- Nutrients
+    -- Nutrients (pass per-crop targets when a crop is planted)
+    local ct = info.cropTargets
     self:_setNutrient(self.detailN, self.detailNStatus,
-        info.nitrogen.value, info.nitrogen.status, "%")
+        info.nitrogen.value, info.nitrogen.status, "%", ct and ct.N)
     self:_setNutrient(self.detailP, self.detailPStatus,
-        info.phosphorus.value, info.phosphorus.status, "%")
+        info.phosphorus.value, info.phosphorus.status, "%", ct and ct.P)
     self:_setNutrient(self.detailK, self.detailKStatus,
-        info.potassium.value, info.potassium.status, "%")
+        info.potassium.value, info.potassium.status, "%", ct and ct.K)
 
     -- pH (0-14 scale, not %)
     if self.detailPH then
@@ -300,26 +301,43 @@ end
 ---@param valueEl    table|nil
 ---@param statusEl   table|nil
 ---@param value      number    0-100
----@param statusStr  string    "good"|"fair"|"poor"
+---@param statusStr  string    "Good"|"Fair"|"Poor"
 ---@param suffix     string    "%" or ""
-function SoilFieldDetailDialog:_setNutrient(valueEl, statusEl, value, statusStr, suffix)
+---@param cropTarget table|nil {min=number, opt=number} per-crop target (internal scale)
+function SoilFieldDetailDialog:_setNutrient(valueEl, statusEl, value, statusStr, suffix, cropTarget)
     suffix = suffix or ""
     if valueEl then
         valueEl:setText(math.floor(value + 0.5) .. suffix)
     end
     if statusEl then
         local label, color
-        -- Status strings from getFieldInfo are capitalized: "Good"/"Fair"/"Poor"
-        local s = statusStr and statusStr:lower() or "poor"
-        if s == "good" then
-            label = tr("sf_pda_status_good", "Good")
-            color = COLOR_GOOD
-        elseif s == "fair" then
-            label = tr("sf_pda_status_fair", "Fair")
-            color = COLOR_FAIR
+        if cropTarget then
+            -- Colour by crop-specific target rather than global thresholds
+            if value >= cropTarget.opt then
+                label = tr("sf_pda_status_good", "Good")
+                color = COLOR_GOOD
+            elseif value >= cropTarget.min then
+                label = tr("sf_pda_status_fair", "Fair")
+                color = COLOR_FAIR
+            else
+                label = tr("sf_pda_status_poor", "Poor")
+                color = COLOR_POOR
+            end
+            -- Append crop-optimal hint so the player knows the target
+            label = label .. " (" .. tostring(cropTarget.opt) .. ")"
         else
-            label = tr("sf_pda_status_poor", "Poor")
-            color = COLOR_POOR
+            -- No crop planted: use global status from getFieldInfo
+            local s = statusStr and statusStr:lower() or "poor"
+            if s == "good" then
+                label = tr("sf_pda_status_good", "Good")
+                color = COLOR_GOOD
+            elseif s == "fair" then
+                label = tr("sf_pda_status_fair", "Fair")
+                color = COLOR_FAIR
+            else
+                label = tr("sf_pda_status_poor", "Poor")
+                color = COLOR_POOR
+            end
         end
         statusEl:setText(label)
         statusEl:setTextColor(unpack(color))

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1110,6 +1110,63 @@ function SoilHUD:formatRateNumber(multiplier, rateConfig)
     end
 end
 
+-- Computes the STEPS index corresponding to the optimal application rate for the
+-- currently planted crop, using the same weighted-deficit formula as calculateAutoRateIndex
+-- but substituting per-crop opt targets from cropTargets instead of AUTO_RATE_TARGETS.
+-- Returns nil when: no crop planted, fill type has no N/P/K, or field already at/above
+-- all relevant crop targets (no tick needed when the field is already fine).
+function SoilHUD:_calcCropTargetRateIdx(fillType)
+    if not fillType then return nil end
+    local info = self.cachedFieldInfo
+    if not info or not info.cropTargets then return nil end
+
+    local profile = SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[fillType.name]
+    if not profile then return nil end
+
+    local ct           = info.cropTargets
+    local totalWeight  = 0
+    local weightedDef  = 0
+    local anyDeficit   = false
+
+    if profile.N and profile.N > 0 and ct.N and ct.N.opt > 0 then
+        local deficit = math.max(0, ct.N.opt - info.nitrogen.value) / ct.N.opt
+        if deficit > 0 then anyDeficit = true end
+        weightedDef  = weightedDef  + deficit * profile.N
+        totalWeight  = totalWeight  + profile.N
+    end
+    if profile.P and profile.P > 0 and ct.P and ct.P.opt > 0 then
+        local deficit = math.max(0, ct.P.opt - info.phosphorus.value) / ct.P.opt
+        if deficit > 0 then anyDeficit = true end
+        weightedDef  = weightedDef  + deficit * profile.P
+        totalWeight  = totalWeight  + profile.P
+    end
+    if profile.K and profile.K > 0 and ct.K and ct.K.opt > 0 then
+        local deficit = math.max(0, ct.K.opt - info.potassium.value) / ct.K.opt
+        if deficit > 0 then anyDeficit = true end
+        weightedDef  = weightedDef  + deficit * profile.K
+        totalWeight  = totalWeight  + profile.K
+    end
+
+    -- No relevant nutrients in this fertilizer, or field already at/above all targets
+    if totalWeight <= 0 or not anyDeficit then return nil end
+
+    local defFraction = weightedDef / totalWeight
+    local targetMult  = 0.20 + defFraction * (1.20 - 0.20)
+    targetMult = math.max(0.20, math.min(1.20, targetMult))
+
+    local steps   = SoilConstants.SPRAYER_RATE.STEPS
+    local bestIdx = SoilConstants.SPRAYER_RATE.DEFAULT_INDEX
+    local bestDiff = math.huge
+    for i, step in ipairs(steps) do
+        local diff = math.abs(step - targetMult)
+        if diff < bestDiff then
+            bestDiff = diff
+            bestIdx  = i
+        end
+    end
+    return bestIdx
+end
+
 -- ── Sprayer rate panel ───────────────────────────────────
 -- Center-scroll design: ← prev prev  CURRENT RATE  next next →
 -- Thin progress bar beneath; burn warning below panel.
@@ -1255,6 +1312,19 @@ function SoilHUD:drawSprayerRatePanel()
     self:drawRect(panelX + barPad, barY, barW, barH, SoilHUD.C_BAR_BG)
     if progress > 0 then
         self:drawRect(panelX + barPad, barY, barW * progress, barH, curCol)
+    end
+
+    -- Crop-optimal rate marker (cyan tick on the progress bar)
+    -- Only shown when a crop is planted AND the field is below that crop's optimal level
+    -- for at least one nutrient covered by the current fill type.
+    local cropOptIdx = self:_calcCropTargetRateIdx(fillType)
+    if cropOptIdx then
+        local optProgress = (cropOptIdx - 1) / (#steps - 1)
+        local tickW = 0.0012 * s
+        local tickH = barH + 0.006 * s
+        local tickX = panelX + barPad + barW * optProgress - tickW * 0.5
+        local tickY = barY - 0.003 * s
+        self:drawRect(tickX, tickY, tickW, tickH, {0.20, 0.85, 0.85, 1.0})
     end
 
     -- Burn warning below panel

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -917,7 +917,7 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info,
         end
     end
 
-    -- Threshold tick marks
+    -- Threshold tick marks (global poor/fair)
     local thresholdKey = label == "N" and "nitrogen"
                       or label == "P" and "phosphorus"
                       or label == "K" and "potassium"
@@ -935,13 +935,39 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info,
         end
     end
 
-    -- Value displayed in ppm
+    -- Per-crop target tick at optimal level (bright cyan, taller than status ticks)
+    local cropTarget = info and info.cropTargets and info.cropTargets[label]
+    if cropTarget then
+        local tickW = 0.0008 * s
+        local tickH = barH + 0.005 * s
+        local tickY = barY - 0.0025 * s
+        local optX  = barX + barW * (cropTarget.opt / 100) - tickW * 0.5
+        self:drawRect(optX, tickY, tickW, tickH, {0.20, 0.85, 0.85, 0.90})
+    end
+
+    -- Value displayed in ppm (with crop-optimal target when a crop is planted)
     local ppmMult = SoilConstants.PPM_DISPLAY and SoilConstants.PPM_DISPLAY[label] or 1.0
     local ppmVal  = math.floor(nutrient.value * ppmMult + 0.5)
     local valX    = barX + barW + 0.006*s
-    setTextColor(col[1], col[2], col[3], 1.0)
-    
+
+    -- Derive color from crop target if available, otherwise keep status color
+    local displayCol = col
+    if cropTarget then
+        if nutrient.value >= cropTarget.opt then
+            displayCol = self:statusColor("Good")
+        elseif nutrient.value >= cropTarget.min then
+            displayCol = self:statusColor("Fair")
+        else
+            displayCol = self:statusColor("Poor")
+        end
+    end
+    setTextColor(displayCol[1], displayCol[2], displayCol[3], 1.0)
+
     local valStr = string.format("%d", ppmVal)
+    if cropTarget then
+        local optPpm = math.floor(cropTarget.opt * ppmMult + 0.5)
+        valStr = valStr .. "/" .. tostring(optPpm)
+    end
     if projectedDelta > 0 then
         local projPpm = math.floor(projectedDelta * ppmMult + 0.5)
         if projPpm > 0 then
@@ -952,7 +978,7 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info,
 
     -- Status label
     setTextAlignment(RenderText.ALIGN_RIGHT)
-    setTextColor(col[1], col[2], col[3], 0.80)
+    setTextColor(displayCol[1], displayCol[2], displayCol[3], 0.80)
     renderText(px + pw - pad, cy + (rowH - 0.009*s) * 0.5, 0.009 * fontMult * s, nutrient.status)
     setTextAlignment(RenderText.ALIGN_LEFT)
 


### PR DESCRIPTION
## Summary

- **fix**: Custom fertilizer fill level (UREA, DAP, UAN32, etc.) no longer disappears after save/quit/reload — fixes issue #258
- **feat**: Per-crop nutrient targets visible in HUD, PDA Field Detail, and sprayer rate panel — closes issue #261

## Changes

### Bug fix — fertilizer save/load (#258)
The `FillUnit.onPostLoad` hook was being installed too late (after the deferred init), so vanilla FS25 had already tried (and failed) to restore custom fill type levels from the savegame. Added `HookManager:installFillUnitHookEarly()` called from `SoilFertilitySystem.new()`, which runs inside the `Mission00.load` prepend — before the original mission loader processes vehicles. Hook changed to `prependedFunction` so custom types are in `supportedFillTypes` before vanilla attempts the restore.

### Feature — per-crop nutrient targets (#261)
- **`Constants.lua`**: New `CROP_NUTRIENT_TARGETS` table — 14 crops + default, each with N/P/K `{min, opt}` on the internal 0-100 scale. Legumes have low N targets; root crops have very high K targets.
- **`SoilFertilitySystem.getFieldInfo()`**: Returns `cropTargets` for the currently planted crop, or `nil` for fallow fields.
- **HUD**: Cyan tick on each nutrient bar at the crop-optimal level; value text shows `126/165` (current ppm / optimal ppm); status color derives from crop-specific targets.
- **PDA Field Detail**: `_setNutrient` color-codes by crop-specific min/opt and appends the target to the label e.g. `"Fair (55)"`.
- **Rate panel** (stretch goal): Cyan tick on the progress bar at the crop-optimal application rate, computed with the same weighted-deficit formula as auto-rate but using per-crop opt values. Suppressed when the field is already at/above all relevant targets.

## Test plan
- [x] Load a save with a spreader full of UREA/DAP — quit — reload — verify fill level survives
- [x] Vanilla FERTILIZER/LIQUIDFERTILIZER save/load unaffected
- [x] Empty spreader saves/loads as empty (no regression)
- [x] Plant wheat on a low-N field — HUD shows cyan tick + `value/opt` format
- [x] PDA Field Detail shows crop-target color coding and `"Fair (55)"` style labels
- [x] Rate panel shows cyan tick when field is below crop targets; tick absent when field is fine
- [x] Fallow fields: no targets shown anywhere — existing display unchanged