### PR TITLE
v2.0.7.0 — Full i18n pass + bug fixes (#273 #277 #278 #279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.7.0] - 2026-04-30
+
+### Added
+- Full i18n pass: every previously hardcoded English string is now an i18n key — HUD labels (pH, OM, ppm, Coverage, Compaction), sprayer rate panel (APP. RATE, BURN RISK warnings, Target), all in-game notifications (welcome banner, field init, Critical Care Alert, Soil Update, Fertilizer Burn, sync error), settings panel categories/section headers/chrome (Admin: YES/NO, Multiplayer, Single Player, back/reset/close buttons), all setting descriptions, all multi-option dropdown values, and all admin action item labels
+- Added 100+ new translation keys to all 26 language files (translation_en.xml with native values; all other 25 files with `[EN]` placeholders ready for community translation)
+
+### Fixed
+- Coverage calculation (#277): field area now correctly reads `field.areaHa` / `field.farmland.areaInHa` per FS25 LUADOC, fixing coverage completing in ~1.5 minutes instead of full-season pace
+- Sprayer rate ghost bar (#278): rate multiplier now passed through to `drawNutrientRow` so the projected ghost bar reflects the current application rate setting
+- Post-harvest HUD alarm (#279): HUD now shows a neutral "Post-harvest · Fertilize" message on the day of harvest instead of an alarming penalty % from freshly depleted soil
+- Weed pressure on grassland (#273): weed growth accumulation and yield penalty are now skipped for grass/poplar/non-row-crop fields
+
+---
+
 ## [2.0.6.4] - 2026-04-29
 
 ### Changed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 2.0.0.0
-**Last Updated**: 2026-04-25
+**Version**: 2.0.7.0
+**Last Updated**: 2026-04-30
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.0.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.0.7.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.0.6.5</version>
+    <version>2.0.6.6</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.0.6.6</version>
+    <version>2.0.7.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -264,7 +264,7 @@ function SoilFertilityManager:deferredSoilSystemInit()
                 -- Show activation notification
                 if self.sfm.settings.showNotifications and g_currentMission and g_currentMission.hud then
                     g_currentMission.hud:showBlinkingWarning(
-                        "Soil & Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands",
+                        g_i18n:getText("sf_notify_welcome"),
                         8000
                     )
                 end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -136,7 +136,7 @@ function SoilFertilitySystem:initialize()
 
     -- Show notification
     if self.settings.enabled and self.settings.showNotifications then
-        self:showNotification("Soil & Fertilizer Mod Active", "Real soil system with full event hooks")
+        self:showNotification(g_i18n:getText("sf_notify_mod_active_title"), g_i18n:getText("sf_notify_mod_active_body"))
     end
 end
 
@@ -757,7 +757,7 @@ function SoilFertilitySystem:update(dt)
                             self.fieldsScanStage = 2
                             self.fieldsScanFrameCounter = 0
                             if g_currentMission and g_currentMission.hud then
-                                g_currentMission.hud:showBlinkingWarning("Soil Mod: Field initialization delayed. Trying alternative method...", 5000)
+                                g_currentMission.hud:showBlinkingWarning(g_i18n:getText("sf_notify_init_delayed"), 5000)
                             end
                         end
                     end
@@ -775,7 +775,7 @@ function SoilFertilitySystem:update(dt)
                     self.fieldsScanPending = false
                     -- Show success notification so player knows recovery worked
                     if g_currentMission and g_currentMission.hud then
-                        g_currentMission.hud:showBlinkingWarning("Soil Mod: Field initialization successful!", 4000)
+                        g_currentMission.hud:showBlinkingWarning(g_i18n:getText("sf_notify_init_success"), 4000)
                     end
                 end
             end
@@ -1482,8 +1482,8 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                     if owner == farmId then isOwned = true end
                 end
                 if isOwned then
-                    self:showNotification("Critical Care Alert",
-                        string.format("Field %d requires immediate attention! Urgency: %d%%",
+                    self:showNotification(g_i18n:getText("sf_notify_critical_title"),
+                        string.format(g_i18n:getText("sf_notify_critical_body"),
                             fieldId, math.floor(urgency)))
                 end
                 field.lastAlertSeason = season
@@ -1847,7 +1847,7 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                            g_currentMission.environment.currentDay) or 0
             if not self.fertNotifyShown then self.fertNotifyShown = {} end
             if self.fertNotifyShown[fieldId] ~= today then
-                self:showNotification("Soil Update", string.format("Field %d fully treated with %s", fieldId, fillType.name))
+                self:showNotification(g_i18n:getText("sf_notify_treated_title"), string.format(g_i18n:getText("sf_notify_treated_body"), fieldId, fillType.name))
                 self.fertNotifyShown[fieldId] = today
             end
         end
@@ -2054,8 +2054,8 @@ function SoilFertilitySystem:applyBurnEffect(fieldId, rateMultiplier)
 
         if self.settings.showNotifications then
             self:showNotification(
-                "Fertilizer Burn",
-                string.format("Field %d: over-application damage (pH %.1f)", fieldId, field.pH)
+                g_i18n:getText("sf_notify_burn_title"),
+                string.format(g_i18n:getText("sf_notify_burn_body"), fieldId, field.pH)
             )
         end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1743,10 +1743,11 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
             local zone = SoilConstants.ZONE
             local cx = math.floor(sprayX / zone.CELL_SIZE)
             local cz = math.floor(sprayZ / zone.CELL_SIZE)
-            -- PHASE 2: integer key — ~3-5× faster than string concat "cx_cz".
-            -- Safe for any realistic FS25 map: cx/cz range ±820 on 16384m map,
-            -- so max key = 820*10000+820 = 8,200,820 — well within Lua integer range.
-            local cellKey = cx * 10000 + cz
+            -- String key keeps save/load/runtime consistent: setXMLString requires a string,
+            -- and the load path (getXMLString) restores keys as strings. Using a number key
+            -- here caused "setXMLString: Expected String, Actual Number" errors on autosave
+            -- and also caused post-load lookups to miss (number key vs stored string key).
+            local cellKey = tostring(cx * 10000 + cz)
 
             -- Coverage tracking: count unique cells visited today
             if not field.coveredCells then field.coveredCells = {} end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -194,8 +194,17 @@ end
 ---@param liters number Amount harvested in liters
 ---@param strawRatio number 0.0-1.0 fraction of straw that was chopped (0 = dropped/collected, 1 = fully chopped)
 function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRatio, area)
+    -- Resolve fruit type for grassland check (used by multiple penalty blocks below)
+    local harvestFruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    local harvestCropName  = harvestFruitDesc and string.lower(harvestFruitDesc.name or "") or ""
+    local harvestIsGrass   = SoilConstants.YIELD_SENSITIVITY and
+                             SoilConstants.YIELD_SENSITIVITY.NON_CROP_NAMES and
+                             SoilConstants.YIELD_SENSITIVITY.NON_CROP_NAMES[harvestCropName]
+
     -- Apply weed pressure yield penalty before nutrient update
-    if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
+    -- Grassland crops (grass, drygrass, poplar) are exempt — they are grazed/mowed,
+    -- not affected by arable weed pressure mechanics.
+    if self.settings.weedPressure and SoilConstants.WEED_PRESSURE and not harvestIsGrass then
         local field = self.fieldData[fieldId]
         if field then
             local wp = SoilConstants.WEED_PRESSURE
@@ -916,9 +925,11 @@ function SoilFertilitySystem:scanFields()
             local actualFieldId = field.farmland and field.farmland.id
 
             if actualFieldId and actualFieldId > 0 then
-                -- FS25: field.fieldArea is the cultivated area in hectares.
-                -- Fallback to farmland area if fieldArea is missing (though it shouldn't be).
-                local area = field.fieldArea or (field.farmland and field.farmland.area) or 1.0
+                -- FS25 API: Field.areaHa = cultivated area in ha (from LUADOC: self.areaHa = sqm/10000).
+                -- Farmland.areaInHa = parcel area in ha. Both checked before defaulting to 1.0
+                -- because the old incorrect names (fieldArea / farmland.area) were always nil,
+                -- causing totalFieldCells to be computed from 1 ha instead of real field size.
+                local area = field.areaHa or (field.farmland and field.farmland.areaInHa) or 1.0
 
                 SoilLogger.debug("Found field %d (%.2f ha)", actualFieldId, area)
 
@@ -948,11 +959,12 @@ function SoilFertilitySystem:scanFields()
     -- SECONDARY SCAN: catch farmlands whose field entry was unreachable via ipairs on
     -- large/custom maps where g_fieldManager.fields has non-sequential indices (64x maps).
     if g_farmlandManager and g_farmlandManager.farmlands then
-        for farmlandId, _ in pairs(g_farmlandManager.farmlands) do
+        for farmlandId, farmlandObj in pairs(g_farmlandManager.farmlands) do
             if type(farmlandId) == "number" and farmlandId > 0 and not self.fieldData[farmlandId] then
-                self:getOrCreateField(farmlandId, true, 1.0)
+                local flArea = (farmlandObj and farmlandObj.areaInHa) or 1.0
+                self:getOrCreateField(farmlandId, true, flArea)
                 fieldCount = fieldCount + 1
-                SoilLogger.debug("Secondary scan caught missed farmland %d", farmlandId)
+                SoilLogger.debug("Secondary scan caught missed farmland %d (%.2f ha)", farmlandId, flArea)
             end
         end
     end
@@ -1317,38 +1329,48 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     end
 
     -- ── Weed pressure daily growth ───────────────────────────────────────────
+    -- Grassland (grass, drygrass, poplar, etc.) is managed by mowing/grazing,
+    -- not herbicides — skip weed pressure growth for those field types.
     if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
-        local wp = SoilConstants.WEED_PRESSURE
-        local pressure = field.weedPressure or 0
-        local herbDays = field.herbicideDaysLeft or 0
+        local cropLower = field.lastCrop and string.lower(field.lastCrop) or nil
+        local isGrassland = cropLower and
+            SoilConstants.YIELD_SENSITIVITY and
+            SoilConstants.YIELD_SENSITIVITY.NON_CROP_NAMES and
+            SoilConstants.YIELD_SENSITIVITY.NON_CROP_NAMES[cropLower]
 
-        if herbDays > 0 then field.herbicideDaysLeft = herbDays - 1 end
+        if not isGrassland then
+            local wp = SoilConstants.WEED_PRESSURE
+            local pressure = field.weedPressure or 0
+            local herbDays = field.herbicideDaysLeft or 0
 
-        if (field.herbicideDaysLeft or 0) <= 0 then
-            local baseRate
-            if     pressure < wp.LOW    then baseRate = wp.GROWTH_RATE_LOW
-            elseif pressure < wp.MEDIUM then baseRate = wp.GROWTH_RATE_MID
-            elseif pressure < wp.HIGH   then baseRate = wp.GROWTH_RATE_HIGH
-            else                             baseRate = wp.GROWTH_RATE_PEAK
-            end
+            if herbDays > 0 then field.herbicideDaysLeft = herbDays - 1 end
 
-            local seasonMult = 1.0
-            if season then
-                if     season == 1 then seasonMult = wp.SEASONAL_SPRING
-                elseif season == 2 then seasonMult = wp.SEASONAL_SUMMER
-                elseif season == 3 then seasonMult = wp.SEASONAL_FALL
-                elseif season == 4 then seasonMult = wp.SEASONAL_WINTER
+            if (field.herbicideDaysLeft or 0) <= 0 then
+                local baseRate
+                if     pressure < wp.LOW    then baseRate = wp.GROWTH_RATE_LOW
+                elseif pressure < wp.MEDIUM then baseRate = wp.GROWTH_RATE_MID
+                elseif pressure < wp.HIGH   then baseRate = wp.GROWTH_RATE_HIGH
+                else                             baseRate = wp.GROWTH_RATE_PEAK
                 end
-            end
 
-            local rainBonus = 0
-            if g_currentMission and g_currentMission.environment and
-               g_currentMission.environment.weather and
-               (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
-                rainBonus = wp.RAIN_BONUS
-            end
+                local seasonMult = 1.0
+                if season then
+                    if     season == 1 then seasonMult = wp.SEASONAL_SPRING
+                    elseif season == 2 then seasonMult = wp.SEASONAL_SUMMER
+                    elseif season == 3 then seasonMult = wp.SEASONAL_FALL
+                    elseif season == 4 then seasonMult = wp.SEASONAL_WINTER
+                    end
+                end
 
-            field.weedPressure = math.min(100, pressure + baseRate * seasonMult + rainBonus)
+                local rainBonus = 0
+                if g_currentMission and g_currentMission.environment and
+                   g_currentMission.environment.weather and
+                   (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
+                    rainBonus = wp.RAIN_BONUS
+                end
+
+                field.weedPressure = math.min(100, pressure + baseRate * seasonMult + rainBonus)
+            end
         end
     end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -333,7 +333,13 @@ function HookManager:registerCustomSprayTypes()
     local liqBase   = baseRates.LIQUIDFERTILIZER.value  -- used as fallback default only
 
     -- Liquid nitrogen / starter types → inherit visual from LIQUIDFERTILIZER
-    local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "INSECTICIDE", "FUNGICIDE",
+    -- NOTE: HERBICIDE must be here so it gets a custom LPS of 1.5/36000 L/s, matching
+    -- INSECTICIDE and FUNGICIDE. Without it, vanilla's native HERBICIDE spray type is
+    -- used (~291 L/ha effective rate vs the intended 1.5 L/ha), causing weed pressure
+    -- to drain far too fast even with the daily cap in onHerbicideAppliedDirect (the
+    -- cap drains its full 30-point budget in the very first metre of a pass, then
+    -- repeats on subsequent game-day passes — issue #276 follow-up bug).
+    local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "HERBICIDE", "INSECTICIDE", "FUNGICIDE",
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
     -- Granular/solid types → inherit visual from FERTILIZER
     local solidNames  = { "UREA", "AMS", "MAP", "DAP", "POTASH",

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -468,7 +468,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
 
     -- Notify user if corruption was detected
     if corruptionDetected and g_currentMission and g_currentMission.hud then
-        g_currentMission.hud:showBlinkingWarning("Soil Mod: Data sync issue detected. Please report if this persists.", 6000)
+        g_currentMission.hud:showBlinkingWarning(g_i18n:getText("sf_notify_sync_error"), 6000)
     end
 
     self:run(connection)

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -700,7 +700,7 @@ function SoilHUD:drawPanel()
     self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
     setTextAlignment(RenderText.ALIGN_RIGHT)
     setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], 0.60)
-    renderText(px + pw - pad, cy + 0.001*s, 0.007 * fontMult * s, "(ppm)")
+    renderText(px + pw - pad, cy + 0.001*s, 0.007 * fontMult * s, g_i18n:getText("sf_hud_unit_ppm"))
     setTextAlignment(RenderText.ALIGN_LEFT)
     cy = cy - pad * 0.8
 
@@ -728,13 +728,13 @@ function SoilHUD:drawPanel()
         local omCol = self:omColor(info.organicMatter)
 
         setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-        renderText(tx, cy, 0.010 * fontMult * s, "pH")
+        renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_label_ph"))
         setTextColor(pHCol[1], pHCol[2], pHCol[3], 1.0)
         renderText(tx + 0.020*s, cy, 0.010 * fontMult * s, string.format("%.1f", info.pH))
 
         local omX = tx + pw * 0.50
         setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-        renderText(omX, cy, 0.010 * fontMult * s, "OM")
+        renderText(omX, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_label_om"))
         setTextColor(omCol[1], omCol[2], omCol[3], 1.0)
         renderText(omX + 0.020*s, cy, 0.010 * fontMult * s, string.format("%.1f%%", info.organicMatter))
 
@@ -827,7 +827,7 @@ function SoilHUD:drawPanel()
                 local minCov = SoilConstants.COVERAGE and SoilConstants.COVERAGE.MIN_FULL_CREDIT or 0.70
                 local covPct = math.floor(cov * 100 + 0.5)
                 local minPct = math.floor(minCov * 100 + 0.5)
-                local covText = string.format("Coverage: %d%% / %d%%", covPct, minPct)
+                local covText = string.format(g_i18n:getText("sf_hud_coverage"), covPct, minPct)
                 local cr, cg, cb = 0.90, 0.35, 0.15  -- amber-red: below threshold
                 if cov >= minCov then cr, cg, cb = 0.32, 0.88, 0.44 end  -- green: at/above
                 local pad = SoilHUD.PAD * s
@@ -852,7 +852,7 @@ function SoilHUD:drawPanel()
                 local pad = SoilHUD.PAD * s
                 setTextAlignment(RenderText.ALIGN_LEFT)
                 setTextColor(cr, cg, cb, 1.0)
-                renderText(px + pad, cy, 0.010 * fontMult * s, string.format("Compaction: %d%%", compPct))
+                renderText(px + pad, cy, 0.010 * fontMult * s, string.format(g_i18n:getText("sf_hud_compaction"), compPct))
                 cy = cy - SoilHUD.LINE_H * s
             end
         end
@@ -1254,9 +1254,9 @@ function SoilHUD:drawSprayerRatePanel()
     -- Separate the mode status from the toggle hint so AUTO is never ambiguous
     local headerText
     if isAuto then
-        headerText = "APP. RATE  ( AUTO: ON )"
+        headerText = g_i18n:getText("sf_sprayer_auto_on")
     else
-        headerText = string.format("APP. RATE  AUTO: OFF [%s]", autoKey)
+        headerText = string.format(g_i18n:getText("sf_sprayer_auto_off"), autoKey)
     end
 
     setTextBold(true)
@@ -1296,7 +1296,7 @@ function SoilHUD:drawSprayerRatePanel()
     if isAuto and fillType then
         local profile = SoilConstants.FERTILIZER_PROFILES[fillType.name]
         if profile then
-            local targetText = "Target: "
+            local targetText = g_i18n:getText("sf_sprayer_target")
             local targets = SoilConstants.SPRAYER_RATE.AUTO_RATE_TARGETS
             if not targets then return end
             if profile.N and profile.N > 0 then targetText = targetText .. targets.N .. "N " end
@@ -1353,10 +1353,10 @@ function SoilHUD:drawSprayerRatePanel()
     setTextAlignment(RenderText.ALIGN_CENTER)
     if curMult >= SoilConstants.SPRAYER_RATE.BURN_GUARANTEED_THRESHOLD then
         setTextColor(1.0, 0.15, 0.15, 1.0)
-        renderText(cx, warnY, 0.010 * fontMult * s, "BURN RISK: GUARANTEED")
+        renderText(cx, warnY, 0.010 * fontMult * s, g_i18n:getText("sf_sprayer_burn_guaranteed"))
     elseif curMult > SoilConstants.SPRAYER_RATE.BURN_RISK_THRESHOLD then
         setTextColor(0.95, 0.65, 0.10, 1.0)
-        renderText(cx, warnY, 0.010 * fontMult * s, "BURN RISK: POSSIBLE")
+        renderText(cx, warnY, 0.010 * fontMult * s, g_i18n:getText("sf_sprayer_burn_possible"))
     end
 
     setTextAlignment(RenderText.ALIGN_LEFT)

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -709,11 +709,14 @@ function SoilHUD:drawPanel()
         local sprayer = self:getCurrentSprayer()
         local fillType = self:getSprayerFillType(sprayer)
         local profile = fillType and SoilConstants.FERTILIZER_PROFILES[fillType.name]
+        -- Rate multiplier — needed so ghost bar reflects current rate setting (issue #278)
+        local rm = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
+        local rateMultiplier = (rm and sprayer) and rm:getMultiplier(sprayer.id) or 1.0
 
         -- N / P / K rows
-        cy = self:drawNutrientRow("N", info.nitrogen,   px, cy, pw, s, fontMult, info, profile, fillType)
-        cy = self:drawNutrientRow("P", info.phosphorus,  px, cy, pw, s, fontMult, info, profile, fillType)
-        cy = self:drawNutrientRow("K", info.potassium,   px, cy, pw, s, fontMult, info, profile, fillType)
+        cy = self:drawNutrientRow("N", info.nitrogen,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
+        cy = self:drawNutrientRow("P", info.phosphorus,  px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
+        cy = self:drawNutrientRow("K", info.potassium,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
 
         -- Divider
         cy = cy - pad * 0.5
@@ -751,33 +754,49 @@ function SoilHUD:drawPanel()
             local tierData = ys.TIERS[tier]
             local thresh   = ys.OPTIMAL_THRESHOLD
 
-            local nDef = math.max(0, thresh - info.nitrogen.value)   / thresh
-            local pDef = math.max(0, thresh - info.phosphorus.value) / thresh
-            local kDef = math.max(0, thresh - info.potassium.value)  / thresh
-            local avgDef = (nDef + pDef + kDef) / 3
-
-            local penalty    = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
-            local penaltyPct = math.floor(penalty * 100 + 0.5)
+            -- If the field was just harvested today, show a softer post-harvest message
+            -- instead of the alarming penalty % caused by freshly depleted soil.
+            -- The forecast reflects next-season potential; nutrients drop on harvest and
+            -- the big red number before fertilizing is misleading (issue #279).
+            local currentDay = g_currentMission and g_currentMission.environment and
+                               g_currentMission.environment.currentDay
+            local justHarvested = currentDay and info.lastHarvest and
+                                  (info.lastHarvest >= currentDay)
 
             local yieldColor, yieldText
-            local yieldPrefix = (not cropLower or cropLower == "") and g_i18n:getText("sf_hud_estYield") or g_i18n:getText("sf_hud_yield")
-            if penaltyPct <= 0 then
-                yieldColor = SoilHUD.C_GOOD
-                yieldText  = string.format("%s: %s", yieldPrefix, g_i18n:getText("sf_hud_optimal"))
-            elseif penaltyPct < 15 then
-                yieldColor = SoilHUD.C_FAIR
-                yieldText  = string.format("%s ~-%d%%", yieldPrefix, penaltyPct)
+            if justHarvested then
+                yieldColor = SoilHUD.C_DIM
+                yieldText  = g_i18n:getText("sf_hud_post_harvest")
             else
-                yieldColor = SoilHUD.C_POOR
-                yieldText  = string.format("%s ~-%d%%", yieldPrefix, penaltyPct)
+                local nDef = math.max(0, thresh - info.nitrogen.value)   / thresh
+                local pDef = math.max(0, thresh - info.phosphorus.value) / thresh
+                local kDef = math.max(0, thresh - info.potassium.value)  / thresh
+                local avgDef = (nDef + pDef + kDef) / 3
+
+                local penalty    = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
+                local penaltyPct = math.floor(penalty * 100 + 0.5)
+
+                local yieldPrefix = (not cropLower or cropLower == "") and g_i18n:getText("sf_hud_estYield") or g_i18n:getText("sf_hud_yield")
+                if penaltyPct <= 0 then
+                    yieldColor = SoilHUD.C_GOOD
+                    yieldText  = string.format("%s: %s", yieldPrefix, g_i18n:getText("sf_hud_optimal"))
+                elseif penaltyPct < 15 then
+                    yieldColor = SoilHUD.C_FAIR
+                    yieldText  = string.format("%s ~-%d%%", yieldPrefix, penaltyPct)
+                else
+                    yieldColor = SoilHUD.C_POOR
+                    yieldText  = string.format("%s ~-%d%%", yieldPrefix, penaltyPct)
+                end
             end
 
             setTextColor(yieldColor[1], yieldColor[2], yieldColor[3], 1.0)
             renderText(tx, cy, 0.010 * fontMult * s, yieldText)
-            setTextAlignment(RenderText.ALIGN_RIGHT)
-            setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], SoilHUD.C_DIM[4])
-            renderText(px + pw - pad, cy, 0.009 * fontMult * s, tierData.label)
-            setTextAlignment(RenderText.ALIGN_LEFT)
+            if not justHarvested then
+                setTextAlignment(RenderText.ALIGN_RIGHT)
+                setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], SoilHUD.C_DIM[4])
+                renderText(px + pw - pad, cy, 0.009 * fontMult * s, tierData.label)
+                setTextAlignment(RenderText.ALIGN_LEFT)
+            end
 
             -- Divider before weed row
             cy = cy - SoilHUD.LINE_H * s
@@ -864,7 +883,7 @@ end
 -- ── Nutrient bar row ─────────────────────────────────────
 -- Returns the new cy after drawing the row.
 -- label must be "N", "P", or "K" — used to look up ppm conversion + thresholds.
-function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info, profile, fillType)
+function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
     local pad    = SoilHUD.PAD * s
     local rowH   = SoilHUD.ROW_H * s
     local barH   = SoilHUD.BAR_H * s
@@ -900,8 +919,10 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info,
             local baseRate = (fillType and br[fillType.name]) or br.DEFAULT
             
             if baseRate then
-                local targetVolume = (info.fieldArea or 1.0) * baseRate.value
-                
+                -- Scale target volume by the current rate so the ghost bar reflects
+                -- what you'll actually apply at this rate setting (issue #278).
+                local targetVolume = (info.fieldArea or 1.0) * baseRate.value * (rateMultiplier or 1.0)
+
                 -- Ghost bar shows the gain remaining to reach the 90% threshold
                 local threshold = targetVolume * (SoilConstants.SPRAYER_RATE.FERTILIZER_COVERAGE_THRESHOLD or 0.90)
                 local remaining = math.max(0, threshold - currentBuffer)

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -98,105 +98,111 @@ local C = {
 -- ── Category definitions ───────────────────────────────────
 local CATEGORIES = {
     {
-        id      = "simulation",
-        label   = "Simulation",
-        desc    = "Farm mechanics, difficulty\nand nutrient cycles",
-        accent  = C.sim_accent,
+        id       = "simulation",
+        labelKey = "sf_panel_cat_sim",
+        descKey  = "sf_panel_cat_sim_desc",
+        accent   = C.sim_accent,
         sections = {
             {
-                header = "Core Systems",
-                items  = { "fertilitySystem", "nutrientCycles", "fertilizerCosts",
-                           "cropRotation", "autoRateControl" }
+                headerKey = "sf_panel_hdr_core",
+                items     = { "fertilitySystem", "nutrientCycles", "fertilizerCosts",
+                              "cropRotation", "autoRateControl" }
             },
             {
-                header = "Difficulty",
-                items  = { "difficulty", "replenishmentRate" }
+                headerKey = "sf_panel_hdr_difficulty",
+                items     = { "difficulty", "replenishmentRate" }
             },
             {
-                header = "Environment",
-                items  = { "seasonalEffects", "rainEffects", "plowingBonus" }
+                headerKey = "sf_panel_hdr_environment",
+                items     = { "seasonalEffects", "rainEffects", "plowingBonus" }
             },
             {
-                header = "Crop Stress",
-                items  = { "weedPressure", "pestPressure", "diseasePressure", "compactionEnabled" }
+                headerKey = "sf_panel_hdr_crop_stress",
+                items     = { "weedPressure", "pestPressure", "diseasePressure", "compactionEnabled" }
             },
         }
     },
     {
-        id      = "display",
-        label   = "Display & HUD",
-        desc    = "HUD appearance, color theme\nposition and font size",
-        accent  = C.disp_accent,
+        id       = "display",
+        labelKey = "sf_panel_cat_display",
+        descKey  = "sf_panel_cat_display_desc",
+        accent   = C.disp_accent,
         sections = {
             {
-                header = "Visibility",
-                items  = { "showHUD", "useImperialUnits" }
+                headerKey = "sf_panel_hdr_visibility",
+                items     = { "showHUD", "useImperialUnits" }
             },
             {
-                header = "HUD Style",
-                items  = { "hudColorTheme", "hudFontSize", "hudTransparency" }
+                headerKey = "sf_panel_hdr_hud_style",
+                items     = { "hudColorTheme", "hudFontSize", "hudTransparency" }
             },
             {
-                header = "Position",
-                items  = { "hudPosition" }
+                headerKey = "sf_panel_hdr_position",
+                items     = { "hudPosition" }
             },
         }
     },
     {
-        id      = "map",
-        label   = "Map Overlay",
-        desc    = "Active overlay layer\nshown in the PDA map",
-        accent  = C.map_accent,
+        id       = "map",
+        labelKey = "sf_panel_cat_overlay",
+        descKey  = "sf_panel_cat_overlay_desc",
+        accent   = C.map_accent,
         sections = {
             {
-                header = "Layer",
-                items  = { "activeMapLayer" }
+                headerKey = "sf_panel_hdr_layer",
+                items     = { "activeMapLayer" }
             },
             {
-                header = "Performance",
-                items  = { "overlayDensity" }
+                headerKey = "sf_panel_hdr_performance",
+                items     = { "overlayDensity" }
             },
         }
     },
 }
 
--- ── Multi-option labels ────────────────────────────────────
+-- ── Multi-option labels (i18n key names resolved at draw time via tr())
 local MULTI_OPTS = {
-    difficulty        = {"Simple", "Realistic", "Hardcore"},
-    replenishmentRate = {"Very Slow (0.25x)", "Slow (0.5x)", "Normal (1.0x)", "Fast (1.5x)", "Very Fast (2.0x)"},
-    hudPosition       = {"Top Right", "Top Left", "Bot Right", "Bot Left", "Ctr Right", "Custom"},
-    hudColorTheme     = {"Green", "Blue", "Amber", "Mono"},
-    hudFontSize       = {"Small", "Medium", "Large"},
-    hudTransparency   = {"Clear", "Light", "Medium", "Dark", "Solid"},
-    activeMapLayer    = {"Off", "Nitrogen", "Phosphorus", "Potassium", "pH",
-                         "Org Matter", "Urgency", "Weed", "Pest", "Disease", "Compaction"},
-    overlayDensity    = {"Low", "Medium", "High"},
+    difficulty        = {"sf_diff_1", "sf_diff_2", "sf_diff_3"},
+    replenishmentRate = {"sf_rr_1", "sf_rr_2", "sf_rr_3", "sf_rr_4", "sf_rr_5"},
+    hudPosition       = {"sf_hud_pos_1", "sf_hud_pos_2", "sf_hud_pos_3",
+                         "sf_hud_pos_4", "sf_hud_pos_5", "sf_hud_pos_6"},
+    hudColorTheme     = {"sf_hud_color_1", "sf_hud_color_2", "sf_hud_color_3", "sf_hud_color_4"},
+    hudFontSize       = {"sf_hud_font_1", "sf_hud_font_2", "sf_hud_font_3"},
+    hudTransparency   = {"sf_hud_trans_1", "sf_hud_trans_2", "sf_hud_trans_3",
+                         "sf_hud_trans_4", "sf_hud_trans_5"},
+    activeMapLayer    = {"sf_layer_1", "sf_layer_2", "sf_layer_3", "sf_layer_4",
+                         "sf_layer_5", "sf_layer_6", "sf_layer_7", "sf_layer_8",
+                         "sf_layer_9", "sf_layer_10", "sf_layer_11"},
+    overlayDensity    = {"sf_density_1", "sf_density_2", "sf_density_3"},
 }
 
--- Short descriptions for each setting
+-- Short descriptions for each setting (i18n key names resolved at draw time via tr())
 local SETTING_DESCS = {
-    fertilitySystem  = "Full soil fertility modeling",
-    nutrientCycles   = "Track N/P/K depletion and recovery",
-    fertilizerCosts  = "Real in-game cost for fertilizers",
-    cropRotation     = "Rotation benefits and penalties",
-    autoRateControl  = "Smart sprayer application rates",
-    difficulty         = "Nutrient drain intensity level",
-    replenishmentRate  = "Fertilizer nutrient restoration speed",
-    seasonalEffects  = "Season-driven soil changes",
-    rainEffects      = "Rain causes nutrient leaching",
-    plowingBonus     = "Plow bonus for soil recovery",
-    weedPressure     = "Track and penalize weed spread",
-    pestPressure     = "Track insect pest infestation",
-    diseasePressure  = "Track fungal crop diseases",
-    compactionEnabled = "Heavy vehicle soil compaction",
-    showHUD          = "Show the soil HUD overlay",
-    useImperialUnits = "Use imperial units (US tons/acre)",
-    hudColorTheme    = "Color palette for HUD elements",
-    hudFontSize      = "HUD text size",
-    hudTransparency  = "HUD background transparency",
-    hudPosition      = "HUD preset anchor position",
-    activeMapLayer   = "Nutrient layer shown in PDA map",
-    overlayDensity   = "Sample point budget (Low=8k, Med=20k, High=40k)",
+    fertilitySystem   = "sf_desc_fertilitySystem",
+    nutrientCycles    = "sf_desc_nutrientCycles",
+    fertilizerCosts   = "sf_desc_fertilizerCosts",
+    cropRotation      = "sf_desc_cropRotation",
+    autoRateControl   = "sf_desc_autoRateControl",
+    difficulty        = "sf_desc_difficulty",
+    replenishmentRate = "sf_desc_replenishmentRate",
+    seasonalEffects   = "sf_desc_seasonalEffects",
+    rainEffects       = "sf_desc_rainEffects",
+    plowingBonus      = "sf_desc_plowingBonus",
+    weedPressure      = "sf_desc_weedPressure",
+    pestPressure      = "sf_desc_pestPressure",
+    diseasePressure   = "sf_desc_diseasePressure",
+    compactionEnabled = "sf_desc_compactionEnabled",
+    showHUD           = "sf_desc_showHUD",
+    useImperialUnits  = "sf_desc_useImperialUnits",
+    hudColorTheme     = "sf_desc_hudColorTheme",
+    hudFontSize       = "sf_desc_hudFontSize",
+    hudTransparency   = "sf_desc_hudTransparency",
+    hudPosition       = "sf_desc_hudPosition",
+    activeMapLayer    = "sf_desc_activeMapLayer",
+    overlayDensity    = "sf_desc_overlayDensity",
+    enabled           = "sf_desc_enabled",
+    debugMode         = "sf_desc_debugMode",
+    showNotifications = "sf_desc_showNotifications",
 }
 
 -- Page states
@@ -211,36 +217,36 @@ local ADMIN_ACCENT = {0.88, 0.25, 0.25}   -- red accent for admin
 
 local ADMIN_SECTIONS = {
     {
-        header = "Mod Control & Difficulty",
-        items  = {
-            { label = "Mod Enabled",         desc = "Activate / deactivate the entire mod",            stype = "setting", id = "enabled" },
-            { label = "Debug Mode",          desc = "Extra logging for troubleshooting",               stype = "setting", id = "debugMode" },
-            { label = "Difficulty",          desc = "Nutrient drain intensity level",                  stype = "setting", id = "difficulty" },
-            { label = "Replenishment Rate",  desc = "Fertilizer nutrient restoration speed",           stype = "setting", id = "replenishmentRate" },
+        headerKey = "sf_panel_hdr_mod_ctrl",
+        items     = {
+            { stype = "setting", id = "enabled" },
+            { stype = "setting", id = "debugMode" },
+            { stype = "setting", id = "difficulty" },
+            { stype = "setting", id = "replenishmentRate" },
         },
     },
     {
-        header = "Systems",
-        items  = {
-            { label = "Fertility System", desc = "Full soil fertility modeling",                stype = "setting", id = "fertilitySystem" },
-            { label = "Nutrient Cycles",  desc = "N/P/K depletion and recovery",               stype = "setting", id = "nutrientCycles" },
-            { label = "Fertilizer Costs", desc = "Real in-game cost for fertilizers",          stype = "setting", id = "fertilizerCosts" },
-            { label = "Notifications",    desc = "In-game soil status notifications",          stype = "setting", id = "showNotifications" },
-            { label = "Seasonal Effects", desc = "Season-driven soil changes",                 stype = "setting", id = "seasonalEffects" },
-            { label = "Rain Effects",     desc = "Rain causes nutrient leaching",              stype = "setting", id = "rainEffects" },
-            { label = "Plowing Bonus",    desc = "Plow bonus for soil recovery",               stype = "setting", id = "plowingBonus" },
-            { label = "Soil Compaction",  desc = "Heavy vehicle compaction effects",            stype = "setting", id = "compactionEnabled" },
+        headerKey = "sf_panel_hdr_systems",
+        items     = {
+            { stype = "setting", id = "fertilitySystem" },
+            { stype = "setting", id = "nutrientCycles" },
+            { stype = "setting", id = "fertilizerCosts" },
+            { stype = "setting", id = "showNotifications" },
+            { stype = "setting", id = "seasonalEffects" },
+            { stype = "setting", id = "rainEffects" },
+            { stype = "setting", id = "plowingBonus" },
+            { stype = "setting", id = "compactionEnabled" },
         },
     },
     {
-        header = "Actions & Field Tools",
-        items  = {
-            { label = "Save Soil Data",      desc = "Force-save all soil data now",            stype = "action", id = "admin_save" },
-            { label = "Reset All Settings",  desc = "Restore every setting to its default",    stype = "danger", id = "admin_reset" },
-            { label = "Drain Vehicle Tanks", desc = "Empty sprayer + implements (50% refund)", stype = "action", id = "admin_drain" },
-            { label = "Current Field Info",  desc = "Soil data for the field at your position",stype = "action", id = "admin_field_info" },
-            { label = "Field Forecast",      desc = "Yield forecast for field at position",    stype = "action", id = "admin_field_forecast" },
-            { label = "List All Fields",     desc = "Dump all field soil data to game log",    stype = "action", id = "admin_list_fields" },
+        headerKey = "sf_panel_hdr_actions",
+        items     = {
+            { stype = "action", id = "admin_save" },
+            { stype = "danger", id = "admin_reset" },
+            { stype = "action", id = "admin_drain" },
+            { stype = "action", id = "admin_field_info" },
+            { stype = "action", id = "admin_field_forecast" },
+            { stype = "action", id = "admin_list_fields" },
         },
     },
 }
@@ -502,9 +508,9 @@ function SoilSettingsPanel:drawInfoBar()
     local isMP    = g_currentMission and g_currentMission.missionDynamicInfo and
                     g_currentMission.missionDynamicInfo.isMultiplayer
 
-    local adminText  = isAdmin and "Admin: YES" or "Admin: NO"
+    local adminText  = isAdmin and tr("sf_panel_admin_yes") or tr("sf_panel_admin_no")
     local adminColor = isAdmin and C.info_admin or C.info_no_adm
-    local modeText   = isMP and "Multiplayer" or "Single Player"
+    local modeText   = isMP and tr("sf_panel_multiplayer") or tr("sf_panel_singleplayer")
 
     local textY = iy + IB_H * 0.25
     self:drawText(PX + PAD, textY, TS_SMALL, adminText, adminColor, RenderText.ALIGN_LEFT, true)
@@ -519,7 +525,7 @@ function SoilSettingsPanel:drawInfoBar()
         local backHover = self:hitTest(bbX, bbY, bbW, bbH, self.mouseX, self.mouseY)
         self:drawRect(bbX, bbY, bbW, bbH, backHover and C.back_hover or C.off_bg)
         self:drawRect(bbX, bbY, 0.002, bbH, C.green_dim)
-        self:drawText(bbX + bbW * 0.5, bbY + bbH * 0.18, TS_SMALL, "< Back", C.white, RenderText.ALIGN_CENTER, false)
+        self:drawText(bbX + bbW * 0.5, bbY + bbH * 0.18, TS_SMALL, tr("sf_panel_btn_back"), C.white, RenderText.ALIGN_CENTER, false)
         self:registerClick("back", bbX, bbY, bbW, bbH)
 
         if self.page == PAGE_CATEGORY then
@@ -529,12 +535,12 @@ function SoilSettingsPanel:drawInfoBar()
             local rbY = bbY
             local resetHover = self:hitTest(rbX, rbY, rbW, bbH, self.mouseX, self.mouseY)
             self:drawRect(rbX, rbY, rbW, bbH, resetHover and {0.50, 0.20, 0.10, 0.70} or C.off_bg)
-            self:drawText(rbX + rbW * 0.5, rbY + bbH * 0.18, TS_SMALL, "Reset Cat.", C.dim, RenderText.ALIGN_CENTER, false)
+            self:drawText(rbX + rbW * 0.5, rbY + bbH * 0.18, TS_SMALL, tr("sf_panel_btn_reset_cat"), C.dim, RenderText.ALIGN_CENTER, false)
             self:registerClick("reset_cat", rbX, rbY, rbW, bbH)
         end
     else
         -- Close hint on landing
-        self:drawText(PX + PW - PAD, textY, TS_SMALL, "SHIFT+O to close", C.hint, RenderText.ALIGN_RIGHT, false)
+        self:drawText(PX + PW - PAD, textY, TS_SMALL, tr("sf_panel_btn_close_hint"), C.hint, RenderText.ALIGN_RIGHT, false)
     end
 end
 
@@ -543,7 +549,7 @@ function SoilSettingsPanel:drawLandingPage()
     -- Header above cards
     local headerY = CY_BOT + CH - 0.042
     self:drawText(PX + PW * 0.5, headerY, TS_SMALL,
-        "Select a category to configure settings", C.hint, RenderText.ALIGN_CENTER, false)
+        tr("sf_panel_select_category"), C.hint, RenderText.ALIGN_CENTER, false)
 
     for i, cat in ipairs(CATEGORIES) do
         local cardX = CX + (i - 1) * (CARD_W + CARD_GAP)
@@ -589,7 +595,7 @@ function SoilSettingsPanel:drawCategoryCard(x, y, w, h, cat, idx)
     -- Category title
     local titleY = y + h - 0.018 - 0.044
     self:drawText(x + w * 0.5, titleY, TS_BODY,
-        string.upper(cat.label), C.white, RenderText.ALIGN_CENTER, true)
+        string.upper(tr(cat.labelKey) or cat.id), C.white, RenderText.ALIGN_CENTER, true)
 
     -- Divider under title
     self:drawRect(x + 0.010, titleY - 0.006, w - 0.020, 0.001, C.divider)
@@ -598,10 +604,11 @@ function SoilSettingsPanel:drawCategoryCard(x, y, w, h, cat, idx)
     local count = 0
     for _, sec in ipairs(cat.sections) do count = count + #sec.items end
 
-    -- Description (2 lines)
+    -- Description (supports \n for manual line breaks; single line is fine too)
     local descY = titleY - 0.038
+    local descStr = tr(cat.descKey) or ""
     local lines = {}
-    for line in (cat.desc .. "\n"):gmatch("([^\n]*)\n") do
+    for line in (descStr .. "\n"):gmatch("([^\n]*)\n") do
         table.insert(lines, line)
     end
     for j, line in ipairs(lines) do
@@ -623,7 +630,7 @@ function SoilSettingsPanel:drawCategoryCard(x, y, w, h, cat, idx)
         hovered and cat.accent or C.off_bg,
         hovered and 0.20 or 1.0)
     self:drawText(btnX + btnW * 0.5, btnY + btnH * 0.18, TS_SMALL,
-        hovered and "Open >>" or "Configure >>",
+        hovered and tr("sf_panel_btn_open") or tr("sf_panel_btn_configure"),
         hovered and cat.accent or C.hint,
         RenderText.ALIGN_CENTER, false)
 
@@ -648,7 +655,7 @@ function SoilSettingsPanel:drawCategoryPage()
         self:drawRect(CX, curY, CW, SEC_H, C.title_bg, 0.60)
         self:drawRect(CX, curY, 0.003, SEC_H, cat.accent)
         self:drawText(CX + 0.012, curY + SEC_H * 0.25, TS_SMALL,
-            string.upper(sec.header), cat.accent, RenderText.ALIGN_LEFT, true)
+            string.upper(tr(sec.headerKey) or ""), cat.accent, RenderText.ALIGN_LEFT, true)
 
         for _, settingId in ipairs(sec.items) do
             curY = curY - ROW_H
@@ -726,7 +733,7 @@ function SoilSettingsPanel:drawAdminPage()
         self:drawRect(CX, curY, CW, SEC_H, C.title_bg, 0.60)
         self:drawRect(CX, curY, 0.003, SEC_H, ADMIN_ACCENT)
         self:drawText(CX + 0.012, curY + SEC_H * 0.25, TS_SMALL,
-            string.upper(sec.header), {ADMIN_ACCENT[1], ADMIN_ACCENT[2], ADMIN_ACCENT[3], 1.0},
+            string.upper(tr(sec.headerKey) or ""), {ADMIN_ACCENT[1], ADMIN_ACCENT[2], ADMIN_ACCENT[3], 1.0},
             RenderText.ALIGN_LEFT, true)
 
         for _, item in ipairs(sec.items) do
@@ -745,8 +752,11 @@ function SoilSettingsPanel:drawAdminPage()
                 local lc = locked and C.lock_text or C.white
                 local dc = locked and {C.lock_text[1]*0.7, C.lock_text[2]*0.7, C.lock_text[3]*0.7, 1} or C.dim
                 if locked then self:drawRect(CX, curY, 0.003, rh, {0.88, 0.60, 0.18, 0.45}) end
-                self:drawText(CX + (locked and 0.010 or 0.008), curY + rh * 0.55, TS_BODY, item.label, lc, RenderText.ALIGN_LEFT, not locked)
-                self:drawText(CX + (locked and 0.010 or 0.008), curY + rh * 0.15, TS_TINY, item.desc, dc, RenderText.ALIGN_LEFT, false)
+                local iLabel = tr(def.uiId .. "_short") or item.id
+                local iDescKey = SETTING_DESCS[item.id]
+                local iDesc = (iDescKey and tr(iDescKey)) or ""
+                self:drawText(CX + (locked and 0.010 or 0.008), curY + rh * 0.55, TS_BODY, iLabel, lc, RenderText.ALIGN_LEFT, not locked)
+                self:drawText(CX + (locked and 0.010 or 0.008), curY + rh * 0.15, TS_TINY, iDesc, dc, RenderText.ALIGN_LEFT, false)
                 local ctrlX = CX + CW - 0.012
                 local ctrlY = curY + (rh - TOGGLE_H) * 0.5
                 if def.type == "boolean" then
@@ -763,8 +773,10 @@ function SoilSettingsPanel:drawAdminPage()
                 local btnY = curY + (rh - btnH) * 0.5
                 local hov  = self:hitTest(btnX, btnY, btnW, btnH, self.mouseX, self.mouseY)
 
-                self:drawText(CX + 0.008, curY + rh * 0.55, TS_BODY, item.label, C.white, RenderText.ALIGN_LEFT, true)
-                self:drawText(CX + 0.008, curY + rh * 0.15, TS_TINY, item.desc, C.dim,   RenderText.ALIGN_LEFT, false)
+                local aLabel = tr("sf_" .. item.id .. "_label") or item.id
+                local aDesc  = tr("sf_" .. item.id .. "_desc") or ""
+                self:drawText(CX + 0.008, curY + rh * 0.55, TS_BODY, aLabel, C.white, RenderText.ALIGN_LEFT, true)
+                self:drawText(CX + 0.008, curY + rh * 0.15, TS_TINY, aDesc, C.dim,   RenderText.ALIGN_LEFT, false)
 
                 local bgCol = isDanger
                     and (hov and {0.65, 0.10, 0.10, 0.95} or {0.30, 0.06, 0.06, 0.85})
@@ -773,7 +785,7 @@ function SoilSettingsPanel:drawAdminPage()
                 self:drawRect(btnX, btnY, btnW, btnH, bgCol)
                 self:drawRect(btnX, btnY, 0.002, btnH, acCol)
                 self:drawText(btnX + btnW * 0.5, btnY + btnH * 0.20, TS_TINY,
-                    isDanger and "!! " .. item.label or ">  " .. item.label,
+                    isDanger and "!! " .. aLabel or ">  " .. aLabel,
                     hov and {1,1,1,1} or {0.75,0.75,0.75,1},
                     RenderText.ALIGN_CENTER, isDanger)
                 self:registerClick("admin_action_" .. item.id, btnX, btnY, btnW, btnH,
@@ -957,7 +969,8 @@ function SoilSettingsPanel:drawSettingRow(x, y, w, settingId, rowIdx, isAdmin)
     self:drawText(labelX, labelY, TS_BODY, labelText, labelColor, RenderText.ALIGN_LEFT, not locked)
 
     -- Description
-    local desc = SETTING_DESCS[settingId] or ""
+    local descKey = SETTING_DESCS[settingId]
+    local desc = (descKey and tr(descKey)) or ""
     self:drawText(labelX, y + ROW_H * 0.15, TS_TINY, desc, descColor, RenderText.ALIGN_LEFT, false)
 
     -- Control (toggle or multi-select) on the right
@@ -1009,8 +1022,9 @@ end
 function SoilSettingsPanel:drawMultiControl(rightX, y, settingId, locked)
     local opts    = MULTI_OPTS[settingId]
     if not opts then return end
-    local val     = self:getValue(settingId) or 1
-    local current = opts[val] or opts[1] or "?"
+    local val        = self:getValue(settingId) or 1
+    local currentKey = opts[val] or opts[1] or ""
+    local current    = (currentKey ~= "" and tr(currentKey)) or currentKey or "?"
 
     local arrowW = 0.022
     local labelW = MULTI_W - arrowW * 2

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Solo &amp; Fertilizante" eh="f31197fb" />
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Definir nível dificuldade: Simples, Realista, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Simples" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realista" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="Sincronizando dados do solo..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="Não foi possível carregar a propriedade do campo. Por favor, feche e reabra o relatório." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Custos Fertilizante" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Azul" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Âmbar" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificuldade" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nível de dificuldade de gestão do solo" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Azul" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Âmbar" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Tamanho da fonte HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Ajustar tamanho do texto para melhor legibilidade" eh="c338854f" />
     <e k="sf_hud_font_1" v="Pequeno" eh="2660064e" />
@@ -88,11 +88,11 @@
     <e k="sf_hud_hint_normal" v="RMB: mover/redimensionar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unidades imperiais" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Exibir taxas em gal/ac e lb/ac (desativado = L/ha e kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restaurar configurações solo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de solo" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="Aumentar taxa de fertilizante" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Reduzir taxa de fertilizante" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Alternar taxa automática" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Relatório Solo &amp;amp; Fertilizante" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Campos Rastreados:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Precisam Fertilizante:" eh="110b60f2" />
@@ -110,12 +110,12 @@
     <e k="sf_report_difficulty" v="Dificuldade:" eh="3abaf54f" />
     <e k="sf_report_col_field" v="Campo" eh="6f16a5f8" />
     <e k="sf_report_col_last_crop" v="Última Colheita" eh="ff41e5eb" />
-    <e k="sf_report_col_fert" v="Fert?" eh="9e6d0eb4" />
+    <e k="sf_report_col_fert" v="[EN] Fert?" eh="9e6d0eb4" />
     <e k="sf_report_no_data" v="Sem dados de solo disponíveis. Caminhe sobre um campo para começar o rastreamento." eh="1528a4cb" />
     <e k="sf_report_prev" v="Ant" eh="14230d11" />
     <e k="sf_report_next" v="Próx" eh="10ac3d04" />
     <e k="sf_report_yes" v="SIM" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Nenhum" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Precisa de nitrogênio" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Nitrogênio baixo" eh="35ad072d" />
@@ -159,11 +159,11 @@
     <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureia 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco)" eh="18015099" />
@@ -185,16 +185,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrogênio: Ideal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fósforo: Ideal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potássio: Ideal" eh="0197b4ba" />
@@ -324,7 +324,7 @@
 		<e k="sf_map_layer_n" v="Nitrogênio" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Fósforo" eh="eb4f2688" />
 		<e k="sf_map_layer_k" v="Potássio" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Matéria Orgânica" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Urgência do Campo" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Pressão de Ervas Daninhas" eh="53f8b936" />
@@ -384,41 +384,41 @@
     <e k="sf_pda_map_legend_excess" v="Excesso" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Pressione Shift+M no jogo para alternar as camadas do mapa de solo." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Abrir Mapa do Solo" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Mudar camada" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plano de tratamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desativar camada" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Todos os Campos" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Campo" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="MO" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Nenhum dado de campo registrado ainda." eh="72265670" />
     <e k="sf_pda_status_good" v="Bom" eh="0c6ad70b" />
     <e k="sf_pda_status_fair" v="Regular" eh="f7f20cf0" />
@@ -474,7 +474,7 @@
 		<e k="sf_treat_action_weed" v="Aplique HERBICIDA imediatamente." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bônus de Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fadiga (x1.15 esgotamento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sem dados disponíveis." eh="c6d95d5e" />
@@ -484,7 +484,7 @@
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Olá, sou eu, o desenvolvedor! Como você pode ver, esta página ainda está em desenvolvimento. As camadas do mapa são apenas visualizações (não funcionais para seleção), e muitos elementos da interface ainda precisam de ajustes finais." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Clique em um campo para ir até ele no mapa" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necessita atenção" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Os campos listados à direita precisam de tratamento. Clique em uma linha para ver os insumos recomendados e as quantidades estimadas." eh="5748d316" />
     </elements>

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necessita atenção" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Os campos listados à direita precisam de tratamento. Clique em uma linha para ver os insumos recomendados e as quantidades estimadas." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="Produção" eh="97345487" />
     <e k="sf_hud_estYield" v="Prod. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ideal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Arraste: mover   Canto: redimensionar   RMB: pronto" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: mover/redimensionar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unidades imperiais" eh="ff2701ad" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="產量" eh="97345487" />
     <e k="sf_hud_estYield" v="預估產量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="拖動：移動   角落：縮放   右鍵：完成" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="右鍵：移動/縮放" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="英制單位" eh="ff2701ad" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="土壤與肥料" eh="d30a22a9" />
@@ -88,11 +88,11 @@
     <e k="sf_hud_hint_normal" v="右鍵：移動/縮放" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="英制單位" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="以 gal/ac 和 lb/ac 顯示施用量（關閉則為 L/ha 和 kg/ha）" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="重置土壤設置" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="切換土壤 HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="增加肥料施用量" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="減少肥料施用量" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="切換自動施用量" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="土壤與肥料報告" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="追蹤的田地：" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="需要肥料：" eh="110b60f2" />
@@ -185,16 +185,16 @@
     <e k="sf_bigBag_starter_function" v="啟動肥（液態）" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="氮：最佳" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="磷：最佳" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="鉀：最佳" eh="0197b4ba" />
@@ -418,39 +418,39 @@
     <e k="sf_pda_map_legend_excess" v="過量" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="在遊戲中按 Shift+M 切換土壤地圖圖層。" eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="打開土壤地圖" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Canvia la capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Pla de tractament" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactiva la capa" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="所有田地" eh="48729e0b" />
     <e k="sf_pda_col_field" v="田地" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="有機質" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="狀態" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="尚無記錄的田地數據。" eh="72265670" />
@@ -518,7 +518,7 @@
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Hola, sóc jo, el desenvolupador! Com pots veure, aquesta pàgina encara està en construcció. Les capes del mapa ara mateix són només previsualitzacions visuals (no funcionals per a la selecció), i molts elements de la interfície encara necessiten el seu acabat final." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Feu clic en un camp per saltar-hi al mapa" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necessita atenció" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Els camps llistats a la dreta necessiten tractament. Feu clic en una fila per veure els inputs recomanats i les quantitats estimades." eh="5748d316" />
     </elements>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -522,5 +522,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necessita atenció" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Els camps llistats a la dreta necessiten tractament. Feu clic en una fila per veure els inputs recomanats i les quantitats estimades." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiální jednotky" eh="ff2701ad" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Půda &amp; Hnojivo" eh="f31197fb" />
@@ -12,12 +12,12 @@
     <e k="sf_rain_effects_long" v="Povolit/zakázat vliv deště na půdu (vymývání živin, změny pH)" eh="de3b14b9" />
     <e k="sf_plowing_bonus_short" v="Bonus Orby" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Povolit/zakázat výhody orby pro úrodnost půdy (zlepšený dusík a organická hmota)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Systém Úrodnosti" eh="f7e27d58" />
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Nastavit úroveň obtížnosti: Jednoduchý, Realistický, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Jednoduchý" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistický" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="[EN] Syncing soil data..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="[EN] Could not load field ownership. Please close and reopen the report." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Náklady Hnojiva" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Zelený" eh="d382816a" />
     <e k="sf_hud_color_2" v="Modrý" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Jantarový" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Obtížnost" eh="7b29ca96" />
     <e k="sf_diff_long" v="Úroveň obtížnosti správy půdy" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Zelený" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Modrý" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Jantarový" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Velikost písma HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Upravte velikost textu pro lepší čitelnost" eh="c338854f" />
     <e k="sf_hud_font_1" v="Malý" eh="2660064e" />
@@ -73,26 +73,26 @@
     <e k="sf_hud_trans_3" v="Střední" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Tmavý" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Plný" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiální jednotky" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Zobrazit dávky v gal/ac a lb/ac (vypnuto = L/ha a kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetovat nastavení půdy" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Přepnout HUD půdy" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="Zvýšit dávku hnojiva" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Snížit dávku hnojiva" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Přepnout automatickou dávku" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Zpráva o Půdě &amp;amp; Hnojivu" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Sledovaná Pole:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Potřebují Hnojivo:" eh="110b60f2" />
@@ -115,7 +115,7 @@
     <e k="sf_report_prev" v="Předch" eh="14230d11" />
     <e k="sf_report_next" v="Další" eh="10ac3d04" />
     <e k="sf_report_yes" v="ANO" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Žádná" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Potřebuje dusík" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Nízký dusík" eh="35ad072d" />
@@ -127,13 +127,13 @@
     <e k="sf_report_rec_ph_monitor" v="Sledovat pH" eh="6dfcded4" />
     <e k="sf_report_rec_om_increase" v="Zvýšit organiku" eh="c2a930af" />
     <e k="sf_report_rec_om_maintain" v="Udržovat organiku" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Potřebuje:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Zdraví půdy: Optimální" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
     <e k="sf_uan32_title" v="UAN 32 Dusíkaté hnojivo (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Dusíkaté hnojivo (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Bezvodý amoniak (N)" eh="3fc85c02" />
@@ -159,59 +159,59 @@
     <e k="sf_bigBag_anhydrous_function" v="Dusíkaté hnojivo (kapalné)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Močovina 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Dusíkaté hnojivo (granulované)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Dusíkaté hnojivo (granulované)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosforečné hnojivo (granulované)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosforečné hnojivo (granulované)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potaš 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Draselné hnojivo (granulované)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Startovní Hnojivo 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
-    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Přepnout vrstvu" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plán ošetření" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Vypnout vrstvu" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Poznámka vývojáře" eh="5320d63f" />
     <e k="sf_pda_help_github" v="VAŠE ZPĚTNÁ VAZBA JE DŮLEŽITÁ! Pokud narazíte na chyby, máte návrhy na nové funkce nebo chcete přispět ke kódu, navštivte projekt na GitHubu. Kdykoli můžete otevřít Issue nebo Pull Request a pomoci zlepšit tento mod pro všechny. Děkujeme za testování!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Ahoj, jsem to já, vývojář! Jak vidíte, tato stránka je stále ve vývoji. Vrstvy mapy jsou momentálně jen vizuální náhledy (nefunkční pro výběr) a mnoho prvků uživatelského rozhraní stále potřebuje finální úpravy." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Kliknutím na pole přejdete na něj v mapě" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Celkem vyžaduje pozornost" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Pole uvedená vpravo potřebují ošetření. Kliknutím na řádek zobrazíte doporučené vstupy a odhadované množství." eh="5748d316" />
     </elements>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Celkem vyžaduje pozornost" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Pole uvedená vpravo potřebují ošetření. Kliknutím na řádek zobrazíte doporučené vstupy a odhadované množství." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Grøn" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blå" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Rav" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Sværhedsgrad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Sværhedsgrad for jordstyring" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -14,7 +14,7 @@
     <e k="sf_hud_theme_1" v="Grøn" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Blå" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Rav" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="HUD-skriftstørrelse" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Juster tekststørrelsen for bedre læsbarhed" eh="c338854f" />
     <e k="sf_hud_font_1" v="Lille" eh="2660064e" />
@@ -26,7 +26,7 @@
     <e k="sf_hud_trans_2" v="Lys" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Mellem" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Mørk" eh="a18366b2" />
-    <e k="sf_hud_trans_5" v="Solid" eh="e41480b6" />
+    <e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mark %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
@@ -37,7 +37,7 @@
     <e k="sf_hud_protected" v="(beskyttet)" eh="8273211e" />
     <e k="sf_hud_yield" v="Udbytte" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. udbytte" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_hint_edit" v="Træk: flyt   Hjørne: ændr størrelse   HMK: færdig" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="HMK: flyt/ændr størrelse" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiale enheder" eh="ff2701ad" />
@@ -69,7 +69,7 @@
     <e k="sf_report_prev" v="Forrige" eh="14230d11" />
     <e k="sf_report_next" v="Næste" eh="10ac3d04" />
     <e k="sf_report_yes" v="JA" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Ingen" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Mangler kvælstof" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Lavt kvælstofniveau" eh="35ad072d" />
@@ -92,7 +92,7 @@
     <e k="sf_uan28_title" v="UAN 28 Gødning (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Vandfri ammoniak (N)" eh="3fc85c02" />
     <e k="sf_starter_title" v="Startgødning 10-34-0 (P)" eh="8c1a1ddc" />
-    <e k="sf_urea_title" v="Urea 46-0-0 (N)" eh="659b3097" />
+    <e k="sf_urea_title" v="[EN] Urea 46-0-0 (N)" eh="659b3097" />
     <e k="sf_ams_title" v="Ammoniumsulfat 21-0-0 (N)" eh="033d1845" />
     <e k="sf_map_title" v="MAP-gødning 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-gødning 18-46-0 (P)" eh="5030a80a" />
@@ -105,19 +105,19 @@
     <e k="sf_insecticide_title" v="Insekticid" eh="5650eeef" />
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Marker %d-%d af %d  |  Side %d af %d" eh="8db851d1" />
-    <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
+    <e k="sf_bigBag_uan32_name" v="[EN] IBC UAN 32-0-0" eh="574747ce" />
     <e k="sf_bigBag_uan32_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
-    <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
+    <e k="sf_bigBag_uan28_name" v="[EN] IBC UAN 28-0-0" eh="7eeec815" />
     <e k="sf_bigBag_uan28_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vandfri Ammoniak 82-0-0" eh="fb09e6ce" />
     <e k="sf_bigBag_anhydrous_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Kvælstofgødning (tør)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Kvælstofgødning (tør)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosfatgødning (tør)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosfatgødning (tør)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgødning (tør)" eh="18015099" />
@@ -176,7 +176,7 @@
     <e k="sf_difficulty_long" v="Angiv sværhedsgrad: Simpel, Realistisk, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Simpel" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistisk" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
     <e k="sf_ui_soilReport_syncing" v="Synkroniserer jorddata..." eh="03f01c4d" />
     <e k="sf_ui_soilReport_syncTimeout" v="Kunne ikke indlæse markejerskab. Luk og genåbn rapporten." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Gødningsomkostninger" eh="6870d88b" />
@@ -213,7 +213,7 @@
     <e k="helpLine_sf_cat_fertilizers" v="Gødningstyper" eh="754d59bd" />
     <e k="helpLine_sf_cat_hud" v="HUD &amp; Jordrapport" eh="9b9888b9" />
     <e k="helpLine_sf_cat_settings" v="Indstillinger" eh="f4f70727" />
-    <e k="helpLine_sf_cat_multiplayer" v="Multiplayer" eh="901a7320" />
+    <e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
     <e k="helpLine_sf_ov_p1_title" v="Hvad gør moddet?" eh="46cbb25b" />
     <e k="helpLine_sf_ov_p1_intro_title" v="Markbaseret jordregistrering" eh="8fe3248d" />
     <e k="helpLine_sf_ov_p1_intro_text" v="Hver mark registrerer uafhængigt fem egenskaber: Kvælstof (N), Fosfor (P), Kalium (K), Organisk materiale (OM) og pH. Værdierne gemmes med din gemte spil og bevares på tværs af sessioner." eh="c30216e6" />
@@ -324,7 +324,7 @@
     <e k="sf_map_layer_n" v="Kvælstof" eh="1e9ef3ba" />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
-    <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
     <e k="sf_map_layer_om" v="Organisk materiale" eh="6305f4bb" />
     <e k="sf_map_layer_urgency" v="Markhastegrad" eh="419ea5af" />
     <e k="sf_map_layer_weed" v="Ukrudtstryk" eh="53f8b936" />
@@ -389,7 +389,7 @@
     <e k="sf_map_btn_cycle_layer" v="Skift lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver lag" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Jordens hurtige reference" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NÆRINGSSTOFFER" eh="9aeb39bf" />
     <e k="sf_help_n" v="N  (Kvælstof)     - Udtømmes hurtigt. Anvend UAN, Urea eller Gylle." eh="f2d0c792" />
@@ -408,14 +408,14 @@
     <e k="sf_help_poor" v="Dårlig - Øjeblikkelig behandling påkrævet." eh="b287d206" />
     <e k="sf_pda_fields_section_title" v="Alle marker" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Mark" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
     <e k="sf_pda_filter_all" v="Filter: Alle marker" eh="a46a8cb2" />
     <e k="sf_pda_filter_owned" v="Filter: Kun ejede" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Ingen markdata registreret endnu." eh="72265670" />
     <e k="sf_pda_status_good" v="God" eh="0c6ad70b" />
     <e k="sf_pda_status_fair" v="Rimelig" eh="f7f20cf0" />
@@ -469,7 +469,7 @@
     <e k="sf_treat_action_weed" v="Anvend HERBICID øjeblikkeligt." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Anvend INSEKTICID øjeblikkeligt." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Anvend FUNGICID øjeblikkeligt." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bælgplantebonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Træthed (x1,15 udtømning)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tilgængelig." eh="c6d95d5e" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="Udbytte" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. udbytte" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Træk: flyt   Hjørne: ændr størrelse   HMK: færdig" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="HMK: flyt/ændr størrelse" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiale enheder" eh="ff2701ad" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -482,5 +482,119 @@
     <e k="sf_pda_map_jump_hint" v="Klik på et felt for at hoppe til det på kortet" eh="006d5371" />
     <e k="sf_pda_map_native_hint" v="Jordlagsvisualiseringen er flyttet! Du kan nu tilgå og skifte alle jordlag direkte fra det native PDA-kortes sidebjælke (ESC &gt; Kort). Se efter kategorien 'Jordlag' i sidebjælkens prikker." eh="87f73b10" />
     <e k="sf_pda_treatment_hint" v="Felterne opført til højre kræver behandling. Klik på en række for at se anbefalede inputs og estimerede mængder." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Boden &amp; Dünger" eh="f31197fb" />
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Schwierigkeitsgrad festlegen: Einfach, Realistisch, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Einfach" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistisch" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="Synchronisiere Bodendaten..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="Konnte Feldbesitz nicht laden. Bitte schließen und öffnen Sie den Bericht erneut." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Düngerkosten" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Grün" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blau" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Bernstein" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Schwierigkeit" eh="7b29ca96" />
     <e k="sf_diff_long" v="Schwierigkeitsgrad der Bodenverwaltung" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Grün" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Blau" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Bernstein" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="HUD-Schriftgröße" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Textgröße für bessere Lesbarkeit anpassen" eh="c338854f" />
     <e k="sf_hud_font_1" v="Klein" eh="2660064e" />
@@ -83,16 +83,16 @@
     <e k="sf_hud_protected" v="(geschützt)" eh="8273211e" />
     <e k="sf_hud_yield" v="Ertrag" eh="97345487" />
     <e k="sf_hud_estYield" v="Gesch. Ertrag" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_hint_edit" v="Ziehen: bewegen   Ecke: Größe ändern   RMT: fertig" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMT: bewegen/Größe ändern" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiale Einheiten" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Ausbringmengen in gal/ac und lb/ac (aus = L/ha und kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeneinstellungen zurücksetzen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Boden-HUD umschalten" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="Düngerrate erhöhen" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Düngerrate verringern" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Auto-Rate umschalten" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Boden- &amp;amp; Düngerbericht" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Verfolgte Felder:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Brauchen Dünger:" eh="110b60f2" />
@@ -115,7 +115,7 @@
     <e k="sf_report_prev" v="Zurück" eh="14230d11" />
     <e k="sf_report_next" v="Weiter" eh="10ac3d04" />
     <e k="sf_report_yes" v="JA" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Keine" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Stickstoff nötig" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Niedriger Stickstoff" eh="35ad072d" />
@@ -159,11 +159,11 @@
     <e k="sf_bigBag_anhydrous_function" v="Stickstoffdünger (flüssig)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Harnstoff 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Stickstoffdünger (trocken)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Stickstoffdünger (trocken)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Phosphordünger (trocken)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Phosphordünger (trocken)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumdünger (trocken)" eh="18015099" />
@@ -185,16 +185,16 @@
     <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Stickstoff: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphor: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Kalium: Optimal" eh="0197b4ba" />
@@ -311,7 +311,7 @@
     <e k="sf_report_rotation_ok" v="Fruchtfolge: OK" eh="df66b3be" />
     <e k="sf_gypsum_title" v="Gips (pH-)" eh="56e6dc36" />
     <e k="sf_compost_title" v="Kompost (Organisch)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Hühnermist (N+P)" eh="338128e2" />
     <e k="sf_pelletized_manure_title" v="Pelletierter Mist (NPK)" eh="c1b39b71" />
     <e k="sf_liquidlime_title" v="Flüssigkalk (pH+)" eh="d4ec4bb9" />
@@ -384,14 +384,14 @@
     <e k="sf_pda_map_legend_excess" v="Überschuss" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Drücken Sie Umschalt+M im Spiel, um Bodenebenen zu wechseln." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Bodenkarte öffnen" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="Durchschn. Bodengesundheit" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="Hofübersicht öffnen" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="Hilfe" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ebene wechseln" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlungsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay deaktivieren" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Boden-Schnellreferenz" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NÄHRSTOFFE" eh="9aeb39bf" />
     <e k="sf_help_n" v="N  (Stickstoff)   - Schnell erschöpft. UAN, Harnstoff oder Mist ausbringen." eh="f2d0c792" />
@@ -411,14 +411,14 @@
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Alle Felder" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Feld" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="Filter: Alle Felder" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="Filter: Nur eigene Felder" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Noch keine Felddaten aufgezeichnet." eh="72265670" />
     <e k="sf_pda_status_good" v="Gut" eh="0c6ad70b" />
     <e k="sf_pda_status_fair" v="Mittel" eh="f7f20cf0" />
@@ -474,7 +474,7 @@
 		<e k="sf_treat_action_weed" v="Sofort HERBIZID ausbringen." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Sofort INSEKTIZID ausbringen." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Sofort FUNGIZID ausbringen." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen-Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Ermüdung (x1,15 Verarmung)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Keine Daten verfügbar." eh="c6d95d5e" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="Ertrag" eh="97345487" />
     <e k="sf_hud_estYield" v="Gesch. Ertrag" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Ziehen: bewegen   Ecke: Größe ändern   RMT: fertig" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMT: bewegen/Größe ändern" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiale Einheiten" eh="ff2701ad" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="Die Bodenkartenebenen wurden verschoben! Alle Bodenebenen sind jetzt direkt über die native PDA-Karte erreichbar (ESC → Karte). Suche nach der Kategorie 'Bodenebenen' in der Seitenleiste." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Gesamt benötigt Aufmerksamkeit" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Die rechts aufgelisteten Felder benötigen Behandlung. Klicke auf eine Zeile, um empfohlene Mittel und geschätzte Mengen zu sehen." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necesita atención" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Los campos listados a la derecha necesitan tratamiento. Hacé clic en una fila para ver los insumos recomendados y las cantidades estimadas." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Azul" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Ámbar" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificultad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nivel de dificultad de gestión del suelo" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Alternar tasa automática" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -111,48 +111,48 @@
     <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Amoniaco Anhidro 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante potásico (seco)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Fertilizante Inicial 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -211,7 +211,7 @@
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Cambiar capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de tratamiento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar capa" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Nota del Dev" eh="5320d63f" />
     <e k="sf_pda_help_github" v="¡TU OPINIÓN IMPORTA! Si encontrás errores, tenés sugerencias de nuevas funciones o querés contribuir al código, visitá el proyecto en GitHub. Podés abrir un Issue o un Pull Request en cualquier momento para ayudar a mejorar este mod para todos. ¡Gracias por probar!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="¡Hola! Soy el desarrollador. Como podés ver, esta página todavía está en construcción. Las capas del mapa son solo vistas previas visuales (no funcionales para la selección) y muchos elementos de la interfaz aún necesitan su acabado final." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Hacé clic en un campo para ir a él en el mapa" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necesita atención" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Los campos listados a la derecha necesitan tratamiento. Hacé clic en una fila para ver los insumos recomendados y las cantidades estimadas." eh="5748d316" />
     </elements>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -193,6 +193,7 @@
     <e k="sf_hud_yield" v="Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -524,5 +524,143 @@
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
     <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+
+    <!-- ======================================================
+         HUD LABELS, UNITS & COVERAGE
+         ====================================================== -->
+    <e k="sf_hud_label_ph" v="pH" />
+    <e k="sf_hud_label_om" v="OM" />
+    <e k="sf_hud_unit_ppm" v="(ppm)" />
+    <e k="sf_hud_coverage" v="Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="Compaction: %d%%" />
+
+    <!-- ======================================================
+         SPRAYER RATE HUD
+         ====================================================== -->
+    <e k="sf_sprayer_auto_on" v="APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="BURN RISK: POSSIBLE" />
+
+    <!-- ======================================================
+         NOTIFICATIONS
+         ====================================================== -->
+    <e k="sf_notify_welcome" v="Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="Soil Update" />
+    <e k="sf_notify_treated_body" v="Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="Soil Mod: Data sync issue detected. Please report if this persists." />
+
+    <!-- ======================================================
+         SETTINGS PANEL — CATEGORIES & SECTION HEADERS
+         ====================================================== -->
+    <e k="sf_panel_cat_sim" v="Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="Difficulty" />
+    <e k="sf_panel_hdr_environment" v="Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="HUD Style" />
+    <e k="sf_panel_hdr_position" v="Position" />
+    <e k="sf_panel_hdr_layer" v="Layer" />
+    <e k="sf_panel_hdr_performance" v="Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="Systems" />
+    <e k="sf_panel_hdr_actions" v="Actions &amp; Field Tools" />
+
+    <!-- ======================================================
+         SETTINGS PANEL — CHROME
+         ====================================================== -->
+    <e k="sf_panel_admin_yes" v="Admin: YES" />
+    <e k="sf_panel_admin_no" v="Admin: NO" />
+    <e k="sf_panel_multiplayer" v="Multiplayer" />
+    <e k="sf_panel_singleplayer" v="Single Player" />
+    <e k="sf_panel_btn_back" v="&lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="Configure >>" />
+    <e k="sf_panel_btn_open" v="Open >>" />
+
+    <!-- ======================================================
+         SETTINGS PANEL — SETTING DESCRIPTIONS
+         ====================================================== -->
+    <e k="sf_desc_enabled" v="Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="HUD text size" />
+    <e k="sf_desc_hudTransparency" v="HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="Sample point budget (Low=8k, Med=20k, High=40k)" />
+
+    <!-- ======================================================
+         SETTINGS PANEL — MULTI-OPTION VALUES
+         ====================================================== -->
+    <e k="sf_rr_1" v="Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="Slow (0.5x)" />
+    <e k="sf_rr_3" v="Normal (1.0x)" />
+    <e k="sf_rr_4" v="Fast (1.5x)" />
+    <e k="sf_rr_5" v="Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="Off" />
+    <e k="sf_layer_2" v="Nitrogen" />
+    <e k="sf_layer_3" v="Phosphorus" />
+    <e k="sf_layer_4" v="Potassium" />
+    <e k="sf_layer_5" v="pH" />
+    <e k="sf_layer_6" v="Org Matter" />
+    <e k="sf_layer_7" v="Urgency" />
+    <e k="sf_layer_8" v="Weed" />
+    <e k="sf_layer_9" v="Pest" />
+    <e k="sf_layer_10" v="Disease" />
+    <e k="sf_layer_11" v="Compaction" />
+    <e k="sf_density_1" v="Low" />
+    <e k="sf_density_2" v="Medium" />
+    <e k="sf_density_3" v="High" />
+
+    <!-- ======================================================
+         SETTINGS PANEL — ADMIN ACTION ITEMS
+         ====================================================== -->
+    <e k="sf_admin_save_label" v="Save Soil Data" />
+    <e k="sf_admin_save_desc" v="Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suelo y Fertilizante" eh="f31197fb" />
@@ -26,9 +26,9 @@
     <e k="sf_nutrients_long" v="Activar/desactivar el agotamiento y la reposición realistas de nutrientes" eh="dbe9c8ff" />
     <e k="sf_difficulty_short" v="Dificultad" eh="7b29ca96" />
     <e k="sf_difficulty_long" v="Establecer nivel de dificultad: Simple, Realista, Hardcore" eh="cfb758a4" />
-    <e k="sf_diff_1" v="Simple" eh="1fbb1e39" />
+    <e k="sf_diff_1" v="[EN] Simple" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realista" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="Sincronizando datos del suelo..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="No se pudo cargar la propiedad del campo. Por favor, cierre y vuelva a abrir el informe." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Costos de Fertilizante" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Azul" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Ámbar" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificultad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nivel de dificultad de la gestión del suelo" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Azul" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Ámbar" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Tamaño de Fuente HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Ajustar el tamaño del texto para una mejor legibilidad" eh="c338854f" />
     <e k="sf_hud_font_1" v="Pequeño" eh="2660064e" />
@@ -88,11 +88,11 @@
     <e k="sf_hud_hint_normal" v="RMB: mover/redimensionar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unidades Imperiales" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Mostrar tasas de aplicación en gal/ac y lb/ac (desactivado = L/ha y kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablecer Ajustes de Suelo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de Suelo" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="Aumentar Tasa de Fertilizante" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Disminuir Tasa de Fertilizante" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Alternar Tasa Auto" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Informe de Suelo y Fertilizante" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Campos Seguidos:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Necesitan Fert.:" eh="110b60f2" />
@@ -115,7 +115,7 @@
     <e k="sf_report_prev" v="Ant." eh="14230d11" />
     <e k="sf_report_next" v="Sig." eh="10ac3d04" />
     <e k="sf_report_yes" v="SÍ" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Ninguno" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Necesita Nitrógeno" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Nitrógeno Bajo" eh="35ad072d" />
@@ -138,7 +138,7 @@
     <e k="sf_uan28_title" v="Fertilizante UAN 28 (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Amoníaco Anhidro (N)" eh="3fc85c02" />
     <e k="sf_starter_title" v="Fertilizante Starter 10-34-0 (P)" eh="8c1a1ddc" />
-    <e k="sf_urea_title" v="Urea 46-0-0 (N)" eh="659b3097" />
+    <e k="sf_urea_title" v="[EN] Urea 46-0-0 (N)" eh="659b3097" />
     <e k="sf_ams_title" v="Sulfato de Amonio 21-0-0 (N)" eh="033d1845" />
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
@@ -157,13 +157,13 @@
     <e k="sf_bigBag_uan28_function" v="Fertilizante de Nitrógeno (líquido)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Amoníaco Anhidro 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Fertilizante de Nitrógeno (líquido)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Fertilizante de Nitrógeno (seco)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Fertilizante de Nitrógeno (seco)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fertilizante de Fósforo (seco)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fertilizante de Fósforo (seco)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante de Potasio (seco)" eh="18015099" />
@@ -185,16 +185,16 @@
     <e k="sf_bigBag_starter_function" v="Fertilizante Starter (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Nitrógeno: Óptimo" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fósforo: Óptimo" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potasio: Óptimo" eh="0197b4ba" />
@@ -324,7 +324,7 @@
 		<e k="sf_map_layer_n" v="Nitrógeno" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Fósforo" eh="eb4f2688" />
 		<e k="sf_map_layer_k" v="Potasio" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Materia Orgánica" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Urgencia del campo" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Presión de Maleza" eh="53f8b936" />
@@ -337,7 +337,7 @@
 		<e k="sf_map_sidebar_label" v="Capa activa" eh="f8a2c198" />
 		<e k="sf_map_sidebar_tooltip" v="Selecciona qué nutriente del suelo mostrar en el mapa" eh="eb926e9a" />
 		<e k="sf_map_overlay_low" v="Bajo" eh="28d0edd0" />
-		<e k="sf_map_overlay_med" v="Med" eh="248c9511" />
+		<e k="sf_map_overlay_med" v="[EN] Med" eh="248c9511" />
 		<e k="sf_map_overlay_high" v="Alto" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
@@ -384,39 +384,39 @@
     <e k="sf_pda_map_legend_excess" v="Exceso" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Pulsa Mayús+M en el juego para cambiar las capas del mapa de suelo." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Abrir mapa de suelo" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Cambiar capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de tratamiento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar capa" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Todos los campos" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Campo" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="MO" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Estado" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Aún no se han registrado datos de campos." eh="72265670" />
@@ -474,7 +474,7 @@
 		<e k="sf_treat_action_weed" v="Aplica HERBICIDA inmediatamente." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Aplica INSECTICIDA inmediatamente." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Aplica FUNGICIDA inmediatamente." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bono de leguminosas (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (agotamiento x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="No hay datos disponibles." eh="c6d95d5e" />
@@ -484,7 +484,7 @@
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="¡Hola! Soy el desarrollador. Como puedes ver, esta página está todavía muy en construcción. Las capas del mapa son solo vistas previas visuales (no funcionales para la selección) y muchos elementos de la interfaz aún necesitan su acabado final." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Haz clic en un campo para ir a él en el mapa" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necesita atención" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Los campos listados a la derecha necesitan tratamiento. Haz clic en una fila para ver los insumos recomendados y las cantidades estimadas." eh="5748d316" />
     </elements>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necesita atención" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Los campos listados a la derecha necesitan tratamiento. Haz clic en una fila para ver los insumos recomendados y las cantidades estimadas." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="Rendimiento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Óptimo" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB: listo" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: mover/redimensionar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unidades Imperiales" eh="ff2701ad" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total nécessitant attention" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Les champs listés à droite nécessitent un traitement. Cliquez sur une ligne pour voir les intrants recommandés et les quantités estimées." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="绿色" eh="d382816a" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="åˆ‡æ¢è‡ªåŠ¨æ–½ç”¨é‡" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -121,38 +121,38 @@
     <e k="sf_bigBag_dap_function" v="磷肥（干燥）" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="大袋氯化钾 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="钾肥（干燥）" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="å¤§è¢‹å¯åŠ¨è‚¥ 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="å¯åŠ¨è‚¥ï¼ˆæ¶²æ€ï¼‰" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Changer la couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de traitement" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Désactiver la couche" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Note du dev" eh="5320d63f" />
     <e k="sf_pda_help_github" v="VOS COMMENTAIRES COMPTENT! Si vous rencontrez des bogues, avez des suggestions pour de nouvelles fonctionnalités ou souhaitez contribuer au code, visitez le projet sur GitHub. Vous pouvez ouvrir un Issue ou une Pull Request en tout temps pour aider à améliorer ce mod pour tous. Merci de tester!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Bonjour, c'est moi le développeur! Comme vous pouvez le voir, cette page est encore en plein développement. Les couches de carte sont actuellement de simples aperçus visuels (non fonctionnels pour la sélection) et plusieurs éléments d'interface ont encore besoin d'ajustements." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Cliquez sur un champ pour y accéder sur la carte" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total nécessitant attention" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Les champs listés à droite nécessitent un traitement. Cliquez sur une ligne pour voir les intrants recommandés et les quantités estimées." eh="5748d316" />
     </elements>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Vihreä" eh="d382816a" />
     <e k="sf_hud_color_2" v="Sininen" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Meripihka" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Vaikeus" eh="7b29ca96" />
     <e k="sf_diff_long" v="Maaperänhallinnan vaikeustaso" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Vaihda automaattinen annostelu" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -111,48 +111,48 @@
     <e k="sf_bigBag_uan28_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Vedetön Ammoniakki 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Typpilannoite (kuiva)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Typpilannoite (kuiva)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosforilannoite (kuiva)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosforilannoite (kuiva)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumsuola 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumlannoite (kuiva)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Startterilannoite 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Startterilannoite (nestemäinen)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Vaihda kerros" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Hoitosuunnitelma" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Poista kerros käytöstä" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Kehittäjän huomio" eh="5320d63f" />
     <e k="sf_pda_help_github" v="PALAUTTEESI ON TÄRKEÄÄ! Jos kohtaat virheitä, sinulla on ehdotuksia uusista ominaisuuksista tai haluat osallistua koodiin, käy projektin GitHub-sivulla. Voit avata Issues- tai Pull Request -pyynnön milloin tahansa auttaaksesi parantamaan tätä modia kaikille. Kiitos testauksesta!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Hei, täällä kehittäjä! Kuten näet, tämä sivu on vielä hyvin kesken. Karttatasot ovat tällä hetkellä vain visuaalisia esikatseluja (eivät toiminnallisia valinnassa), ja monet käyttöliittymäelementit tarvitsevat vielä viimeistelyä." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Napsauta kenttää siirtyäksesi siihen kartalla" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Yhteensä huomiota vaativat" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Oikealla luetellut pellot tarvitsevat hoitoa. Napsauta riviä nähdäksesi suositellut panokset ja arvioidut määrät." eh="5748d316" />
     </elements>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Yhteensä huomiota vaativat" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Oikealla luetellut pellot tarvitsevat hoitoa. Napsauta riviä nähdäksesi suositellut panokset ja arvioidut määrät." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1,491 +1,531 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
-    <e k="sf_section" v="Sol &amp; Engrais" eh="f31197fb" />
+    <e k="sf_section" v="Sol et engrais" eh="d30a22a9" />
     <e k="sf_enabled_short" v="Activer le mod" eh="cf7fea13" />
-    <e k="sf_enabled_long" v="Activer ou désactiver le module sol &amp; engrais" eh="a891399a" />
+    <e k="sf_enabled_long" v="Activer ou désactiver le mod sol et engrais" eh="e377fd59" />
     <e k="sf_debug_short" v="Mode DEBUG" eh="2ddcdc76" />
-    <e k="sf_debug_long" v="Activer/désactiver le mode DEBUG (journalisation supplémentaire)" eh="f6f20240" />
-    <e k="sf_seasonal_effects_short" v="Effets Saisonniers" eh="c16ea608" />
-    <e k="sf_seasonal_effects_long" v="Activer/désactiver l'impact saisonnier sur les nutriments du sol (stimulation printanière, ralentissement automnal)" eh="3eea94c7" />
-    <e k="sf_rain_effects_short" v="Effets Pluie" eh="a2a1758b" />
+    <e k="sf_debug_long" v="Activer/désactiver le mode debug (journalisation supplémentaire)" eh="f6f20240" />
+    <e k="sf_seasonal_effects_short" v="Effets saisonniers" eh="c16ea608" />
+    <e k="sf_seasonal_effects_long" v="Activer/désactiver l'impact saisonnier sur les nutriments du sol (accélération de la croissance au printemps, ralentissement en automne)" eh="3eea94c7" />
+    <e k="sf_rain_effects_short" v="Effets de pluie" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activer/désactiver l'impact de la pluie sur le sol (lessivage des nutriments, changements de pH)" eh="de3b14b9" />
-    <e k="sf_plowing_bonus_short" v="Bonus Labour" eh="541ec752" />
-    <e k="sf_plowing_bonus_long" v="Activer/désactiver les avantages du labour pour la fertilité du sol (amélioration de l'azote et de la matière organique)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Pression des adventices" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Activer/désactiver la croissance dynamique des mauvaises herbes et l'impact sur le rendement" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pression des ravageurs" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Activer/désactiver le système d'infestation d'insectes et de ravageurs" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Pression des maladies" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Activer/désactiver le système de maladies fongiques et des cultures" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="Compactage du sol" eh="00000000" />
-    <e k="sf_compaction_long" v="Activer ou désactiver le système de compactage du sol par les véhicules lourds" eh="00000000" />
-    <e k="sf_fertility_short" v="Système de Fertilité" eh="f7e27d58" />
+    <e k="sf_plowing_bonus_short" v="Bonus de labour" eh="541ec752" />
+    <e k="sf_plowing_bonus_long" v="Activer/désactiver les bénéfices du labour sur la fertilité du sol (amélioration de l'azote et de la matière organique)" eh="fe701c1c" />
+    <e k="sf_weed_pressure_short" v="Pression des mauvaises herbes" eh="53f8b936" />
+    <e k="sf_weed_pressure_long" v="Activer/désactiver la croissance dynamique des mauvaises herbes et leur impact sur le rendement" eh="ac99a865" />
+    <e k="sf_pest_pressure_short" v="Pression des ravageurs" eh="18a7c2be" />
+    <e k="sf_pest_pressure_long" v="Activer/désactiver le système d'infestation d'insectes et de ravageurs" eh="2ba11abc" />
+    <e k="sf_disease_pressure_short" v="Pression des maladies" eh="2b805cc9" />
+    <e k="sf_disease_pressure_long" v="Activer/désactiver le système de maladies fongiques et des cultures" eh="9080edbc" />
+    <e k="sf_compaction_short" v="Compaction du sol" eh="68734a56" />
+    <e k="sf_compaction_long" v="Activer/désactiver le système de compaction du sol par les véhicules lourds" eh="a0995ec5" />
+    <e k="sf_fertility_short" v="Système de fertilité" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Activer/désactiver le système de fertilité du sol dynamique" eh="ea074366" />
-    <e k="sf_nutrients_short" v="Cycles Nutriments" eh="ffab595d" />
-    <e k="sf_nutrients_long" v="Activer/désactiver l'épuisement et le réapprovisionnement réalistes des nutriments" eh="dbe9c8ff" />
+    <e k="sf_nutrients_short" v="Cycles des nutriments" eh="ffab595d" />
+    <e k="sf_nutrients_long" v="Activer/désactiver l'épuisement et la reconstitution réalistes des nutriments" eh="dbe9c8ff" />
     <e k="sf_difficulty_short" v="Difficulté" eh="7b29ca96" />
     <e k="sf_difficulty_long" v="Définir le niveau de difficulté : Simple, Réaliste, Hardcore" eh="cfb758a4" />
-    <e k="sf_diff_1" v="[EN] Simple" eh="1fbb1e39" />
+    <e k="sf_diff_1" v="Simple" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Réaliste" eh="408c999f" />
-    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
-		<e k="sf_ui_soilReport_syncing" v="Synchronisation des données du sol..." eh="03f01c4d" />
-		<e k="sf_ui_soilReport_syncTimeout" v="Impossible de charger la propriété des champs. Veuillez fermer et rouvrir le rapport." eh="9f699982" />
-    <e k="sf_fertilizer_cost_short" v="Coûts Engrais" eh="6870d88b" />
-    <e k="sf_fertilizer_cost_long" v="Activer/désactiver les coûts d'achat d'engrais réalistes" eh="12b03fbb" />
-    <e k="sf_notifications_short" v="[EN] Notifications" eh="a274f4d4" />
-    <e k="sf_notifications_long" v="Activer/désactiver les notifications de sol et d'engrais" eh="9a872f8f" />
-    <e k="sf_show_hud_short" v="Afficher HUD" eh="c94fd4d7" />
-    <e k="sf_show_hud_long" v="Afficher/masquer l'HUD d'info sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
-    <e k="sf_hud_position_short" v="Position HUD" eh="5ac371f2" />
-    <e k="sf_hud_position_long" v="Choisir où l'HUD d'info sol apparaît à l'écran" eh="d7b9c109" />
+    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_ui_soilReport_syncing" v="Synchronisation des données du sol..." eh="03f01c4d" />
+    <e k="sf_ui_soilReport_syncTimeout" v="Impossible de charger la propriété des champs. Veuillez fermer et rouvrir le rapport." eh="9f699982" />
+    <e k="sf_fertilizer_cost_short" v="Coûts des engrais" eh="6870d88b" />
+    <e k="sf_fertilizer_cost_long" v="Activer/désactiver les coûts réalistes d'achat des engrais" eh="12b03fbb" />
+    <e k="sf_notifications_short" v="Notifications" eh="a274f4d4" />
+    <e k="sf_notifications_long" v="Activer/désactiver les notifications du sol et des engrais" eh="9a872f8f" />
+    <e k="sf_show_hud_short" v="Afficher le HUD" eh="c94fd4d7" />
+    <e k="sf_show_hud_long" v="Afficher/masquer l'interface HUD d'informations sur le sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
+    <e k="sf_hud_position_short" v="Position du HUD" eh="5ac371f2" />
+    <e k="sf_hud_position_long" v="Choisir où l'interface HUD du sol apparaît à l'écran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="En haut à droite" eh="5f9f6784" />
     <e k="sf_hud_pos_2" v="En haut à gauche" eh="ac71274a" />
     <e k="sf_hud_pos_3" v="En bas à droite" eh="4d297f5d" />
     <e k="sf_hud_pos_4" v="En bas à gauche" eh="7eb55425" />
-    <e k="sf_hud_pos_5" v="Centre droit" eh="d7afdc5a" />
+    <e k="sf_hud_pos_5" v="Centre droite" eh="d7afdc5a" />
     <e k="sf_hud_pos_6" v="Personnalisé" eh="90589c47" />
-    <e k="sf_hud_color_theme_short" v="Thème de couleur HUD" eh="4a73f95b" />
-    <e k="sf_hud_color_theme_long" v="Choisir le schéma de couleurs pour l'affichage des infos sol" eh="3218bca6" />
+    <e k="sf_hud_color_theme_short" v="Thème de couleur du HUD" eh="4a73f95b" />
+    <e k="sf_hud_color_theme_long" v="Choisir le thème de couleur de l'affichage des informations du sol" eh="3218bca6" />
     <e k="sf_hud_color_1" v="Vert" eh="d382816a" />
     <e k="sf_hud_color_2" v="Bleu" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Ambre" eh="88068e33" />
-    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="Monochrome" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficulté" eh="7b29ca96" />
-    <e k="sf_diff_long" v="Niveau de difficulté de gestion du sol" eh="d6f4560c" />
-		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
-		<e k="sf_rr_long" v="[EN] How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
-    <e k="sf_auto_rate_short" v="Contrôle automatique du débit" eh="6f99137d" />
-    <e k="sf_auto_rate_long" v="Ajuste automatiquement le taux d'application selon les besoins du champ" eh="a9ca9f6b" />
+    <e k="sf_diff_long" v="Niveau de difficulté de la gestion du sol" eh="d6f4560c" />
+    <e k="sf_rr_short" v="Taux de reconstitution" eh="b363b336" />
+    <e k="sf_rr_long" v="Vitesse à laquelle l'engrais restaure les nutriments du champ (0.25x très lent à 2.0x très rapide)" eh="afe78a6d" />
+    <e k="sf_auto_rate_short" v="Contrôle automatique du taux" eh="6f99137d" />
+    <e k="sf_auto_rate_long" v="Ajuste automatiquement la dose d'engrais selon les besoins du champ" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Vert" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Bleu" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Ambre" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
-    <e k="sf_hud_font_size_short" v="Taille police HUD" eh="fd6ca64a" />
+    <e k="sf_hud_theme_4" v="Monochrome" eh="5d9b47bd" />
+    <e k="sf_hud_font_size_short" v="Taille de la police du HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Ajuster la taille du texte pour une meilleure lisibilité" eh="c338854f" />
     <e k="sf_hud_font_1" v="Petit" eh="2660064e" />
     <e k="sf_hud_font_2" v="Moyen" eh="87f8a6ab" />
     <e k="sf_hud_font_3" v="Grand" eh="3a69b34c" />
-    <e k="sf_hud_transparency_short" v="Transparence HUD" eh="e8a009e4" />
-    <e k="sf_hud_transparency_long" v="Définir niveau transparence fond (Clair = transparent, Solide = opaque)" eh="152e390a" />
-    <e k="sf_hud_trans_1" v="Clair" eh="dc30bc0c" />
+    <e k="sf_hud_transparency_short" v="Transparence du HUD" eh="e8a009e4" />
+    <e k="sf_hud_transparency_long" v="Définir le niveau de transparence du fond (Transparent = voir à travers, Plein = opaque)" eh="152e390a" />
+    <e k="sf_hud_trans_1" v="Transparent" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Léger" eh="9914a0ce" />
     <e k="sf_hud_trans_3" v="Moyen" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Sombre" eh="a18366b2" />
-    <e k="sf_hud_trans_5" v="Solide" eh="e41480b6" />
+    <e k="sf_hud_trans_5" v="Plein" eh="e41480b6" />
+    <e k="sf_use_imperial_short" v="Unités impériales" eh="ff2701ad" />
+    <e k="sf_use_imperial_long" v="Afficher les doses d'application en gal/acre et lb/acre (désactivé = L/ha et kg/ha)" eh="17efa489" />
+    <e k="sf_active_map_layer_short" v="Couche de carte active" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="Couche de nutriments affichée en superposition sur la carte PDA" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="Détail de la carte" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="Budget de points d'échantillonnage pour la superposition du sol sur la PDA. Faible = meilleures performances, Élevé = couverture plus complète sur les grandes cartes." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="Ouvrir les paramètres du sol" eh="2e31c0dd" />
+    <e k="sf_reset" v="Réinitialiser les paramètres du sol" eh="467bc2f5" />
+    <e k="input_SF_TOGGLE_HUD" v="Activer/désactiver le HUD du sol" eh="f0224a10" />
+    <e k="input_SF_HUD_DRAG" v="Mode déplacement du HUD" eh="cb2eb762" />
+    <e k="input_SF_SOIL_REPORT" v="Rapport de sol" eh="c33180ef" />
+    <e k="input_SF_RATE_UP" v="Augmenter la dose d'engrais" eh="6e601ef5" />
+    <e k="input_SF_RATE_DOWN" v="Diminuer la dose d'engrais" eh="30712026" />
+    <e k="input_SF_TOGGLE_AUTO" v="Activer/désactiver le mode automatique" eh="a8642cf0" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="Changer la couche de carte du sol" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="Ouvrir la PDA du sol" eh="7d70f7b4" />
+    <e k="sf_report_title" v="Rapport Sol et engrais" eh="a76f8218" />
+    <e k="sf_report_fields_tracked" v="Champs suivis :" eh="7b1e59b8" />
+    <e k="sf_report_need_fert" v="Besoin d'engrais :" eh="110b60f2" />
+    <e k="sf_report_farm_health" v="Santé de la ferme :" eh="a5330ade" />
+    <e k="sf_report_back" v="Retour" eh="0557fa92" />
+    <e k="sf_report_difficulty" v="Difficulté :" eh="3abaf54f" />
+    <e k="sf_report_col_field" v="Champ" eh="6f16a5f8" />
+    <e k="sf_report_col_last_crop" v="Dernière culture" eh="ff41e5eb" />
+    <e k="sf_report_col_fert" v="Engrais ?" eh="9e6d0eb4" />
+    <e k="sf_report_no_data" v="Aucune donnée de sol disponible. Marchez sur un champ pour commencer le suivi." eh="1528a4cb" />
+    <e k="sf_report_prev" v="Préc." eh="14230d11" />
+    <e k="sf_report_next" v="Suiv." eh="10ac3d04" />
+    <e k="sf_report_yes" v="OUI" eh="7469a286" />
+    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_none" v="Aucun" eh="6adf97f8" />
+    <e k="sf_report_rec_n_poor" v="Besoin d'azote" eh="5dca0711" />
+    <e k="sf_report_rec_n_fair" v="Azote faible" eh="35ad072d" />
+    <e k="sf_report_rec_p_poor" v="Besoin de phosphore" eh="e8fa326f" />
+    <e k="sf_report_rec_p_fair" v="Phosphore faible" eh="077e12cf" />
+    <e k="sf_report_rec_k_poor" v="Besoin de potassium" eh="f23194e0" />
+    <e k="sf_report_rec_k_fair" v="Potassium faible" eh="2006c0a2" />
+    <e k="sf_report_rec_ph_adjust" v="Ajuster le pH" eh="84f6bbbc" />
+    <e k="sf_report_rec_ph_monitor" v="Surveiller le pH" eh="6dfcded4" />
+    <e k="sf_report_rec_om_increase" v="Augmenter la matière organique" eh="c2a930af" />
+    <e k="sf_report_rec_om_maintain" v="Maintenir la matière organique" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="Risque de ravageurs" eh="22e0f3bf" />
+    <e k="sf_report_rec_disease" v="Risque de maladies" eh="c342956b" />
+    <e k="sf_report_rec_needs" v="Besoin :" eh="3e6d95cf" />
+    <e k="sf_report_rec_optimal" v="Santé du sol : optimale" eh="6ee9d19b" />
+    <e k="sf_report_rec_good" v="Bon" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="Moyen" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="Mauvais" eh="0e94d017" />
+    <e k="sf_uan32_title" v="Engrais UAN 32 (N)" eh="90913bb8" />
+    <e k="sf_uan28_title" v="Engrais UAN 28 (N)" eh="9d902cd7" />
+    <e k="sf_anhydrous_title" v="Ammoniac anhydre (N)" eh="3fc85c02" />
+    <e k="sf_starter_title" v="Engrais de démarrage 10-34-0 (P)" eh="8c1a1ddc" />
+    <e k="sf_urea_title" v="Urée 46-0-0 (N)" eh="659b3097" />
+    <e k="sf_ams_title" v="Sulfate d'ammonium 21-0-0 (N)" eh="033d1845" />
+    <e k="sf_map_title" v="Engrais MAP 11-52-0 (P)" eh="31aa2534" />
+    <e k="sf_dap_title" v="Engrais DAP 18-46-0 (P)" eh="5030a80a" />
+    <e k="sf_potash_title" v="Potasse 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_liquid_urea_title" v="Urée liquide (N)" eh="7fee4f12" />
+    <e k="sf_liquid_ams_title" v="Sulfate d'ammonium liquide (N)" eh="0daf3a6f" />
+    <e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
+    <e k="sf_liquid_dap_title" v="DAP liquide (P)" eh="86bd893e" />
+    <e k="sf_liquid_potash_title" v="Potasse liquide (K)" eh="72ac9fd3" />
+    <e k="sf_insecticide_title" v="Insecticide" eh="5650eeef" />
+    <e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
+    <e k="sf_report_page_info" v="Champs %d-%d sur %d  |  Page %d sur %d" eh="8db851d1" />
+    <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
+    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
+    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniac anhydre 82-0-0" eh="fb09e6ce" />
+    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
+    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec)" eh="18015099" />
+    <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
+    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_name" v="IBC Sulfate d'ammonium liquide" eh="32e6c8bb" />
+    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_map_name" v="IBC MAP liquide" eh="4628addb" />
+    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_name" v="IBC DAP liquide" eh="82fb3c06" />
+    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_potash_name" v="IBC Potasse liquide" eh="7176856d" />
+    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide)" eh="52169d4a" />
+    <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
+    <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
+    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquide)" eh="09580f6b" />
+    <e k="sf_bigBag_fungicide_name" v="IBC Fongicide" eh="2a1c78d4" />
+    <e k="sf_bigBag_fungicide_function" v="Fongicide (liquide)" eh="745c34cb" />
+    <e k="sf_bigBag_starter_function" v="Engrais de démarrage (liquide)" eh="2c36ea57" />
+    <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
+    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec)" eh="51503c54" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fumier de poulet" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fumier pelletisé" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="Cuve de chaux liquide" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="Agent d'augmentation du pH (liquide)" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITEUR DE SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Allez sur un champ" eh="62c55e9e" />
+    <e k="sf_hud_noField" v="Marchez sur un champ" eh="62c55e9e" />
     <e k="sf_hud_fallow" v="Jachère" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Mauvaises herbes" eh="324181de" />
     <e k="sf_hud_pests" v="Ravageurs" eh="2fed5101" />
     <e k="sf_hud_disease" v="Maladie" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protégé)" eh="8273211e" />
     <e k="sf_hud_yield" v="Rendement" eh="97345487" />
-    <e k="sf_hud_estYield" v="Rendement est." eh="32a4135e" />
-    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_estYield" v="Rend. estimé" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
     <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   RMB: terminé" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: déplacer/redimensionner" eh="afc8f13b" />
-    <e k="sf_use_imperial_short" v="Unités impériales" eh="ff2701ad" />
-    <e k="sf_use_imperial_long" v="Afficher les doses en gal/ac et lb/ac (désactivé = L/ha et kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Couche de carte active" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Couche de nutriments affichée en superposition sur la carte du PDA" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Détail de la carte" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Nombre de points d’échantillonnage pour l’affichage du sol sur le PDA. Faible = meilleures performances (FPS), Élevé = couverture plus complète sur les grandes cartes." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Ouvrir les paramètres du sol" eh="2e31c0dd" />
-    <e k="sf_reset" v="Réinitialiser paramètres sol" eh="467bc2f5" />
-    <e k="input_SF_TOGGLE_HUD" v="Activer/désactiver HUD sol" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="Mode de déplacement du HUD" eh="00000000" />
-    <e k="input_SF_SOIL_REPORT" v="Rapport Sol" eh="c33180ef" />
-    <e k="input_SF_RATE_UP" v="Augmenter le taux d'engrais" eh="6e601ef5" />
-    <e k="input_SF_RATE_DOWN" v="Réduire le taux d'engrais" eh="30712026" />
-    <e k="input_SF_TOGGLE_AUTO" v="Basculer taux auto" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Changer la couche de la carte du sol" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Ouvrir le PDA du sol" eh="7d70f7b4" />
-    <e k="sf_report_title" v="Rapport Sol &amp;amp; Engrais" eh="a76f8218" />
-    <e k="sf_report_fields_tracked" v="Champs Suivis:" eh="7b1e59b8" />
-    <e k="sf_report_need_fert" v="Besoin d'Engrais:" eh="110b60f2" />
-		<e k="sf_report_farm_health" v="Santé de la ferme:" eh="a5330ade" />
-		<e k="sf_report_back" v="Retour" eh="0557fa92" />
-    <e k="sf_report_difficulty" v="Difficulté:" eh="3abaf54f" />
-    <e k="sf_report_col_field" v="Champ" eh="6f16a5f8" />
-    <e k="sf_report_col_last_crop" v="Dernière Récolte" eh="ff41e5eb" />
-    <e k="sf_report_col_fert" v="Eng?" eh="9e6d0eb4" />
-    <e k="sf_report_no_data" v="Aucune donnée de sol disponible. Marchez sur un champ pour commencer le suivi." eh="1528a4cb" />
-    <e k="sf_report_prev" v="Préc" eh="14230d11" />
-    <e k="sf_report_next" v="Suiv" eh="10ac3d04" />
-    <e k="sf_report_yes" v="OUI" eh="7469a286" />
-    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
-    <e k="sf_report_none" v="Aucun" eh="6adf97f8" />
-    <e k="sf_report_rec_n_poor" v="Azote nécessaire" eh="5dca0711" />
-    <e k="sf_report_rec_n_fair" v="Azote faible" eh="35ad072d" />
-    <e k="sf_report_rec_p_poor" v="Phosphore nécessaire" eh="e8fa326f" />
-    <e k="sf_report_rec_p_fair" v="Phosphore faible" eh="077e12cf" />
-    <e k="sf_report_rec_k_poor" v="Potassium nécessaire" eh="f23194e0" />
-    <e k="sf_report_rec_k_fair" v="Potassium faible" eh="2006c0a2" />
-    <e k="sf_report_rec_ph_adjust" v="Ajuster le pH" eh="84f6bbbc" />
-    <e k="sf_report_rec_ph_monitor" v="Surveiller le pH" eh="6dfcded4" />
-    <e k="sf_report_rec_om_increase" v="Augmenter MO" eh="c2a930af" />
-    <e k="sf_report_rec_om_maintain" v="Maintenir MO" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Risque de ravageurs" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Risque de maladie" eh="e7655847" />
-    <e k="sf_report_rec_needs" v="Besoins:" eh="3e6d95cf" />
-    <e k="sf_report_rec_optimal" v="Santé sol: Optimale" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Bon" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Moyen" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Mauvais" eh="0e94d017" />
-    <e k="sf_uan32_title" v="UAN 32 Engrais azoté (N)" eh="90913bb8" />
-    <e k="sf_uan28_title" v="UAN 28 Engrais azoté (N)" eh="9d902cd7" />
-    <e k="sf_anhydrous_title" v="Ammoniac anhydre (N)" eh="3fc85c02" />
-    <e k="sf_starter_title" v="Engrais starter 10-34-0 (P)" eh="8c1a1ddc" />
-    <e k="sf_urea_title" v="Urée 46-0-0 (N)" eh="659b3097" />
-    <e k="sf_ams_title" v="Sulfate d'ammonium 21-0-0 (N)" eh="033d1845" />
-    <e k="sf_map_title" v="Engrais MAP 11-52-0 (P)" eh="31aa2534" />
-    <e k="sf_dap_title" v="Engrais DAP 18-46-0 (P)" eh="5030a80a" />
-    <e k="sf_potash_title" v="Potasse 0-0-60 (K)" eh="8db6c54c" />
-		<e k="sf_liquid_urea_title" v="Urée liquide (N)" eh="7fee4f12" />
-		<e k="sf_liquid_ams_title" v="Sulfate d'ammonium liquide (N)" eh="0daf3a6f" />
-		<e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
-		<e k="sf_liquid_dap_title" v="DAP liquide (P)" eh="86bd893e" />
-		<e k="sf_liquid_potash_title" v="Potasse liquide (K)" eh="72ac9fd3" />
-		<e k="sf_insecticide_title" v="[EN] Insecticide" eh="5650eeef" />
-		<e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
-    <e k="sf_report_page_info" v="Champs %d-%d sur %d  |  Page %d sur %d" eh="8db851d1" />
-    <e k="sf_bigBag_uan32_name" v="Big Bag UAN 32-0-0" eh="7bdc4d9d" />
-    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide)" eh="27de5f41" />
-    <e k="sf_bigBag_uan28_name" v="Big Bag UAN 28-0-0" eh="997781d5" />
-    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide)" eh="27de5f41" />
-    <e k="sf_bigBag_anhydrous_name" v="Big Bag Ammoniac Anhydre 82-0-0" eh="44914201" />
-    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Engrais phosphoré (sec)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Engrais phosphoré (sec)" eh="0cc85c60" />
-    <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="Big Bag Urée Liquide" eh="a4d4c642" />
-		<e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="Big Bag AMS Liquide" eh="d57c1316" />
-		<e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="Big Bag MAP Liquide" eh="323d4972" />
-		<e k="sf_bigBag_liquid_map_function" v="Engrais phosphoré (liquide)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="Big Bag DAP Liquide" eh="da992701" />
-		<e k="sf_bigBag_liquid_dap_function" v="Engrais phosphoré (liquide)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="Big Bag Potasse Liquide" eh="839fca36" />
-		<e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide)" eh="52169d4a" />
-    <e k="sf_bigBag_starter_name" v="Big Bag Engrais Starter 10-34-0" eh="953fd6c0" />
-    <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquide)" eh="09580f6b" />
-    <e k="sf_bigBag_fungicide_name" v="Big Bag Fongicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fongicide (liquide)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Engrais starter (liquide)" eh="2c36ea57" />
-		<e k="sf_bigBag_gypsum_name" v="Big Bag de gypse" eh="40fc8169" />
-		<e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Engrais organique (solide)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag fumier de poule" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (solide)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag fumier granulé" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (solide)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Cuve de chaux liquide" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent rehausseur de pH (liquide)" eh="7a118b6d" />
-    <e k="sf_report_detail_n_ok" v="Azote: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphore: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_detail_n_ok" v="Azote : optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="Phosphore : optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="Potassium : optimal" eh="0197b4ba" />
     <e k="sf_report_status_monitor" v="Surveiller" eh="d2986ac8" />
     <e k="sf_report_status_adjust" v="Ajuster" eh="51d7a685" />
     <e k="sf_report_status_maintain" v="Maintenir" eh="ade01a5a" />
     <e k="sf_report_status_increase" v="Augmenter" eh="aac247ca" />
     <e k="sf_report_pressure_low" v="Faible" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Modéré" eh="1eb79d43" />
+    <e k="sf_report_pressure_moderate" v="Moyen" eh="1eb79d43" />
     <e k="sf_report_pressure_high" v="Élevé" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" eh="022663e0" />
+    <e k="sf_report_yield_hint" v="Basé sur N/P/K par rapport au seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
-		<e k="helpLine_sf_cat_overview" v="Aperçu" eh="3b878279" />
-		<e k="helpLine_sf_cat_started" v="Mise en route" eh="bf647454" />
-		<e k="helpLine_sf_cat_nutrients" v="Nutriments du sol" eh="64377acf" />
-		<e k="helpLine_sf_cat_fertilizers" v="Engrais" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="HUD &amp;amp; Rapport de sol" eh="9b9888b9" />
-		<e k="helpLine_sf_cat_settings" v="Paramètres" eh="f4f70727" />
-		<e k="helpLine_sf_cat_multiplayer" v="Multijoueur" eh="901a7320" />
-		<e k="helpLine_sf_ov_p1_title" v="Ce qu'il fait" eh="46cbb25b" />
-		<e k="helpLine_sf_ov_p1_intro_title" v="Suivi du sol par champ" eh="8fe3248d" />
-		<e k="helpLine_sf_ov_p1_intro_text" v="Chaque champ suit indépendamment cinq propriétés : Azote (N), Phosphore (P), Potassium (K), Matière Organique (MO) et pH. Les valeurs sont sauvegardées avec votre partie et persistent entre les sessions." eh="c30216e6" />
-		<e k="helpLine_sf_ov_p1_flow_title" v="Le cycle des nutriments" eh="15b0d408" />
-		<e k="helpLine_sf_ov_p1_flow_text" v="Les cultures absorbent les nutriments lors de la récolte. L'engrais, le fumier, le lisier et la chaux les restaurent. Le mod suit un budget de nutriments réaliste - ce que les cultures prélèvent, vous devez le restituer." eh="418041f0" />
-		<e k="helpLine_sf_ov_p2_title" v="Effets environnementaux" eh="e139e84f" />
-		<e k="helpLine_sf_ov_p2_rain_title" v="Pluie et lessivage" eh="33e0d8ea" />
-		<e k="helpLine_sf_ov_p2_rain_text" v="La pluie lessive l'azote le plus fortement, puis le potassium, puis le phosphore. Elle acidifie également lentement le pH au fil du temps. Les effets de la pluie peuvent être désactivés dans les paramètres." eh="91e39cc6" />
-		<e k="helpLine_sf_ov_p2_season_title" v="Saisons et récupération des jachères" eh="ad2009c8" />
-		<e k="helpLine_sf_ov_p2_season_text" v="Le printemps ajoute +0,03 N par jour (activité biologique). L'automne retire 0,02 N par jour. Les champs laissés non plantés pendant plus de 7 jours récupèrent lentement tous leurs nutriments par eux-mêmes." eh="e5ebb3b2" />
-		<e k="helpLine_sf_gs_p1_title" v="Vos premiers pas" eh="bdd0e0a7" />
-		<e k="helpLine_sf_gs_p1_hud_title" v="Ouvrir l'HUD (touche J)" eh="e1bdea72" />
-		<e k="helpLine_sf_gs_p1_hud_text" v="Appuyez sur J pour basculer l'affichage du sol en direct. Il montre N, P, K, pH et MO pour le champ où vous vous trouvez. Les statuts Bon / Moyen / Mauvais vous indiquent ce qui nécessite votre attention d'un coup d'œil." eh="53cef520" />
-		<e k="helpLine_sf_gs_p1_report_title" v="Ouvrir le rapport de sol (touche K)" eh="e71446cd" />
-		<e k="helpLine_sf_gs_p1_report_text" v="Appuyez sur K pour ouvrir le rapport complet sur les sols de la ferme. Chaque champ est répertorié avec un statut de nutriment code couleur, trié par urgence. Cliquez sur la flèche de n'importe quelle ligne pour une vue détaillée avec des recommandations." eh="9a0d32a6" />
-		<e k="helpLine_sf_gs_p2_title" v="Fertiliser et récolter" eh="1a52ac04" />
-		<e k="helpLine_sf_gs_p2_fert_title" v="Fertilisation des champs" eh="ea52ec26" />
-		<e k="helpLine_sf_gs_p2_fert_text" v="Appliquez de l'engrais avec n'importe quel pulvérisateur ou épandeur standard. Le mod reconnaît tous les types du jeu de base plus 9 types personnalisés (UAN-32, MAP, Potasse, etc.). Chaque type restaure différents nutriments - voir la catégorie Engrais pour les profils complets." eh="fe906e29" />
-		<e k="helpLine_sf_gs_p2_harvest_title" v="Épuisement par la récolte" eh="a67b6cb5" />
-		<e k="helpLine_sf_gs_p2_harvest_text" v="Chaque récolte prélève des nutriments du champ. Les cultures exigeantes (pomme de terre, betterave sucrière, soja) épuisent nettement plus que les cultures légères (orge, avoine). Re-vérifiez l'HUD ou le rapport de sol après chaque cycle de récolte." eh="63f90ed4" />
-		<e k="helpLine_sf_gs_p3_title" v="Difficulté" eh="7b29ca96" />
-		<e k="helpLine_sf_gs_p3_levels_title" v="Trois niveaux de difficulté" eh="52611188" />
-		<e k="helpLine_sf_gs_p3_levels_text" v="Simple (0,7x) : 30%% d'épuisement en moins - idéal pour les nouveaux joueurs. Réaliste (1,0x) : équilibré, calibré sur les taux agricoles réels. Hardcore (1,5x) : 50%% d'épuisement en plus - gestion intensive du sol requise." eh="f4f1ea30" />
-		<e k="helpLine_sf_gs_p3_access_title" v="Modification des paramètres" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="Ouvrez les paramètres via ESC &amp;gt; Paramètres &amp;gt; Sol &amp;amp; Engrais. En multijoueur, seul l'administrateur du serveur peut modifier les paramètres de simulation. Toutes les options d'affichage de l'HUD sont par joueur et ne sont pas partagées." eh="f36a5639" />
-		<e k="helpLine_sf_nu_p1_title" v="Azote et Phosphore" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="Azote (N) — Échelle : 0 à 100" eh="10a358f4" />
-		<e k="helpLine_sf_nu_p1_n_text" v="Le nutriment le plus mobile - s'épuise le plus vite et se lessive fortement par temps de pluie. Mauvais : en dessous de 30. Bon : au-dessus de 50. Relever avec : engrais liquide, UAN-32, UAN-28, ammoniac anhydre, urée, AMS, fumier ou lisier." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="Phosphore (P) — Échelle : 0 à 100" eh="979bba64" />
-		<e k="helpLine_sf_nu_p1_p_text" v="Se lie fortement au sol et se lessive très lentement. S'épuise principalement par la récolte. Le colza a la demande en P la plus élevée. Mauvais : en dessous de 25. Bon : au-dessus de 45. Relever avec : MAP, DAP, engrais starter ou engrais liquide." eh="92c5ac66" />
-		<e k="helpLine_sf_nu_p2_title" v="Potassium et pH" eh="6bd92f25" />
-		<e k="helpLine_sf_nu_p2_k_title" v="Potassium (K) - Échelle 0 à 100" eh="2a16e8bc" />
-		<e k="helpLine_sf_nu_p2_k_text" v="Critique pour les cultures de racines et tubercules. La pomme de terre et la betterave sucrière épuisent fortement le K à chaque récolte. Se lessive modérément par temps de pluie. Mauvais : en dessous de 20. Bon : au-dessus de 40. Relever avec : potasse (0-0-60), lisier, digestat ou engrais liquide." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="pH — Échelle : 5,0 à 7,5" eh="944beca2" />
-		<e k="helpLine_sf_nu_p2_ph_text" v="La plupart des cultures s'épanouissent entre un pH de 6,5 et 7,0. La pluie acidifie lentement le sol au fil du temps. Le pH ne se rétablit pas de lui-même - seule la chaux ou la chaux liquide l'augmente. Mauvais : en dessous de 5,5. Appliquer de la chaux si le pH chute avant la prochaine plantation." eh="08e0aefd" />
-		<e k="helpLine_sf_nu_p3_title" v="Matière Organique" eh="6305f4bb" />
-		<e k="helpLine_sf_nu_p3_om_title" v="Matière Organique (MO) - Échelle 0 à 10" eh="58f490f3" />
-		<e k="helpLine_sf_nu_p3_om_text" v="Se constitue très lentement et n'est pas épuisée par la récolte. Mauvaise : en dessous de 2,5. Bonne : au-dessus de 4,0. Relever avec : fumier, lisier, digestat, compost, biosolides, litière de poulet, fumier granulé, ou en broyant la paille sur le champ." eh="f9a02359" />
-		<e k="helpLine_sf_nu_p3_fallow_title" v="Récupération des jachères" eh="14133b0b" />
-		<e k="helpLine_sf_nu_p3_fallow_text" v="Un champ laissé sans culture pendant plus de 7 jours récupère lentement ses nutriments. Par jour : N +0,07, P +0,03, K +0,05, MO +0,01. La rotation des cultures et les périodes de repos ont une réelle valeur dans ce mod." eh="81fa82b3" />
-		<e k="helpLine_sf_fe_p1_title" v="Types du jeu de base" eh="fd941c0d" />
-		<e k="helpLine_sf_fe_p1_base_title" v="Liquide, Solide, Fumier et Lisier" eh="4668dca7" />
-		<e k="helpLine_sf_fe_p1_base_text" v="L'engrais liquide apporte un équilibre N+P+K. L'engrais solide est plus riche en N et P. Le fumier et le lisier apportent N, P, K et de la matière organique. Le digestat (sous-produit du biogaz) est riche en K et apporte également de la MO. Tous s'appliquent avec l'équipement standard." eh="64069a56" />
-		<e k="helpLine_sf_fe_p1_lime_title" v="Chaux et correction du pH" eh="8933cce1" />
-		<e k="helpLine_sf_fe_p1_lime_text" v="La chaux est la seule correction de pH du jeu de base - elle n'ajoute pas de nutriments. Les types personnalisés Chaux Liquide et Gypse augmentent également le pH (le gypse ajoute un peu de MO aussi). Appliquer lorsque le pH descend en dessous de 6,0 pour maintenir les cultures dans leur plage optimale." eh="833a967f" />
-		<e k="helpLine_sf_fe_p2_title" v="Sources personnalisées d'azote et PK" eh="1021f8c9" />
-		<e k="helpLine_sf_fe_p2_n_title" v="Sources d'azote (big bags personnalisés)" eh="9dfe5a5a" />
-		<e k="helpLine_sf_fe_p2_n_text" v="L'UAN-32 (32-0-0) et l'UAN-28 (28-0-0) sont des solutions azotées liquides. L'ammoniac anhydre (82-0-0) est le produit le plus riche en N par litre. L'urée (46-0-0) et l'AMS (21-0-0-24S) sont des granulés secs. Tous sont uniquement azotés - aucun effet sur le P, le K ou le pH." eh="6a100c25" />
-		<e k="helpLine_sf_fe_p2_pk_title" v="Sources de Phosphore et Potassium" eh="a2d4091b" />
-		<e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0) : plus fort taux de P par litre. DAP (18-46-0) : fort P avec un peu de N. Potasse (0-0-60) : K pur. Starter (10-34-0) : produit riche en P pour application localisée avec équilibre N+K. Tous disponibles en big bags achetables au magasin." eh="75a86964" />
-		<e k="helpLine_sf_fe_p3_title" v="Produits organiques et risque de brûlure" eh="7ab807d1" />
-		<e k="helpLine_sf_fe_p3_organic_title" v="Produits organiques et à libération lente" eh="0199e6be" />
-		<e k="helpLine_sf_fe_p3_organic_text" v="Le compost est le plus puissant bâtisseur de MO (+0,12 par 1 000 L). Les biosolides et la litière de poulet ajoutent N, P et MO. Le fumier granulé est un produit organique équilibré concentré. Tous sont des types de remplissage personnalisés disponibles lorsque des mods d'équipement compatibles sont installés." eh="3d16e4ee" />
-		<e k="helpLine_sf_fe_p3_burn_title" v="Risque de brûlure par surdosage" eh="e986cc54" />
-		<e k="helpLine_sf_fe_p3_burn_text" v="L'application au-dessus de 1,25x le taux de base risque de brûler les cultures (-0,15 pH et -5 N). À 1,50x ou plus, la brûlure est garantie à chaque passage (-0,30 pH et -12 N). Utilisez les touches Augmenter/Diminuer débit SF dans le véhicule pour contrôler le taux d'application." eh="7bccc46a" />
-		<e k="helpLine_sf_hu_p1_title" v="L'HUD de sol" eh="6522879b" />
-		<e k="helpLine_sf_hu_p1_toggle_title" v="Basculer l'HUD (touche J)" eh="402283ba" />
-		<e k="helpLine_sf_hu_p1_toggle_text" v="Appuyez sur J pour afficher ou masquer l'incrustation du sol en direct. Il détecte le champ sur lequel vous vous trouvez et affiche N, P, K, pH et MO. Lorsque les paramètres Adventices, Ravageurs ou Maladies sont activés, ces lignes apparaissent en bas du panneau." eh="3dcb9bfe" />
-		<e k="helpLine_sf_hu_p1_status_title" v="Lire le statut" eh="291c3aac" />
-		<e k="helpLine_sf_hu_p1_status_text" v="Chaque nutriment indique Bon (aucune action nécessaire), Moyen (envisager un traitement prochainement) ou Mauvais (action nécessaire - rendement affecté). Le badge global dans la barre de titre reflète la pire valeur parmi toutes les dimensions suivies, y compris les adventices, ravageurs et maladies." eh="3b8c2c6e" />
-		<e k="helpLine_sf_hu_p2_title" v="Pressions sur la santé des champs" eh="b4d35b30" />
-		<e k="helpLine_sf_hu_p2_press_title" v="Adventices, Ravageurs et Maladies" eh="0a3fae00" />
-		<e k="helpLine_sf_hu_p2_press_text" v="Trois scores de pression (0 à 100) suivent les menaces biologiques par champ. Sans intervention, ils réduisent le rendement à la récolte : Adventices jusqu'à -30%%, Ravageurs -20%%, Maladies -25%%. Les lignes HUD W, I et D montrent la sévérité par code couleur : vert (faible), jaune (modérée), rouge (élevée)." eh="3fc3c400" />
-		<e k="helpLine_sf_hu_p2_treat_title" v="Traiter la pression" eh="cb24bf50" />
-		<e k="helpLine_sf_hu_p2_treat_text" v="L'herbicide réduit la pression des adventices - tout travail du sol la remet également à zéro. L'insecticide réduit la pression des ravageurs de 25 pts et supprime la repousse pendant 10 jours. Le fongicide réduit les maladies de 20 pts et les supprime pendant 12 jours. Chaque système peut être désactivé dans les paramètres." eh="4d65bdec" />
-		<e k="helpLine_sf_hu_p3_title" v="Le rapport de sol" eh="35fcce6c" />
-		<e k="helpLine_sf_hu_p3_open_title" v="Ouvrir le rapport (touche K)" eh="62e3f629" />
-		<e k="helpLine_sf_hu_p3_open_text" v="Appuyez sur K pour ouvrir le rapport complet sur les sols de la ferme. La barre de résumé indique le total des champs suivis, combien ont besoin d'engrais, et un pourcentage pondéré de santé de la ferme. Les champs sont triés par urgence - le pire état en premier." eh="38a5bd2e" />
-		<e k="helpLine_sf_hu_p3_detail_title" v="Détails du champ et recommandations" eh="c99d2b89" />
-		<e k="helpLine_sf_hu_p3_detail_text" v="Cliquez sur la flèche de n'importe quelle ligne pour ouvrir la vue détaillée de ce champ : valeurs nutritives, niveaux de pression, prévision de pénalité de rendement, et une liste de recommandations à puces vous indiquant exactement quoi appliquer. Appuyez sur Retour ou Échap pour revenir au tableau." eh="38dd2c6d" />
-		<e k="helpLine_sf_se_p1_title" v="Paramètres de simulation" eh="cbf13e3c" />
-		<e k="helpLine_sf_se_p1_server_title" v="Paramètres du serveur (Admin uniquement en multijoueur)" eh="49f37ed7" />
-		<e k="helpLine_sf_se_p1_server_text" v="Système de fertilité, cycles de nutriments, effets saisonniers, effets de la pluie, bonus de labour, pression Adventices/Ravageurs/Maladies, coûts des engrais, notifications, rotation des cultures et contrôle automatique du débit. En multijoueur, seul l'administrateur du serveur peut les modifier. Les changements se synchronisent instantanément pour tous les clients." eh="abca5e43" />
-		<e k="helpLine_sf_se_p1_diff_title" v="Difficulté" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="Simple (0,7x) réduit l'épuisement de 30%% pour une expérience décontractée. Réaliste (1,0x) est le réglage équilibré par défaut. Hardcore (1,5x) augmente l'épuisement de 50%% pour une gestion intensive du sol. Accès via ESC &amp;gt; Paramètres &amp;gt; Sol &amp;amp; Engrais." eh="740a3a4e" />
-		<e k="helpLine_sf_se_p2_title" v="HUD et contrôle du débit" eh="399f4910" />
-		<e k="helpLine_sf_se_p2_hud_title" v="Options HUD par joueur" eh="0df76500" />
-		<e k="helpLine_sf_se_p2_hud_text" v="Chaque joueur contrôle son propre HUD - non synchronisé avec le serveur. Options : Afficher HUD (on/off), Position (5 préréglages + glisser), Thème de couleur (Vert / Bleu / Ambre / Mono), Taille police (Petit / Moyen / Grand), Transparence (25%% à 100%%), Unités impériales (on/off)." eh="f3934884" />
-		<e k="helpLine_sf_se_p2_rate_title" v="Contrôle du débit du pulvérisateur" eh="5ecdfa23" />
-		<e k="helpLine_sf_se_p2_rate_text" v="Dans un pulvérisateur ou un épandeur, utilisez Augmenter débit SF (]) et Diminuer débit SF ([) pour ajuster le taux d'application de 0,10x à 2,00x. Activez le contrôle automatique du débit (Maj+L) pour laisser le mod cibler automatiquement les niveaux de nutriments optimaux et éviter le risque de brûlure." eh="dd385e39" />
-		<e k="helpLine_sf_mp_p1_title" v="Fonctionnement du multijoueur" eh="8a4ce30e" />
-		<e k="helpLine_sf_mp_p1_auth_title" v="Simulation faisant autorité sur le serveur" eh="8d324792" />
-		<e k="helpLine_sf_mp_p1_auth_text" v="Toute la simulation du sol s'exécute sur le serveur. Les clients reçoivent les données complètes des champs et les paramètres lors de la connexion, avec une nouvelle tentative automatique si le serveur est encore en cours de chargement. Les paramètres d'affichage de l'HUD (position, thème, taille) sont par joueur et ne sont jamais synchronisés avec le serveur." eh="db72a3f9" />
-		<e k="helpLine_sf_mp_p1_ded_title" v="Serveurs dédiés" eh="4d3a45ba" />
-		<e k="helpLine_sf_mp_p1_ded_text" v="Les serveurs dédiés exécutent la simulation complète sans aucune surcharge d'HUD ou de GUI - c'est attendu et normal. Utilisez les commandes de console (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) pour gérer et vérifier les paramètres sur un serveur dédié." eh="3df784d6" />
-		<e k="helpLine_sf_mp_p2_title" v="Compatibilité PrecisionFarming" eh="3647a30c" />
-		<e k="helpLine_sf_mp_p2_compat_title" v="Exécuter les deux mods ensemble" eh="bc5325f5" />
-		<e k="helpLine_sf_mp_p2_compat_text" v="Les deux mods s'exécutent de manière totalement indépendante et sont entièrement compatibles. Un passage d'engrais met à jour les deux en même temps - vous n'avez pas besoin de fertiliser deux fois. Les zones de sol de PF et les valeurs N/P/K de SoilFertilizer utilisent des modèles différents et ne seront pas identiques." eh="5c9f8ada" />
-		<e k="helpLine_sf_mp_p2_workflow_title" v="Flux de travail pratique" eh="b6f73f04" />
-		<e k="helpLine_sf_mp_p2_workflow_text" v="Utilisez PrecisionFarming pour voir où dans un champ une attention est requise (précision par sous-zone). Utilisez l'HUD et le rapport de sol de SoilFertilizer pour voir quel nutriment appliquer. Un seul passage satisfait les deux mods simultanément et ils ne donneront jamais de conseils contradictoires." eh="cde2c27c" />
+
+   <!-- ======================================================
+         LIGNES D’AIDE (ESC > Aide > Sol & Fertilisation réalistes)
+         ====================================================== -->
+
+    <!-- Catégories -->
+    <e k="helpLine_sf_cat_overview" v="Aperçu" eh="3b878279" />
+    <e k="helpLine_sf_cat_started" v="Premiers pas" eh="bf647454" />
+    <e k="helpLine_sf_cat_nutrients" v="Nutriments du sol" eh="64377acf" />
+    <e k="helpLine_sf_cat_fertilizers" v="Engrais" eh="754d59bd" />
+    <e k="helpLine_sf_cat_hud" v="HUD &amp; rapport de sol" eh="9b9888b9" />
+    <e k="helpLine_sf_cat_settings" v="Paramètres" eh="f4f70727" />
+    <e k="helpLine_sf_cat_multiplayer" v="Multijoueur" eh="901a7320" />
+
+    <!-- Categorie 1: Aperçu -->
+    <e k="helpLine_sf_ov_p1_title" v="Ce que cela fait" eh="46cbb25b" />
+    <e k="helpLine_sf_ov_p1_intro_title" v="Suivi du sol par champ" eh="8fe3248d" />
+    <e k="helpLine_sf_ov_p1_intro_text" v="Chaque champ suit indépendamment cinq propriétés : Azote (N), Phosphore (P), Potassium (K), Matière organique (OM) et pH. Les valeurs sont sauvegardées dans votre partie et persistent entre les sessions." eh="c30216e6" />
+    <e k="helpLine_sf_ov_p1_flow_title" v="Cycle des nutriments" eh="15b0d408" />
+    <e k="helpLine_sf_ov_p1_flow_text" v="Les cultures retirent des nutriments à la récolte. Les engrais, le fumier, le lisier et la chaux les restaurent. Le mod suit un budget nutritif réaliste - ce que les cultures prélèvent, vous devez le restituer." eh="418041f0" />
+
+    <e k="helpLine_sf_ov_p2_title" v="Effets environnementaux" eh="e139e84f" />
+    <e k="helpLine_sf_ov_p2_rain_title" v="Pluie et lessivage" eh="33e0d8ea" />
+    <e k="helpLine_sf_ov_p2_rain_text" v="La pluie lessive principalement l'Azote, puis le Potassium, puis le Phosphore. Elle acidifie aussi lentement le pH au fil du temps. Les effets de la pluie peuvent être désactivés dans les paramètres." eh="91e39cc6" />
+    <e k="helpLine_sf_ov_p2_season_title" v="Saisons et récupération des jachères" eh="ad2009c8" />
+    <e k="helpLine_sf_ov_p2_season_text" v="Le printemps ajoute +0.03 N par jour (activité biologique). L'automne retire 0.02 N par jour. Les champs laissés sans culture pendant plus de 7 jours récupèrent lentement tous les nutriments." eh="e5ebb3b2" />
+
+    <!-- Categorie 2: Prise en main -->
+    <e k="helpLine_sf_gs_p1_title" v="Premiers pas" eh="bdd0e0a7" />
+    <e k="helpLine_sf_gs_p1_hud_title" v="Ouvrir le HUD (touche J)" eh="e1bdea72" />
+    <e k="helpLine_sf_gs_p1_hud_text" v="Appuyez sur J pour activer l'affichage du sol en temps réel. Il montre N, P, K, pH et OM pour le champ sur lequel vous vous trouvez. Les états Bon / Moyen / Mauvais indiquent rapidement les besoins." eh="53cef520" />
+    <e k="helpLine_sf_gs_p1_report_title" v="Ouvrir le rapport de sol (touche K)" eh="e71446cd" />
+    <e k="helpLine_sf_gs_p1_report_text" v="Appuyez sur K pour ouvrir le rapport complet de la ferme. Tous les champs sont listés avec un code couleur selon leur état nutritif, triés par priorité. Cliquez sur la flèche pour un détail complet avec recommandations." eh="9a0d32a6" />
+
+    <e k="helpLine_sf_gs_p2_title" v="Fertiliser et récolte" eh="1a52ac04" />
+    <e k="helpLine_sf_gs_p2_fert_title" v="Fertilisation des champs" eh="ea52ec26" />
+    <e k="helpLine_sf_gs_p2_fert_text" v="Appliquez de l'engrais avec n'importe quel pulvérisateur ou épandeur standard. Le mod reconnaît tous les types du jeu de base ainsi que 9 types personnalisés (UAN-32, MAP, Potasse, etc.). Chaque type restaure différents nutriments - voir la catégorie Engrais pour les détails." eh="fe906e29" />
+    <e k="helpLine_sf_gs_p2_harvest_title" v="Épuisement à la récolte" eh="a67b6cb5" />
+    <e k="helpLine_sf_gs_p2_harvest_text" v="Chaque récolte retire des nutriments du champ. Les cultures exigeantes (pomme de terre, betterave sucrière, soja) épuisent beaucoup plus que les cultures légères (orge, avoine). Vérifiez le HUD ou le rapport après chaque cycle." eh="63f90ed4" />
+
+    <e k="helpLine_sf_gs_p3_title" v="Difficulté" eh="7b29ca96" />
+    <e k="helpLine_sf_gs_p3_levels_title" v="Trois niveaux de difficulté" eh="52611188" />
+    <e k="helpLine_sf_gs_p3_levels_text" v="Simple (0.7x) : 30% de réduction d'épuisement - adapté aux nouveaux joueurs. Réaliste (1.0x) : équilibré, basé sur des valeurs agricoles réelles. Hardcore (1.5x) : 50% d'épuisement en plus - gestion intensive requise." eh="f4f1ea30" />
+    <e k="helpLine_sf_gs_p3_access_title" v="Modification des paramètres" eh="b421c88f" />
+    <e k="helpLine_sf_gs_p3_access_text" v="Ouvrez les paramètres via ESC &gt; Settings &gt; Soil &amp; Fertilizer. En multijoueur, seul l'administrateur peut modifier les paramètres de simulation. Tous les réglages d'affichage HUD sont individuels et non partagés." eh="f36a5639" />
+
+    <!-- Categorie 3: Nutriments du sol -->
+    <e k="helpLine_sf_nu_p1_title" v="Azote et Phosphore" eh="27d37372" />
+    <e k="helpLine_sf_nu_p1_n_title" v="Azote (N) - Échelle 0 à 100" eh="10a358f4" />
+    <e k="helpLine_sf_nu_p1_n_text" v="Nutriment le plus mobile - s'épuise le plus vite et est fortement lessivé par la pluie. Mauvais : en dessous de 30. Bon : au-dessus de 50. À augmenter avec : engrais liquide, UAN-32, UAN-28, ammoniac anhydre, urée, AMS, fumier ou lisier." eh="58d62253" />
+    <e k="helpLine_sf_nu_p1_p_title" v="Phosphore (P) - Échelle 0 à 100" eh="979bba64" />
+    <e k="helpLine_sf_nu_p1_p_text" v="Se fixe fortement au sol et est très lentement lessivé. Principalement épuisé par la récolte. Le colza a la plus forte demande en P. Mauvais : en dessous de 25. Bon : au-dessus de 45. À augmenter avec : MAP, DAP, engrais de démarrage ou engrais liquide." eh="92c5ac66" />
+
+    <e k="helpLine_sf_nu_p2_title" v="Potassium et pH" eh="6bd92f25" />
+    <e k="helpLine_sf_nu_p2_k_title" v="Potassium (K) - Échelle 0 à 100" eh="2a16e8bc" />
+    <e k="helpLine_sf_nu_p2_k_text" v="Essentiel pour les cultures racinaires et tubercules. La pomme de terre et la betterave sucrière épuisent fortement le K à chaque récolte. Lessivage modéré par la pluie. Mauvais : en dessous de 20. Bon : au-dessus de 40. À augmenter avec : potasse (0-0-60), lisier, digestat ou engrais liquide." eh="7230fee4" />
+    <e k="helpLine_sf_nu_p2_ph_title" v="pH - Échelle 5.0 à 7.5" eh="944beca2" />
+    <e k="helpLine_sf_nu_p2_ph_text" v="La plupart des cultures prospèrent entre pH 6.5 et 7.0. La pluie acidifie lentement le sol avec le temps. Le pH ne remonte pas naturellement - seule la chaux ou la chaux liquide permet de l'augmenter. Mauvais : en dessous de 5.5. Appliquez de la chaux si le pH baisse avant la prochaine plantation." eh="08e0aefd" />
+
+    <e k="helpLine_sf_nu_p3_title" v="Matière organique" eh="6305f4bb" />
+    <e k="helpLine_sf_nu_p3_om_title" v="Matière organique (OM) - Échelle 0 à 10" eh="58f490f3" />
+    <e k="helpLine_sf_nu_p3_om_text" v="Augmente très lentement et n'est pas épuisée par la récolte. Mauvais : en dessous de 2.5. Bon : au-dessus de 4.0. À augmenter avec : fumier, lisier, digestat, compost, biosolides, fientes de poulet, fumier pelletisé ou en broyant la paille dans le champ." eh="f9a02359" />
+    <e k="helpLine_sf_nu_p3_fallow_title" v="Récupération des jachères" eh="14133b0b" />
+    <e k="helpLine_sf_nu_p3_fallow_text" v="Un champ laissé sans culture pendant 7 jours ou plus récupère lentement ses nutriments. Par jour : N +0.07, P +0.03, K +0.05, OM +0.01. La rotation des cultures et les périodes de repos ont donc une vraie valeur dans ce mod." eh="81fa82b3" />
+
+    <!-- Categorie 4: Engrais -->
+    <e k="helpLine_sf_fe_p1_title" v="Types du jeu de base" eh="fd941c0d" />
+    <e k="helpLine_sf_fe_p1_base_title" v="Liquide, solide, fumier et lisier" eh="4668dca7" />
+    <e k="helpLine_sf_fe_p1_base_text" v="L'engrais liquide apporte un N+P+K équilibré. L'engrais solide est plus riche en N et P. Le fumier et le lisier ajoutent N, P, K et matière organique. Le digestat (sous-produit de méthanisation) est riche en K et ajoute aussi de la MO. Tous sont appliqués avec le matériel standard." eh="64069a56" />
+    <e k="helpLine_sf_fe_p1_lime_title" v="Chaux et correction du pH" eh="8933cce1" />
+    <e k="helpLine_sf_fe_p1_lime_text" v="La chaux est le seul moyen du jeu de base pour corriger le pH - elle n'ajoute aucun nutriment. Les types personnalisés Chaux liquide et Gypse augmentent aussi le pH (le gypse ajoute légèrement de la MO). Appliquez lorsque le pH descend sous 6.0 pour rester dans la zone optimale." eh="833a967f" />
+
+    <e k="helpLine_sf_fe_p2_title" v="Sources personnalisées d'azote et PK" eh="1021f8c9" />
+    <e k="helpLine_sf_fe_p2_n_title" v="Sources d'azote (big bags personnalisés)" eh="9dfe5a5a" />
+    <e k="helpLine_sf_fe_p2_n_text" v="UAN-32 (32-0-0) et UAN-28 (28-0-0) sont des solutions azotées liquides. L'ammoniac anhydre (82-0-0) est le produit le plus riche en azote par litre. L'urée (46-0-0) et l'AMS (21-0-0-24S) sont des granulés secs. Tous sont uniquement azotés - aucun effet sur P, K ou pH." eh="6a100c25" />
+    <e k="helpLine_sf_fe_p2_pk_title" v="Sources de phosphore et potassium" eh="a2d4091b" />
+    <e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0) : plus forte teneur en P par litre. DAP (18-46-0) : riche en P avec un peu d'azote. Potasse (0-0-60) : potassium pur. Engrais de démarrage (10-34-0) : produit riche en P avec N et K équilibrés. Tous disponibles en big bags achetables en magasin." eh="75a86964" />
+
+    <e k="helpLine_sf_fe_p3_title" v="Produits organiques et risque de brûlure" eh="7ab807d1" />
+    <e k="helpLine_sf_fe_p3_organic_title" v="Produits organiques et à libération lente" eh="0199e6be" />
+    <e k="helpLine_sf_fe_p3_organic_text" v="Le compost est le meilleur apport en matière organique (+0.12 pour 1 000 L). Les biosolides et fientes de poulet ajoutent N, P et MO. Le fumier pelletisé est un engrais organique équilibré concentré. Tous sont des produits personnalisés disponibles avec les mods de matériel compatibles." eh="3d16e4ee" />
+    <e k="helpLine_sf_fe_p3_burn_title" v="Risque de brûlure par surdosage" eh="e986cc54" />
+    <e k="helpLine_sf_fe_p3_burn_text" v="Appliquer plus de 1.25x la dose de base provoque un risque de brûlure (-0.15 pH et -5 N). À 1.50x ou plus, la brûlure est garantie à chaque passage (-0.30 pH et -12 N). Utilisez les touches SF Augmenter / Diminuer la dose dans le véhicule pour contrôler l'application." eh="7bccc46a" />
+
+    <!-- Categorie 5: HUD et rapport de sol -->
+    <e k="helpLine_sf_hu_p1_title" v="HUD du sol" eh="6522879b" />
+    <e k="helpLine_sf_hu_p1_toggle_title" v="Activer le HUD (touche J)" eh="402283ba" />
+    <e k="helpLine_sf_hu_p1_toggle_text" v="Appuyez sur J pour afficher ou masquer l'overlay de sol en temps réel. Il détecte le champ sur lequel vous êtes et affiche N, P, K, pH et OM. Lorsque les options mauvaises herbes, ravageurs ou maladies sont activées, elles apparaissent en bas du panneau." eh="3dcb9bfe" />
+    <e k="helpLine_sf_hu_p1_status_title" v="Lecture du statut" eh="291c3aac" />
+    <e k="helpLine_sf_hu_p1_status_text" v="Chaque nutriment affiche Bon (aucune action), Moyen (à traiter bientôt) ou Mauvais (action requise - impact sur rendement). Le badge global reflète la pire valeur de tous les paramètres suivis." eh="3b8c2c6e" />
+
+    <e k="helpLine_sf_hu_p2_title" v="Pressions du champ" eh="b4d35b30" />
+    <e k="helpLine_sf_hu_p2_press_title" v="Mauvaises herbes, ravageurs et maladies" eh="0a3fae00" />
+    <e k="helpLine_sf_hu_p2_press_text" v="Trois scores de pression (0 à 100) suivent les menaces biologiques. Sans traitement, ils réduisent le rendement : mauvaises herbes jusqu'à -30 %, ravageurs -20 %, maladies -25 %. Les indicateurs W, I et D sont codés par couleur : vert (faible), jaune (moyen), rouge (élevé)." eh="3fc3c400" />
+    <e k="helpLine_sf_hu_p2_treat_title" v="Traitement des pressions" eh="cb24bf50" />
+    <e k="helpLine_sf_hu_p2_treat_text" v="Les herbicides réduisent les mauvaises herbes - le travail du sol les remet à zéro. Les insecticides réduisent les ravageurs de 25 points et bloquent leur retour pendant 10 jours. Les fongicides réduisent les maladies de 20 points et les bloquent pendant 12 jours. Chaque système peut être désactivé dans les paramètres." eh="4d65bdec" />
+
+    <e k="helpLine_sf_hu_p3_title" v="Rapport de sol" eh="35fcce6c" />
+    <e k="helpLine_sf_hu_p3_open_title" v="Ouverture du rapport (touche K)" eh="62e3f629" />
+    <e k="helpLine_sf_hu_p3_open_text" v="Appuyez sur K pour ouvrir le rapport complet de la ferme. La barre de résumé montre le nombre total de champs suivis, ceux nécessitant de l'engrais et la santé globale de la ferme en pourcentage. Les champs sont triés par urgence." eh="38a5bd2e" />
+    <e k="helpLine_sf_hu_p3_detail_title" v="Détails et recommandations" eh="c99d2b89" />
+    <e k="helpLine_sf_hu_p3_detail_text" v="Cliquez sur la flèche d'une ligne pour ouvrir le détail : valeurs de nutriments, pressions, estimation de perte de rendement et liste de recommandations précises. Retournez avec Retour ou Échap." eh="38dd2c6d" />
+
+    <!-- Categorie 6: Paramètres -->
+    <e k="helpLine_sf_se_p1_title" v="Paramètres de simulation" eh="cbf13e3c" />
+    <e k="helpLine_sf_se_p1_server_title" v="Paramètres serveur (Admin uniquement en multijoueur)" eh="49f37ed7" />
+    <e k="helpLine_sf_se_p1_server_text" v="Système de fertilité, cycles des nutriments, effets saisonniers, effets de pluie, bonus de labour, pression des mauvaises herbes/ravageurs/maladies, coûts des engrais, notifications, rotation des cultures et contrôle automatique du dosage. En multijoueur, seul l'administrateur du serveur peut modifier ces paramètres. Les changements sont synchronisés instantanément avec tous les clients." eh="abca5e43" />
+    <e k="helpLine_sf_se_p1_diff_title" v="Difficulté" eh="7b29ca96" />
+    <e k="helpLine_sf_se_p1_diff_text" v="Simple (0.7x) réduit l'épuisement de 30% pour une expérience détendue. Réaliste (1.0x) est le mode équilibré par défaut. Hardcore (1.5x) augmente l'épuisement de 50% pour une gestion intensive du sol. Accès via ESC &gt; Paramètres &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
+
+    <e k="helpLine_sf_se_p2_title" v="HUD et contrôle du dosage" eh="399f4910" />
+    <e k="helpLine_sf_se_p2_hud_title" v="Options HUD par joueur" eh="0df76500" />
+    <e k="helpLine_sf_se_p2_hud_text" v="Chaque joueur contrôle son propre HUD - non synchronisé avec le serveur. Options : Afficher le HUD (on/off), Position (5 préréglages + déplacement manuel), Thème de couleur (Vert / Bleu / Ambre / Monochrome), Taille de police (Petit / Moyen / Grand), Transparence (25% à 100%), Unités impériales (on/off)." eh="f3934884" />
+    <e k="helpLine_sf_se_p2_rate_title" v="Contrôle du dosage du pulvérisateur" eh="5ecdfa23" />
+    <e k="helpLine_sf_se_p2_rate_text" v="Dans un pulvérisateur ou épandeur, utilisez SF Augmenter le dosage (]) et SF Diminuer le dosage ([) pour ajuster le taux d'application de 0.10x à 2.00x. Activez le contrôle automatique (Shift+L) pour laisser le mod viser automatiquement les niveaux optimaux et éviter les brûlures." eh="dd385e39" />
+
+    <!-- Categorie 7: Multijoueur et PrecisionFarming -->
+    <e k="helpLine_sf_mp_p1_title" v="Fonctionnement du multijoueur" eh="8a4ce30e" />
+    <e k="helpLine_sf_mp_p1_auth_title" v="Simulation côté serveur" eh="8d324792" />
+    <e k="helpLine_sf_mp_p1_auth_text" v="Toute la simulation du sol est exécutée sur le serveur. Les clients reçoivent toutes les données des champs et paramètres à la connexion, avec nouvelle tentative automatique si le serveur charge encore. Les paramètres d'affichage HUD (position, thème, taille) sont propres à chaque joueur et ne sont jamais synchronisés." eh="db72a3f9" />
+    <e k="helpLine_sf_mp_p1_ded_title" v="Serveurs dédiés" eh="4d3a45ba" />
+    <e k="helpLine_sf_mp_p1_ded_text" v="Les serveurs dédiés exécutent la simulation complète sans interface HUD ou GUI - c'est normal et attendu. Utilisez les commandes console (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) pour gérer et vérifier les paramètres sur un serveur dédié." eh="3df784d6" />
+
+    <e k="helpLine_sf_mp_p2_title" v="Compatibilité PrecisionFarming" eh="3647a30c" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="Utilisation des deux mods ensemble" eh="bc5325f5" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="Les deux mods fonctionnent entièrement de manière indépendante et sont totalement compatibles. Un seul passage de fertilisation met à jour les deux systèmes en même temps - il n'est pas nécessaire de fertiliser deux fois. Les zones de sol de PF et les valeurs N/P/K de SoilFertilizer utilisent des modèles différents et ne seront pas identiques." eh="5c9f8ada" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="Méthode pratique" eh="b6f73f04" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="Utilisez PrecisionFarming pour voir où intervenir dans le champ (précision par sous-zone). Utilisez le HUD et le rapport de sol de SoilFertilizer pour savoir quel nutriment appliquer. Un seul passage satisfait les deux mods simultanément et ils ne donnent jamais de conseils contradictoires." eh="cde2c27c" />
+
     <e k="sf_crop_rotation_short" v="Rotation des cultures" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Activer/désactiver le bonus de rotation des cultures et la fatigue de la monoculture (les séquences de légumineuses restaurent l'azote ; les saisons consécutives de même culture augmentent l'épuisement)" eh="958b4212" />
+    <e k="sf_crop_rotation_long" v="Activer/désactiver le bonus de rotation des cultures et la fatigue des monocultures (les légumineuses restaurent l'azote ; les cultures répétées augmentent l'épuisement)" eh="958b4212" />
     <e k="sf_report_rotation_bonus" v="Bonus de rotation" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue : Même culture" eh="46135880" />
+    <e k="sf_report_rotation_fatigue" v="Fatigue : même culture" eh="46135880" />
     <e k="sf_report_rotation_ok" v="Rotation : OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypse (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organique)" eh="c3e2071a" />
+    <e k="sf_gypsum_title" v="Gypse (pH-)" eh="d66da34c" />
+    <e k="sf_compost_title" v="Compost (organique)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biosolides (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Fumier de poulet (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Fumier granulé (NPK)" eh="c1b39b71" />
+    <e k="sf_pelletized_manure_title" v="Fumier pelletisé (NPK)" eh="c1b39b71" />
     <e k="sf_liquidlime_title" v="Chaux liquide (pH+)" eh="d4ec4bb9" />
     <e k="helpLine_sf_nu_p4_title" v="Rotation des cultures" eh="def2c162" />
     <e k="helpLine_sf_nu_p4_bonus_title" v="Bonus de rotation" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Cultiver une légumineuse (soja, pois, fèves) après une non-légumineuse ajoute un apport gratuit en azote chaque printemps pendant 3 jours." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="Cultiver une légumineuse (soja, pois, haricots) après une autre culture ajoute un bonus gratuit d'azote chaque printemps pendant 3 jours." eh="e1fce95b" />
     <e k="helpLine_sf_nu_p4_fatigue_title" v="Fatigue des cultures" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planter la même culture deux saisons de suite augmente l'extraction des nutriments de 15%%. Faites tourner les cultures pour éviter la fatigue du sol." eh="1613f3c6" />
-		<e k="sf_map_layer_off" v="Carte du sol : Désactivée" eh="3e654ade" />
-		<e k="sf_map_layer_n" v="Azote" eh="1e9ef3ba" />
-		<e k="sf_map_layer_p" v="Phosphore" eh="eb4f2688" />
-		<e k="sf_map_layer_k" v="[EN] Potassium" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
-		<e k="sf_map_layer_om" v="Matière Organique" eh="6305f4bb" />
-		<e k="sf_map_layer_urgency" v="Urgence au champ" eh="419ea5af" />
-		<e k="sf_map_layer_weed" v="Pression des adventices" eh="53f8b936" />
-		<e k="sf_map_layer_pest" v="Pression des ravageurs" eh="18a7c2be" />
-		<e k="sf_map_layer_disease" v="Pression des maladies" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
-		<e k="sf_map_overlay_cycle" v="Maj+M : Faire défiler les couches" eh="032fdac7" />
-		<e k="sf_map_page_title" v="Couches de sol" eh="04a675fb" />
-		<e k="sf_map_sidebar_header" v="Couche de carte de sol" eh="81332549" />
-		<e k="sf_map_sidebar_label" v="Couche active" eh="f8a2c198" />
-		<e k="sf_map_sidebar_tooltip" v="Sélectionnez le nutriment à afficher sur la carte" eh="eb926e9a" />
-		<e k="sf_map_overlay_low" v="Faible" eh="28d0edd0" />
-		<e k="sf_map_overlay_med" v="Moyen" eh="248c9511" />
-		<e k="sf_map_overlay_high" v="Élevé" eh="655d20c1" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planter la même culture deux saisons d'affilée augmente l'extraction de nutriments de 15%. Faites tourner les cultures pour éviter la fatigue du sol." eh="1613f3c6" />
 
-    <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Sol &amp; Engrais" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Carte du sol" eh="59f988b2" />
+    <!-- Superposition carte des sols (SoilMapOverlay.lua) -->
+    <e k="sf_map_layer_off" v="Carte des sols : Désactivée" eh="3e654ade" />
+    <e k="sf_map_layer_n" v="Azote" eh="1e9ef3ba" />
+    <e k="sf_map_layer_p" v="Phosphore" eh="eb4f2688" />
+    <e k="sf_map_layer_k" v="Potassium" eh="3a4edc67" />
+    <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_om" v="Matière organique" eh="6305f4bb" />
+    <e k="sf_map_layer_urgency" v="Urgence des champs" eh="419ea5af" />
+    <e k="sf_map_layer_weed" v="Pression des mauvaises herbes" eh="53f8b936" />
+    <e k="sf_map_layer_pest" v="Pression des ravageurs" eh="18a7c2be" />
+    <e k="sf_map_layer_disease" v="Pression des maladies" eh="2b805cc9" />
+    <e k="sf_map_layer_compaction" v="Compaction du sol" eh="19cf3ee7" />
+    <e k="sf_map_overlay_cycle" v="Shift+M : Changer la couche du sol" eh="032fdac7" />
+    <e k="sf_map_page_title" v="Couches du sol" eh="04a675fb" />
+    <e k="sf_map_sidebar_header" v="Couche de la carte des sols" eh="81332549" />
+    <e k="sf_map_sidebar_label" v="Couche active" eh="f8a2c198" />
+    <e k="sf_map_sidebar_tooltip" v="Sélectionnez le nutriment du sol à afficher sur la carte" eh="eb926e9a" />
+    <e k="sf_map_overlay_low" v="Faible" eh="28d0edd0" />
+    <e k="sf_map_overlay_med" v="Moyen" eh="248c9511" />
+    <e k="sf_map_overlay_high" v="Élevé" eh="655d20c1" />
+
+    <!-- Écran PDA des sols (SoilPDAScreen.lua) -->
+    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="Carte des sols" eh="59f988b2" />
     <e k="sf_pda_tab_fields" v="Champs" eh="a4ca5edd" />
     <e k="sf_pda_tab_treatment" v="Plan de traitement" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Aperçu de la ferme" eh="47f2c19a" />
+    <e k="sf_pda_section_farm_overview" v="Vue d'ensemble de la ferme" eh="47f2c19a" />
     <e k="sf_pda_fields_tracked_label" v="Champs suivis" eh="c763e26e" />
     <e k="sf_pda_fields_owned_label" v="Champs possédés" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Nutriments moy." eh="f06b2704" />
+    <e k="sf_pda_section_avg_nutrients" v="Moyenne des nutriments" eh="f06b2704" />
     <e k="sf_pda_avg_n_label" v="Azote (N)" eh="25cee53b" />
     <e k="sf_pda_avg_p_label" v="Phosphore (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
     <e k="sf_pda_avg_ph_label" v="Niveau de pH" eh="0c85daad" />
     <e k="sf_pda_avg_om_label" v="Matière organique" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Pression culture" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Adventice" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Ravageur" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Maladie" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Nécessite attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Besoin engrais" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="Aucune donnée de champ." eh="ba71c6b1" />
-    <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Couches de carte de sol" eh="85d63132" />
+    <e k="sf_pda_section_pressure" v="Pression des cultures" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="Mauvaises herbes" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="Ravageurs" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="Maladies" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="Nécessite une attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="Besoin d'engrais" eh="fa9ded5e" />
+    <e k="sf_pda_total_urgent_label" v="Total nécessitant une attention" eh="b3ce2db9" />
+    <e k="sf_pda_no_data_left" v="Aucune donnée de champ pour le moment." eh="ba71c6b1" />
+	
+    <!-- Onglet Carte -->
+    <e k="sf_pda_map_section_title" v="Couches de la carte des sols" eh="85d63132" />
     <e k="sf_pda_map_active_layer" v="Couche active" eh="f8a2c198" />
-    <e k="sf_pda_map_layer_off_desc" v="Aucune couche activée. Maj+M pour faire défiler." eh="009d9017" />
+    <e k="sf_pda_map_layer_off_desc" v="Aucune couche de sol active. Veuillez sélectionner une couche à afficher." eh="3bd7e65a" />
     <e k="sf_pda_map_layer_n_desc" v="Teneur en azote sur tous les champs. Vert = bon, rouge = épuisé." eh="60484ead" />
     <e k="sf_pda_map_layer_p_desc" v="Teneur en phosphore sur tous les champs. Vert = bon, rouge = épuisé." eh="9fa2e72d" />
     <e k="sf_pda_map_layer_k_desc" v="Teneur en potassium sur tous les champs. Vert = bon, rouge = épuisé." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Niveau de pH du sol. La plage optimale est 6,5-7,0 (vert)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Teneur en matière organique. Plus elle est élevée, mieux c'est pour la fertilité à long terme." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Urgence de traitement combinée. Rouge = nécessite une attention immédiate." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Niveau de pression des adventices. Rouge = forte infestation, appliquer de l'herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Niveau de pression des ravageurs. Rouge = forte infestation, appliquer de l'insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Niveau de pression des maladies. Rouge = éclosion active, appliquer du fongicide." eh="5d32d30a" />
+    <e k="sf_pda_map_layer_ph_desc" v="Niveau de pH du sol. Plage optimale 6.5-7.0 (vert)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="Teneur en matière organique. Plus élevé = meilleure fertilité à long terme." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="Urgence globale de traitement. Rouge = action immédiate requise." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="Niveau de pression des mauvaises herbes. Rouge = forte infestation, appliquer herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="Niveau de pression des ravageurs. Rouge = forte infestation, appliquer insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="Niveau de pression des maladies. Rouge = épidémie active, appliquer fongicide." eh="5d32d30a" />
     <e k="sf_pda_map_legend_title" v="Légende de la carte" eh="86448402" />
     <e k="sf_pda_map_legend_good" v="Bon" eh="0c6ad70b" />
     <e k="sf_pda_map_legend_fair" v="Moyen" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Mauvais / Faible" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Faible" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_poor" v="Faible / Bas" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="Bas" eh="28d0edd0" />
     <e k="sf_pda_map_legend_medium" v="Moyen" eh="87f8a6ab" />
     <e k="sf_pda_map_legend_high" v="Élevé" eh="655d20c1" />
     <e k="sf_pda_map_legend_excess" v="Excès" eh="d1d25b9f" />
-    <e k="sf_pda_map_instructions" v="Appuyez sur Maj+M en jeu pour faire défiler les couches de sol." eh="b13603aa" />
-    <e k="sf_pda_map_open_btn" v="Ouvrir la carte du sol" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Aperçu de la carte indisponible" eh="00000000" />
-		<e k="sf_map_health_overall" v="Santé moyenne du sol" eh="5533cbe3" />
-		<e k="sf_map_btn_report" v="Ouvrir le résumé de la ferme" eh="6f0800e8" />
-		<e k="sf_map_btn_help" v="Note développeur (PAS ENCORE FONCTIONNEL)" eh="800e465a" />
-    <e k="sf_map_btn_cycle_layer" v="Changer la couche" eh="875dbf22" />
+    <e k="sf_pda_map_instructions" v="Sélectionnez une couche dans la barre latérale pour l'afficher sur la carte." eh="eee76c81" />
+    <e k="sf_pda_map_jump_hint" v="Cliquez sur un champ pour vous y rendre sur la carte" eh="006d5371" />
+    <e k="sf_pda_map_native_hint" v="La visualisation des couches de sol a été déplacée ! Vous pouvez maintenant accéder et activer toutes les couches directement depuis la barre latérale native de la carte PDA (ESC > Carte). Cherchez la catégorie 'Couches de sol' dans les points de la barre latérale." eh="87f73b10" />
+    <e k="sf_pda_map_open_btn" v="NOTE DEV" eh="ef40b93f" />
+    <e k="sf_pda_btn_help" v="Aide" eh="6a26f548" />
+    <e k="sf_pda_help_text" v="Salut ! C'est moi le développeur ! J'ai déplacé les couches de sol vers la carte PDA native (ESC > Carte) pour une expérience plus fluide. Vous pouvez maintenant sélectionner les couches directement dans la barre latérale. La page PDA est encore en cours d'amélioration, restez à l'écoute !" eh="58e05bdf" />
+    <e k="sf_pda_help_github" v="VOS RETOURS COMPTENT ! Si vous rencontrez des bugs, avez des suggestions de fonctionnalités ou souhaitez contribuer au code, veuillez visiter le projet sur GitHub. Vous pouvez ouvrir une Issue ou une Pull Request à tout moment pour améliorer ce mod. Merci pour vos tests !" eh="3a10b023" />
+    <e k="sf_pda_help_note" v="Note : L'onglet couches de sol sur la page carte ne fonctionne pas. Je suis au courant du problème et je travaille sur un correctif (cela peut prendre du temps)." eh="2d8f5dc7" />
+    <e k="sf_pda_map_unavailable" v="Aperçu de la carte indisponible" eh="43983f81" />
+    <e k="sf_map_health_overall" v="Santé moyenne du sol" eh="5533cbe3" />
+    <e k="sf_map_btn_report" v="Ouvrir l'aperçu de la ferme" eh="6f0800e8" />
+    <e k="sf_map_btn_help" v="Note dev (PAS ENCORE FONCTIONNEL)" eh="800e465a" />
+    <e k="sf_map_btn_cycle_layer" v="Changer de couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de traitement" eh="4ba012e2" />
-    <e k="sf_map_btn_disable" v="Désactiver la couche" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_map_btn_disable" v="Désactiver la superposition" eh="8e75dec5" />
+    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Référence rapide du sol" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NUTRIMENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N (Azote) – S’épuise rapidement. Appliquer UAN, Urée ou fumier." eh="f2d0c792" />
-    <e k="sf_help_p" v="P (Phosphore) – Durable. Appliquer MAP ou DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K (Potassium) – Appliquer de la potasse. Important pour les racines." eh="e0217634" />
-    <e k="sf_help_om" v="MO (Matière organique) – Augmente lentement. Incorporer du fumier/compost." eh="a4e29617" />
+    <e k="sf_help_n" v="N (Azote)     - Se dégrade vite. Appliquer UAN, Urée ou fumier." eh="f2d0c792" />
+    <e k="sf_help_p" v="P (Phosphore) - Durable. Appliquer MAP ou DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="K (Potassium)  - Appliquer potasse. Important pour les racines." eh="e0217634" />
+    <e k="sf_help_om" v="OM (Mat. org.) - Construction lente. Incorporer fumier/compost." eh="a4e29617" />
     <e k="sf_help_soil_header" v="CHIMIE DU SOL" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH 6,5–7,0 = idéal. < 6,5 appliquer de la chaux. > 7,5 appliquer du gypse." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="PRESSION SUR LES CULTURES" eh="132b0f66" />
-    <e k="sf_help_weed" v="Adventices > 20 % – Appliquer un herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Ravageurs > 20 % – Appliquer un insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Maladies > 20 % – Appliquer un fongicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="NIVEAUX D’ÉTAT" eh="b081c2c6" />
-    <e k="sf_help_good" v="Bon – Aucune action nécessaire." eh="03910bec" />
-    <e k="sf_help_fair" v="Moyen – Surveiller / apport préventif." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Mauvais – Traitement immédiat requis." eh="b287d206" />
-    <!-- Fields Tab -->
+    <e k="sf_help_ph" v="pH  6.5-7.0 = Idéal. < 6.5 appliquer chaux. > 7.5 appliquer gypse." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="PRESSION DES CULTURES" eh="132b0f66" />
+    <e k="sf_help_weed" v="Mauvaises herbes > 20% - Appliquer herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="Ravageurs > 20% - Appliquer insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="Maladies > 20% - Appliquer fongicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="NIVEAUX DE STATUT" eh="b081c2c6" />
+    <e k="sf_help_good" v="Bon - Aucune action requise." eh="03910bec" />
+    <e k="sf_help_fair" v="Moyen - Surveillance / entretien préventif." eh="2922eb1c" />
+    <e k="sf_help_poor" v="Mauvais - Traitement immédiat requis." eh="b287d206" />
+
+    <!-- Onglet Champs -->
     <e k="sf_pda_fields_section_title" v="Tous les champs" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Champ" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
-		<e k="sf_pda_filter_all" v="Filtre : Tous les champs" eh="a46a8cb2" />
-		<e k="sf_pda_filter_owned" v="Filtre : Champs possédés uniquement" eh="258cb971" />
-    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_n" v="N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_filter_all" v="Filtre : Tous les champs" eh="a46a8cb2" />
+    <e k="sf_pda_filter_owned" v="Filtre : Propriétés uniquement" eh="258cb971" />
+    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="MO" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Statut" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="Aucune donnée de champ enregistrée." eh="72265670" />
+    <e k="sf_pda_no_fields" v="Aucune donnée de champ enregistrée pour le moment." eh="72265670" />
     <e k="sf_pda_status_good" v="Bon" eh="0c6ad70b" />
     <e k="sf_pda_status_fair" v="Moyen" eh="f7f20cf0" />
     <e k="sf_pda_status_poor" v="Mauvais" eh="0e94d017" />
-    <!-- Treatment Tab -->
+	
+    <!-- Onglet Traitement -->
     <e k="sf_pda_treatment_section_title" v="Plan de traitement" eh="4ba012e2" />
     <e k="sf_pda_col_priority" v="Urgence" eh="c94e3850" />
     <e k="sf_pda_col_needs" v="Besoins" eh="94d6125d" />
     <e k="sf_pda_no_treatment" v="Tous les champs sont en bon état." eh="fa985166" />
+    <e k="sf_pda_treatment_hint" v="Les champs listés à droite nécessitent un traitement. Cliquez sur une ligne pour voir les intrants recommandés et les quantités estimées." eh="5748d316" />
     <e k="sf_pda_need_n" v="Azote" eh="1e9ef3ba" />
     <e k="sf_pda_need_p" v="Phosphore" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="Ajustement pH" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="Correction pH" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
     <e k="sf_pda_need_disease" v="Fongicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
     <e k="sf_pda_treatment_minor" v="Mineur" eh="6fed0c37" />
-    <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
+
+    <!-- Boîte de dialogue détail champ (SoilFieldDetailDialog.lua) -->
     <e k="sf_detail_title" v="Détail du champ" eh="03b5acd7" />
     <e k="sf_detail_close" v="Fermer" eh="d3d2e617" />
     <e k="sf_detail_field_label" v="Champ #" eh="228118ab" />
     <e k="sf_detail_urgency_label" v="Urgence :" eh="9a83237c" />
     <e k="sf_detail_section_nutrients" v="Nutriments du sol" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Pression culture" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Historique culture" eh="54c27499" />
+    <e k="sf_detail_section_pressure" v="Pression des cultures" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="Historique des cultures" eh="54c27499" />
     <e k="sf_detail_n_label" v="Azote (N)" eh="25cee53b" />
     <e k="sf_detail_p_label" v="Phosphore (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
     <e k="sf_detail_ph_label" v="Niveau de pH" eh="0c85daad" />
     <e k="sf_detail_om_label" v="Matière organique" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Pression adventices" eh="53f8b936" />
+    <e k="sf_detail_weed_label" v="Pression mauvaises herbes" eh="53f8b936" />
     <e k="sf_detail_pest_label" v="Pression ravageurs" eh="18a7c2be" />
     <e k="sf_detail_disease_label" v="Pression maladies" eh="2b805cc9" />
     <e k="sf_detail_last_crop_label" v="Dernière culture" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Statut rotation" eh="83f7f522" />
-		<e k="sf_treat_title" v="Prescription de traitement" eh="0ccc3ee5" />
-		<e k="sf_treat_section_soil" v="Amélioration du sol" eh="09e016e4" />
-		<e k="sf_treat_section_fert" v="Application de nutriments" eh="76521e8e" />
-		<e k="sf_treat_section_prot" v="Protection des cultures" eh="bd3fe9cd" />
-		<e k="sf_treat_hint" v="Consultez la section 'Produits' du magasin pour les engrais spécialisés." eh="540bff4d" />
-		<e k="sf_treat_action_optimal" v="Optimal - Aucune action nécessaire." eh="4501a96b" />
-		<e k="sf_treat_action_lime" v="Appliquer de la CHAUX ou de la CHAUX LIQUIDE pour augmenter le pH." eh="d1420b97" />
-		<e k="sf_treat_action_gypsum" v="Appliquer du GYPSE pour abaisser le pH / améliorer la structure." eh="4cb3f0dc" />
-		<e k="sf_treat_action_om_low" v="Enfouir du FUMIER, COMPOST, ou broyer la paille." eh="33ec544c" />
-		<e k="sf_treat_action_om_fair" v="Surveiller. Maintenir les apports organiques." eh="ae3af748" />
-		<e k="sf_treat_action_n_poor" v="Appliquer UAN32, URÉE, ou AMMONIAC ANHYDRE." eh="ebc225b0" />
-		<e k="sf_treat_action_n_fair" v="Appliquer de l'AMS ou un engrais STARTER." eh="dc8fbeba" />
-		<e k="sf_treat_action_p_poor" v="Appliquer du MAP ou du DAP (Phosphore)." eh="ec2d9afa" />
-		<e k="sf_treat_action_p_fair" v="Appliquer un engrais MÉLANGÉ." eh="6f802546" />
-		<e k="sf_treat_action_k_poor" v="Appliquer de la POTASSE (Potassium)." eh="bb2960f3" />
-		<e k="sf_treat_action_k_fair" v="Appliquer un engrais MÉLANGÉ." eh="6f802546" />
-		<e k="sf_treat_action_weed" v="Appliquer de l'HERBICIDE immédiatement." eh="625551c5" />
-		<e k="sf_treat_action_pest" v="Appliquer de l'INSECTICIDE immédiatement." eh="f4db9a03" />
-		<e k="sf_treat_action_disease" v="Appliquer du FONGICIDE immédiatement." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Bonus Légumineuse (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (épuisement x1.15)" eh="522a6d93" />
+    <e k="sf_detail_rotation_label" v="Statut de rotation" eh="83f7f522" />
+
+    <!-- Boîte de dialogue prescription traitement (SoilTreatmentDialog.lua) -->
+    <e k="sf_treat_title" v="Prescription de traitement" eh="0ccc3ee5" />
+    <e k="sf_treat_section_soil" v="Amélioration du sol" eh="09e016e4" />
+    <e k="sf_treat_section_fert" v="Application de nutriments" eh="76521e8e" />
+    <e k="sf_treat_section_prot" v="Protection des cultures" eh="bd3fe9cd" />
+    <e k="sf_treat_hint" v="Référez-vous à la section 'Produits' de la boutique pour les engrais spécialisés." eh="540bff4d" />
+    <e k="sf_treat_action_optimal" v="Optimal - Aucune action requise." eh="4501a96b" />
+    <e k="sf_treat_action_lime" v="Appliquer CHAUX ou CHAUX LIQUIDE pour augmenter le pH." eh="d1420b97" />
+    <e k="sf_treat_action_gypsum" v="Appliquer GYPSE pour réduire le pH / améliorer la structure." eh="4cb3f0dc" />
+    <e k="sf_treat_action_om_low" v="Incorporer FUMIER, COMPOST ou broyer la paille." eh="33ec544c" />
+    <e k="sf_treat_action_om_fair" v="Surveiller. Maintenir les apports organiques." eh="ae3af748" />
+    <e k="sf_treat_action_n_poor" v="Appliquer UAN32, URÉE ou ANHYDRE." eh="ebc225b0" />
+    <e k="sf_treat_action_n_fair" v="Appliquer AMS ou engrais STARTER." eh="dc8fbeba" />
+    <e k="sf_treat_action_p_poor" v="Appliquer MAP ou DAP (Phosphore)." eh="ec2d9afa" />
+    <e k="sf_treat_action_p_fair" v="Appliquer ENGRAIS mélangé." eh="6f802546" />
+    <e k="sf_treat_action_k_poor" v="Appliquer POTASSE (Potassium)." eh="bb2960f3" />
+    <e k="sf_treat_action_k_fair" v="Appliquer ENGRAIS mélangé." eh="6f802546" />
+    <e k="sf_treat_action_weed" v="Appliquer HERBICIDE immédiatement." eh="625551c5" />
+    <e k="sf_treat_action_pest" v="Appliquer INSECTICIDE immédiatement." eh="f4db9a03" />
+    <e k="sf_treat_action_disease" v="Appliquer FONGICIDE immédiatement." eh="9228323a" />
+    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="Bonus légumineuse (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 épuisement)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée disponible." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="Aucun enregistré" eh="a4b5a996" />
-    <e k="sf_pda_btn_help" v="Note du dev" eh="5320d63f" />
-    <e k="sf_pda_help_github" v="VOS RETOURS COMPTENT ! Si vous rencontrez des bugs, avez des suggestions de nouvelles fonctionnalités ou souhaitez contribuer au code, rendez-vous sur le projet GitHub. Vous pouvez ouvrir une Issue ou une Pull Request à tout moment pour aider à améliorer ce mod pour tout le monde. Merci pour vos tests !" eh="3a10b023" />
-		<e k="sf_pda_help_note" v="Note : l’onglet des couches de sol sur la page de la carte NE FONCTIONNE PAS. Je suis au courant du problème et je travaille sur un correctif (cela peut prendre un certain temps)." eh="2d8f5dc7" />
-    <e k="sf_pda_help_text" v="Bonjour, c'est moi le développeur ! Comme vous pouvez le voir, cette page est encore très en cours de développement. Les couches de carte sont actuellement de simples aperçus visuels (non fonctionnels pour la sélection) et de nombreux éléments d'interface nécessitent encore leur finition." eh="58e05bdf" />
-    <e k="sf_pda_map_jump_hint" v="Cliquez sur un champ pour y accéder sur la carte" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="La visualisation des couches de sol a été déplacée ! Vous pouvez désormais accéder et activer/désactiver toutes les couches de sol directement depuis la barre latérale de la carte PDA (ESC > Carte). Cherchez la catégorie « Couches de sol » dans les points de la barre latérale." eh="87f73b10" />
-    <e k="sf_pda_total_urgent_label" v="Total nécessitant attention" eh="b3ce2db9" />
-    <e k="sf_pda_treatment_hint" v="Les champs listés à droite nécessitent un traitement. Cliquez sur une ligne pour voir les intrants recommandés et les quantités estimées." eh="5748d316" />
+    <e k="sf_detail_no_crop" v="Aucune donnée enregistrée" eh="a4b5a996" />
     </elements>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -193,6 +193,7 @@
     <e k="sf_hud_yield" v="Rendement" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. estimé" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   RMB: terminé" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: déplacer/redimensionner" eh="afc8f13b" />
     <e k="sf_report_detail_n_ok" v="Azote : optimal" eh="13782bd9" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Sol &amp; Engrais" eh="f31197fb" />
@@ -26,14 +26,14 @@
     <e k="sf_nutrients_long" v="Activer/désactiver l'épuisement et le réapprovisionnement réalistes des nutriments" eh="dbe9c8ff" />
     <e k="sf_difficulty_short" v="Difficulté" eh="7b29ca96" />
     <e k="sf_difficulty_long" v="Définir le niveau de difficulté : Simple, Réaliste, Hardcore" eh="cfb758a4" />
-    <e k="sf_diff_1" v="Simple" eh="1fbb1e39" />
+    <e k="sf_diff_1" v="[EN] Simple" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Réaliste" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="Synchronisation des données du sol..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="Impossible de charger la propriété des champs. Veuillez fermer et rouvrir le rapport." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Coûts Engrais" eh="6870d88b" />
     <e k="sf_fertilizer_cost_long" v="Activer/désactiver les coûts d'achat d'engrais réalistes" eh="12b03fbb" />
-    <e k="sf_notifications_short" v="Notifications" eh="a274f4d4" />
+    <e k="sf_notifications_short" v="[EN] Notifications" eh="a274f4d4" />
     <e k="sf_notifications_long" v="Activer/désactiver les notifications de sol et d'engrais" eh="9a872f8f" />
     <e k="sf_show_hud_short" v="Afficher HUD" eh="c94fd4d7" />
     <e k="sf_show_hud_long" v="Afficher/masquer l'HUD d'info sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Vert" eh="d382816a" />
     <e k="sf_hud_color_2" v="Bleu" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Ambre" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficulté" eh="7b29ca96" />
     <e k="sf_diff_long" v="Niveau de difficulté de gestion du sol" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Vert" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Bleu" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Ambre" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Taille police HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Ajuster la taille du texte pour une meilleure lisibilité" eh="c338854f" />
     <e k="sf_hud_font_1" v="Petit" eh="2660064e" />
@@ -83,7 +83,7 @@
     <e k="sf_hud_protected" v="(protégé)" eh="8273211e" />
     <e k="sf_hud_yield" v="Rendement" eh="97345487" />
     <e k="sf_hud_estYield" v="Rendement est." eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   RMB: terminé" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: déplacer/redimensionner" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unités impériales" eh="ff2701ad" />
@@ -115,7 +115,7 @@
     <e k="sf_report_prev" v="Préc" eh="14230d11" />
     <e k="sf_report_next" v="Suiv" eh="10ac3d04" />
     <e k="sf_report_yes" v="OUI" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Aucun" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Azote nécessaire" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Azote faible" eh="35ad072d" />
@@ -148,7 +148,7 @@
 		<e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
 		<e k="sf_liquid_dap_title" v="DAP liquide (P)" eh="86bd893e" />
 		<e k="sf_liquid_potash_title" v="Potasse liquide (K)" eh="72ac9fd3" />
-		<e k="sf_insecticide_title" v="Insecticide" eh="5650eeef" />
+		<e k="sf_insecticide_title" v="[EN] Insecticide" eh="5650eeef" />
 		<e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Champs %d-%d sur %d  |  Page %d sur %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="Big Bag UAN 32-0-0" eh="7bdc4d9d" />
@@ -159,11 +159,11 @@
     <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Engrais azoté (sec)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Engrais azoté (sec)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Engrais phosphoré (sec)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Engrais phosphoré (sec)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Engrais potassique (sec)" eh="18015099" />
@@ -185,9 +185,9 @@
     <e k="sf_bigBag_starter_function" v="Engrais starter (liquide)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="Big Bag de gypse" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
     <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_function" v="Engrais organique (solide)" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag fumier de poule" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (solide)" eh="374c7b1e" />
@@ -197,7 +197,7 @@
     <e k="sf_bigBag_liquidlime_function" v="Agent rehausseur de pH (liquide)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Azote: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphore: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
     <e k="sf_report_status_monitor" v="Surveiller" eh="d2986ac8" />
     <e k="sf_report_status_adjust" v="Ajuster" eh="51d7a685" />
     <e k="sf_report_status_maintain" v="Maintenir" eh="ade01a5a" />
@@ -323,8 +323,8 @@
 		<e k="sf_map_layer_off" v="Carte du sol : Désactivée" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="Azote" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Phosphore" eh="eb4f2688" />
-		<e k="sf_map_layer_k" v="Potassium" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+		<e k="sf_map_layer_k" v="[EN] Potassium" eh="3a4edc67" />
+		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Matière Organique" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Urgence au champ" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Pression des adventices" eh="53f8b936" />
@@ -351,7 +351,7 @@
     <e k="sf_pda_section_avg_nutrients" v="Nutriments moy." eh="f06b2704" />
     <e k="sf_pda_avg_n_label" v="Azote (N)" eh="25cee53b" />
     <e k="sf_pda_avg_p_label" v="Phosphore (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
     <e k="sf_pda_avg_ph_label" v="Niveau de pH" eh="0c85daad" />
     <e k="sf_pda_avg_om_label" v="Matière organique" eh="6305f4bb" />
     <e k="sf_pda_section_pressure" v="Pression culture" eh="a73974d0" />
@@ -391,7 +391,7 @@
     <e k="sf_map_btn_cycle_layer" v="Changer la couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de traitement" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Désactiver la couche" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Référence rapide du sol" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NUTRIMENTS" eh="9aeb39bf" />
     <e k="sf_help_n" v="N (Azote) – S’épuise rapidement. Appliquer UAN, Urée ou fumier." eh="f2d0c792" />
@@ -411,12 +411,12 @@
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Tous les champs" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Champ" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="Filtre : Tous les champs" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="Filtre : Champs possédés uniquement" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
     <e k="sf_pda_col_om" v="MO" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Statut" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Aucune donnée de champ enregistrée." eh="72265670" />
@@ -430,12 +430,12 @@
     <e k="sf_pda_no_treatment" v="Tous les champs sont en bon état." eh="fa985166" />
     <e k="sf_pda_need_n" v="Azote" eh="1e9ef3ba" />
     <e k="sf_pda_need_p" v="Phosphore" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
     <e k="sf_pda_need_ph" v="Ajustement pH" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
     <e k="sf_pda_need_disease" v="Fongicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
     <e k="sf_pda_treatment_minor" v="Mineur" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
     <e k="sf_detail_title" v="Détail du champ" eh="03b5acd7" />
@@ -447,7 +447,7 @@
     <e k="sf_detail_section_history" v="Historique culture" eh="54c27499" />
     <e k="sf_detail_n_label" v="Azote (N)" eh="25cee53b" />
     <e k="sf_detail_p_label" v="Phosphore (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
     <e k="sf_detail_ph_label" v="Niveau de pH" eh="0c85daad" />
     <e k="sf_detail_om_label" v="Matière organique" eh="6305f4bb" />
     <e k="sf_detail_weed_label" v="Pression adventices" eh="53f8b936" />
@@ -474,7 +474,7 @@
 		<e k="sf_treat_action_weed" v="Appliquer de l'HERBICIDE immédiatement." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Appliquer de l'INSECTICIDE immédiatement." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Appliquer du FONGICIDE immédiatement." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bonus Légumineuse (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (épuisement x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée disponible." eh="c6d95d5e" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -528,5 +528,119 @@
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 épuisement)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée disponible." eh="c6d95d5e" />
     <e k="sf_detail_no_crop" v="Aucune donnée enregistrée" eh="a4b5a996" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Angolszász mértékegységek" eh="ff2701ad" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Talaj &amp; Műtrágya" eh="f31197fb" />
@@ -12,12 +12,12 @@
     <e k="sf_rain_effects_long" v="Engedélyezze/tiltsa az eső hatását a talajra (tápanyag kimosódás, pH-változások)" eh="de3b14b9" />
     <e k="sf_plowing_bonus_short" v="Szántás Bónusz" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="A szántás előnyeinek engedélyezése/tiltása a talaj termékenységére (javított nitrogén és szerves anyag)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Termékenységi Rendszer" eh="f7e27d58" />
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Nehézségi szint beállítása: Egyszerű, Realisztikus, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Egyszerű" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realisztikus" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="[EN] Syncing soil data..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="[EN] Could not load field ownership. Please close and reopen the report." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Műtrágya Költségek" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Zöld" eh="d382816a" />
     <e k="sf_hud_color_2" v="Kék" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Borostyán" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Nehézség" eh="7b29ca96" />
     <e k="sf_diff_long" v="Talajkezelés nehézségi szintje" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Zöld" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Kék" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Borostyán" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="HUD betűméret" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Állítsa be a szöveg méretét a jobb olvashatóság érdekében" eh="c338854f" />
     <e k="sf_hud_font_1" v="Kicsi" eh="2660064e" />
@@ -73,26 +73,26 @@
     <e k="sf_hud_trans_3" v="Közepes" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Sötét" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Tömör" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Angolszász mértékegységek" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Kijuttatási normák gal/ac és lb/ac egységben (ki = L/ha és kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="Műtrágya arány növelése" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Műtrágya arány csökkentése" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Automatikus adagolás váltása" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Talaj &amp;amp; Műtrágya Jelentés" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Követett Mezők:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Műtrágya Szükséges:" eh="110b60f2" />
@@ -115,7 +115,7 @@
     <e k="sf_report_prev" v="Előző" eh="14230d11" />
     <e k="sf_report_next" v="Köv" eh="10ac3d04" />
     <e k="sf_report_yes" v="IGEN" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Nincs" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Nitrogén szükséges" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Alacsony nitrogén" eh="35ad072d" />
@@ -127,13 +127,13 @@
     <e k="sf_report_rec_ph_monitor" v="pH figyelése" eh="6dfcded4" />
     <e k="sf_report_rec_om_increase" v="Szerves anyag növelése" eh="c2a930af" />
     <e k="sf_report_rec_om_maintain" v="Szerves anyag fenntartása" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
     <e k="sf_report_rec_needs" v="Szükséges:" eh="3e6d95cf" />
     <e k="sf_report_rec_optimal" v="Talaj egészség: Optimális" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
     <e k="sf_uan32_title" v="UAN 32 Nitrogén műtrágya (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Nitrogén műtrágya (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Vízmentes ammónia (N)" eh="3fc85c02" />
@@ -159,59 +159,59 @@
     <e k="sf_bigBag_anhydrous_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Karbamid 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Hamuzsír 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Starter Műtrágya 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
-    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Réteg váltás" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kezelési terv" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Réteg kikapcsolása" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Fejlesztői megjegyzés" eh="5320d63f" />
     <e k="sf_pda_help_github" v="A VISSZAJELZÉSED SZÁMÍT! Ha hibákat találsz, új funkciókra vonatkozó javaslataid vannak, vagy szeretnél hozzájárulni a kódhoz, látogasd meg a projektet a GitHubon. Bármikor megnyithatsz egy Issue-t vagy Pull Request-et, hogy segítsd jobbá tenni ezt a modot mindenki számára. Köszönöm a tesztelést!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Szia, én vagyok a fejlesztő! Ahogy láthatod, ez az oldal még nagyon fejlesztés alatt áll. A térképrétegek jelenleg csak vizuális előnézetek (kiválasztásra nem működnek), és sok felhasználói felület elem még véglegesítésre vár." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Kattints egy mezőre, hogy a térképen is megjelenjen" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Összesen figyelmet igényel" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="A jobb oldalon felsorolt mezők kezelést igényelnek. Kattints egy sorra az ajánlott bemenetek és becsült mennyiségek megtekintéséhez." eh="5748d316" />
     </elements>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Összesen figyelmet igényel" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="A jobb oldalon felsorolt mezők kezelést igényelnek. Kattints egy sorra az ajánlott bemenetek és becsült mennyiségek megtekintéséhez." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total yang memerlukan perhatian" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Bidang yang tercantum di sebelah kanan memerlukan perawatan. Klik baris untuk melihat input yang disarankan dan perkiraan jumlahnya." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Hijau" eh="d382816a" />
     <e k="sf_hud_color_2" v="Biru" eh="9594eec9" />
-    <e k="sf_hud_color_3" v="Amber" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_3" v="[EN] Amber" eh="88068e33" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Kesulitan" eh="7b29ca96" />
     <e k="sf_diff_long" v="Tingkat kesulitan manajemen tanah" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Beralih laju otomatis" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -111,48 +111,48 @@
     <e k="sf_bigBag_uan28_function" v="Pupuk nitrogen (cair)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Amonia Anhidrat 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Pupuk nitrogen (cair)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Pupuk nitrogen (kering)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Pupuk nitrogen (kering)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Pupuk fosfor (kering)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Pupuk fosfor (kering)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Pupuk kalium (kering)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Pupuk Starter 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Pupuk starter (cair)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ganti lapisan" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Rencana perawatan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Nonaktifkan overlay" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Catatan Dev" eh="5320d63f" />
     <e k="sf_pda_help_github" v="MASUKAN ANDA PENTING! Jika Anda menemukan bug, memiliki saran fitur baru, atau ingin berkontribusi pada kode, kunjungi proyek di GitHub. Anda dapat membuka Issue atau Pull Request kapan saja untuk membantu membuat mod ini lebih baik bagi semua orang. Terima kasih telah menguji!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Halo, saya sang pengembang! Seperti yang Anda lihat, halaman ini masih dalam pengerjaan. Layer peta saat ini hanya pratinjau visual (tidak berfungsi untuk pemilihan), dan banyak elemen UI masih memerlukan polesan akhir." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Klik bidang untuk melompat ke sana di peta" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total yang memerlukan perhatian" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Bidang yang tercantum di sebelah kanan memerlukan perawatan. Klik baris untuk melihat input yang disarankan dan perkiraan jumlahnya." eh="5748d316" />
     </elements>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -482,5 +482,119 @@
 		<e k="sf_pda_map_native_hint" v="La visualizzazione dei livelli del suolo è stata spostata! Ora puoi accedere e attivare tutti i livelli del suolo direttamente dalla barra laterale della mappa PDA nativa (ESC > Mappa). Cerca la categoria 'Livelli del suolo' nei punti della barra laterale." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totale che richiede attenzione" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="I campi elencati a destra necessitano di trattamento. Clicca su una riga per vedere gli input consigliati e le quantità stimate." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="Resa" eh="97345487" />
     <e k="sf_hud_estYield" v="Resa Stim." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ottimale" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Trascina: muovi  Angolo: ridimensiona  RMB: fatto" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: muovi/ridimensiona" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unità imperiali" eh="ff2701ad" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suolo &amp; Fertilizzante" eh="f31197fb" />
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Imposta livello difficoltà: Semplice, Realistico, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Semplice" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistico" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="Sincronizzazione dati suolo..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="Impossibile caricare la proprietà dei campi. Chiudi e riapri il rapporto." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Costi Fertilizzante" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blu" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Ambra" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficoltà" eh="7b29ca96" />
     <e k="sf_diff_long" v="Imposta livello difficoltà: Semplice, Realistica, Hardcore" eh="cfb758a4" />
 		<e k="sf_rr_short" v="Tasso di ripristino" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Blu" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Ambra" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Dimensione carattere HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Regola dimensione testo per migliore leggibilità" eh="c338854f" />
     <e k="sf_hud_font_1" v="Piccolo" eh="2660064e" />
@@ -110,12 +110,12 @@
     <e k="sf_report_difficulty" v="Difficoltà:" eh="3abaf54f" />
     <e k="sf_report_col_field" v="Campo" eh="6f16a5f8" />
     <e k="sf_report_col_last_crop" v="Ultimo Raccolto" eh="ff41e5eb" />
-    <e k="sf_report_col_fert" v="Fert?" eh="9e6d0eb4" />
+    <e k="sf_report_col_fert" v="[EN] Fert?" eh="9e6d0eb4" />
     <e k="sf_report_no_data" v="Nessun dato disponibile. Cammina su un campo per iniziare il tracciamento." eh="1528a4cb" />
     <e k="sf_report_prev" v="Prec" eh="14230d11" />
     <e k="sf_report_next" v="Succ" eh="10ac3d04" />
     <e k="sf_report_yes" v="SÌ" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Nessuno" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Serve azoto" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Azoto basso" eh="35ad072d" />
@@ -138,7 +138,7 @@
     <e k="sf_uan28_title" v="UAN 28 Fertilizzante azotato (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Ammoniaca anidra (N)" eh="3fc85c02" />
     <e k="sf_starter_title" v="Fertilizzante starter 10-34-0 (P)" eh="8c1a1ddc" />
-    <e k="sf_urea_title" v="Urea 46-0-0 (N)" eh="659b3097" />
+    <e k="sf_urea_title" v="[EN] Urea 46-0-0 (N)" eh="659b3097" />
     <e k="sf_ams_title" v="Solfato di ammonio 21-0-0 (N)" eh="033d1845" />
     <e k="sf_map_title" v="Fertilizzante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizzante DAP 18-46-0 (P)" eh="5030a80a" />
@@ -157,13 +157,13 @@
     <e k="sf_bigBag_uan28_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Ammoniaca Anidra 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fertilizzante fosfatico (secco)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fertilizzante fosfatico (secco)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassio 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizzante potassico (secco)" eh="18015099" />
@@ -185,7 +185,7 @@
     <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="Miglioratore del suolo (secco)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
     <e k="sf_bigBag_compost_function" v="Miglioratore organico (secco)" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolidi" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_function" v="Fertilizzante organico (secco)" eh="374c7b1e" />
@@ -324,7 +324,7 @@
 		<e k="sf_map_layer_n" v="Azoto" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Fosforo" eh="eb4f2688" />
 		<e k="sf_map_layer_k" v="Potassio" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Sostanza Organica" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Urgenza Campo" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Presenza Erbe Infestanti" eh="53f8b936" />
@@ -388,7 +388,7 @@
     <e k="sf_map_btn_cycle_layer" v="Cambia livello" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Piano di trattamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disabilita overlay" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Riferimento Rapido Suolo" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NUTRIENTI" eh="9aeb39bf" />
     <e k="sf_help_n" v="N (Azoto) - Si consuma velocemente. Applica UAN, Urea o Letame." eh="f2d0c792" />
@@ -407,13 +407,13 @@
     <e k="sf_help_poor" v="Scarso - Trattamento immediato richiesto." eh="b287d206" />
     <e k="sf_pda_fields_section_title" v="Tutti i Campi" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Campo" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="Filtro: Tutti i Campi" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="Filtro: Solo di Proprietà" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Stato" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Nessun dato registrato sui campi." eh="72265670" />
     <e k="sf_pda_status_good" v="Buono" eh="0c6ad70b" />
@@ -468,7 +468,7 @@
 		<e k="sf_treat_action_weed" v="Applica ERBICIDA immediatamente." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Applica INSETTICIDA immediatamente." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Applica FUNGICIDA immediatamente." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bonus Leguminose (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Stanchezza (deplezione x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nessun dato disponibile." eh="c6d95d5e" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Imposta livello difficoltà: Semplice, Realistico, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Semplice" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistico" eh="408c999f" />
-    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="Difficile" eh="1c800aa9" />
 		<e k="sf_ui_soilReport_syncing" v="Sincronizzazione dati suolo..." eh="03f01c4d" />
 		<e k="sf_ui_soilReport_syncTimeout" v="Impossibile caricare la proprietà dei campi. Chiudi e riapri il rapporto." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Costi Fertilizzante" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blu" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Ambra" eh="88068e33" />
-    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Difficoltà" eh="7b29ca96" />
     <e k="sf_diff_long" v="Imposta livello difficoltà: Semplice, Realistica, Hardcore" eh="cfb758a4" />
 		<e k="sf_rr_short" v="Tasso di ripristino" eh="b363b336" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Blu" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Ambra" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Dimensione carattere HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Regola dimensione testo per migliore leggibilità" eh="c338854f" />
     <e k="sf_hud_font_1" v="Piccolo" eh="2660064e" />
@@ -110,12 +110,12 @@
     <e k="sf_report_difficulty" v="Difficoltà:" eh="3abaf54f" />
     <e k="sf_report_col_field" v="Campo" eh="6f16a5f8" />
     <e k="sf_report_col_last_crop" v="Ultimo Raccolto" eh="ff41e5eb" />
-    <e k="sf_report_col_fert" v="[EN] Fert?" eh="9e6d0eb4" />
+    <e k="sf_report_col_fert" v="Fert?" eh="9e6d0eb4" />
     <e k="sf_report_no_data" v="Nessun dato disponibile. Cammina su un campo per iniziare il tracciamento." eh="1528a4cb" />
     <e k="sf_report_prev" v="Prec" eh="14230d11" />
     <e k="sf_report_next" v="Succ" eh="10ac3d04" />
     <e k="sf_report_yes" v="SÌ" eh="7469a286" />
-    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Nessuno" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Serve azoto" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Azoto basso" eh="35ad072d" />
@@ -138,7 +138,7 @@
     <e k="sf_uan28_title" v="UAN 28 Fertilizzante azotato (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Ammoniaca anidra (N)" eh="3fc85c02" />
     <e k="sf_starter_title" v="Fertilizzante starter 10-34-0 (P)" eh="8c1a1ddc" />
-    <e k="sf_urea_title" v="[EN] Urea 46-0-0 (N)" eh="659b3097" />
+    <e k="sf_urea_title" v="Urea 46-0-0 (N)" eh="659b3097" />
     <e k="sf_ams_title" v="Solfato di ammonio 21-0-0 (N)" eh="033d1845" />
     <e k="sf_map_title" v="Fertilizzante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizzante DAP 18-46-0 (P)" eh="5030a80a" />
@@ -157,13 +157,13 @@
     <e k="sf_bigBag_uan28_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Ammoniaca Anidra 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fertilizzante fosfatico (secco)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fertilizzante fosfatico (secco)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassio 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizzante potassico (secco)" eh="18015099" />
@@ -185,7 +185,7 @@
     <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="Miglioratore del suolo (secco)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
     <e k="sf_bigBag_compost_function" v="Miglioratore organico (secco)" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolidi" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_function" v="Fertilizzante organico (secco)" eh="374c7b1e" />
@@ -324,7 +324,7 @@
 		<e k="sf_map_layer_n" v="Azoto" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Fosforo" eh="eb4f2688" />
 		<e k="sf_map_layer_k" v="Potassio" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
+		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Sostanza Organica" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Urgenza Campo" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Presenza Erbe Infestanti" eh="53f8b936" />
@@ -388,7 +388,7 @@
     <e k="sf_map_btn_cycle_layer" v="Cambia livello" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Piano di trattamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disabilita overlay" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Riferimento Rapido Suolo" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NUTRIENTI" eh="9aeb39bf" />
     <e k="sf_help_n" v="N (Azoto) - Si consuma velocemente. Applica UAN, Urea o Letame." eh="f2d0c792" />
@@ -407,13 +407,13 @@
     <e k="sf_help_poor" v="Scarso - Trattamento immediato richiesto." eh="b287d206" />
     <e k="sf_pda_fields_section_title" v="Tutti i Campi" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Campo" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="Filtro: Tutti i Campi" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="Filtro: Solo di Proprietà" eh="258cb971" />
-    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Stato" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Nessun dato registrato sui campi." eh="72265670" />
     <e k="sf_pda_status_good" v="Buono" eh="0c6ad70b" />
@@ -468,7 +468,7 @@
 		<e k="sf_treat_action_weed" v="Applica ERBICIDA immediatamente." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Applica INSETTICIDA immediatamente." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Applica FUNGICIDA immediatamente." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bonus Leguminose (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Stanchezza (deplezione x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nessun dato disponibile." eh="c6d95d5e" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="要対応の合計" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="右側に表示されているフィールドは処理が必要です。行をクリックすると推奨する投入物と推定量が確認できます。" eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="グリーン" eh="d382816a" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="è‡ªå‹•ãƒ¬ãƒ¼ãƒˆåˆ‡ã‚Šæ›¿ãˆ" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -121,38 +121,38 @@
     <e k="sf_bigBag_dap_function" v="リン酸肥料（乾燥）" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="ãƒ“ãƒƒã‚°ãƒãƒƒã‚° å¡©åŒ–ã‚«ãƒª 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="カリウム肥料（乾燥）" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="ãƒ“ãƒƒã‚°ãƒãƒƒã‚° ã‚¹ã‚¿ãƒ¼ã‚¿ãƒ¼è‚¥æ–™ 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="スターター肥料（液体）" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="レイヤー切替" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="施肥計画" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="オーバーレイ無効" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="開発者メモ" eh="5320d63f" />
     <e k="sf_pda_help_github" v="フィードバックをお待ちしています！バグを発見した場合、新機能の提案がある場合、またはコードに貢献したい場合は、GitHubのプロジェクトをご覧ください。いつでもIssueまたはPull Requestを開いて、このModをより良くするお手伝いができます。テストへのご協力ありがとうございます！" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="こんにちは、開発者です！ご覧の通り、このページはまだ開発中です。マップレイヤーは現在ビジュアルプレビューのみ（選択機能は未実装）であり、多くのUI要素はまだ最終調整が必要です。" eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="フィールドをクリックしてマップ上でジャンプ" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="要対応の合計" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="右側に表示されているフィールドは処理が必要です。行をクリックすると推奨する投入物と推定量が確認できます。" eh="5748d316" />
     </elements>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="ì´ˆë¡" eh="d382816a" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="ìžë™ ì‚´í¬ëŸ‰ ì „í™˜" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -121,38 +121,38 @@
     <e k="sf_bigBag_dap_function" v="ì¸ì‚° ë¹„ë£Œ (ê³ ì²´)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="빅백 칼리 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="칼리 비료 (고체)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="빅백 스타터 비료 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="스타터 비료 (액체)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="레이어 전환" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="처리 계획" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="오버레이 비활성화" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="개발자 노트" eh="5320d63f" />
     <e k="sf_pda_help_github" v="여러분의 피드백이 중요합니다! 버그를 발견하거나 새로운 기능에 대한 제안이 있거나 코드에 기여하고 싶다면 GitHub 프로젝트를 방문해 주세요. 언제든지 Issue나 Pull Request를 열어 모든 사람을 위해 이 모드를 더 나아지게 도와주세요. 테스트에 감사드립니다!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="안녕하세요, 저는 개발자입니다! 보시다시피 이 페이지는 아직 많이 개발 중입니다. 지도 레이어는 현재 시각적 미리보기만 가능하며(선택 기능 미구현), 많은 UI 요소들이 아직 최종 마무리가 필요합니다." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="필드를 클릭하면 지도에서 해당 위치로 이동합니다" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="주의가 필요한 총 수" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="오른쪽에 나열된 필드는 처리가 필요합니다. 행을 클릭하면 권장 투입물과 예상 수량을 확인할 수 있습니다." eh="5748d316" />
     </elements>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="주의가 필요한 총 수" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="오른쪽에 나열된 필드는 처리가 필요합니다. 행을 클릭하면 권장 투입물과 예상 수량을 확인할 수 있습니다." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -487,5 +487,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totaal dat aandacht nodig heeft" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="De velden rechts hebben behandeling nodig. Klik op een rij om aanbevolen inputs en geschatte hoeveelheden te zien." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="Opbrengst" eh="97345487" />
     <e k="sf_hud_estYield" v="Verw. opbrengst" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimaal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Sleep: verplaatsen   Hoek: formaat wijzigen   Rechtsklik: gereed" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="Rechtsklik: verplaatsen/vergroten" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiale eenheden" eh="ff2701ad" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Bodem &amp; Meststoffen" eh="d30a22a9" />
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Moeilijkheidsgraad instellen: Eenvoudig, Realistisch, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Eenvoudig" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistisch" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
     <e k="sf_ui_soilReport_syncing" v="Bodemgegevens synchroniseren..." eh="03f01c4d" />
     <e k="sf_ui_soilReport_syncTimeout" v="Kon veldeigendom niet laden. Sluit en heropen het rapport." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Meststofkosten" eh="6870d88b" />
@@ -49,8 +49,8 @@
     <e k="sf_hud_color_theme_long" v="Kies het kleurenschema voor de bodem-info weergave" eh="3218bca6" />
     <e k="sf_hud_color_1" v="Groen" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blauw" eh="9594eec9" />
-    <e k="sf_hud_color_3" v="Amber" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_3" v="[EN] Amber" eh="88068e33" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Moeilijkheid" eh="7b29ca96" />
     <e k="sf_diff_long" v="Moeilijkheidsgraad bodembeheer" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -59,18 +59,18 @@
     <e k="sf_auto_rate_long" v="Past automatisch de bemestingssnelheid aan op basis van veldbehoeften" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Groen" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Blauw" eh="9594eec9" />
-    <e k="sf_hud_theme_3" v="Amber" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_3" v="[EN] Amber" eh="88068e33" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="HUD Lettergrootte" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Pas de tekstgrootte aan voor betere leesbaarheid" eh="c338854f" />
     <e k="sf_hud_font_1" v="Klein" eh="2660064e" />
-    <e k="sf_hud_font_2" v="Medium" eh="87f8a6ab" />
+    <e k="sf_hud_font_2" v="[EN] Medium" eh="87f8a6ab" />
     <e k="sf_hud_font_3" v="Groot" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD Transparantie" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Stel het transparantie-niveau van de achtergrond in" eh="152e390a" />
     <e k="sf_hud_trans_1" v="Helder" eh="dc30bc0c" />
     <e k="sf_hud_trans_2" v="Licht" eh="9914a0ce" />
-    <e k="sf_hud_trans_3" v="Medium" eh="87f8a6ab" />
+    <e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
     <e k="sf_hud_trans_4" v="Donker" eh="a18366b2" />
     <e k="sf_hud_trans_5" v="Massief" eh="e41480b6" />
     <e k="sf_hud_title" v="BODEM MONITOR" eh="f8cda642" />
@@ -88,11 +88,11 @@
     <e k="sf_hud_hint_normal" v="Rechtsklik: verplaatsen/vergroten" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiale eenheden" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Toon doseringen in gal/ac en lb/ac (uit = L/ha en kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeminstellingen herstellen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bodem HUD in-/uitschakelen" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -100,8 +100,8 @@
     <e k="input_SF_RATE_UP" v="Meststofdosering verhogen" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Meststofdosering verlagen" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Auto-modus wisselen" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Bodem- &amp; Meststoffenrapport" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Velden gevolgd:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Meststof nodig:" eh="110b60f2" />
@@ -115,7 +115,7 @@
     <e k="sf_report_prev" v="Vorige" eh="14230d11" />
     <e k="sf_report_next" v="Volgende" eh="10ac3d04" />
     <e k="sf_report_yes" v="JA" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Geen" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Stikstof nodig" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Lage stikstof" eh="35ad072d" />
@@ -148,8 +148,8 @@
     <e k="sf_liquid_map_title" v="Vloeibare MAP (P)" eh="3ce7c8c9" />
     <e k="sf_liquid_dap_title" v="Vloeibare DAP (P)" eh="86bd893e" />
     <e k="sf_liquid_potash_title" v="Vloeibare Kali (K)" eh="72ac9fd3" />
-    <e k="sf_insecticide_title" v="Insecticide" eh="5650eeef" />
-    <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
+    <e k="sf_insecticide_title" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_fungicide_title" v="[EN] Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Velden %d-%d van %d  |  Pagina %d van %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="Big Bag UAN 32-0-0" eh="7bdc4d9d" />
     <e k="sf_bigBag_uan32_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
@@ -159,11 +159,11 @@
     <e k="sf_bigBag_anhydrous_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureum 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Stikstofmeststof (droog)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Stikstofmeststof (droog)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosfaatmeststof (droog)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosfaatmeststof (droog)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kali 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kalimeststof (droog)" eh="18015099" />
@@ -185,16 +185,16 @@
     <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
     <e k="sf_report_detail_n_ok" v="Stikstof: Optimaal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fosfor: Optimaal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Kalium: Optimaal" eh="0197b4ba" />
@@ -231,7 +231,7 @@
     <e k="helpLine_sf_cat_fertilizers" v="Meststoffen" eh="754d59bd" />
     <e k="helpLine_sf_cat_hud" v="HUD &amp; Bodemrapport" eh="9b9888b9" />
     <e k="helpLine_sf_cat_settings" v="Instellingen" eh="f4f70727" />
-    <e k="helpLine_sf_cat_multiplayer" v="Multiplayer" eh="901a7320" />
+    <e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
 		<e k="helpLine_sf_ov_p1_intro_title" v="[EN] Per-Field Soil Tracking" eh="8fe3248d" />
 		<e k="helpLine_sf_ov_p1_intro_text" v="[EN] Every field independently tracks five properties: Nitrogen (N), Phosphorus (P), Potassium (K), Organic Matter (OM), and pH. Values are saved with your savegame and persist across sessions." eh="c30216e6" />
@@ -256,7 +256,7 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
 		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
@@ -306,7 +306,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -327,7 +327,7 @@
     <e k="sf_map_layer_n" v="Stikstof" eh="1e9ef3ba" />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
-    <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
     <e k="sf_map_layer_om" v="Organische stof" eh="6305f4bb" />
     <e k="sf_map_layer_urgency" v="Veld urgentie" eh="419ea5af" />
     <e k="sf_map_layer_weed" v="Onkruiddruk" eh="53f8b936" />
@@ -385,40 +385,40 @@
     <e k="sf_pda_map_legend_excess" v="Overschot" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Druk op Shift+M in de game om door de bodemkaartlagen te wisselen." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Bodemkaart" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Laag wisselen" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandelingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay uitschakelen" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <e k="sf_pda_fields_section_title" v="Alle Velden" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Veld" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
     <e k="sf_pda_filter_all" v="Filter: Alle velden" eh="a46a8cb2" />
     <e k="sf_pda_filter_owned" v="Filter: Alleen eigen velden" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Nog geen veldgegevens vastgelegd." eh="72265670" />
     <e k="sf_pda_status_good" v="Goed" eh="0c6ad70b" />
     <e k="sf_pda_status_fair" v="Redelijk" eh="f7f20cf0" />
@@ -431,9 +431,9 @@
     <e k="sf_pda_need_p" v="Fosfor" eh="eb4f2688" />
     <e k="sf_pda_need_k" v="Kalium" eh="3a4edc67" />
     <e k="sf_pda_need_ph" v="pH Aanpassen" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
     <e k="sf_pda_need_multiple" v="Meerdere" eh="a0bf169f" />
     <e k="sf_pda_treatment_minor" v="Gering" eh="6fed0c37" />
     <e k="sf_detail_title" v="Velddetails" eh="03b5acd7" />
@@ -453,7 +453,7 @@
     <e k="sf_detail_disease_label" v="Ziektedruk" eh="2b805cc9" />
     <e k="sf_detail_last_crop_label" v="Vorig gewas" eh="ff41e5eb" />
     <e k="sf_detail_rotation_label" v="Rotatiestatus" eh="83f7f522" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Bodemmoeheid (x1.15 uitputting)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Geen gegevens beschikbaar." eh="c6d95d5e" />
@@ -483,7 +483,7 @@
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Hoi, ik ben de ontwikkelaar! Zoals je kunt zien, is deze pagina nog volop in ontwikkeling. De kaartlagen zijn momenteel slechts visuele previews (niet functioneel voor selectie) en veel UI-elementen moeten nog hun definitieve afwerking krijgen." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Klik op een veld om ernaar te springen op de kaart" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totaal dat aandacht nodig heeft" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="De velden rechts hebben behandeling nodig. Klik op een rij om aanbevolen inputs en geschatte hoeveelheden te zien." eh="5748d316" />
     </elements>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Grønn" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blå" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Rav" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Vanskelighet" eh="7b29ca96" />
     <e k="sf_diff_long" v="Vanskelighetsgrad for jordforvaltning" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Veksle automatisk rate" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -111,48 +111,48 @@
     <e k="sf_bigBag_uan28_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Vannfri Ammoniakk 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Nitrogengjødsel (tørr)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Nitrogengjødsel (tørr)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosfatgjødsel (tørr)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosfatgjødsel (tørr)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgjødsel (tørr)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Startgjødsel 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Startgjødsel (flytende)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Bytt lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver lag" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Utviklernotat" eh="5320d63f" />
     <e k="sf_pda_help_github" v="TILBAKEMELDINGEN DIN BETYR NOE! Hvis du oppdager feil, har forslag til nye funksjoner eller ønsker å bidra til koden, besøk prosjektet på GitHub. Du kan åpne en Issue eller en Pull Request når som helst for å hjelpe med å gjøre denne moden bedre for alle. Takk for testingen!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Hei, det er jeg, utvikleren! Som du kan se, er denne siden fortsatt veldig under utvikling. Kartlagene er for øyeblikket bare visuelle forhåndsvisninger (ikke-funksjonelle for valg), og mange UI-elementer trenger fortsatt sin endelige finpuss." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Klikk på et jorde for å hoppe til det på kartet" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totalt som trenger oppmerksomhet" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Jordene som er oppført til høyre trenger behandling. Klikk på en rad for å se anbefalte innsatsmidler og estimerte mengder." eh="5748d316" />
     </elements>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totalt som trenger oppmerksomhet" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Jordene som er oppført til høyre trenger behandling. Klikk på en rad for å se anbefalte innsatsmidler og estimerte mengder." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -28,7 +28,7 @@
     <e k="sf_difficulty_long" v="Ustaw poziom trudności: Prosty, Realistyczny, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Prosty" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistyczny" eh="408c999f" />
-    <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
+    <e k="sf_diff_3" v="[EN] Hardcore" eh="1c800aa9" />
 	<e k="sf_ui_soilReport_syncing" v="Synchronizowanie danych gleby..." eh="03f01c4d" />
 	<e k="sf_ui_soilReport_syncTimeout" v=" Nie można załadować właściciela pola. Proszę zamknąć i ponownie otworzyć raport." eh="9f699982" />
     <e k="sf_fertilizer_cost_short" v="Koszty Nawozu" eh="6870d88b" />
@@ -50,7 +50,7 @@
     <e k="sf_hud_color_1" v="Zielony" eh="d382816a" />
     <e k="sf_hud_color_2" v="Niebieski" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Bursztynowy" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Trudność" eh="7b29ca96" />
     <e k="sf_diff_long" v="Poziom trudności zarządzania glebą" eh="d6f4560c" />
     <e k="sf_auto_rate_short" v="Automatyczna kontrola dawki" eh="6f99137d" />
@@ -60,7 +60,7 @@
     <e k="sf_hud_theme_1" v="Zielony" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Niebieski" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Bursztynowy" eh="88068e33" />
-    <e k="sf_hud_theme_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_theme_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_hud_font_size_short" v="Rozmiar czcionki HUD" eh="fd6ca64a" />
     <e k="sf_hud_font_size_long" v="Dostosuj rozmiar tekstu dla lepszej czytelności" eh="c338854f" />
     <e k="sf_hud_font_1" v="Mały" eh="2660064e" />
@@ -117,7 +117,7 @@
     <e k="sf_report_prev" v="Poprz" eh="14230d11" />
     <e k="sf_report_next" v="Nast" eh="10ac3d04" />
     <e k="sf_report_yes" v="TAK" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Brak" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Potrzebny azot" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Dostateczny azot" eh="35ad072d" />
@@ -172,11 +172,11 @@
     <e k="sf_bigBag_anhydrous_function" v="Nawóz azotowy (ciekły)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Mocznik 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Nawóz azotowy (suchy)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Nawóz azotowy (suchy)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Nawóz fosforowy (suchy)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Nawóz fosforowy (suchy)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Sól potasowa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Nawóz potasowy (suchy)" eh="18015099" />
@@ -339,7 +339,7 @@
 	<e k="sf_map_layer_n" v="Azot" eh="1e9ef3ba" />
 	<e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
 	<e k="sf_map_layer_k" v="Potas" eh="3a4edc67" />
-	<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+	<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 	<e k="sf_map_layer_om" v="Materia organiczna" eh="6305f4bb" />
 	<e k="sf_map_layer_urgency" v="Piorytet pola" eh="419ea5af" />
 	<e k="sf_map_layer_weed" v="Presja chwastów" eh="53f8b936" />
@@ -406,7 +406,7 @@
     <e k="sf_map_btn_cycle_layer" v="Zmień warstwę" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan działania" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Wyłącz nakładkę" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Szybki przegląd gleby" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="Składniki odżywcze" eh="9aeb39bf" />
     <e k="sf_help_n" v="N  (Azot)     - Wykorzystywany szybko. Zastosuj UAN, Moczenik lub Obornik." eh="f2d0c792" />
@@ -426,14 +426,14 @@
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Wszystkie Pola" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Pole" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 	<e k="sf_pda_filter_all" v="Filtr: Wszystkie Pola" eh="a46a8cb2" />
 	<e k="sf_pda_filter_owned" v="Filtr: Własne Pola" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Brak zebranych danych z pola." eh="72265670" />
     <e k="sf_pda_status_good" v="Dobry" eh="0c6ad70b" />
     <e k="sf_pda_status_fair" v="Umiarkowany" eh="f7f20cf0" />
@@ -491,7 +491,7 @@
 	<e k="sf_treat_action_weed" v="Zastosuj Herbicyd natychmiast." eh="625551c5" />
 	<e k="sf_treat_action_pest" v="Zastosuj Insektycyd natychmiast." eh="f4db9a03" />
 	<e k="sf_treat_action_disease" v="Zastosuj Fungicyd natychmiast." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Bonus roślin strączkowych (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Degreadacja gleby przez monokulture (x1.15 wyjałowienie gleby)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Brak dostępnych danych." eh="c6d95d5e" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -506,5 +506,119 @@
 	<e k="sf_pda_map_native_hint" v="Funkcja wizualizacji warstw gleby została przeniesiona! Teraz możesz wyświetlać i przełączać wszystkie warstwy gleby bezpośrednio z natywnego paska bocznego aplikacji PDA Map (ESC &amp;gt; Map). Poszukaj kategorii „Warstwy gleby" wśród ikonek na pasku bocznym." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Łącznie wymaga uwagi" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Pola wymienione po prawej stronie wymagają działania. Kliknij wiersz, aby zobaczyć zalecane środki i szacowane ilości." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -84,6 +84,7 @@
     <e k="sf_hud_yield" v="Plon" eh="97345487" />
     <e k="sf_hud_estYield" v="Szac. plon" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optymalny" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Przegciągnięcie: przesuń   ku górze: zmien rozmiar   RMB: gotowe" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: przesuń/zmień rozmiar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Jednostki imperialne" eh="ff2701ad" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Azul" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Âmbar" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificuldade" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nível de dificuldade de gestão do solo" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Alternar taxa automática" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -113,46 +113,46 @@
     <e k="sf_bigBag_anhydrous_function" v="Fertilizante azotado (líquido)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureia 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Fertilizante azotado (seco)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Fertilizante azotado (seco)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fertilizante fosfatado (seco)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fertilizante fosfatado (seco)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Fertilizante Inicial 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Mudar camada" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plano de tratamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desativar camada" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Nota do Dev" eh="5320d63f" />
     <e k="sf_pda_help_github" v="O SEU FEEDBACK IMPORTA! Se encontrar erros, tiver sugestões para novas funcionalidades ou quiser contribuir para o código, visite o projeto no GitHub. Pode abrir um Issue ou um Pull Request a qualquer momento para ajudar a melhorar este mod para todos. Obrigado por testar!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Olá, sou eu, o desenvolvedor! Como pode ver, esta página ainda está em desenvolvimento. As camadas do mapa são apenas pré-visualizações visuais (não funcionais para seleção) e muitos elementos da interface ainda precisam de ajustes finais." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Clique num campo para saltar para ele no mapa" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necessita atenção" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Os campos listados à direita precisam de tratamento. Clique numa linha para ver os inputs recomendados e as quantidades estimadas." eh="5748d316" />
     </elements>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total que necessita atenção" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Os campos listados à direita precisam de tratamento. Clique numa linha para ver os inputs recomendados e as quantidades estimadas." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total necesită atenție" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Câmpurile listate în dreapta necesită tratament. Faceți clic pe un rând pentru a vedea inputurile recomandate și cantitățile estimate." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
     <e k="sf_hud_color_2" v="Albastru" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Chihlimbar" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Dificultate" eh="7b29ca96" />
     <e k="sf_diff_long" v="Nivelul de dificultate al managementului solului" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Comutare rată automată" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -113,46 +113,46 @@
     <e k="sf_bigBag_anhydrous_function" v="Îngrășământ azotat (lichid)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Uree 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Îngrășământ azotat (uscat)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Îngrășământ azotat (uscat)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Îngrășământ fosforic (uscat)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Îngrășământ fosforic (uscat)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasiu 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Îngrășământ potasic (uscat)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Îngrășământ Starter 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Îngrășământ starter (lichid)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Schimbă stratul" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de tratament" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Dezactivează stratul" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Notă dev" eh="5320d63f" />
     <e k="sf_pda_help_github" v="FEEDBACK-UL TĂU CONTEAZĂ! Dacă întâlnești erori, ai sugestii pentru funcții noi sau dorești să contribui la cod, vizitează proiectul pe GitHub. Poți deschide un Issue sau un Pull Request oricând pentru a ajuta la îmbunătățirea acestui mod pentru toți. Mulțumim pentru testare!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Salut, eu sunt dezvoltatorul! După cum poți vedea, această pagină este încă în lucru. Straturile hărții sunt în prezent doar previzualizări vizuale (nefuncționale pentru selecție) și multe elemente UI mai au nevoie de finisare." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Faceți clic pe un câmp pentru a sări la el pe hartă" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Total necesită atenție" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Câmpurile listate în dreapta necesită tratament. Faceți clic pe un rând pentru a vedea inputurile recomandate și cantitățile estimate." eh="5748d316" />
     </elements>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Почва и удобрения" eh="f31197fb" />
@@ -102,7 +102,7 @@
     <e k="sf_report_prev" v="Назад" eh="14230d11" />
     <e k="sf_report_next" v="Далее" eh="10ac3d04" />
     <e k="sf_report_yes" v="ДА" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Нет" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Требуется азот" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Низкое содержание азота" eh="35ad072d" />
@@ -173,7 +173,7 @@
 		<e k="sf_bigBag_gypsum_name" v="МКР Гипс" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="Почвоулучшитель (сухой)" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="МКР Биоотходы" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_function" v="Органическая почвенная добавка (сухая)" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="МКР Куриный помет" eh="cb60fddc" />
@@ -324,7 +324,7 @@
 		<e k="sf_map_layer_n" v="Азот" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Фосфор" eh="eb4f2688" />
 		<e k="sf_map_layer_k" v="Калий" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Органические вещества" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Степень срочности" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Давление сорняков" eh="53f8b936" />
@@ -391,13 +391,13 @@
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Все поля" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Поле" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="Фильтр: Все поля" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="Фильтр: Только мои" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Статус" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Пока данные с мест не зафиксированы." eh="72265670" />
     <e k="sf_pda_status_good" v="Хорошо" eh="0c6ad70b" />
@@ -454,7 +454,7 @@
 		<e k="sf_treat_action_weed" v="Немедленно внесите ГЕРБИЦИД." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Немедленно внесите ИНСКЕТИЦИД." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Немедленно внесите ФУНГИЦИД." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Бонус за бобовые (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Утомление (снижение на 1,15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Данные отсутствуют." eh="c6d95d5e" />
@@ -463,7 +463,7 @@
     <e k="sf_map_btn_cycle_layer" v="Сменить слой" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="План обработки" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Отключить слой" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Краткий справочник по почвам" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="ПИТАТЕЛЬНЫЕ ВЕЩЕСТВА" eh="9aeb39bf" />
     <e k="sf_help_n" v="Азот (N) быстро истощается. Используйте мочевину, мочевину или навоз." eh="f2d0c792" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="Визуализация почвенных слоев переместилась! Теперь вы можете получить доступ ко всем почвенным слоям и переключать их непосредственно из боковой панели карты КПК (ESC > Карта). Найдите категорию «Почвенные слои» в точках боковой панели." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Всего требует внимания" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Поля, перечисленные справа, требуют обработки. Нажмите на строку, чтобы увидеть рекомендуемые средства и примерные количества." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -193,6 +193,7 @@
     <e k="sf_hud_yield" v="Урожай" eh="97345487" />
     <e k="sf_hud_estYield" v="Ожид. урожай" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Перетаскивание: движение   Угол: размер   ПКМ: готово" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="ПКМ: движение/размер" eh="afc8f13b" />
 		<e k="sf_report_detail_n_ok" v="Азот: Оптимальный" eh="13782bd9" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Grön" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blå" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Bärnsten" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Svårighetsgrad" eh="7b29ca96" />
     <e k="sf_diff_long" v="Svårighetsgrad för markförvaltning" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Växla automatisk hastighet" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -111,48 +111,48 @@
     <e k="sf_bigBag_uan28_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="Big Bag Vattenfri Ammoniak 82-0-0" eh="44914201" />
     <e k="sf_bigBag_anhydrous_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
-    <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
+    <e k="sf_bigBag_urea_name" v="[EN] Big Bag Urea 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Kvävegödsel (torr)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Kvävegödsel (torr)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosfatgödsel (torr)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosfatgödsel (torr)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgödsel (torr)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Startgödsel 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Startgödsel (flytande)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Byt lager" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Inaktivera lager" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Utvecklarnotering" eh="5320d63f" />
     <e k="sf_pda_help_github" v="DIN FEEDBACK SPELAR ROLL! Om du stöter på buggar, har förslag på nya funktioner eller vill bidra till koden, besök projektet på GitHub. Du kan öppna en Issue eller en Pull Request när som helst för att hjälpa till att förbättra den här modden för alla. Tack för testningen!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Hej, det är jag, utvecklaren! Som du kan se är den här sidan fortfarande under uppbyggnad. Kartlagren är för närvarande bara visuella förhandsvisningar (ej funktionella för val), och många UI-element behöver fortfarande sin slutliga finish." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Klicka på ett fält för att hoppa till det på kartan" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totalt behöver uppmärksamhet" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Fälten listade till höger behöver behandling. Klicka på en rad för att se rekommenderade insatsmedel och uppskattade mängder." eh="5748d316" />
     </elements>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Totalt behöver uppmärksamhet" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Fälten listade till höger behöver behandling. Klicka på en rad för att se rekommenderade insatsmedel och uppskattade mängder." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Toplam dikkat gerektiren" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Sağda listelenen tarlalar tedavi gerektiriyor. Önerilen girdileri ve tahmini miktarları görmek için bir satıra tıklayın." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Yeşil" eh="d382816a" />
     <e k="sf_hud_color_2" v="Mavi" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Kehribar" eh="88068e33" />
-    <e k="sf_hud_color_4" v="Mono" eh="5d9b47bd" />
+    <e k="sf_hud_color_4" v="[EN] Mono" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Zorluk" eh="7b29ca96" />
     <e k="sf_diff_long" v="Toprak yönetimi zorluk seviyesi" eh="d6f4560c" />
 		<e k="sf_rr_short" v="[EN] Replenishment Rate" eh="b363b336" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Otomatik dozlamayı aç/kapat" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -113,46 +113,46 @@
     <e k="sf_bigBag_anhydrous_function" v="Azotlu gübre (sıvı)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Üre 46-0-0" eh="8e8cbaae" />
     <e k="sf_bigBag_urea_function" v="Azotlu gübre (kuru)" eh="63efea20" />
-    <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
+    <e k="sf_bigBag_ams_name" v="[EN] Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
     <e k="sf_bigBag_ams_function" v="Azotlu gübre (kuru)" eh="63efea20" />
-    <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
+    <e k="sf_bigBag_map_name" v="[EN] Big Bag MAP 11-52-0" eh="8a5a059b" />
     <e k="sf_bigBag_map_function" v="Fosforlu gübre (kuru)" eh="0cc85c60" />
-    <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
+    <e k="sf_bigBag_dap_name" v="[EN] Big Bag DAP 18-46-0" eh="fb4e9987" />
     <e k="sf_bigBag_dap_function" v="Fosforlu gübre (kuru)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potas 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Potasyumlu gübre (kuru)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Big Bag Başlangıç Gübresi 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Başlangıç gübresi (sıvı)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Katmanı değiştir" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Tedavi planı" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Katmanı kapat" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Geliştirici Notu" eh="5320d63f" />
     <e k="sf_pda_help_github" v="GERİ BİLDİRİMİNİZ ÖNEMLİ! Hata bulursanız, yeni özellik önerileriniz varsa veya koda katkıda bulunmak istiyorsanız GitHub'daki projeyi ziyaret edin. Bu modu herkes için daha iyi hale getirmeye yardımcı olmak için istediğiniz zaman bir Issue veya Pull Request açabilirsiniz. Test ettiğiniz için teşekkürler!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Merhaba, geliştirici benim! Gördüğünüz gibi bu sayfa hâlâ yapım aşamasında. Harita katmanları şu an yalnızca görsel önizlemeler (seçim için işlevsel değil) ve pek çok arayüz öğesi hâlâ son rötuşlara ihtiyaç duyuyor." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Haritada o noktaya atlamak için bir tarlaya tıklayın" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Toplam dikkat gerektiren" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Sağda listelenen tarlalar tedavi gerektiriyor. Önerilen girdileri ve tahmini miktarları görmek için bir satıra tıklayın." eh="5748d316" />
     </elements>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -193,6 +193,7 @@
     <e k="sf_hud_yield" v="Врожай" eh="97345487" />
     <e k="sf_hud_estYield" v="Очік. врожай" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="Перетягування: рух   Кут: розмір   ПКМ: готово" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="ПКМ: рух/розмір" eh="afc8f13b" />
     <e k="sf_report_detail_n_ok" v="Азот: Оптимальний" eh="13782bd9" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -489,5 +489,119 @@
 		<e k="sf_pda_map_native_hint" v="Візуалізацію шарів ґрунту перенесено! Тепер ви можете отримати доступ до всіх шарів ґрунту та перемикати їх безпосередньо з бічної панелі карти PDA (ESC і Карта). Знайдіть категорію «Шари ґрунту» на бічній панелі з крапками." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Всього потребує уваги" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Поля, перераховані праворуч, потребують обробки. Натисніть на рядок, щоб побачити рекомендовані засоби та приблизні кількості." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Грунт та добриво" eh="f31197fb" />
@@ -79,7 +79,7 @@
     <e k="sf_active_map_layer_long" v="Шар поживних речовин, показаний у вигляді накладення на карті PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Деталі карти" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Приклад розподілу ресурсів для накладення текстури ґрунту в PDA. Низький рівень = краща частота кадрів, Високий рівень = більш щільне покриття на великих картах." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Скинути налаштування ґрунту" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Перемкнути HUD ґрунту" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="Режим HUD Drag" eh="00000000" />
@@ -87,8 +87,8 @@
     <e k="input_SF_RATE_UP" v="Збільшити норму добрива" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Зменшити норму добрива" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Перемкнути автоматичний режим" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
     <e k="sf_report_title" v="Звіт про ґрунт та добриво" eh="a76f8218" />
     <e k="sf_report_fields_tracked" v="Відстежувані поля:" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Потребують добрива:" eh="110b60f2" />
@@ -102,7 +102,7 @@
     <e k="sf_report_prev" v="Попер" eh="14230d11" />
     <e k="sf_report_next" v="Наст" eh="10ac3d04" />
     <e k="sf_report_yes" v="ТАК" eh="7469a286" />
-    <e k="sf_report_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_report_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_report_none" v="Немає" eh="6adf97f8" />
     <e k="sf_report_rec_n_poor" v="Потрібен азот" eh="5dca0711" />
     <e k="sf_report_rec_n_fair" v="Низький азот" eh="35ad072d" />
@@ -325,7 +325,7 @@
 		<e k="sf_map_layer_n" v="Азот" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="Фосфор" eh="eb4f2688" />
 		<e k="sf_map_layer_k" v="Калій" eh="3a4edc67" />
-		<e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+		<e k="sf_map_layer_ph" v="[EN] pH" eh="397dff20" />
 		<e k="sf_map_layer_om" v="Органічні речовини" eh="6305f4bb" />
 		<e k="sf_map_layer_urgency" v="Рівень терміновості" eh="419ea5af" />
 		<e k="sf_map_layer_weed" v="Тиск бур'янів" eh="53f8b936" />
@@ -392,13 +392,13 @@
     <!-- Fields Tab -->
     <e k="sf_pda_fields_section_title" v="Усі поля" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Поле" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="Фільтр: Усі поля" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="Фільтр: Тільки мої" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Статус" eh="ec53a8c4" />
     <e k="sf_pda_no_fields" v="Наразі даних з місць не надійшло." eh="72265670" />
     <e k="sf_pda_status_good" v="Добре" eh="0c6ad70b" />
@@ -455,7 +455,7 @@
 		<e k="sf_treat_action_weed" v="Негайно внесіть ГЕРБІЦИД." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="Негайно внесіть ІНСЕКТИЦИД." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="Негайно внесіть ФУНГІЦИД." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Бонус за бобові (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Втома (зниження на 1,15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Дані відсутні." eh="c6d95d5e" />
@@ -464,9 +464,9 @@
     <e k="sf_map_btn_cycle_layer" v="Змінити шар" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="План обробки" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Вимкнути шар" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
     <e k="sf_help_n" v="N (азот) – швидко виснажується. Вносьте КАС, сечовину або гній." eh="f2d0c792" />
     <e k="sf_help_p" v="P (фосфор) – тривалої дії. Застосовуйте MAP або DAP." eh="fdfbd91e" />
     <e k="sf_help_k" v="K (Калій) – Внесіть поташ. Важливо для коренів." eh="e0217634" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -488,5 +488,119 @@
 		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Tổng số cần chú ý" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Các cánh đồng được liệt kê bên phải cần được xử lý. Nhấp vào một hàng để xem đầu vào được đề xuất và số lượng ước tính." eh="5748d316" />
+    <!-- HUD labels -->
+    <e k="sf_hud_label_ph" v="[EN] pH" />
+    <e k="sf_hud_label_om" v="[EN] OM" />
+    <e k="sf_hud_unit_ppm" v="[EN] (ppm)" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" />
+    <!-- Sprayer rate HUD -->
+    <e k="sf_sprayer_auto_on" v="[EN] APP. RATE  ( AUTO: ON )" />
+    <e k="sf_sprayer_auto_off" v="[EN] APP. RATE  AUTO: OFF [%s]" />
+    <e k="sf_sprayer_target" v="[EN] Target: " />
+    <e k="sf_sprayer_burn_guaranteed" v="[EN] BURN RISK: GUARANTEED" />
+    <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" />
+    <!-- Notifications -->
+    <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" />
+    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" />
+    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" />
+    <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." />
+    <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" />
+    <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" />
+    <e k="sf_notify_critical_body" v="[EN] Field %d requires immediate attention! Urgency: %d%%" />
+    <e k="sf_notify_treated_title" v="[EN] Soil Update" />
+    <e k="sf_notify_treated_body" v="[EN] Field %d fully treated with %s" />
+    <e k="sf_notify_burn_title" v="[EN] Fertilizer Burn" />
+    <e k="sf_notify_burn_body" v="[EN] Field %d: over-application damage (pH %.1f)" />
+    <e k="sf_notify_sync_error" v="[EN] Soil Mod: Data sync issue detected. Please report if this persists." />
+    <!-- Panel categories -->
+    <e k="sf_panel_cat_sim" v="[EN] Simulation" />
+    <e k="sf_panel_cat_sim_desc" v="[EN] Farm mechanics, difficulty and nutrient cycles" />
+    <e k="sf_panel_cat_display" v="[EN] Display &amp; HUD" />
+    <e k="sf_panel_cat_display_desc" v="[EN] HUD appearance, color theme, position and font size" />
+    <e k="sf_panel_cat_overlay" v="[EN] Map Overlay" />
+    <e k="sf_panel_cat_overlay_desc" v="[EN] Active overlay layer shown in the PDA map" />
+    <e k="sf_panel_hdr_core" v="[EN] Core Systems" />
+    <e k="sf_panel_hdr_difficulty" v="[EN] Difficulty" />
+    <e k="sf_panel_hdr_environment" v="[EN] Environment" />
+    <e k="sf_panel_hdr_crop_stress" v="[EN] Crop Stress" />
+    <e k="sf_panel_hdr_visibility" v="[EN] Visibility" />
+    <e k="sf_panel_hdr_hud_style" v="[EN] HUD Style" />
+    <e k="sf_panel_hdr_position" v="[EN] Position" />
+    <e k="sf_panel_hdr_layer" v="[EN] Layer" />
+    <e k="sf_panel_hdr_performance" v="[EN] Performance" />
+    <e k="sf_panel_hdr_mod_ctrl" v="[EN] Mod Control &amp; Difficulty" />
+    <e k="sf_panel_hdr_systems" v="[EN] Systems" />
+    <e k="sf_panel_hdr_actions" v="[EN] Actions &amp; Field Tools" />
+    <!-- Panel chrome -->
+    <e k="sf_panel_admin_yes" v="[EN] Admin: YES" />
+    <e k="sf_panel_admin_no" v="[EN] Admin: NO" />
+    <e k="sf_panel_multiplayer" v="[EN] Multiplayer" />
+    <e k="sf_panel_singleplayer" v="[EN] Single Player" />
+    <e k="sf_panel_btn_back" v="[EN] &lt; Back" />
+    <e k="sf_panel_btn_reset_cat" v="[EN] Reset Cat." />
+    <e k="sf_panel_btn_close_hint" v="[EN] SHIFT+O to close" />
+    <e k="sf_panel_select_category" v="[EN] Select a category to configure settings" />
+    <e k="sf_panel_btn_configure" v="[EN] Configure &gt;&gt;" />
+    <e k="sf_panel_btn_open" v="[EN] Open &gt;&gt;" />
+    <!-- Setting descriptions -->
+    <e k="sf_desc_enabled" v="[EN] Activate / deactivate the entire mod" />
+    <e k="sf_desc_debugMode" v="[EN] Extra logging for troubleshooting" />
+    <e k="sf_desc_fertilitySystem" v="[EN] Full soil fertility modeling" />
+    <e k="sf_desc_nutrientCycles" v="[EN] Track N/P/K depletion and recovery" />
+    <e k="sf_desc_fertilizerCosts" v="[EN] Real in-game cost for fertilizers" />
+    <e k="sf_desc_showNotifications" v="[EN] In-game soil status notifications" />
+    <e k="sf_desc_showHUD" v="[EN] Show the soil HUD overlay" />
+    <e k="sf_desc_hudPosition" v="[EN] HUD preset anchor position" />
+    <e k="sf_desc_hudColorTheme" v="[EN] Color palette for HUD elements" />
+    <e k="sf_desc_hudFontSize" v="[EN] HUD text size" />
+    <e k="sf_desc_hudTransparency" v="[EN] HUD background transparency" />
+    <e k="sf_desc_seasonalEffects" v="[EN] Season-driven soil changes" />
+    <e k="sf_desc_rainEffects" v="[EN] Rain causes nutrient leaching" />
+    <e k="sf_desc_plowingBonus" v="[EN] Plow bonus for soil recovery" />
+    <e k="sf_desc_weedPressure" v="[EN] Track and penalize weed spread" />
+    <e k="sf_desc_pestPressure" v="[EN] Track insect pest infestation" />
+    <e k="sf_desc_diseasePressure" v="[EN] Track fungal crop diseases" />
+    <e k="sf_desc_compactionEnabled" v="[EN] Heavy vehicle soil compaction" />
+    <e k="sf_desc_difficulty" v="[EN] Nutrient drain intensity level" />
+    <e k="sf_desc_replenishmentRate" v="[EN] Fertilizer nutrient restoration speed" />
+    <e k="sf_desc_useImperialUnits" v="[EN] Use imperial units (US tons/acre)" />
+    <e k="sf_desc_autoRateControl" v="[EN] Smart sprayer application rates" />
+    <e k="sf_desc_cropRotation" v="[EN] Rotation benefits and penalties" />
+    <e k="sf_desc_activeMapLayer" v="[EN] Nutrient layer shown in PDA map" />
+    <e k="sf_desc_overlayDensity" v="[EN] Sample point budget (Low=8k, Med=20k, High=40k)" />
+    <!-- Multi-option values -->
+    <e k="sf_rr_1" v="[EN] Very Slow (0.25x)" />
+    <e k="sf_rr_2" v="[EN] Slow (0.5x)" />
+    <e k="sf_rr_3" v="[EN] Normal (1.0x)" />
+    <e k="sf_rr_4" v="[EN] Fast (1.5x)" />
+    <e k="sf_rr_5" v="[EN] Very Fast (2.0x)" />
+    <e k="sf_layer_1" v="[EN] Off" />
+    <e k="sf_layer_2" v="[EN] Nitrogen" />
+    <e k="sf_layer_3" v="[EN] Phosphorus" />
+    <e k="sf_layer_4" v="[EN] Potassium" />
+    <e k="sf_layer_5" v="[EN] pH" />
+    <e k="sf_layer_6" v="[EN] Org Matter" />
+    <e k="sf_layer_7" v="[EN] Urgency" />
+    <e k="sf_layer_8" v="[EN] Weed" />
+    <e k="sf_layer_9" v="[EN] Pest" />
+    <e k="sf_layer_10" v="[EN] Disease" />
+    <e k="sf_layer_11" v="[EN] Compaction" />
+    <e k="sf_density_1" v="[EN] Low" />
+    <e k="sf_density_2" v="[EN] Medium" />
+    <e k="sf_density_3" v="[EN] High" />
+    <!-- Admin action items -->
+    <e k="sf_admin_save_label" v="[EN] Save Soil Data" />
+    <e k="sf_admin_save_desc" v="[EN] Force-save all soil data now" />
+    <e k="sf_admin_reset_label" v="[EN] Reset All Settings" />
+    <e k="sf_admin_reset_desc" v="[EN] Restore every setting to its default" />
+    <e k="sf_admin_drain_label" v="[EN] Drain Vehicle Tanks" />
+    <e k="sf_admin_drain_desc" v="[EN] Empty sprayer + implements (50% refund)" />
+    <e k="sf_admin_field_info_label" v="[EN] Current Field Info" />
+    <e k="sf_admin_field_info_desc" v="[EN] Soil data for the field at your position" />
+    <e k="sf_admin_field_forecast_label" v="[EN] Field Forecast" />
+    <e k="sf_admin_field_forecast_desc" v="[EN] Yield forecast for field at position" />
+    <e k="sf_admin_list_fields_label" v="[EN] List All Fields" />
+    <e k="sf_admin_list_fields_desc" v="[EN] Dump all field soil data to game log" />
     </elements>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Xanh lá" eh="d382816a" />
@@ -27,26 +27,26 @@
 		<e k="sf_hud_trans_3" v="[EN] Medium" eh="87f8a6ab" />
 		<e k="sf_hud_trans_4" v="[EN] Dark" eh="a18366b2" />
 		<e k="sf_hud_trans_5" v="[EN] Solid" eh="e41480b6" />
-    <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
-    <e k="sf_hud_field" v="Field %d" eh="08988997" />
-    <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
-    <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
-    <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
-    <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
-    <e k="sf_hud_protected" v="(protected)" eh="8273211e" />
-    <e k="sf_hud_yield" v="Yield" eh="97345487" />
-    <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
-    <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_title" v="[EN] SOIL MONITOR" eh="f8cda642" />
+    <e k="sf_hud_field" v="[EN] Field %d" eh="08988997" />
+    <e k="sf_hud_noField" v="[EN] Walk onto a field" eh="62c55e9e" />
+    <e k="sf_hud_fallow" v="[EN] Fallow" eh="eafe5913" />
+    <e k="sf_hud_weeds" v="[EN] Weeds" eh="324181de" />
+    <e k="sf_hud_pests" v="[EN] Pests" eh="2fed5101" />
+    <e k="sf_hud_disease" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_hud_protected" v="[EN] (protected)" eh="8273211e" />
+    <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
+    <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
-    <e k="sf_active_map_layer_short" v="Active Map Layer" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
-    <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
+    <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />
+    <e k="sf_active_map_layer_long" v="[EN] Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
+    <e k="sf_overlay_density_short" v="[EN] Map Detail" eh="a525859a" />
+    <e k="sf_overlay_density_long" v="[EN] Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="input_SF_OPEN_SETTINGS" v="[EN] Open Soil Settings" eh="2e31c0dd" />
 		<e k="sf_reset" v="[EN] Reset Soil Settings" eh="467bc2f5" />
 		<e k="input_SF_TOGGLE_HUD" v="[EN] Toggle Soil HUD" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="[EN] HUD Drag Mode" eh="cb2eb762" />
@@ -54,9 +54,9 @@
 		<e k="input_SF_RATE_UP" v="[EN] Increase Fertilizer Rate" eh="6e601ef5" />
 		<e k="input_SF_RATE_DOWN" v="[EN] Decrease Fertilizer Rate" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="Chuyển đổi tốc độ tự động" eh="a8642cf0" />
-        <e k="input_SF_CYCLE_MAP_LAYER" v="Cycle Soil Map Layer" eh="8e4a716c" />
-        <e k="input_SF_SOIL_PDA" v="Open Soil PDA" eh="7d70f7b4" />
-		<e k="sf_report_title" v="[EN] Soil &amp;amp;amp; Fertilizer Report" eh="a76f8218" />
+        <e k="input_SF_CYCLE_MAP_LAYER" v="[EN] Cycle Soil Map Layer" eh="8e4a716c" />
+        <e k="input_SF_SOIL_PDA" v="[EN] Open Soil PDA" eh="7d70f7b4" />
+		<e k="sf_report_title" v="[EN] Soil &amp; Fertilizer Report" eh="a76f8218" />
 		<e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
 		<e k="sf_report_need_fert" v="[EN] Need Fertilizer:" eh="110b60f2" />
 		<e k="sf_report_farm_health" v="[EN] Farm Health:" eh="a5330ade" />
@@ -81,13 +81,13 @@
 		<e k="sf_report_rec_ph_monitor" v="[EN] Monitor pH" eh="6dfcded4" />
 		<e k="sf_report_rec_om_increase" v="[EN] Increase Organic Matter" eh="c2a930af" />
 		<e k="sf_report_rec_om_maintain" v="[EN] Maintain Organic Matter" eh="e7655847" />
-    <e k="sf_report_rec_pest" v="Pest Risk" eh="c2a930af" />
-    <e k="sf_report_rec_disease" v="Disease Risk" eh="e7655847" />
+    <e k="sf_report_rec_pest" v="[EN] Pest Risk" eh="c2a930af" />
+    <e k="sf_report_rec_disease" v="[EN] Disease Risk" eh="e7655847" />
 		<e k="sf_report_rec_needs" v="[EN] Needs:" eh="3e6d95cf" />
 		<e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
 		<e k="sf_uan32_title" v="[EN] UAN 32 Fertilizer (N)" eh="90913bb8" />
 		<e k="sf_uan28_title" v="[EN] UAN 28 Fertilizer (N)" eh="9d902cd7" />
 		<e k="sf_anhydrous_title" v="[EN] Anhydrous Ammonia (N)" eh="3fc85c02" />
@@ -121,38 +121,38 @@
     <e k="sf_bigBag_dap_function" v="Phân bón lân (dạng khô)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Túi lớn Kali 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Phân bón kali (dạng khô)" eh="18015099" />
-		<e k="sf_bigBag_liquid_urea_name" v="[EN] Big Bag Liquid Urea" eh="c40b906f" />
+		<e k="sf_bigBag_liquid_urea_name" v="[EN] IBC Liquid Urea" eh="c40b906f" />
 		<e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_ams_name" v="[EN] Big Bag Liquid AMS" eh="32e6c8bb" />
+		<e k="sf_bigBag_liquid_ams_name" v="[EN] IBC Liquid AMS" eh="32e6c8bb" />
 		<e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid)" eh="27de5f41" />
-		<e k="sf_bigBag_liquid_map_name" v="[EN] Big Bag Liquid MAP" eh="4628addb" />
+		<e k="sf_bigBag_liquid_map_name" v="[EN] IBC Liquid MAP" eh="4628addb" />
 		<e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_dap_name" v="[EN] Big Bag Liquid DAP" eh="82fb3c06" />
+		<e k="sf_bigBag_liquid_dap_name" v="[EN] IBC Liquid DAP" eh="82fb3c06" />
 		<e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
-		<e k="sf_bigBag_liquid_potash_name" v="[EN] Big Bag Liquid Potash" eh="7176856d" />
+		<e k="sf_bigBag_liquid_potash_name" v="[EN] IBC Liquid Potash" eh="7176856d" />
 		<e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid)" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="Túi lá»›n Phân Bón Khá»Ÿi Äáº§u 10-34-0" eh="953fd6c0" />
     <e k="sf_bigBag_insecticide_name" v="Big Bag Insecticide" eh="fa0200a7" />
-    <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="[EN] Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="Big Bag Fungicide" eh="a3d4e59c" />
-    <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
+    <e k="sf_bigBag_fungicide_function" v="[EN] Fungicide (liquid)" eh="745c34cb" />
     <e k="sf_bigBag_starter_function" v="Phân bón khá»Ÿi Ä‘áº§u (dáº¡ng lá»ng)" eh="2c36ea57" />
 		<e k="sf_bigBag_gypsum_name" v="[EN] Big Bag Gypsum" eh="40fc8169" />
 		<e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry)" eh="51503c54" />
-    <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_compost_name" v="[EN] Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="[EN] Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_name" v="[EN] Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_name" v="[EN] Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_liquidlime_name" v="[EN] Liquid Lime Tank" eh="4f8caca1" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid)" eh="7a118b6d" />
 
-		<e k="sf_section" v="[EN] Soil &amp;amp; Fertilizer" eh="d30a22a9" />
+		<e k="sf_section" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
 		<e k="sf_enabled_short" v="[EN] Enable Mod" eh="cf7fea13" />
-		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp;amp; fertilizer mod" eh="e377fd59" />
+		<e k="sf_enabled_long" v="[EN] Enable or disable the soil &amp; fertilizer mod" eh="e377fd59" />
 		<e k="sf_debug_short" v="[EN] DEBUG Mode" eh="2ddcdc76" />
 		<e k="sf_debug_long" v="[EN] Enable/disable debug mode (extra logging)" eh="f6f20240" />
 		<e k="sf_seasonal_effects_short" v="[EN] Seasonal Effects" eh="c16ea608" />
@@ -161,12 +161,12 @@
 		<e k="sf_rain_effects_long" v="[EN] Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
 		<e k="sf_plowing_bonus_short" v="[EN] Plowing Bonus" eh="541ec752" />
 		<e k="sf_plowing_bonus_long" v="[EN] Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
-    <e k="sf_weed_pressure_short" v="Weed Pressure" eh="7f71ee68" />
-    <e k="sf_weed_pressure_long" v="Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
-    <e k="sf_pest_pressure_short" v="Pest Pressure" eh="eb771556" />
-    <e k="sf_pest_pressure_long" v="Enable/disable insect and pest infestation system" eh="18015099" />
-    <e k="sf_disease_pressure_short" v="Disease Pressure" eh="953fd6c0" />
-    <e k="sf_disease_pressure_long" v="Enable/disable fungal and crop disease system" eh="2c36ea57" />
+    <e k="sf_weed_pressure_short" v="[EN] Weed Pressure" eh="7f71ee68" />
+    <e k="sf_weed_pressure_long" v="[EN] Enable/disable dynamic weed growth and yield impact" eh="27de5f41" />
+    <e k="sf_pest_pressure_short" v="[EN] Pest Pressure" eh="eb771556" />
+    <e k="sf_pest_pressure_long" v="[EN] Enable/disable insect and pest infestation system" eh="18015099" />
+    <e k="sf_disease_pressure_short" v="[EN] Disease Pressure" eh="953fd6c0" />
+    <e k="sf_disease_pressure_long" v="[EN] Enable/disable fungal and crop disease system" eh="2c36ea57" />
     <e k="sf_compaction_short" v="[EN] Soil Compaction" eh="68734a56" />
     <e k="sf_compaction_long" v="[EN] Enable/disable heavy vehicle soil compaction system" eh="a0995ec5" />
 		<e k="sf_fertility_short" v="[EN] Fertility System" eh="f7e27d58" />
@@ -195,23 +195,23 @@
 		<e k="sf_hud_pos_5" v="[EN] Center Right" eh="d7afdc5a" />
 		<e k="sf_hud_pos_6" v="[EN] Custom" eh="90589c47" />
 		<e k="sf_hud_color_theme_short" v="[EN] HUD Color Theme" eh="4a73f95b" />
-		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
-    <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
-    <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />
-    <e k="sf_report_status_monitor" v="Monitor" eh="d2986ac8" />
-    <e k="sf_report_status_adjust" v="Adjust" eh="51d7a685" />
-    <e k="sf_report_status_maintain" v="Maintain" eh="ade01a5a" />
-    <e k="sf_report_status_increase" v="Increase" eh="aac247ca" />
-    <e k="sf_report_pressure_low" v="Low" eh="28d0edd0" />
-    <e k="sf_report_pressure_moderate" v="Moderate" eh="1eb79d43" />
-    <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
-    <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
-    <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+		<e k="sf_hud_color_theme_long" v="[EN] Choose the color scheme for soil info display" eh="3218bca6" />    <e k="sf_report_detail_n_ok" v="[EN] Nitrogen: Optimal" eh="13782bd9" />
+    <e k="sf_report_detail_p_ok" v="[EN] Phosphorus: Optimal" eh="dbc90f11" />
+    <e k="sf_report_detail_k_ok" v="[EN] Potassium: Optimal" eh="0197b4ba" />
+    <e k="sf_report_status_monitor" v="[EN] Monitor" eh="d2986ac8" />
+    <e k="sf_report_status_adjust" v="[EN] Adjust" eh="51d7a685" />
+    <e k="sf_report_status_maintain" v="[EN] Maintain" eh="ade01a5a" />
+    <e k="sf_report_status_increase" v="[EN] Increase" eh="aac247ca" />
+    <e k="sf_report_pressure_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_report_pressure_moderate" v="[EN] Moderate" eh="1eb79d43" />
+    <e k="sf_report_pressure_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_report_yield_hint" v="[EN] Based on N/P/K vs optimal threshold" eh="022663e0" />
+    <e k="sf_report_yield_loss" v="[EN] Yield ~-%d%%" eh="d64d5d59" />
 		<e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
 		<e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
 		<e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
 		<e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
-		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp;amp; Soil Report" eh="9b9888b9" />
+		<e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="9b9888b9" />
 		<e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
 		<e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 		<e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
@@ -238,16 +238,16 @@
 		<e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
 		<e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
 		<e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
-		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
+		<e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="f36a5639" />
 		<e k="helpLine_sf_nu_p1_title" v="[EN] Nitrogen and Phosphorus" eh="27d37372" />
-		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N)  —  Scale: 0 to 100" eh="10a358f4" />
+		<e k="helpLine_sf_nu_p1_n_title" v="[EN] Nitrogen (N) - Scale 0 to 100" eh="10a358f4" />
 		<e k="helpLine_sf_nu_p1_n_text" v="[EN] Most mobile nutrient - depletes fastest and leaches heavily in rain. Poor: below 30. Good: above 50. Raise with: liquid fertilizer, UAN-32, UAN-28, anhydrous ammonia, urea, AMS, manure, or slurry." eh="58d62253" />
-		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P)  —  Scale: 0 to 100" eh="979bba64" />
+		<e k="helpLine_sf_nu_p1_p_title" v="[EN] Phosphorus (P) - Scale 0 to 100" eh="979bba64" />
 		<e k="helpLine_sf_nu_p1_p_text" v="[EN] Binds tightly to soil and leaches very slowly. Depletes mainly through harvest. Canola has the highest P demand. Poor: below 25. Good: above 45. Raise with: MAP, DAP, starter fertilizer, or liquid fertilizer." eh="92c5ac66" />
 		<e k="helpLine_sf_nu_p2_title" v="[EN] Potassium and pH" eh="6bd92f25" />
 		<e k="helpLine_sf_nu_p2_k_title" v="[EN] Potassium (K) - Scale 0 to 100" eh="2a16e8bc" />
 		<e k="helpLine_sf_nu_p2_k_text" v="[EN] Critical for root and tuber crops. Potato and sugar beet deplete K heavily each harvest. Leaches moderately in rain. Poor: below 20. Good: above 40. Raise with: potash (0-0-60), slurry, digestate, or liquid fertilizer." eh="7230fee4" />
-		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH  —  Scale: 5.0 to 7.5" eh="944beca2" />
+		<e k="helpLine_sf_nu_p2_ph_title" v="[EN] pH - Scale 5.0 to 7.5" eh="944beca2" />
 		<e k="helpLine_sf_nu_p2_ph_text" v="[EN] Most crops thrive at pH 6.5 to 7.0. Rain slowly acidifies soil over time. pH does not recover on its own - only lime or liquid lime raises it. Poor: below 5.5. Apply lime if pH is falling before the next planting." eh="08e0aefd" />
 		<e k="helpLine_sf_nu_p3_title" v="[EN] Organic Matter" eh="6305f4bb" />
 		<e k="helpLine_sf_nu_p3_om_title" v="[EN] Organic Matter (OM) - Scale 0 to 10" eh="58f490f3" />
@@ -288,7 +288,7 @@
 		<e k="helpLine_sf_se_p1_server_title" v="[EN] Server Settings (Admin Only in Multiplayer)" eh="49f37ed7" />
 		<e k="helpLine_sf_se_p1_server_text" v="[EN] Fertility System, Nutrient Cycles, Seasonal Effects, Rain Effects, Plowing Bonus, Weed/Pest/Disease Pressure, Fertilizer Costs, Notifications, Crop Rotation, and Auto-Rate Control. In multiplayer, only the server admin can change these. Changes sync to all clients instantly." eh="abca5e43" />
 		<e k="helpLine_sf_se_p1_diff_title" v="[EN] Difficulty" eh="7b29ca96" />
-		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &amp;gt; Settings &amp;gt; Soil &amp;amp; Fertilizer." eh="740a3a4e" />
+		<e k="helpLine_sf_se_p1_diff_text" v="[EN] Simple (0.7x) reduces depletion by 30% for a relaxed experience. Realistic (1.0x) is the balanced default. Hardcore (1.5x) increases depletion by 50% for intensive soil management. Access via ESC &gt; Settings &gt; Soil &amp; Fertilizer." eh="740a3a4e" />
 		<e k="helpLine_sf_se_p2_title" v="[EN] HUD and Rate Control" eh="399f4910" />
 		<e k="helpLine_sf_se_p2_hud_title" v="[EN] Per-Player HUD Options" eh="0df76500" />
 		<e k="helpLine_sf_se_p2_hud_text" v="[EN] Each player controls their own HUD - not synced to the server. Options: Show HUD (on/off), Position (5 presets + drag), Color Theme (Green / Blue / Amber / Mono), Font Size (Small / Medium / Large), Transparency (25% to 100%), Imperial Units (on/off)." eh="f3934884" />
@@ -304,22 +304,22 @@
 		<e k="helpLine_sf_mp_p2_compat_text" v="[EN] Both mods run fully independently and are fully compatible. One fertilizer pass updates both at the same time - you do not need to fertilize twice. PF's soil zones and SoilFertilizer's N/P/K values use different models and will not be identical." eh="5c9f8ada" />
 		<e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Practical Workflow" eh="b6f73f04" />
 		<e k="helpLine_sf_mp_p2_workflow_text" v="[EN] Use PrecisionFarming to see where in a field needs attention (sub-zone precision). Use SoilFertilizer's HUD and soil report to see what nutrient to apply. One pass satisfies both mods simultaneously and they will never give contradictory advice." eh="cde2c27c" />
-    <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
-    <e k="sf_report_rotation_bonus" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: Same Crop" eh="46135880" />
-    <e k="sf_report_rotation_ok" v="Rotation: OK" eh="df66b3be" />
-    <e k="sf_gypsum_title" v="Gypsum (pH-)" eh="56e6dc36" />
-    <e k="sf_compost_title" v="Compost (Organic)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Biosolids (N+P)" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="Chicken Manure (N+P)" eh="338128e2" />
-    <e k="sf_pelletized_manure_title" v="Pelletized Manure (NPK)" eh="c1b39b71" />
-    <e k="sf_liquidlime_title" v="Liquid Lime (pH+)" eh="d4ec4bb9" />
-    <e k="helpLine_sf_nu_p4_title" v="Crop Rotation" eh="def2c162" />
-    <e k="helpLine_sf_nu_p4_bonus_title" v="Rotation Bonus" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
-    <e k="helpLine_sf_nu_p4_fatigue_title" v="Crop Fatigue" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
+    <e k="sf_crop_rotation_short" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="sf_crop_rotation_long" v="[EN] Enable/disable crop rotation bonus and mono-crop fatigue (legume sequences restore nitrogen; same-crop consecutive seasons increase depletion)" eh="958b4212" />
+    <e k="sf_report_rotation_bonus" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: Same Crop" eh="46135880" />
+    <e k="sf_report_rotation_ok" v="[EN] Rotation: OK" eh="df66b3be" />
+    <e k="sf_gypsum_title" v="[EN] Gypsum (pH-)" eh="56e6dc36" />
+    <e k="sf_compost_title" v="[EN] Compost (Organic)" eh="c3e2071a" />
+    <e k="sf_biosolids_title" v="[EN] Biosolids (N+P)" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="[EN] Chicken Manure (N+P)" eh="338128e2" />
+    <e k="sf_pelletized_manure_title" v="[EN] Pelletized Manure (NPK)" eh="c1b39b71" />
+    <e k="sf_liquidlime_title" v="[EN] Liquid Lime (pH+)" eh="d4ec4bb9" />
+    <e k="helpLine_sf_nu_p4_title" v="[EN] Crop Rotation" eh="def2c162" />
+    <e k="helpLine_sf_nu_p4_bonus_title" v="[EN] Rotation Bonus" eh="2831a7ac" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="[EN] Growing a legume crop (soybeans, peas, beans) after a non-legume adds a free nitrogen boost each spring for 3 days." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_fatigue_title" v="[EN] Crop Fatigue" eh="236a590c" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="[EN] Planting the same crop two seasons in a row increases nutrient extraction by 15%. Rotate crops to avoid soil fatigue." eh="1613f3c6" />
 		<e k="sf_map_layer_off" v="[EN] Soil Map: Off" eh="3e654ade" />
 		<e k="sf_map_layer_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
 		<e k="sf_map_layer_p" v="[EN] Phosphorus" eh="eb4f2688" />
@@ -341,120 +341,120 @@
 		<e k="sf_map_overlay_high" v="[EN] High" eh="655d20c1" />
 
     <!-- Soil PDA Screen (SoilPDAScreen.lua) -->
-    <e k="sf_pda_screen_title" v="Soil &amp; Fertilizer" eh="d30a22a9" />
-    <e k="sf_pda_tab_map" v="Soil Map" eh="59f988b2" />
-    <e k="sf_pda_tab_fields" v="Fields" eh="a4ca5edd" />
-    <e k="sf_pda_tab_treatment" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Farm Overview" eh="47f2c19a" />
-    <e k="sf_pda_fields_tracked_label" v="Fields Tracked" eh="c763e26e" />
-    <e k="sf_pda_fields_owned_label" v="Fields Owned" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Avg. Nutrients" eh="f06b2704" />
-    <e k="sf_pda_avg_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_pda_avg_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_pda_avg_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_pda_avg_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_pda_avg_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_pda_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_pda_weed_label" v="Weed" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Pest" eh="8f2aee79" />
-    <e k="sf_pda_disease_label" v="Disease" eh="e7067a8c" />
-    <e k="sf_pda_section_attention" v="Needs Attention" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="Need Fertilizer" eh="fa9ded5e" />
-    <e k="sf_pda_no_data_left" v="No field data yet." eh="ba71c6b1" />
+    <e k="sf_pda_screen_title" v="[EN] Soil &amp; Fertilizer" eh="d30a22a9" />
+    <e k="sf_pda_tab_map" v="[EN] Soil Map" eh="59f988b2" />
+    <e k="sf_pda_tab_fields" v="[EN] Fields" eh="a4ca5edd" />
+    <e k="sf_pda_tab_treatment" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_section_farm_overview" v="[EN] Farm Overview" eh="47f2c19a" />
+    <e k="sf_pda_fields_tracked_label" v="[EN] Fields Tracked" eh="c763e26e" />
+    <e k="sf_pda_fields_owned_label" v="[EN] Fields Owned" eh="335f5f7e" />
+    <e k="sf_pda_section_avg_nutrients" v="[EN] Avg. Nutrients" eh="f06b2704" />
+    <e k="sf_pda_avg_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_pda_avg_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_pda_avg_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_pda_avg_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_pda_avg_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_pda_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_pda_weed_label" v="[EN] Weed" eh="2b75024d" />
+    <e k="sf_pda_pest_label" v="[EN] Pest" eh="8f2aee79" />
+    <e k="sf_pda_disease_label" v="[EN] Disease" eh="e7067a8c" />
+    <e k="sf_pda_section_attention" v="[EN] Needs Attention" eh="80e48bc3" />
+    <e k="sf_pda_needs_fert_label" v="[EN] Need Fertilizer" eh="fa9ded5e" />
+    <e k="sf_pda_no_data_left" v="[EN] No field data yet." eh="ba71c6b1" />
     <!-- Map Tab -->
-    <e k="sf_pda_map_section_title" v="Soil Map Layers" eh="85d63132" />
-    <e k="sf_pda_map_active_layer" v="Active Layer" eh="f8a2c198" />
+    <e k="sf_pda_map_section_title" v="[EN] Soil Map Layers" eh="85d63132" />
+    <e k="sf_pda_map_active_layer" v="[EN] Active Layer" eh="f8a2c198" />
     <e k="sf_pda_map_layer_off_desc" v="No soil layer active. Press Shift+M to cycle layers." eh="009d9017" />
-    <e k="sf_pda_map_layer_n_desc" v="Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
-    <e k="sf_pda_map_legend_title" v="Map Legend" eh="86448402" />
-    <e k="sf_pda_map_legend_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_map_legend_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_map_legend_poor" v="Poor / Low" eh="32aa75ff" />
-    <e k="sf_pda_map_legend_low" v="Low" eh="28d0edd0" />
-    <e k="sf_pda_map_legend_medium" v="Medium" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="High" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="Excess" eh="d1d25b9f" />
+    <e k="sf_pda_map_layer_n_desc" v="[EN] Nitrogen content across all fields. Green = good, red = depleted." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="[EN] Phosphorus content across all fields. Green = good, red = depleted." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="[EN] Potassium content across all fields. Green = good, red = depleted." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="[EN] Soil pH level. Optimal range is 6.5-7.0 (green)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="[EN] Organic matter content. Higher is better for long-term fertility." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="[EN] Combined treatment urgency. Red = needs immediate attention." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="[EN] Weed pressure level. Red = high infestation, apply herbicide." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="[EN] Pest pressure level. Red = high infestation, apply insecticide." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="[EN] Disease pressure level. Red = active outbreak, apply fungicide." eh="5d32d30a" />
+    <e k="sf_pda_map_legend_title" v="[EN] Map Legend" eh="86448402" />
+    <e k="sf_pda_map_legend_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_map_legend_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_map_legend_poor" v="[EN] Poor / Low" eh="32aa75ff" />
+    <e k="sf_pda_map_legend_low" v="[EN] Low" eh="28d0edd0" />
+    <e k="sf_pda_map_legend_medium" v="[EN] Medium" eh="87f8a6ab" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
+    <e k="sf_pda_map_legend_excess" v="[EN] Excess" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Press Shift+M in-game to cycle soil map layers." eh="b13603aa" />
     <e k="sf_pda_map_open_btn" v="Open Soil Map" eh="0901ae30" />
-    <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="[EN] Map preview unavailable" eh="00000000" />
 		<e k="sf_map_health_overall" v="[EN] Average Soil Health" eh="5533cbe3" />
 		<e k="sf_map_btn_report" v="[EN] Open Farm Overview" eh="6f0800e8" />
 		<e k="sf_map_btn_help" v="[EN] Dev Note (NOT WORKING YET)" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Đổi lớp" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kế hoạch xử lý" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Tắt lớp phủ" eh="8e75dec5" />
-    <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
-    <e k="sf_help_p" v="P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
-    <e k="sf_help_om" v="OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
-    <e k="sf_help_soil_header" v="SOIL CHEMISTRY" eh="19c67ff5" />
-    <e k="sf_help_ph" v="pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
-    <e k="sf_help_pressure_header" v="CROP PRESSURE" eh="132b0f66" />
-    <e k="sf_help_weed" v="Weed    > 20% - Apply Herbicide." eh="c8d890df" />
-    <e k="sf_help_pest" v="Pest    > 20% - Apply Insecticide." eh="f4932a05" />
-    <e k="sf_help_disease" v="Disease > 20% - Apply Fungicide." eh="1bfd0913" />
-    <e k="sf_help_status_header" v="STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_help_good" v="Good - No action needed." eh="03910bec" />
-    <e k="sf_help_fair" v="Fair - Monitor / preventive top-up." eh="2922eb1c" />
-    <e k="sf_help_poor" v="Poor - Immediate treatment required." eh="b287d206" />
+    <e k="sf_treat_action_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_help_title" v="[EN] Soil Quick Reference" eh="8986bb6d" />
+    <e k="sf_help_nutrients_header" v="[EN] NUTRIENTS" eh="9aeb39bf" />
+    <e k="sf_help_n" v="[EN] N  (Nitrogen)     - Depletes fast. Apply UAN, Urea, or Manure." eh="f2d0c792" />
+    <e k="sf_help_p" v="[EN] P  (Phosphorus)   - Long-lasting. Apply MAP or DAP." eh="fdfbd91e" />
+    <e k="sf_help_k" v="[EN] K  (Potassium)    - Apply Potash. Important for roots." eh="e0217634" />
+    <e k="sf_help_om" v="[EN] OM (Organic Mat.) - Builds slowly. Plow in manure/compost." eh="a4e29617" />
+    <e k="sf_help_soil_header" v="[EN] SOIL CHEMISTRY" eh="19c67ff5" />
+    <e k="sf_help_ph" v="[EN] pH  6.5-7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum." eh="8929304d" />
+    <e k="sf_help_pressure_header" v="[EN] CROP PRESSURE" eh="132b0f66" />
+    <e k="sf_help_weed" v="[EN] Weed    > 20% - Apply Herbicide." eh="c8d890df" />
+    <e k="sf_help_pest" v="[EN] Pest    > 20% - Apply Insecticide." eh="f4932a05" />
+    <e k="sf_help_disease" v="[EN] Disease > 20% - Apply Fungicide." eh="1bfd0913" />
+    <e k="sf_help_status_header" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_help_good" v="[EN] Good - No action needed." eh="03910bec" />
+    <e k="sf_help_fair" v="[EN] Fair - Monitor / preventive top-up." eh="2922eb1c" />
+    <e k="sf_help_poor" v="[EN] Poor - Immediate treatment required." eh="b287d206" />
     <!-- Fields Tab -->
-    <e k="sf_pda_fields_section_title" v="All Fields" eh="48729e0b" />
-    <e k="sf_pda_col_field" v="Field" eh="6f16a5f8" />
-    <e k="sf_pda_col_n" v="N%" eh="30740562" />
-    <e k="sf_pda_col_p" v="P%" eh="0a5e03bc" />
+    <e k="sf_pda_fields_section_title" v="[EN] All Fields" eh="48729e0b" />
+    <e k="sf_pda_col_field" v="[EN] Field" eh="6f16a5f8" />
+    <e k="sf_pda_col_n" v="[EN] N%" eh="30740562" />
+    <e k="sf_pda_col_p" v="[EN] P%" eh="0a5e03bc" />
 		<e k="sf_pda_filter_all" v="[EN] Filter: All Fields" eh="a46a8cb2" />
 		<e k="sf_pda_filter_owned" v="[EN] Filter: Owned Only" eh="258cb971" />
-    <e k="sf_pda_col_k" v="K%" eh="43e4d0bf" />
-    <e k="sf_pda_col_ph" v="pH" eh="397dff20" />
-    <e k="sf_pda_col_om" v="OM" eh="bfbebc07" />
-    <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
-    <e k="sf_pda_no_fields" v="No field data recorded yet." eh="72265670" />
-    <e k="sf_pda_status_good" v="Good" eh="0c6ad70b" />
-    <e k="sf_pda_status_fair" v="Fair" eh="f7f20cf0" />
-    <e k="sf_pda_status_poor" v="Poor" eh="0e94d017" />
+    <e k="sf_pda_col_k" v="[EN] K%" eh="43e4d0bf" />
+    <e k="sf_pda_col_ph" v="[EN] pH" eh="397dff20" />
+    <e k="sf_pda_col_om" v="[EN] OM" eh="bfbebc07" />
+    <e k="sf_pda_col_status" v="[EN] Status" eh="ec53a8c4" />
+    <e k="sf_pda_no_fields" v="[EN] No field data recorded yet." eh="72265670" />
+    <e k="sf_pda_status_good" v="[EN] Good" eh="0c6ad70b" />
+    <e k="sf_pda_status_fair" v="[EN] Fair" eh="f7f20cf0" />
+    <e k="sf_pda_status_poor" v="[EN] Poor" eh="0e94d017" />
     <!-- Treatment Tab -->
-    <e k="sf_pda_treatment_section_title" v="Treatment Plan" eh="4ba012e2" />
-    <e k="sf_pda_col_priority" v="Urgency" eh="c94e3850" />
-    <e k="sf_pda_col_needs" v="Needs" eh="94d6125d" />
-    <e k="sf_pda_no_treatment" v="All fields are in good condition." eh="fa985166" />
-    <e k="sf_pda_need_n" v="Nitrogen" eh="1e9ef3ba" />
-    <e k="sf_pda_need_p" v="Phosphorus" eh="eb4f2688" />
-    <e k="sf_pda_need_k" v="Potassium" eh="3a4edc67" />
-    <e k="sf_pda_need_ph" v="pH Adjust" eh="0570e9d2" />
-    <e k="sf_pda_need_weed" v="Herbicide" eh="1029736e" />
-    <e k="sf_pda_need_pest" v="Insecticide" eh="5650eeef" />
-    <e k="sf_pda_need_disease" v="Fungicide" eh="e8512698" />
-    <e k="sf_pda_need_multiple" v="Multiple" eh="a0bf169f" />
-    <e k="sf_pda_treatment_minor" v="Minor" eh="6fed0c37" />
+    <e k="sf_pda_treatment_section_title" v="[EN] Treatment Plan" eh="4ba012e2" />
+    <e k="sf_pda_col_priority" v="[EN] Urgency" eh="c94e3850" />
+    <e k="sf_pda_col_needs" v="[EN] Needs" eh="94d6125d" />
+    <e k="sf_pda_no_treatment" v="[EN] All fields are in good condition." eh="fa985166" />
+    <e k="sf_pda_need_n" v="[EN] Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_pda_need_p" v="[EN] Phosphorus" eh="eb4f2688" />
+    <e k="sf_pda_need_k" v="[EN] Potassium" eh="3a4edc67" />
+    <e k="sf_pda_need_ph" v="[EN] pH Adjust" eh="0570e9d2" />
+    <e k="sf_pda_need_weed" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_pda_need_pest" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_pda_need_disease" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_pda_need_multiple" v="[EN] Multiple" eh="a0bf169f" />
+    <e k="sf_pda_treatment_minor" v="[EN] Minor" eh="6fed0c37" />
     <!-- Field Detail Dialog (SoilFieldDetailDialog.lua) -->
-    <e k="sf_detail_title" v="Field Detail" eh="03b5acd7" />
-    <e k="sf_detail_close" v="Close" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Field #" eh="228118ab" />
-    <e k="sf_detail_urgency_label" v="Urgency:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="Soil Nutrients" eh="64377acf" />
-    <e k="sf_detail_section_pressure" v="Crop Pressure" eh="a73974d0" />
-    <e k="sf_detail_section_history" v="Crop History" eh="54c27499" />
-    <e k="sf_detail_n_label" v="Nitrogen (N)" eh="25cee53b" />
-    <e k="sf_detail_p_label" v="Phosphorus (P)" eh="75cb5cd6" />
-    <e k="sf_detail_k_label" v="Potassium (K)" eh="39797137" />
-    <e k="sf_detail_ph_label" v="pH Level" eh="0c85daad" />
-    <e k="sf_detail_om_label" v="Organic Matter" eh="6305f4bb" />
-    <e k="sf_detail_weed_label" v="Weed Pressure" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Pest Pressure" eh="18a7c2be" />
-    <e k="sf_detail_disease_label" v="Disease Pressure" eh="2b805cc9" />
-    <e k="sf_detail_last_crop_label" v="Last Crop" eh="ff41e5eb" />
-    <e k="sf_detail_rotation_label" v="Rotation Status" eh="83f7f522" />
+    <e k="sf_detail_title" v="[EN] Field Detail" eh="03b5acd7" />
+    <e k="sf_detail_close" v="[EN] Close" eh="d3d2e617" />
+    <e k="sf_detail_field_label" v="[EN] Field #" eh="228118ab" />
+    <e k="sf_detail_urgency_label" v="[EN] Urgency:" eh="9a83237c" />
+    <e k="sf_detail_section_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="sf_detail_section_pressure" v="[EN] Crop Pressure" eh="a73974d0" />
+    <e k="sf_detail_section_history" v="[EN] Crop History" eh="54c27499" />
+    <e k="sf_detail_n_label" v="[EN] Nitrogen (N)" eh="25cee53b" />
+    <e k="sf_detail_p_label" v="[EN] Phosphorus (P)" eh="75cb5cd6" />
+    <e k="sf_detail_k_label" v="[EN] Potassium (K)" eh="39797137" />
+    <e k="sf_detail_ph_label" v="[EN] pH Level" eh="0c85daad" />
+    <e k="sf_detail_om_label" v="[EN] Organic Matter" eh="6305f4bb" />
+    <e k="sf_detail_weed_label" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_detail_pest_label" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_detail_disease_label" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_detail_last_crop_label" v="[EN] Last Crop" eh="ff41e5eb" />
+    <e k="sf_detail_rotation_label" v="[EN] Rotation Status" eh="83f7f522" />
 		<e k="sf_treat_title" v="[EN] Treatment Prescription" eh="0ccc3ee5" />
 		<e k="sf_treat_section_soil" v="[EN] Soil Amelioration" eh="09e016e4" />
 		<e k="sf_treat_section_fert" v="[EN] Nutrient Application" eh="76521e8e" />
@@ -474,17 +474,17 @@
 		<e k="sf_treat_action_weed" v="[EN] Apply HERBICIDE immediately." eh="625551c5" />
 		<e k="sf_treat_action_pest" v="[EN] Apply INSECTICIDE immediately." eh="f4db9a03" />
 		<e k="sf_treat_action_disease" v="[EN] Apply FUNGICIDE immediately." eh="9228323a" />
-    <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
-    <e k="sf_detail_no_crop" v="None recorded" eh="a4b5a996" />
+    <e k="sf_detail_rotation_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="sf_detail_rotation_bonus" v="[EN] Legume Bonus (+N)" eh="8ab86f6a" />
+    <e k="sf_detail_rotation_fatigue" v="[EN] Fatigue (x1.15 depletion)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="[EN] No data available." eh="c6d95d5e" />
+    <e k="sf_detail_no_crop" v="[EN] None recorded" eh="a4b5a996" />
     <e k="sf_pda_btn_help" v="Ghi chú Dev" eh="5320d63f" />
     <e k="sf_pda_help_github" v="PHẢN HỒI CỦA BẠN RẤT QUAN TRỌNG! Nếu bạn gặp lỗi, có gợi ý về tính năng mới hoặc muốn đóng góp vào mã nguồn, hãy truy cập dự án trên GitHub. Bạn có thể mở Issue hoặc Pull Request bất kỳ lúc nào để giúp cải thiện mod này cho mọi người. Cảm ơn bạn đã kiểm thử!" eh="3a10b023" />
 		<e k="sf_pda_help_note" v="[EN] Note: The soil layers tab on the map page is NOT WORKING. Im aware of the issue and working on a fix. (which might take some time)" eh="2d8f5dc7" />
     <e k="sf_pda_help_text" v="Xin chào, tôi là nhà phát triển! Như bạn có thể thấy, trang này vẫn đang được phát triển. Các lớp bản đồ hiện chỉ là bản xem trước trực quan (chưa có chức năng chọn) và nhiều phần tử giao diện vẫn cần được tinh chỉnh lần cuối." eh="58e05bdf" />
     <e k="sf_pda_map_jump_hint" v="Nhấp vào một cánh đồng để chuyển đến nó trên bản đồ" eh="006d5371" />
-		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &amp;gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
+		<e k="sf_pda_map_native_hint" v="[EN] The soil layer visualization has moved! You can now access and toggle all soil layers directly from the native PDA Map sidebar (ESC &gt; Map). Look for the 'Soil Layers' category in the sidebar dots." eh="87f73b10" />
     <e k="sf_pda_total_urgent_label" v="Tổng số cần chú ý" eh="b3ce2db9" />
     <e k="sf_pda_treatment_hint" v="Các cánh đồng được liệt kê bên phải cần được xử lý. Nhấp vào một hàng để xem đầu vào được đề xuất và số lượng ước tính." eh="5748d316" />
     </elements>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -38,6 +38,7 @@
     <e k="sf_hud_yield" v="[EN] Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />


### PR DESCRIPTION
## Summary

- **Full i18n overhaul**: Every previously hardcoded English string is now a proper i18n key. This covers HUD labels (pH, OM, ppm, Coverage, Compaction), the sprayer rate panel (APP. RATE header, BURN RISK warnings, Target label), all in-game notification messages, the entire settings panel (category names, section headers, chrome text, setting descriptions, multi-option dropdown values, admin action item labels/descs)
- **100+ new translation keys** added to all 26 language files — `translation_en.xml` has native values, all other 25 files have `[EN] ...` placeholders ready for community translators
- **Bug fix #277**: Field area coverage calculation corrected — was always returning 1.0 ha due to wrong API property names; now correctly reads `field.areaHa` / `field.farmland.areaInHa`
- **Bug fix #278**: Sprayer rate ghost bar now reflects the actual rate multiplier setting
- **Bug fix #279**: Post-harvest HUD no longer shows alarming red penalty % on the day of harvest
- **Bug fix #273**: Weed pressure accumulation and yield penalty now skipped for grass/poplar/non-row-crop fields

## Test plan

- [ ] Launch game, confirm welcome notification appears and is readable
- [ ] Walk onto a field, confirm HUD shows pH / OM / ppm labels
- [ ] Confirm Coverage and Compaction rows display correctly
- [ ] Open settings panel (SHIFT+O), confirm all category names, section headers, descriptions, and dropdown values are visible
- [ ] Open Admin panel, confirm all action item labels and descriptions show
- [ ] Spray a field, confirm APP. RATE header and BURN RISK warnings are visible
- [ ] Confirm all 25 non-English translation files load without XML errors
- [ ] Verify sprayer ghost bar changes when rate is adjusted (issue #278)
- [ ] Harvest a field, confirm HUD shows "Post-harvest · Fertilize" on harvest day (issue #279)
- [ ] Confirm weed pressure does not accumulate on grass fields (issue #273)