### PR TITLE
fix: reduce excessive log output when debug mode is off (v2.1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.1.0.0] - 2026-05-06
+
+### Added
+- **Section Control support** ([#299](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/299), [#298](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/298)) — reads `spec_variableWorkWidth.sections[i].isActive` and scales nutrient credit to the fraction of boom actively spraying. Works with vanilla Section Control and Precision Farming's ExtendedSprayer.
+- **Per-section field attribution** ([#300](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/300)) — nutrient credit is distributed across each active boom section using its `maxWidthNode` world position, enabling accurate field attribution when a wide boom straddles a field boundary.
+- **Weed pressure clears on seeding** ([#304](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/304)) — sowing a crop now resets weed pressure to zero, matching real-world practice where emergence suppresses weeds at the seedling stage. Cultivation weed reduction also raised from 20% to 100%.
+
+### Fixed
+- **Slurry & manure had near-zero soil effect** ([#311](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/311)) — LIQUIDMANURE, MANURE, and DIGESTATE were missing from the custom spray type LPS registration. They fell through to vanilla spray type LPS (often near-zero or undefined), causing `wap.usage` per frame to be tiny and nutrient gain/coverage to be negligible. All three now get `customLPS = 14000 / 36000 = 0.38889 L/s`, consistent with the calibrated rate-to-LPS formula used by all other custom types.
+- **Coverage indicator severely under-reported** ([#309](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/309), [#296](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/296)) — cell-based tracker compared rootNode path against total field cells, making a 28 m boom look like a 1 m boom. Replaced with area-based tracking: `areaThisTick = liters / baseRate_per_ha`. Coverage now advances correctly regardless of boom width or working speed.
+- **Harvest nutrient extraction too aggressive** ([#305](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/305)) — depletion was not normalised by field area, causing large fields to lose far more nutrients than small ones per unit of yield. Factor is now `(harvestedLiters / 1000) / fieldAreaHa`.
+- **Biosolids and chicken manure couldn't load into manure spreaders** ([#308](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/308)) — fill unit patch now covers MANURE-base fill units as well as FERTILIZER-base, allowing these dry organic types to load from bags into manure spreaders.
+- **Incorrect white granular texture on new fill types** ([#307](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/307)) — biosolids, dry chicken manure, and other new fill types now render with correct dark compost textures instead of the white granular default fallback.
+- **Log file filled with position spam during field work** ([#312](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/312)) — per-frame cultivation, plowing, and sowing position messages demoted from `info` to `debug` level.
+
+---
+
 ## [2.0.8.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.1.1.0] - 2026-05-06
+
+### Fixed
+- **Spray visual not appearing for custom fill types** — the visual effect hook was manually starting `FertilizerMotionPathEffect` objects with stale spline entity IDs, producing per-frame `getClosestSplinePosition` script errors and no visible spray. Removed the hook entirely: `ExtendedSprayerEffects` vehicles drive the nozzle shader plane automatically; plain `Sprayer` vehicles use the vanilla `updateSprayerEffects` path, which activates once `processSprayerArea` sets `lastSprayTime`.
+- **Ground density map not updating for custom spray types** — `installDensityMapSprayHook` used `Utils.prependedFunction`, which runs our function *before* the original. Because `wap.sprayType` and `wap.sprayFillType` are set *inside* `onStartWorkAreaProcessing`, our spray-type remap was operating on nil values. Changed to `Utils.appendedFunction` so the vanilla index is remapped after the original populates it. Custom types (LIQUIDLIME, UAN32, etc.) now correctly write the ground colour overlay.
+
+### Known Limitations (Precision Farming DLC)
+- **See & Spray** — not supported in this release. The weed pressure bridge integration is present in the codebase but non-functional; spot-spray nozzles will not activate from our weed pressure data.
+- **PWM nozzle control** — not supported. Per-nozzle pulse-width modulation is a Precision Farming feature and has no integration with this mod.
+- **Section Control + PF dependency** — section-based nutrient credit scaling requires Precision Farming's `ExtendedSprayer` for per-nozzle section state management. Without PF, all sections default to active (coverage fraction 1.0), which is still correct behaviour at field boundaries for vanilla Section Control.
+
+---
+
 ## [2.1.0.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -372,7 +372,10 @@ All integrations are detected automatically at runtime and fail gracefully if th
 |---|---|
 | 🌱 **Base game lime indicator** | The base game's "needs liming" flag is a separate system from our pH tracking. Both update when you apply lime through the sprayer, but the indicators can show different states until the field is treated. Workaround: disable the base game's liming requirement in **Settings → Farming → Liming** to rely solely on our HUD. |
 | 🌐 **Multiplayer** | Soil simulation runs on the server only. Clients receive synced state on join and after each harvest or fertiliser event. |
-| 🔬 **Precision Farming** | Compatible — both mods track nutrients independently. No conflicts. |
+| 🔬 **Precision Farming (general)** | Compatible — both mods track nutrients independently. No conflicts. |
+| ❌ **See & Spray (PF DLC)** | The Precision Farming See-and-Spray spot-spray feature is **not supported** in this release. The weed pressure bridge integration exists in the codebase but is non-functional. Spot nozzles will behave as if our weed data is not present. |
+| ❌ **PWM nozzle control (PF DLC)** | Pulse Width Modulation (per-nozzle rate control) is a Precision Farming feature and is **not supported** by this mod. |
+| ⚠️ **Section Control** | Section-based nutrient credit scaling works correctly but requires **Precision Farming's ExtendedSprayer** to be active for section states to be managed per-nozzle. Without PF, all sections are treated as active (coverage fraction = 1.0), which is still correct for plain Section Control at field boundaries. |
 
 ---
 
@@ -390,7 +393,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.0.8.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.1.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.0.0</version>
+    <version>2.1.1.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.1.0</version>
+    <version>2.1.2.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -284,7 +284,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if vHudOk and vHudId then
                     g_SoilFertilityManager.vehicleHUDEventId = vHudId
-                    SoilLogger.info("HUD toggle (J) registered in VEHICLE context")
+                    SoilLogger.debug("HUD toggle (J) registered in VEHICLE context")
                 end
 
                 -- Soil Report (K) in vehicle
@@ -296,7 +296,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     )
                     if vRepOk and vRepId then
                         g_SoilFertilityManager.vehicleReportEventId = vRepId
-                        SoilLogger.info("Soil Report (K) registered in VEHICLE context")
+                        SoilLogger.debug("Soil Report (K) registered in VEHICLE context")
                     end
                 end
 
@@ -308,7 +308,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if upOk and upId then
                     g_SoilFertilityManager.rateUpEventId = upId
-                    SoilLogger.info("Rate UP (]) registered in VEHICLE context")
+                    SoilLogger.debug("Rate UP (]) registered in VEHICLE context")
                 end
 
                 -- Rate DOWN ([)
@@ -319,7 +319,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if downOk and downId then
                     g_SoilFertilityManager.rateDownEventId = downId
-                    SoilLogger.info("Rate DOWN ([) registered in VEHICLE context")
+                    SoilLogger.debug("Rate DOWN ([) registered in VEHICLE context")
                 end
 
                 -- Auto toggle (Shift+L)
@@ -330,7 +330,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if autoOk and autoId then
                     g_SoilFertilityManager.toggleAutoEventId = autoId
-                    SoilLogger.info("Auto toggle (Shift+L) registered in VEHICLE context")
+                    SoilLogger.debug("Auto toggle (Shift+L) registered in VEHICLE context")
                 end
 
                 -- Settings panel (Shift+O) in VEHICLE context
@@ -343,7 +343,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if vSpOk and vSpId then
                         g_SoilFertilityManager.vehicleSettingsPanelEventId = vSpId
                         binding:setActionEventTextVisibility(vSpId, false)
-                        SoilLogger.info("Settings panel (Shift+O) registered in VEHICLE context")
+                        SoilLogger.debug("Settings panel (Shift+O) registered in VEHICLE context")
                     end
                 end
 
@@ -357,7 +357,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if vDragOk and vDragId then
                         g_SoilFertilityManager.vehicleHudDragEventId = vDragId
                         binding:setActionEventTextVisibility(vDragId, false)
-                        SoilLogger.info("HUD drag (RMB) registered in VEHICLE context")
+                        SoilLogger.debug("HUD drag (RMB) registered in VEHICLE context")
                     end
                 end
 
@@ -376,7 +376,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if pHudOk and pHudId then
                     g_SoilFertilityManager.toggleHUDEventId = pHudId
-                    SoilLogger.info("HUD toggle (J) re-registered in PLAYER context after vehicle exit")
+                    SoilLogger.debug("HUD toggle (J) re-registered in PLAYER context after vehicle exit")
                 end
 
                 if g_SoilFertilityManager.soilReportDialog then
@@ -387,7 +387,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     )
                     if pRepOk and pRepId then
                         g_SoilFertilityManager.soilReportEventId = pRepId
-                        SoilLogger.info("Soil Report (K) re-registered in PLAYER context after vehicle exit")
+                        SoilLogger.debug("Soil Report (K) re-registered in PLAYER context after vehicle exit")
                     end
                 end
 
@@ -400,7 +400,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if pMapOk and pMapId then
                         g_SoilFertilityManager.cycleMapLayerEventId = pMapId
                         binding:setActionEventTextVisibility(pMapId, false)
-                        SoilLogger.info("Map layer cycle (Shift+M) re-registered in PLAYER context after vehicle exit")
+                        SoilLogger.debug("Map layer cycle (Shift+M) re-registered in PLAYER context after vehicle exit")
                     end
                 end
 
@@ -413,7 +413,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if pSpOk and pSpId then
                         g_SoilFertilityManager.settingsPanelEventId = pSpId
                         binding:setActionEventTextVisibility(pSpId, false)
-                        SoilLogger.info("Settings panel (Shift+O) re-registered in PLAYER context after vehicle exit")
+                        SoilLogger.debug("Settings panel (Shift+O) re-registered in PLAYER context after vehicle exit")
                     end
                 end
 
@@ -426,12 +426,12 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if pDragOk and pDragId then
                         g_SoilFertilityManager.hudDragEventId = pDragId
                         binding:setActionEventTextVisibility(pDragId, false)
-                        SoilLogger.info("HUD drag (RMB) re-registered in PLAYER context after vehicle exit")
+                        SoilLogger.debug("HUD drag (RMB) re-registered in PLAYER context after vehicle exit")
                     end
                 end
 
                 binding:endActionEventsModification()
-                SoilLogger.info("PLAYER context inputs restored after vehicle exit")
+                SoilLogger.debug("PLAYER context inputs restored after vehicle exit")
 
                 _soilVehicleHookActive = false
             end
@@ -1107,14 +1107,14 @@ function SoilFertilityManager:delete()
     if self._inputHookOriginal and PlayerInputComponent then
         PlayerInputComponent.registerActionEvents = self._inputHookOriginal
         self._inputHookOriginal = nil
-        SoilLogger.info("PlayerInputComponent hook restored")
+        SoilLogger.debug("PlayerInputComponent hook restored")
     end
 
     -- Restore InputBinding.endActionEventsModification hook if we installed one
     if self._vehicleInputHookOriginal and InputBinding then
         InputBinding.endActionEventsModification = self._vehicleInputHookOriginal
         self._vehicleInputHookOriginal = nil
-        SoilLogger.info("InputBinding.endActionEventsModification hook restored")
+        SoilLogger.debug("InputBinding.endActionEventsModification hook restored")
     end
 
     -- Clean up sprayer rate state

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -106,7 +106,7 @@ function SoilFertilitySystem:initialize()
         -- Propagate to shared constants so SoilMapOverlay reads the same resolution
         SoilConstants.ZONE.CELL_SIZE    = self.cellSize
         SoilConstants.ZONE.CELL_AREA_HA = self.cellAreaHa
-        SoilLogger.info("[PERF-P3] Map %.0fm (%.1fx) → cell %dm  %.4f ha/cell",
+        SoilLogger.debug("[PERF-P3] Map %.0fm (%.1fx) → cell %dm  %.4f ha/cell",
             mapSize, scale, self.cellSize, self.cellAreaHa)
     end
 
@@ -404,7 +404,7 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
         -- Field sold / abandoned — pull it out of the active simulation set.
         -- fieldData intentionally kept: new owner inherits the soil conditions.
         self:_removeFromActiveSet(fieldId)
-        SoilLogger.info("[PERF-P1] Field %d released by farm — removed from active set (data preserved)", fieldId)
+        SoilLogger.debug("[PERF-P1] Field %d released by farm — removed from active set (data preserved)", fieldId)
         return
     end
 
@@ -412,7 +412,7 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
     local field = self:getOrCreateField(fieldId, true)
     if field then
         self:_addToActiveSet(fieldId)
-        SoilLogger.info("[PERF-P1] Field %d acquired by farm %d — added to active set", fieldId, farmId)
+        SoilLogger.debug("[PERF-P1] Field %d acquired by farm %d — added to active set", fieldId, farmId)
     end
 end
 
@@ -907,7 +907,7 @@ function SoilFertilitySystem:update(dt)
                 -- Update lastSeason only after the full pass so all fields see the
                 -- same spring-transition flag (captured at batch-queue time).
                 self.lastSeason = self._dailyBatchSeason
-                SoilLogger.info("[PERF-P4] Day %d daily batch complete: %d field(s) in final slice, %d total",
+                SoilLogger.debug("[PERF-P4] Day %d daily batch complete: %d field(s) in final slice, %d total",
                     self._dailyBatchDay, processed, n)
             else
                 SoilLogger.debug("[PERF-P4] Day %d batch progress: cursor %d/%d (+%d this frame)",
@@ -1167,7 +1167,7 @@ function SoilFertilitySystem:_rebuildActiveList()
     table.sort(list)  -- stable order for deterministic batch processing
     self._activeFieldList = list
     self._activeListDirty = false
-    SoilLogger.info("[PERF-P1] Active list rebuilt: %d owned field(s)", #list)
+    SoilLogger.debug("[PERF-P1] Active list rebuilt: %d owned field(s)", #list)
 end
 
 -- Get or create field data
@@ -1295,7 +1295,7 @@ function SoilFertilitySystem:updateDailySoil()
     self._pendingDailyUpdate = true
     self._dailyBatchCursor   = 0
 
-    SoilLogger.info("[PERF-P4] Day %d: queued daily update for %d active field(s) (batch=%d/frame)",
+    SoilLogger.debug("[PERF-P4] Day %d: queued daily update for %d active field(s) (batch=%d/frame)",
         currentDay, #self._activeFieldList, self.DAILY_BATCH_SIZE)
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -34,7 +34,7 @@ function HookManager:getFieldIdAtWorldPosition(x, z)
         local BASE_MAP   = 4096
         local BASE_BLOCK = 2
         local blockSize  = math.max(BASE_BLOCK, math.floor(BASE_BLOCK * (mapSize / BASE_MAP)))
-        SoilLogger.info("[PERF-P5] MapDataGrid: map=%.0fm  blockSize=%dm", mapSize, blockSize)
+        SoilLogger.debug("[PERF-P5] MapDataGrid: map=%.0fm  blockSize=%dm", mapSize, blockSize)
         local ok, result = pcall(MapDataGrid.createFromBlockSize, mapSize, blockSize)
         if ok and result then
             self.fieldIdCache = result

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3243,10 +3243,9 @@ function HookManager:installSprayerVisualEffectHook()
     local function startSprayerEffects(vehicle, vanillaFillType)
         local spec = vehicle.spec_sprayer
         if not spec then return end
-        if spec.effects and #spec.effects > 0 then
-            g_effectManager:setEffectTypeInfo(spec.effects, vanillaFillType)
-            g_effectManager:startEffects(spec.effects)
-        end
+        -- Do NOT touch spec.effects — it is the boom-level nozzle effect list managed
+        -- per-section by vanilla's section control. Starting it here overrides the
+        -- individual section shutoff FS25 already performed correctly.
         for _, st in ipairs(spec.sprayTypes or {}) do
             if st.effects and #st.effects > 0 then
                 g_effectManager:setEffectTypeInfo(st.effects, vanillaFillType)
@@ -3260,7 +3259,7 @@ function HookManager:installSprayerVisualEffectHook()
     local function stopSprayerEffects(vehicle)
         local spec = vehicle.spec_sprayer
         if not spec then return end
-        g_effectManager:stopEffects(spec.effects)
+        -- Same rationale: leave spec.effects to vanilla section control.
         for _, st in ipairs(spec.sprayTypes or {}) do
             g_effectManager:stopEffects(st.effects)
             g_animationManager:stopAnimations(st.animationNodes)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3243,9 +3243,10 @@ function HookManager:installSprayerVisualEffectHook()
     local function startSprayerEffects(vehicle, vanillaFillType)
         local spec = vehicle.spec_sprayer
         if not spec then return end
-        -- Do NOT touch spec.effects — it is the boom-level nozzle effect list managed
-        -- per-section by vanilla's section control. Starting it here overrides the
-        -- individual section shutoff FS25 already performed correctly.
+        if spec.effects and #spec.effects > 0 then
+            g_effectManager:setEffectTypeInfo(spec.effects, vanillaFillType)
+            g_effectManager:startEffects(spec.effects)
+        end
         for _, st in ipairs(spec.sprayTypes or {}) do
             if st.effects and #st.effects > 0 then
                 g_effectManager:setEffectTypeInfo(st.effects, vanillaFillType)
@@ -3259,7 +3260,7 @@ function HookManager:installSprayerVisualEffectHook()
     local function stopSprayerEffects(vehicle)
         local spec = vehicle.spec_sprayer
         if not spec then return end
-        -- Same rationale: leave spec.effects to vanilla section control.
+        g_effectManager:stopEffects(spec.effects)
         for _, st in ipairs(spec.sprayTypes or {}) do
             g_effectManager:stopEffects(st.effects)
             g_animationManager:stopAnimations(st.animationNodes)

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -268,7 +268,7 @@ function SoilRequestFullSyncEvent:run(connection)
             end
             local isLast = (batchIndex == totalBatches)
             connection:sendEvent(SoilFieldBatchSyncEvent.new(batch, isLast))
-            SoilLogger.info("Server: Field batch %d/%d sent (%d fields)", batchIndex, totalBatches, endIdx - startIdx + 1)
+            SoilLogger.debug("Server: Field batch %d/%d sent (%d fields)", batchIndex, totalBatches, endIdx - startIdx + 1)
         end
     elseif g_currentMission and g_currentMission.addUpdateable then
         -- Listen server / local host path: drip-feed batches via addUpdateable
@@ -306,7 +306,7 @@ function SoilRequestFullSyncEvent:run(connection)
                 local isLast = (self.batchIndex == self.totalBatches)
                 self.connection:sendEvent(SoilFieldBatchSyncEvent.new(batch, isLast))
 
-                SoilLogger.info("Server: Field batch %d/%d sent (%d fields)",
+                SoilLogger.debug("Server: Field batch %d/%d sent (%d fields)",
                     self.batchIndex, self.totalBatches, endIdx - startIdx + 1)
 
                 self.batchIndex = self.batchIndex + 1

--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -37,7 +37,7 @@ function Settings:setDifficulty(difficulty)
             difficultyName = "Hardcore"
         end
 
-        SoilLogger.info("Difficulty set to: %s", difficultyName)
+        SoilLogger.debug("Difficulty set to: %s", difficultyName)
     end
 end
 


### PR DESCRIPTION
## Summary

- Downgraded all `[PERF-Px]`-tagged diagnostic messages to debug-only (were logging every game day and on every field ownership change)
- Downgraded per-vehicle-enter/exit input registration messages to debug-only (~13 messages per enter/exit event)
- Downgraded network batch progress messages to debug-only (fired multiple times per player join)
- Downgraded `setDifficulty` log call to debug-only (fired on every settings sync)

All changes affect only log verbosity — no gameplay logic was modified.

## Test plan

- [ ] Verify log.txt shows no `[SoilFertilizer]` spam during normal gameplay with debug mode off
- [ ] Verify `[OK]` hook installation messages still appear at startup
- [ ] Verify all messages reappear when `SoilDebug` console command is toggled on
- [ ] Test on dedicated server — confirm quiet log during field purchases, player joins, and day changes

Closes #314