### PR TITLE
fix: restore RMB scope — only capture when cursor is over HUD (2.1.3.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.2.0</version>
+    <version>2.1.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -328,16 +328,20 @@ end
 function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     if not self.initialized then return false end
 
-    -- RMB: toggle edit mode — BEFORE showHUD/visible guards so it works reliably
-    -- on foot as well as in a vehicle (fix from GitHub issue #130).
+    -- RMB: toggle edit mode.
+    -- Exit edit mode anywhere on screen (natural cancel behaviour).
+    -- Enter edit mode only when cursor is over the HUD panel — this prevents
+    -- consuming RMB events that belong to other mods (CoursePlay, AutoDrive, etc.)
+    -- when the player is not interacting with the soil HUD.
     if isDown and button == Input.MOUSE_BUTTON_RIGHT then
         if self.settings.enabled then
             if self.editMode then
                 self:exitEditMode()
-            else
+                return true
+            elseif self.settings.showHUD and self.visible and self:isPointerOverHUD(posX, posY) then
                 self:enterEditMode()
+                return true
             end
-            return true
         end
         return false
     end


### PR DESCRIPTION
## Summary

- **Fix**: RMB (right mouse button) conflict with CoursePlay and AutoDrive is resolved. The HUD edit mode now only activates when the cursor is actually hovering over the soil HUD panel — previously, any RMB click anywhere on screen was consumed by this mod, preventing other mods from receiving the event.
- Exiting edit mode still works with RMB from anywhere on screen (natural cancel behaviour).

## What changed

- `src/ui/SoilHUD.lua` — `onMouseEvent` RMB enter-edit guard now checks `isPointerOverHUD()` before consuming the event; exit-edit path is unchanged.

## Migration

No save migration needed. No settings changes.