### PR TITLE
fix: rebind HUD edit mode from RMB to Shift+H — eliminates CoursePlay/AutoDrive conflict (2.1.4.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -103,7 +103,7 @@
             <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_o" />
         </actionBinding>
         <actionBinding action="SF_HUD_DRAG">
-            <binding device="KB_MOUSE_DEFAULT" input="MOUSE_BUTTON_RIGHT" />
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h" />
         </actionBinding>
     </inputBinding>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.3.0</version>
+    <version>2.1.4.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -190,7 +190,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     end
                 end
 
-                -- HUD drag toggle (SF_HUD_DRAG, default RMB) — PLAYER context
+                -- HUD drag toggle (SF_HUD_DRAG, default Shift+H) — PLAYER context
                 if g_SoilFertilityManager.soilHUD then
                     local dragOk, dragId = g_inputBinding:registerActionEvent(
                         InputAction.SF_HUD_DRAG, g_SoilFertilityManager,
@@ -200,7 +200,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if dragOk and dragId then
                         g_SoilFertilityManager.hudDragEventId = dragId
                         g_inputBinding:setActionEventTextVisibility(dragId, false)
-                        SoilLogger.info("HUD drag (RMB) registered in PLAYER context")
+                        SoilLogger.info("HUD drag (Shift+H) registered in PLAYER context")
                     end
                 end
 
@@ -247,7 +247,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 -- endActionEventsModification fires on every vehicle mount/seat change
                 -- (including Courseplay seat cycling). Without cleanup, duplicate
                 -- registrations accumulate — callbacks fire 2-3× per keypress and
-                -- SF_HUD_DRAG (RMB) toggles drag mode on then immediately back off.
+                -- SF_HUD_DRAG (Shift+H) toggles edit mode.
                 --
                 -- IMPORTANT: Also purge PLAYER context event IDs here. FS25's
                 -- removeActionEvent works by action slot, not strictly by context.
@@ -347,7 +347,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     end
                 end
 
-                -- HUD drag toggle (SF_HUD_DRAG, default RMB) — VEHICLE context
+                -- HUD drag toggle (SF_HUD_DRAG, default Shift+H) — VEHICLE context
                 if g_SoilFertilityManager.soilHUD then
                     local vDragOk, vDragId = binding:registerActionEvent(
                         InputAction.SF_HUD_DRAG, g_SoilFertilityManager,
@@ -357,7 +357,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if vDragOk and vDragId then
                         g_SoilFertilityManager.vehicleHudDragEventId = vDragId
                         binding:setActionEventTextVisibility(vDragId, false)
-                        SoilLogger.debug("HUD drag (RMB) registered in VEHICLE context")
+                        SoilLogger.debug("HUD drag (Shift+H) registered in VEHICLE context")
                     end
                 end
 
@@ -426,7 +426,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     if pDragOk and pDragId then
                         g_SoilFertilityManager.hudDragEventId = pDragId
                         binding:setActionEventTextVisibility(pDragId, false)
-                        SoilLogger.debug("HUD drag (RMB) re-registered in PLAYER context after vehicle exit")
+                        SoilLogger.debug("HUD drag (Shift+H) re-registered in PLAYER context after vehicle exit")
                     end
                 end
 
@@ -627,7 +627,7 @@ function SoilFertilityManager:onOpenSettingsInput()
     end
 end
 
--- Input callback for HUD drag toggle (SF_HUD_DRAG, default RMB)
+-- Input callback for HUD drag toggle (SF_HUD_DRAG, default Shift+H)
 function SoilFertilityManager:onHUDDragInput()
     if not self.soilHUD then return end
     -- Don't steal RMB when HUD is hidden or mod is disabled — prevents mouse cursor

--- a/src/main.lua
+++ b/src/main.lua
@@ -338,13 +338,11 @@ if FillTypeManager and type(FillTypeManager.loadModFillTypes) == "function" then
     FillTypeManager.loadModFillTypes = Utils.prependedFunction(FillTypeManager.loadModFillTypes, injectSFModFillTypes)
 end
 
--- Route mouse events to SoilHUD (for drag/resize edit mode)
--- RMB only enters edit mode when cursor is over the panel (no cross-contamination).
--- We always call onMouseEvent regardless of eventUsed — SoilHUD:onMouseEvent only
--- returns true (consumes the event) when cursor is over the panel OR already in edit
--- mode, so we never steal clicks from game systems.  The old `not eventUsed` guard
--- prevented RMB from reaching the HUD when the game had already tagged the event
--- (e.g. player controller on foot), breaking cursor activation on foot.
+-- Route mouse events to SoilHUD (for drag/resize edit mode).
+-- Edit mode is entered via Shift+H (SF_HUD_DRAG input action) — not via RMB.
+-- RMB only exits edit mode (and only when this mod is already in edit mode).
+-- This guarantees RMB is never consumed during normal play, preserving
+-- CoursePlay, AutoDrive, and other mods that rely on RMB.
 local soilMouseHandler = {}
 function soilMouseHandler:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     -- Settings panel eats input first when open

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -3,7 +3,7 @@
 -- =========================================================
 -- Soil HUD Overlay - live field soil monitor
 -- Shows N/P/K/pH/OM for the field the player is standing on.
--- Toggle with J key. RMB on panel to drag/resize.
+-- Toggle with J key. Shift+H to enter HUD edit mode; RMB or Shift+H again to exit.
 -- =========================================================
 -- Author: TisonK
 -- =========================================================
@@ -328,20 +328,13 @@ end
 function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     if not self.initialized then return false end
 
-    -- RMB: toggle edit mode.
-    -- Exit edit mode anywhere on screen (natural cancel behaviour).
-    -- Enter edit mode only when cursor is over the HUD panel — this prevents
-    -- consuming RMB events that belong to other mods (CoursePlay, AutoDrive, etc.)
-    -- when the player is not interacting with the soil HUD.
+    -- RMB: cancel/exit edit mode only. Never enters edit mode (that's Shift+H via SF_HUD_DRAG).
+    -- This ensures RMB is never consumed during normal play, so CoursePlay and AutoDrive
+    -- receive their RMB events uninterrupted.
     if isDown and button == Input.MOUSE_BUTTON_RIGHT then
-        if self.settings.enabled then
-            if self.editMode then
-                self:exitEditMode()
-                return true
-            elseif self.settings.showHUD and self.visible and self:isPointerOverHUD(posX, posY) then
-                self:enterEditMode()
-                return true
-            end
+        if self.editMode then
+            self:exitEditMode()
+            return true
         end
         return false
     end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -85,7 +85,7 @@
     <e k="sf_hud_estYield" v="Prod. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ideal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="Arraste: mover   Canto: redimensionar   RMB: pronto" eh="987ebf45" />
+    <e k="sf_hud_hint_edit" v="Arraste: mover   Canto: redimensionar   RMB/Shift+H: pronto" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: mover/redimensionar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unidades imperiais" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Exibir taxas em gal/ac e lb/ac (desativado = L/ha e kg/ha)" eh="17efa489" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -86,7 +86,7 @@
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="拖動：移動   角落：縮放   右鍵：完成" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="右鍵：移動/縮放" eh="afc8f13b" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
     <e k="sf_use_imperial_short" v="英制單位" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="以 gal/ac 和 lb/ac 顯示施用量（關閉則為 L/ha 和 kg/ha）" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -85,8 +85,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Imperiální jednotky" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Zobrazit dávky v gal/ac a lb/ac (vypnuto = L/ha a kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -40,7 +40,7 @@
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="Efterhøst - Gød" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Træk: flyt   Hjørne: ændr størrelse   HMK: færdig" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="HMK: flyt/ændr størrelse" eh="afc8f13b" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
     <e k="sf_use_imperial_short" v="Imperiale enheder" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Vis udbringningsrater i gal/ac og lb/ac (fra = L/ha og kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Aktivt kortlag" eh="1861765f" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -86,7 +86,7 @@
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Ziehen: bewegen   Ecke: Größe ändern   RMT: fertig" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMT: bewegen/Größe ändern" eh="afc8f13b" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
     <e k="sf_use_imperial_short" v="Imperiale Einheiten" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Ausbringmengen in gal/ac und lb/ac (aus = L/ha und kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Soil &amp; Fertilizer" eh="d30a22a9" />
@@ -194,8 +194,8 @@
     <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
     <e k="sf_report_detail_n_ok" v="Nitrogen: Optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphorus: Optimal" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Potassium: Optimal" eh="0197b4ba" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -85,7 +85,7 @@
     <e k="sf_hud_estYield" v="Rend. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Óptimo" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB: listo" eh="987ebf45" />
+    <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB/Shift+H: listo" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: mover/redimensionar" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unidades Imperiales" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Mostrar tasas de aplicación en gal/ac y lb/ac (desactivado = L/ha y kg/ha)" eh="17efa489" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -194,7 +194,7 @@
     <e k="sf_hud_estYield" v="Rend. estimé" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="Post-récolte · Fertiliser" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   RMB: terminé" eh="987ebf45" />
+    <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   RMB/Shift+H: terminé" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: déplacer/redimensionner" eh="afc8f13b" />
     <e k="sf_report_detail_n_ok" v="Azote : optimal" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Phosphore : optimal" eh="dbc90f11" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -85,8 +85,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Angolszász mértékegységek" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Kijuttatási normák gal/ac és lb/ac egységben (ki = L/ha és kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -85,7 +85,7 @@
     <e k="sf_hud_estYield" v="Resa Stim." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ottimale" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="Trascina: muovi  Angolo: ridimensiona  RMB: fatto" eh="987ebf45" />
+    <e k="sf_hud_hint_edit" v="Trascina: muovi  Angolo: ridimensiona  RMB/Shift+H: fatto" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: muovi/ridimensiona" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unità imperiali" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Mostra le dosi in gal/ac e lb/ac (off = L/ha e kg/ha)" eh="17efa489" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -86,7 +86,7 @@
     <e k="sf_hud_optimal" v="Optimaal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="Na de oogst · Bemesten" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Sleep: verplaatsen   Hoek: formaat wijzigen   Rechtsklik: gereed" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="Rechtsklik: verplaatsen/vergroten" eh="afc8f13b" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
     <e k="sf_use_imperial_short" v="Imperiale eenheden" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Toon doseringen in gal/ac en lb/ac (uit = L/ha en kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Actieve kaartlaag" eh="1861765f" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -194,7 +194,7 @@
     <e k="sf_hud_estYield" v="Szac. plon" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optymalny" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="Nawożenie po zbiorze" eh="d64d5d59" />
-    <e k="sf_hud_hint_edit" v="Przegciągnięcie: przesuń   ku górze: zmien rozmiar   RMB: gotowe" eh="987ebf45" />
+    <e k="sf_hud_hint_edit" v="Przegciągnięcie: przesuń   ku górze: zmien rozmiar   RMB/Shift+H: gotowe" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: przesuń/zmień rozmiar" eh="afc8f13b" />
     <e k="sf_report_detail_n_ok" v="Azot: Optymalny" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Fosfor: Optymalny" eh="dbc90f11" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -195,7 +195,7 @@
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Перетаскивание: движение   Угол: размер   ПКМ: готово" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="ПКМ: движение/размер" eh="afc8f13b" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
 		<e k="sf_report_detail_n_ok" v="Азот: Оптимальный" eh="13782bd9" />
 		<e k="sf_report_detail_p_ok" v="Фосфор: Оптимальный" eh="dbc90f11" />
 		<e k="sf_report_detail_k_ok" v="Калий: Оптимальный" eh="0197b4ba" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -195,7 +195,7 @@
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Перетягування: рух   Кут: розмір   ПКМ: готово" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="ПКМ: рух/розмір" eh="afc8f13b" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="00000000" />
     <e k="sf_report_detail_n_ok" v="Азот: Оптимальний" eh="13782bd9" />
     <e k="sf_report_detail_p_ok" v="Фосфор: Оптимальний" eh="dbc90f11" />
     <e k="sf_report_detail_k_ok" v="Калій: Оптимальний" eh="0197b4ba" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -39,8 +39,8 @@
     <e k="sf_hud_estYield" v="[EN] Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB: done" eh="987ebf45" />
-    <e k="sf_hud_hint_normal" v="[EN] RMB: move/resize" eh="afc8f13b" />
+    <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="987ebf45" />
+    <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="afc8f13b" />
 		<e k="sf_use_imperial_short" v="[EN] Imperial Units" eh="ff2701ad" />
 		<e k="sf_use_imperial_long" v="[EN] Show application rates in gal/ac and lb/ac (off = L/ha and kg/ha)" eh="17efa489" />
     <e k="sf_active_map_layer_short" v="[EN] Active Map Layer" eh="1861765f" />


### PR DESCRIPTION
## Summary

- **Root cause found and fixed**: The `SF_HUD_DRAG` input action was bound to `MOUSE_BUTTON_RIGHT` in `modDesc.xml`, consuming RMB at the FS25 input system level — before any hover check could happen. This was the true source of the CoursePlay/AutoDrive conflict (v2.1.3.0 only partially fixed the secondary mouseEvent path).
- **New binding**: `SF_HUD_DRAG` is now bound to `Shift+H` by default. Rebindable in-game via the standard Controls menu.
- **RMB behaviour**: RMB now **only exits** edit mode (when already in it, with cursor visible). It is never consumed during normal play.
- **All 26 translation files** updated: `sf_hud_hint_normal` now shows `Shift+H: move/resize`; `sf_hud_hint_edit` shows `RMB/Shift+H: done`.

## Migration

No save migration needed. Players who previously rebound `SF_HUD_DRAG` in-game will need to rebind once — the default switches from RMB to Shift+H.