### PR TITLE
fix: gate runtime UI log messages behind debug mode

### DIFF
--- a/src/hooks/SoilMapHooks.lua
+++ b/src/hooks/SoilMapHooks.lua
@@ -25,7 +25,7 @@ local function isSoilPageActive(frame)
     if isActive ~= frame._soilPageWasActive then
         frame._soilPageWasActive = isActive
         if isActive then
-            SoilLogger.info("SoilMapHooks: PDA Soil page activated")
+            SoilLogger.debug("SoilMapHooks: PDA Soil page activated")
         end
     end
     
@@ -81,7 +81,7 @@ function SoilMapHooks:onLoadMapFinished()
             end
             if ref then
                 soilOverlay.ingameMapRef = ref
-                SoilLogger.info("SoilMapHooks: ingameMap ref cached for minimap overlay (state=%s)", tostring(ref.state))
+                SoilLogger.debug("SoilMapHooks: ingameMap ref cached for minimap overlay (state=%s)", tostring(ref.state))
             else
                 SoilLogger.warning("SoilMapHooks: could not capture ingameMap ref — minimap overlay will not render")
             end
@@ -101,7 +101,7 @@ function SoilMapHooks:setupMapOverview()
     -- FS25 InGameMenuMapFrame.mapSelectorTexts is usually 1-indexed table of strings
     table.insert(self.mapSelectorTexts, pageText)
     self.soilMapPageIndex = #self.mapSelectorTexts
-    SoilLogger.info("SoilMapHooks: Registered native page index %d", self.soilMapPageIndex)
+    SoilLogger.debug("SoilMapHooks: Registered native page index %d", self.soilMapPageIndex)
 
     self.mapOverviewSelector:setTexts(self.mapSelectorTexts)
 
@@ -122,7 +122,7 @@ function SoilMapHooks:onClickMapOverviewSelector(state)
         return
     end
 
-    SoilLogger.info("SoilMapHooks: Selector changed to Soil page (%d)", state)
+    SoilLogger.debug("SoilMapHooks: Selector changed to Soil page (%d)", state)
 
     local soilOverlay = getSoilOverlay(self)
     if soilOverlay == nil then return end
@@ -179,7 +179,7 @@ function SoilMapHooks.onDrawIngameMapElement(elementSelf, ...)
     local _soilOverlay = g_SoilFertilityManager and g_SoilFertilityManager.soilMapOverlay
     if _soilOverlay and not _soilOverlay.ingameMapRef and elementSelf.ingameMap.layout then
         _soilOverlay.ingameMapRef = elementSelf.ingameMap
-        SoilLogger.info("SoilMapHooks: ingameMap ref captured from PDA draw (fallback)")
+        SoilLogger.debug("SoilMapHooks: ingameMap ref captured from PDA draw (fallback)")
     end
 
     -- Walk up (max 6 levels) to find the frame that has soilMapPageIndex

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -86,11 +86,11 @@ end
 
 ---@param fieldId number
 function SoilFieldDetailDialog.show(fieldId)
-    SoilLogger.info("SoilFieldDetailDialog.show(fieldId=%s)", tostring(fieldId))
+    SoilLogger.debug("SoilFieldDetailDialog.show(fieldId=%s)", tostring(fieldId))
     
     -- Lazy-register if not yet loaded
     if SoilFieldDetailDialog.INSTANCE == nil then
-        SoilLogger.info("SoilFieldDetailDialog: lazy-registering from show()")
+        SoilLogger.debug("SoilFieldDetailDialog: lazy-registering from show()")
         SoilFieldDetailDialog.register(SF_DETAIL_MOD_DIR)
     end
 
@@ -104,11 +104,11 @@ function SoilFieldDetailDialog.show(fieldId)
     
     -- Ensure we are in a state to show a dialog
     if g_gui:getIsGuiVisible() then
-        SoilLogger.info("SoilFieldDetailDialog: showing dialog via showDialog()")
+        SoilLogger.debug("SoilFieldDetailDialog: showing dialog via showDialog()")
         g_gui:showDialog("SoilFieldDetailDialog")
     else
         -- PDA might be closed, but we were called somehow?
-        SoilLogger.info("SoilFieldDetailDialog: showing via showGui()")
+        SoilLogger.debug("SoilFieldDetailDialog: showing via showGui()")
         g_gui:showGui("SoilFieldDetailDialog")
     end
 end
@@ -117,7 +117,7 @@ end
 
 function SoilFieldDetailDialog:onGuiSetupFinished()
     SoilFieldDetailDialog:superClass().onGuiSetupFinished(self)
-    SoilLogger.info("SoilFieldDetailDialog: onGuiSetupFinished")
+    SoilLogger.debug("SoilFieldDetailDialog: onGuiSetupFinished")
 
     -- Cache references
     self.detailTitle         = self:getDescendantById("detailTitle")
@@ -145,13 +145,13 @@ function SoilFieldDetailDialog:onGuiSetupFinished()
 end
 
 function SoilFieldDetailDialog:onOpen()
-    SoilLogger.info("SoilFieldDetailDialog: onOpen(fieldId=%s)", tostring(self._fieldId))
+    SoilLogger.debug("SoilFieldDetailDialog: onOpen(fieldId=%s)", tostring(self._fieldId))
     SoilFieldDetailDialog:superClass().onOpen(self)
     self:_populateData()
 end
 
 function SoilFieldDetailDialog:onClose()
-    SoilLogger.info("SoilFieldDetailDialog: onClose()")
+    SoilLogger.debug("SoilFieldDetailDialog: onClose()")
     SoilFieldDetailDialog:superClass().onClose(self)
     self._fieldId = nil
 end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -177,7 +177,7 @@ function SoilHUD:enterEditMode()
             end
         end
     end
-    SoilLogger.info("[SoilHUD] Edit mode ON")
+    SoilLogger.debug("[SoilHUD] Edit mode ON")
 end
 
 function SoilHUD:exitEditMode()
@@ -199,7 +199,7 @@ function SoilHUD:exitEditMode()
             g_SoilFertilityManager.settingsUI:refreshUI()
         end
     end
-    SoilLogger.info("[SoilHUD] Edit mode OFF — pos=(%.3f,%.3f) scale=%.2f",
+    SoilLogger.debug("[SoilHUD] Edit mode OFF — pos=(%.3f,%.3f) scale=%.2f",
         self.panelX, self.panelY, self.scale)
 end
 

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -154,7 +154,7 @@ function SoilMapOverlay:setLayer(layerIdx)
     if self.settings.activeMapLayer == layerIdx then return end
     self.settings.activeMapLayer = layerIdx
     self:requestRefresh()
-    SoilLogger.info("SoilMapOverlay: layer set to %d (%s)", layerIdx, g_i18n:getText(SoilMapOverlay.LAYER_KEYS[layerIdx] or "unknown"))
+    SoilLogger.debug("SoilMapOverlay: layer set to %d (%s)", layerIdx, g_i18n:getText(SoilMapOverlay.LAYER_KEYS[layerIdx] or "unknown"))
 end
 
 function SoilMapOverlay:cycleLayer()
@@ -321,7 +321,7 @@ function SoilMapOverlay:updateSamplePoints(force)
     end
 
     if g_currentMission == nil or g_fieldManager == nil then
-        SoilLogger.info("SoilMapOverlay: Sampling aborted - mission or fieldManager nil")
+        SoilLogger.debug("SoilMapOverlay: Sampling aborted - mission or fieldManager nil")
         return
     end
 
@@ -331,7 +331,7 @@ function SoilMapOverlay:updateSamplePoints(force)
     -- a single centroid point for very small fields or when polygon data is absent.
     local fields = g_fieldManager.fields
     if fields == nil then
-        SoilLogger.info("SoilMapOverlay: g_fieldManager.fields is nil")
+        SoilLogger.debug("SoilMapOverlay: g_fieldManager.fields is nil")
         return
     end
 
@@ -418,10 +418,10 @@ function SoilMapOverlay:updateSamplePoints(force)
     end
 
     if totalPoints > 0 then
-        SoilLogger.info("SoilMapOverlay: Sampled %d polygon fill points for layer %d (fields: %d)",
+        SoilLogger.debug("SoilMapOverlay: Sampled %d polygon fill points for layer %d (fields: %d)",
                         totalPoints, layerIdx, #fields)
     else
-        SoilLogger.info("SoilMapOverlay: No fields found to sample (fields count: %d)", #fields)
+        SoilLogger.debug("SoilMapOverlay: No fields found to sample (fields count: %d)", #fields)
     end
 end
 

--- a/src/ui/SoilPDAScreen.lua
+++ b/src/ui/SoilPDAScreen.lua
@@ -537,7 +537,7 @@ end
 -- ── SmoothList Delegate ───────────────────────────────────
 
 function SoilPDAScreen:onListSelectionChanged(list, section, index)
-    SoilLogger.info("SoilPDAScreen: onListSelectionChanged index: %s", tostring(index))
+    SoilLogger.debug("SoilPDAScreen: onListSelectionChanged index: %s", tostring(index))
     if index > 0 then
         if list == self.sidebarFieldList then
             self.selectedFieldIndex = index
@@ -553,7 +553,7 @@ end
 function SoilPDAScreen:onClickFieldRow(element)
     -- Use stored index from population
     local index = element and element.rowDataIndex
-    SoilLogger.info("SoilPDAScreen: onClickFieldRow index: %s", tostring(index))
+    SoilLogger.debug("SoilPDAScreen: onClickFieldRow index: %s", tostring(index))
     if index and index > 0 then
         self:_openFieldDetail(index)
     end
@@ -562,7 +562,7 @@ end
 --- Called by ListItem.onClick in PDA Treatment tab (XML)
 function SoilPDAScreen:onClickTreatmentRow(element)
     local index = element and element.rowDataIndex
-    SoilLogger.info("SoilPDAScreen: onClickTreatmentRow index: %s", tostring(index))
+    SoilLogger.debug("SoilPDAScreen: onClickTreatmentRow index: %s", tostring(index))
     if index and index > 0 then
         self:_openTreatmentDetail(index)
     end
@@ -572,7 +572,7 @@ end
 
 function SoilPDAScreen:_openFieldDetail(index)
     local entry = self.fieldData[index]
-    SoilLogger.info("SoilPDAScreen: _openFieldDetail index=%s, fieldId=%s", tostring(index), tostring(entry and entry.fieldId))
+    SoilLogger.debug("SoilPDAScreen: _openFieldDetail index=%s, fieldId=%s", tostring(index), tostring(entry and entry.fieldId))
     if not entry then return end
     if SoilFieldDetailDialog then
         SoilFieldDetailDialog.show(entry.fieldId)
@@ -581,7 +581,7 @@ end
 
 function SoilPDAScreen:_openTreatmentDetail(index)
     local entry = self.treatmentData[index]
-    SoilLogger.info("SoilPDAScreen: _openTreatmentDetail index=%s, fieldId=%s", tostring(index), tostring(entry and entry.fieldId))
+    SoilLogger.debug("SoilPDAScreen: _openTreatmentDetail index=%s, fieldId=%s", tostring(index), tostring(entry and entry.fieldId))
     if not entry then return end
     if SoilTreatmentDialog then
         SoilTreatmentDialog.show(entry.fieldId)

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -341,7 +341,7 @@ function SoilSettingsPanel:open()
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(true, true)
     end
-    SoilLogger.info("SoilSettingsPanel: opened")
+    SoilLogger.debug("SoilSettingsPanel: opened")
 end
 
 function SoilSettingsPanel:close()
@@ -350,7 +350,7 @@ function SoilSettingsPanel:close()
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(false)
     end
-    SoilLogger.info("SoilSettingsPanel: closed")
+    SoilLogger.debug("SoilSettingsPanel: closed")
 end
 
 -- Called every frame by SoilFertilityManager:update(). Keeps cursor shown and camera frozen.

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -79,7 +79,7 @@ end
 
 ---@param fieldId number
 function SoilTreatmentDialog.show(fieldId)
-    SoilLogger.info("SoilTreatmentDialog.show(fieldId=%s)", tostring(fieldId))
+    SoilLogger.debug("SoilTreatmentDialog.show(fieldId=%s)", tostring(fieldId))
     
     if SoilTreatmentDialog.INSTANCE == nil then
         SoilTreatmentDialog.register(SF_TREAT_MOD_DIR)


### PR DESCRIPTION
## Summary
- 18 `SoilLogger.info` calls that fire repeatedly during normal gameplay demoted to `SoilLogger.debug`
- Affected files: `SoilPDAScreen`, `SoilMapHooks`, `SoilMapOverlay`, `SoilSettingsPanel`, `SoilFieldDetailDialog`, `SoilTreatmentDialog`, `SoilHUD`
- One-time startup/initialization messages remain as `info`; with DEBUG OFF the log is now silent during play

## Test plan
- [ ] Launch game with DEBUG Mode OFF — no `[SoilFertilizer]` spam in log during normal play (open PDA, navigate field list, change map layers, open settings panel)
- [ ] Enable DEBUG Mode — all messages reappear as expected
- [ ] Startup still logs initialization messages (hooks installed, system ready)

Closes #314