### PR TITLE
i18n: update French and Polish translations (community contributions)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.5.0</version>
+    <version>2.1.5.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -640,12 +640,12 @@
     <e k="sf_admin_save_desc" v="Forcer l'enregistrement de toutes les données du sol maintenant" eh="f365613a" />
     <e k="sf_admin_reset_label" v="Réinitialiser tous les paramètres" eh="6e7d5f9f" />
     <e k="sf_admin_reset_desc" v="Restaurer tous les paramètres par défaut" eh="599b7454" />
-		<e k="sf_panel_hdr_field_tools" v="[EN] Field Tools" eh="2b250a56" />
-		<e k="sf_nav_field_tools_label" v="[EN] Field Tools" eh="2b250a56" />
-		<e k="sf_nav_field_tools_desc" v="[EN] Open specific tools to inspect and modify field states" eh="360db19b" />
-		<e k="sf_panel_hdr_vehicle_tools" v="[EN] Vehicle Tools" eh="9b6d6e4c" />
-		<e k="sf_nav_vehicle_tools_label" v="[EN] Vehicle Tools" eh="9b6d6e4c" />
-		<e k="sf_nav_vehicle_tools_desc" v="[EN] Open specific tools for connected vehicles and implements" eh="1a8b2100" />
+	<e k="sf_panel_hdr_field_tools" v="Outils de champ" eh="2b250a56" />
+    <e k="sf_nav_field_tools_label" v="Outils de champ" eh="2b250a56" />
+    <e k="sf_nav_field_tools_desc" v="Ouvrir des outils spécifiques pour inspecter et modifier l’état des champs" eh="360db19b" />
+    <e k="sf_panel_hdr_vehicle_tools" v="Outils des véhicules" eh="9b6d6e4c" />
+    <e k="sf_nav_vehicle_tools_label" v="Outils des véhicules" eh="9b6d6e4c" />
+    <e k="sf_nav_vehicle_tools_desc" v="Ouvrir des outils spécifiques pour les véhicules et outils connectés" eh="1a8b2100" />
     <e k="sf_admin_drain_label" v="Vider les réservoirs des véhicules" eh="d216b101" />
     <e k="sf_admin_drain_desc" v="Vider pulvérisateur + outils (50% remboursé)" eh="5e048a34" />
     <e k="sf_admin_field_info_label" v="Infos du champ actuel" eh="5df500d6" />
@@ -654,17 +654,17 @@
     <e k="sf_admin_field_forecast_desc" v="Prévision de rendement pour le champ à la position" eh="67e56b9d" />
     <e k="sf_admin_list_fields_label" v="Lister tous les champs" eh="efeb1b25" />
     <e k="sf_admin_list_fields_desc" v="Exporter toutes les données de sol des champs dans le log du jeu" eh="c9fa812e" />
-		<e k="sf_admin_field_set_state_label" v="[EN] Set Field State" eh="5b0d7a31" />
-		<e k="sf_admin_field_set_state_desc" v="[EN] Manually tweak N, P, K, pH, and OM values for current field" eh="a491e190" />
-		<e k="sf_admin_field_recover_label" v="[EN] Recover Field" eh="e1c82ff0" />
-		<e k="sf_admin_field_recover_desc" v="[EN] Reset the current field to default safe values (fix mistakes)" eh="68b687a2" />
+	<e k="sf_admin_field_set_state_label" v="Définir l'état du champ" eh="5b0d7a31" />
+    <e k="sf_admin_field_set_state_desc" v="Modifier manuellement les valeurs N, P, K, pH et MO du champ actuel" eh="a491e190" />
+    <e k="sf_admin_field_recover_label" v="Restaurer le champ" eh="e1c82ff0" />
+    <e k="sf_admin_field_recover_desc" v="Réinitialiser le champ actuel avec des valeurs sûres par défaut (corriger les erreurs)" eh="68b687a2" />
     <e k="sf_infobox_title" v="Nutriments du sol" eh="64377acf" />
     <e k="sf_infobox_grade" v="Qualité du sol" eh="65d1be5f" />
     <e k="sf_infobox_needs" v="Besoins" eh="94d6125d" />
     <e k="sf_infobox_fertilizer" v="Engrais" eh="cd248829" />
 
     <!-- ======================================================
-         FIELD INFO BOX (native FS25 FIELD INFO panel extension)
+         BOÎTE D'INFORMATIONS DU CHAMP (extension du panneau d'informations de champ natif FS25)
          ====================================================== -->
     <e k="sf_fieldinfo_box_title" v="Nutriments du sol" eh="64377acf" />
     <e k="sf_fieldinfo_grade" v="Qualité du sol" eh="65d1be5f" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -84,8 +84,8 @@
     <e k="sf_hud_yield" v="Resa" eh="97345487" />
     <e k="sf_hud_estYield" v="Resa Stim." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ottimale" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
-    <e k="sf_hud_hint_edit" v="Trascina: muovi  Angolo: ridimensiona  RMB/Shift+H: fatto" eh="987ebf45" />
+    <e k="sf_hud_post_harvest" v="Post-raccolta · Concimazione" eh="634de6fe" />
+    <e k="sf_hud_hint_edit" v="Trascina: muovi  Angolo: ridimensiona  RMB: fatto" eh="987ebf45" />
     <e k="sf_hud_hint_normal" v="RMB: muovi/ridimensiona" eh="afc8f13b" />
     <e k="sf_use_imperial_short" v="Unità imperiali" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Mostra le dosi in gal/ac e lb/ac (off = L/ha e kg/ha)" eh="17efa489" />
@@ -588,12 +588,12 @@
     <e k="sf_admin_save_desc" v="Forza il salvataggio di tutti i dati del suolo ora" eh="f365613a" />
     <e k="sf_admin_reset_label" v="Reset Tutte le Impostazioni" eh="6e7d5f9f" />
     <e k="sf_admin_reset_desc" v="Ripristina ogni impostazione al valore predefinito" eh="599b7454" />
-		<e k="sf_panel_hdr_field_tools" v="[EN] Field Tools" eh="2b250a56" />
-		<e k="sf_nav_field_tools_label" v="[EN] Field Tools" eh="2b250a56" />
-		<e k="sf_nav_field_tools_desc" v="[EN] Open specific tools to inspect and modify field states" eh="360db19b" />
-		<e k="sf_panel_hdr_vehicle_tools" v="[EN] Vehicle Tools" eh="9b6d6e4c" />
-		<e k="sf_nav_vehicle_tools_label" v="[EN] Vehicle Tools" eh="9b6d6e4c" />
-		<e k="sf_nav_vehicle_tools_desc" v="[EN] Open specific tools for connected vehicles and implements" eh="1a8b2100" />
+		<e k="sf_panel_hdr_field_tools" v="Strumenti Campo" eh="2b250a56" />
+    <e k="sf_nav_field_tools_label" v="Strumenti Campo" eh="2b250a56" />
+    <e k="sf_nav_field_tools_desc" v="Apri strumenti specifici per ispezionare e modificare lo stato dei campi" eh="360db19b" />
+    <e k="sf_panel_hdr_vehicle_tools" v="Strumenti Veicolo" eh="9b6d6e4c" />
+    <e k="sf_nav_vehicle_tools_label" v="Strumenti Veicolo" eh="9b6d6e4c" />
+    <e k="sf_nav_vehicle_tools_desc" v="Apri strumenti specifici per veicoli e attrezzi collegati" eh="1a8b2100" />
     <e k="sf_admin_drain_label" v="Svuota Serbatoi Veicolo" eh="d216b101" />
     <e k="sf_admin_drain_desc" v="Svuota irroratrice + attrezzi (rimborso 50%)" eh="5e048a34" />
     <e k="sf_admin_field_info_label" v="Info Campo Corrente" eh="5df500d6" />
@@ -602,10 +602,10 @@
     <e k="sf_admin_field_forecast_desc" v="Previsione della resa per il campo in posizione" eh="67e56b9d" />
     <e k="sf_admin_list_fields_label" v="Elenca Tutti i Campi" eh="efeb1b25" />
     <e k="sf_admin_list_fields_desc" v="Esporta tutti i dati del suolo nel log di gioco" eh="c9fa812e" />
-		<e k="sf_admin_field_set_state_label" v="[EN] Set Field State" eh="5b0d7a31" />
-		<e k="sf_admin_field_set_state_desc" v="[EN] Manually tweak N, P, K, pH, and OM values for current field" eh="a491e190" />
-		<e k="sf_admin_field_recover_label" v="[EN] Recover Field" eh="e1c82ff0" />
-		<e k="sf_admin_field_recover_desc" v="[EN] Reset the current field to default safe values (fix mistakes)" eh="68b687a2" />
+    <e k="sf_admin_field_set_state_label" v="Imposta Stato Campo" eh="5b0d7a31" />
+    <e k="sf_admin_field_set_state_desc" v="Modifica manualmente i valori di N, P, K, pH e SO per il campo attuale" eh="a491e190" />
+    <e k="sf_admin_field_recover_label" v="Ripristina Campo" eh="e1c82ff0" />
+    <e k="sf_admin_field_recover_desc" v="Ripristina il campo attuale ai valori predefiniti di sicurezza (corregge errori)" eh="68b687a2" />
     <e k="sf_infobox_title" v="Nutrienti del Suolo" eh="64377acf" />
     <e k="sf_infobox_grade" v="Qualità Suolo" eh="65d1be5f" />
     <e k="sf_infobox_needs" v="Fabbisogni" eh="94d6125d" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -18,8 +18,8 @@
     <e k="sf_pest_pressure_long" v="Włącz/wyłącz system  szkodników i owadów" eh="18015099" />
     <e k="sf_disease_pressure_short" v="Presja chorób" eh="953fd6c0" />
     <e k="sf_disease_pressure_long" v="Włącz/wyłącz system chorób grzybowych i roślinnych" eh="2c36ea57" />
-    <e k="sf_compaction_short" v="Zagęszczenie Gleby" eh="00000000" />
-    <e k="sf_compaction_long" v="Włącz/wyłącz system zagęszczenia gleby" eh="00000000" />
+    <e k="sf_compaction_short" v="Zagęszczenie Gleby" eh="68734a56" />
+    <e k="sf_compaction_long" v="Włącz/wyłącz system zagęszczenia gleby" eh="a0995ec5" />
     <e k="sf_fertility_short" v="System Żyzności" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Włącz/wyłącz dynamiczny system żyzności gleby" eh="ea074366" />
     <e k="sf_nutrients_short" v="Cykle Składników" eh="ffab595d" />
@@ -82,7 +82,7 @@
     <e k="input_SF_OPEN_SETTINGS" v="Otwórz ustawienia gleby" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetuj ustawienia gleby" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Przełącz HUD gleby" eh="f0224a10" />
-    <e k="input_SF_HUD_DRAG" v="Tryb przeciągania HUD" eh="00000000" />
+    <e k="input_SF_HUD_DRAG" v="Tryb przeciągania HUD" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Raport Gleby" eh="c33180ef" />
     <e k="input_SF_RATE_UP" v="Zwiększ dawkę nawozu" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Zmniejsz dawkę nawozu" eh="30712026" />
@@ -365,7 +365,7 @@
 	<e k="sf_map_layer_weed" v="Presja chwastów" eh="53f8b936" />
 	<e k="sf_map_layer_pest" v="Presja szkodników" eh="18a7c2be" />
 	<e k="sf_map_layer_disease" v="Presja chorób" eh="2b805cc9" />
-    <e k="sf_map_layer_compaction" v="Zagęszczenie" eh="00000000" />
+    <e k="sf_map_layer_compaction" v="Zagęszczenie" eh="19cf3ee7" />
 	<e k="sf_map_overlay_cycle" v="Shift+M: przełącz warstwy gleby" eh="032fdac7" />
 	<e k="sf_map_page_title" v="Warstwy gleby" eh="04a675fb" />
 	<e k="sf_map_sidebar_header" v="Warstwa mapy glebowej" eh="81332549" />
@@ -426,7 +426,7 @@
     <e k="sf_pda_help_text" v="Cześć, jestem deweloperem! Jak widzisz, ta strona jest jeszcze w trakcie budowy. Warstwy mapy to obecnie tylko podglądy wizualne (niedziałające do zaznaczania), a wiele elementów interfejsu wymaga jeszcze ostatecznych poprawek." eh="58e05bdf" />
     <e k="sf_pda_help_github" v="TWOJA OPINIA MA ZNACZENIE! Jeśli napotkasz błędy, masz sugestie dotyczące nowych funkcji lub chcesz wnieść wkład w kod, odwiedź projekt na GitHubie. Możesz otworzyć Issue lub Pull Request w dowolnym momencie, aby pomóc ulepszyć ten mod dla wszystkich. Dziękujemy za testowanie!" eh="3a10b023" />
 	<e k="sf_pda_help_note" v="Zakładka &quot;Warstwy gleby&quot; na stronie mapy NIE DZIAŁA. Wiem o tym i pracuję nad rozwiązaniem tego problemu (co może trochę potrwać)." eh="2d8f5dc7" />
-    <e k="sf_pda_map_unavailable" v="Podgląd mapy niedostępny" eh="00000000" />
+    <e k="sf_pda_map_unavailable" v="Podgląd mapy niedostępny" eh="43983f81" />
 	<e k="sf_map_health_overall" v="Średni poziom zdrowia gleby" eh="5533cbe3" />
 	<e k="sf_map_btn_report" v="Otwórz przegląd gospodarstwa" eh="6f0800e8" />
 	<e k="sf_map_btn_help" v=" Notatka od wydawcy (aktualnie nie działa)" eh="800e465a" />
@@ -654,12 +654,12 @@
     <e k="sf_admin_save_desc" v="Wymuś zapisanie wszystkich danych gleby" eh="f365613a" />
     <e k="sf_admin_reset_label" v="Resetuj wszystkie ustawienia" eh="6e7d5f9f" />
     <e k="sf_admin_reset_desc" v="Przywróć każde ustawienie do wartości domyślnej" eh="599b7454" />
-		<e k="sf_panel_hdr_field_tools" v="[EN] Field Tools" eh="2b250a56" />
-		<e k="sf_nav_field_tools_label" v="[EN] Field Tools" eh="2b250a56" />
-		<e k="sf_nav_field_tools_desc" v="[EN] Open specific tools to inspect and modify field states" eh="360db19b" />
-		<e k="sf_panel_hdr_vehicle_tools" v="[EN] Vehicle Tools" eh="9b6d6e4c" />
-		<e k="sf_nav_vehicle_tools_label" v="[EN] Vehicle Tools" eh="9b6d6e4c" />
-		<e k="sf_nav_vehicle_tools_desc" v="[EN] Open specific tools for connected vehicles and implements" eh="1a8b2100" />
+    <e k="sf_panel_hdr_field_tools" v="Narzędzia pola" eh="2b250a56" />
+    <e k="sf_nav_field_tools_label" v="Narzędzia pola" eh="2b250a56" />
+    <e k="sf_nav_field_tools_desc" v="Otwórz konkretne narzędzia do inspekcji i modyfikacji stanu pola" eh="360db19b" />
+    <e k="sf_panel_hdr_vehicle_tools" v="Narzędzia pojazdu" eh="9b6d6e4c" />
+    <e k="sf_nav_vehicle_tools_label" v="Narzędzia pojazdu" eh="9b6d6e4c" />
+    <e k="sf_nav_vehicle_tools_desc" v="Otwórz konkretne narzędzia dla połączonych pojazdów i urządzeń" eh="1a8b2100" />
     <e k="sf_admin_drain_label" v="Opróżnij zbiorniki pojazdu" eh="d216b101" />
     <e k="sf_admin_drain_desc" v="Opróżnij opryskiwacz + narzędzia (50% zwrotu)" eh="5e048a34" />
     <e k="sf_admin_field_info_label" v="Informacje o polu" eh="5df500d6" />
@@ -668,10 +668,10 @@
     <e k="sf_admin_field_forecast_desc" v="Prognoza plonu dla pola na którym jesteś" eh="67e56b9d" />
     <e k="sf_admin_list_fields_label" v="Lista wszystkich pól" eh="efeb1b25" />
     <e k="sf_admin_list_fields_desc" v="Zapisz dane wszystkich pól do logu gry" eh="c9fa812e" />
-		<e k="sf_admin_field_set_state_label" v="[EN] Set Field State" eh="5b0d7a31" />
-		<e k="sf_admin_field_set_state_desc" v="[EN] Manually tweak N, P, K, pH, and OM values for current field" eh="a491e190" />
-		<e k="sf_admin_field_recover_label" v="[EN] Recover Field" eh="e1c82ff0" />
-		<e k="sf_admin_field_recover_desc" v="[EN] Reset the current field to default safe values (fix mistakes)" eh="68b687a2" />
+    <e k="sf_admin_field_set_state_label" v="Ustaw stan pola" eh="5b0d7a31" />
+    <e k="sf_admin_field_set_state_desc" v="Ręcznie dostosuj wartości N, P, K, pH i OM dla aktualnego pola" eh="a491e190" />
+    <e k="sf_admin_field_recover_label" v="Przywróć pole" eh="e1c82ff0" />
+    <e k="sf_admin_field_recover_desc" v="Zresetuj aktualne pole do domyślnych bezpiecznych wartości (napraw błędy)" eh="68b687a2" />
     <e k="sf_infobox_title" v="Składniki odżywcze gleby" eh="64377acf" />
     <e k="sf_infobox_grade" v="Stopień gleby" eh="65d1be5f" />
     <e k="sf_infobox_needs" v="Potrzeby" eh="94d6125d" />


### PR DESCRIPTION
## Summary

- **French (fr):** 10 previously-untranslated `[EN]` keys now translated — native update by Squall39 (Seb) via [#256](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/256)
- **Polish (pl):** 10 previously-untranslated `[EN]` keys now translated — native update by DanielloHQ via [#256](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/256); also corrected 5 stale `00000000` `eh` hashes

Keys covered in both languages: `sf_panel_hdr_field_tools`, `sf_nav_field_tools_*`, `sf_panel_hdr_vehicle_tools`, `sf_nav_vehicle_tools_*`, `sf_admin_field_set_state_*`, `sf_admin_field_recover_*`

## Notes
- PL: preserved our `sf_notify_welcome` (contributor's version referenced outdated `Shift+O` binding)
- PL: preserved our `sf_hud_hint_edit` (contributor's version was missing `Shift+H`)

## Test plan
- [ ] Load game with French locale — verify Field Tools / Vehicle Tools / admin panel labels render in French
- [ ] Load game with Polish locale — verify same sections render in Polish
- [ ] No `[EN]` prefix visible in either locale