### PR TITLE
2.1.5.2 — Fix weeder/hoe crash + debug log spam

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.5.1</version>
+    <version>2.1.5.2</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -435,7 +435,7 @@ function SoilFertilitySystem:onSowing(fieldId)
     -- Fully resets weed pressure: the physical act of drilling/planting breaks
     -- weed root systems and buries surface seeds in the seed furrow.
     if self.settings.weedPressure and SoilConstants.WEED_PRESSURE and (field.weedPressure or 0) > 0 then
-        self:debug("[Sowing] Field %d: weed %.0f -> 0", fieldId, field.weedPressure)
+        SoilLogger.debug("[Sowing] Field %d: weed %.0f -> 0", fieldId, field.weedPressure)
         field.weedPressure = 0
         field.herbicideDaysLeft = 0
         changed = true
@@ -458,7 +458,7 @@ function SoilFertilitySystem:onPlowing(fieldId)
     local field = self:getOrCreateField(fieldId, true)
     if not field then return end
 
-    self:debug("[Plowing] Field %d triggered (plowingBonus=%s, weedPressure=%s)",
+    SoilLogger.debug("[Plowing] Field %d triggered (plowingBonus=%s, weedPressure=%s)",
         fieldId, tostring(self.settings.plowingBonus), tostring(self.settings.weedPressure))
 
     local changed = false
@@ -487,13 +487,13 @@ function SoilFertilitySystem:onPlowing(fieldId)
             changed = true
         end
 
-        self:debug("[Plowing] Field %d: OM %.1f->%.1f, pH %.2f->%.2f",
+        SoilLogger.debug("[Plowing] Field %d: OM %.1f->%.1f, pH %.2f->%.2f",
             fieldId, omBefore, omAfter, phBefore, phAfter)
     end
 
     -- Plowing benefit 3: Reset weed pressure (independent of plowingBonus)
     if self.settings.weedPressure and (field.weedPressure or 0) > 0 then
-        self:debug("[Plowing] Field %d: weed %.0f -> 0", fieldId, field.weedPressure)
+        SoilLogger.debug("[Plowing] Field %d: weed %.0f -> 0", fieldId, field.weedPressure)
         field.weedPressure = 0
         field.herbicideDaysLeft = 0
         changed = true
@@ -503,7 +503,7 @@ function SoilFertilitySystem:onPlowing(fieldId)
     if self.settings.pestPressure and SoilConstants.PLOWING.PEST_PRESSURE_REDUCTION and (field.pestPressure or 0) > 0 then
         local before = field.pestPressure
         field.pestPressure = math.max(0, before - SoilConstants.PLOWING.PEST_PRESSURE_REDUCTION)
-        self:debug("[Plowing] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
+        SoilLogger.debug("[Plowing] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
         changed = true
     end
 
@@ -511,7 +511,7 @@ function SoilFertilitySystem:onPlowing(fieldId)
     if self.settings.diseasePressure and SoilConstants.PLOWING.DISEASE_PRESSURE_REDUCTION and (field.diseasePressure or 0) > 0 then
         local before = field.diseasePressure
         field.diseasePressure = math.max(0, before - SoilConstants.PLOWING.DISEASE_PRESSURE_REDUCTION)
-        self:debug("[Plowing] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
+        SoilLogger.debug("[Plowing] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
         changed = true
     end
 
@@ -532,7 +532,7 @@ function SoilFertilitySystem:onCultivation(fieldId)
     local field = self:getOrCreateField(fieldId, false)
     if not field then return end
 
-    self:debug("[Cultivation] Field %d triggered (weedPressure=%.0f)", fieldId, field.weedPressure or 0)
+    SoilLogger.debug("[Cultivation] Field %d triggered (weedPressure=%.0f)", fieldId, field.weedPressure or 0)
 
     local changed = false
     local c = SoilConstants.CULTIVATION
@@ -540,21 +540,21 @@ function SoilFertilitySystem:onCultivation(fieldId)
     if self.settings.weedPressure and c.WEED_PRESSURE_REDUCTION and (field.weedPressure or 0) > 0 then
         local before = field.weedPressure
         field.weedPressure = math.max(0, before - c.WEED_PRESSURE_REDUCTION)
-        self:debug("[Cultivation] Field %d: weed %.0f -> %.0f", fieldId, before, field.weedPressure)
+        SoilLogger.debug("[Cultivation] Field %d: weed %.0f -> %.0f", fieldId, before, field.weedPressure)
         changed = true
     end
 
     if self.settings.pestPressure and c.PEST_PRESSURE_REDUCTION and (field.pestPressure or 0) > 0 then
         local before = field.pestPressure
         field.pestPressure = math.max(0, before - c.PEST_PRESSURE_REDUCTION)
-        self:debug("[Cultivation] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
+        SoilLogger.debug("[Cultivation] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
         changed = true
     end
 
     if self.settings.diseasePressure and c.DISEASE_PRESSURE_REDUCTION and (field.diseasePressure or 0) > 0 then
         local before = field.diseasePressure
         field.diseasePressure = math.max(0, before - c.DISEASE_PRESSURE_REDUCTION)
-        self:debug("[Cultivation] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
+        SoilLogger.debug("[Cultivation] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
         changed = true
     end
 
@@ -580,7 +580,7 @@ function SoilFertilitySystem:onStripTill(fieldId)
     local st = SoilConstants.STRIP_TILL
     local changed = false
 
-    self:debug("[StripTill] Field %d triggered — weed=%.0f pest=%.0f disease=%.0f OM=%.2f",
+    SoilLogger.debug("[StripTill] Field %d triggered — weed=%.0f pest=%.0f disease=%.0f OM=%.2f",
         fieldId,
         field.weedPressure    or 0,
         field.pestPressure    or 0,
@@ -591,7 +591,7 @@ function SoilFertilitySystem:onStripTill(fieldId)
     if self.settings.weedPressure and (field.weedPressure or 0) > 0 then
         local before = field.weedPressure
         field.weedPressure = math.max(0, before - st.WEED_PRESSURE_REDUCTION)
-        self:debug("[StripTill] Field %d: weed %.0f -> %.0f", fieldId, before, field.weedPressure)
+        SoilLogger.debug("[StripTill] Field %d: weed %.0f -> %.0f", fieldId, before, field.weedPressure)
         changed = true
     end
 
@@ -599,7 +599,7 @@ function SoilFertilitySystem:onStripTill(fieldId)
     if self.settings.pestPressure and (field.pestPressure or 0) > 0 then
         local before = field.pestPressure
         field.pestPressure = math.max(0, before - st.PEST_PRESSURE_REDUCTION)
-        self:debug("[StripTill] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
+        SoilLogger.debug("[StripTill] Field %d: pest %.0f -> %.0f", fieldId, before, field.pestPressure)
         changed = true
     end
 
@@ -607,7 +607,7 @@ function SoilFertilitySystem:onStripTill(fieldId)
     if self.settings.diseasePressure and (field.diseasePressure or 0) > 0 then
         local before = field.diseasePressure
         field.diseasePressure = math.max(0, before - st.DISEASE_PRESSURE_REDUCTION)
-        self:debug("[StripTill] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
+        SoilLogger.debug("[StripTill] Field %d: disease %.0f -> %.0f", fieldId, before, field.diseasePressure)
         changed = true
     end
 
@@ -618,7 +618,7 @@ function SoilFertilitySystem:onStripTill(fieldId)
                                   omBefore + st.OM_BOOST)
         if omAfter > omBefore then
             field.organicMatter = omAfter
-            self:debug("[StripTill] Field %d: OM %.2f -> %.2f", fieldId, omBefore, omAfter)
+            SoilLogger.debug("[StripTill] Field %d: OM %.2f -> %.2f", fieldId, omBefore, omAfter)
             changed = true
         end
     end


### PR DESCRIPTION
## Summary

- **Fix**: Weeder/hoe usage caused a Lua error (`attempt to call missing method 'debug'`) — affected cultivation, plowing, sowing, and strip-till hooks (#321)
- **Fix**: Debug log messages no longer flood the game log when DEBUG Mode is off (#314)
- **i18n**: Updated French, Polish, and Italian translations (community contributions)

## Migration

No savegame changes required. Drop in the new zip and go.