### PR TITLE
feat: startup InfoDialog with version, changelog, and author info (v2.1.5.3)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.5.2</version>
+    <version>2.1.5.3</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -579,18 +579,20 @@ function SoilFertilityManager:deferredSoilSystemInit()
                 self.sfm:loadSoilData()
 
                 -- Show activation dialog
+                -- The hardcoded values are here for a reason, and will NOT be translated.
                 if self.sfm.settings.showNotifications and InfoDialog.INSTANCE ~= nil then
-                    local modInfo = g_modManager and g_modManager:getModByName(g_currentModName)
+                    local modInfo = g_modManager and g_modManager:getModByName(self.sfm.modName)
                     local version = (modInfo and modInfo.version) or "?"
                     local sep = "--------------------------------"
-                    local text = "Soil & Fertilizer  |  v" .. version .. "\n"
+                    local text = "FS25_SoilFertilizer  |  v" .. version .. "\n"
+                        .. "Author: TisonK\n"
                         .. sep .. "\n\n"
                         .. "What's new:\n"
+                        .. "  - Created this new version dialog on startup\n"
                         .. "  - Removed Precision Farming dependency\n"
                         .. "  - Fixed debug logging in field hooks\n"
                         .. "  - Community translations updated (FR, PL, IT)\n\n"
-                        .. sep .. "\n"
-                        .. "Author: TisonK\n\n"
+                        .. sep .. "\n\n"
                         .. g_i18n:getText("sf_startup_dialog_footer")
                     InfoDialog.show(text)
                 end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -578,12 +578,21 @@ function SoilFertilityManager:deferredSoilSystemInit()
                 -- Load saved soil data now that savegameDirectory is set
                 self.sfm:loadSoilData()
 
-                -- Show activation notification
-                if self.sfm.settings.showNotifications and g_currentMission and g_currentMission.hud then
-                    g_currentMission.hud:showBlinkingWarning(
-                        g_i18n:getText("sf_notify_mod_active_hud"),
-                        8000
-                    )
+                -- Show activation dialog
+                if self.sfm.settings.showNotifications and InfoDialog.INSTANCE ~= nil then
+                    local modInfo = g_modManager and g_modManager:getModByName(g_currentModName)
+                    local version = (modInfo and modInfo.version) or "?"
+                    local sep = "--------------------------------"
+                    local text = "Soil & Fertilizer  |  v" .. version .. "\n"
+                        .. sep .. "\n\n"
+                        .. "What's new:\n"
+                        .. "  - Removed Precision Farming dependency\n"
+                        .. "  - Fixed debug logging in field hooks\n"
+                        .. "  - Community translations updated (FR, PL, IT)\n\n"
+                        .. sep .. "\n"
+                        .. "Author: TisonK\n\n"
+                        .. g_i18n:getText("sf_startup_dialog_footer")
+                    InfoDialog.show(text)
                 end
             end)
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -134,10 +134,6 @@ function SoilFertilitySystem:initialize()
     -- Log multifruit compatibility status
     self:logCropProfileStatus()
 
-    -- Show notification
-    if self.settings.enabled and self.settings.showNotifications then
-        self:showNotification(g_i18n:getText("sf_notify_mod_active_title"), g_i18n:getText("sf_notify_mod_active_body"))
-    end
 end
 
 -- Log which registered fruit types have explicit extraction profiles

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Solo &amp; Fertilizante" eh="f31197fb" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -532,7 +532,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="土壤與肥料" eh="d30a22a9" />
@@ -532,8 +532,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Půda &amp; Hnojivo" eh="f31197fb" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -491,7 +491,7 @@
     <e k="sf_sprayer_burn_possible" v="RISIKO FOR SVIDNING: MULIG" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Jord &amp; gødningsmod aktiv | j = hud | k = jordrapport | skriv 'soilfertility' for at se kommandoer" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="Jordmod: initialisering af marken er forsinket. forsøger alternativ metode..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Jordmod: initialisering af marken gennemført!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Kritisk alarm" eh="3f981d0c" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Grøn" eh="d382816a" />
@@ -491,8 +491,7 @@
     <e k="sf_sprayer_burn_possible" v="RISIKO FOR SVIDNING: MULIG" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Jord &amp; gødningsmod aktiv | j = hud | k = jordrapport | skriv 'soilfertility' for at se kommandoer" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="Jord &amp; gødningsmod aktiv" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="Realistisk jordsystem med fuld event-integration" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="Jordmod: initialisering af marken er forsinket. forsøger alternativ metode..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Jordmod: initialisering af marken gennemført!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Kritisk alarm" eh="3f981d0c" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Boden &amp; Dünger" eh="f31197fb" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Soil &amp; Fertilizer" eh="d30a22a9" />
@@ -542,7 +542,7 @@
          NOTIFICATIONS
          ====================================================== -->
     <e k="sf_notify_welcome" v="Soil &amp; Fertilizer Mod Active | Shift+O to open settings | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -542,8 +542,7 @@
          NOTIFICATIONS
          ====================================================== -->
     <e k="sf_notify_welcome" v="Soil &amp; Fertilizer Mod Active | Shift+O to open settings | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="FS25_SoilFertilizer | v2.0.9.1 | Author: TisonK" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="Happy farming!" />
     <e k="sf_notify_init_delayed" v="Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suelo y Fertilizante" eh="f31197fb" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="绿色" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Vihreä" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -539,7 +539,7 @@
     
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Mod Sol &amp; Engrais actif | J = HUD | K = Rapport du sol | Tapez 'soilfertility' pour les commandes" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="Mod Sol : initialisation des champs retardée. Tentative d'une méthode alternative..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Mod Sol : initialisation des champs réussie !" eh="46214360" />
     <e k="sf_notify_critical_title" v="Alerte critique" eh="3f981d0c" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Sol et engrais" eh="d30a22a9" />
@@ -539,8 +539,7 @@
     
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Mod Sol &amp; Engrais actif | J = HUD | K = Rapport du sol | Tapez 'soilfertility' pour les commandes" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="Mod Sol &amp; Engrais actif" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="Système de sol réaliste avec gestion complète des événements" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="Mod Sol : initialisation des champs retardée. Tentative d'une méthode alternative..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Mod Sol : initialisation des champs réussie !" eh="46214360" />
     <e k="sf_notify_critical_title" v="Alerte critique" eh="3f981d0c" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Talaj &amp; Műtrágya" eh="f31197fb" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Hijau" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -491,7 +491,7 @@
     <e k="sf_sprayer_burn_possible" v="RISCHIO BRUCIATURA: POSSIBILE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Mod Soil &amp; Fertilizer Attiva | J = HUD | K = Analisi Suolo | Scrivi 'soilfertility' per i comandi" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="Soil Mod: Inizializzazione campo ritardata. Prova metodo alternativo..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Soil Mod: Inizializzazione campo riuscita!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Allerta Cura Critica" eh="3f981d0c" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suolo &amp; Fertilizzante" eh="f31197fb" />
@@ -491,8 +491,7 @@
     <e k="sf_sprayer_burn_possible" v="RISCHIO BRUCIATURA: POSSIBILE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Mod Soil &amp; Fertilizer Attiva | J = HUD | K = Analisi Suolo | Scrivi 'soilfertility' per i comandi" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="Mod Soil &amp; Fertilizer Attiva" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="Sistema del suolo realistico con hook completi" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="Soil Mod: Inizializzazione campo ritardata. Prova metodo alternativo..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Soil Mod: Inizializzazione campo riuscita!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Allerta Cura Critica" eh="3f981d0c" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="グリーン" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="ì´ˆë¡" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -496,7 +496,7 @@
     <e k="sf_sprayer_burn_possible" v="VERBRANDINGSRISICO: MOGELIJK" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Bodem &amp; Meststof Mod Actief | J = HUD | K = Bodemrapport | Typ 'soilfertility' voor opdrachten" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="Bodem Mod: Veldinitialisatie vertraagd. Alternatieve methode wordt geprobeerd..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Bodem Mod: Veldinitialisatie geslaagd!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Kritieke Zorgwaarschuwing" eh="3f981d0c" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Bodem &amp; Meststoffen" eh="d30a22a9" />
@@ -496,8 +496,7 @@
     <e k="sf_sprayer_burn_possible" v="VERBRANDINGSRISICO: MOGELIJK" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Bodem &amp; Meststof Mod Actief | J = HUD | K = Bodemrapport | Typ 'soilfertility' voor opdrachten" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="Bodem &amp; Meststof Mod Actief" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="Echt bodemsysteem met volledige gebeurteniskoppelingen" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="Bodem Mod: Veldinitialisatie vertraagd. Alternatieve methode wordt geprobeerd..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Bodem Mod: Veldinitialisatie geslaagd!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Kritieke Zorgwaarschuwing" eh="3f981d0c" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Grønn" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -541,7 +541,7 @@
          NOTIFICATIONS
          ====================================================== -->
     <e k="sf_notify_welcome" v="Realistyczne Nawożenie &amp; Gleby Włączone | J = HUD | K = Raport glebowy | Użyj 'soilfertility' dla komend" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="Mod gleby Opóźnienie w inicjalizacji pola. Próbuję zastosować alternatywną metodę..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Mod gleby: Inicjalizacja pola zakończona sukcesem!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Krytyczne zaniedbanie" eh="3f981d0c" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Gleba &amp; Nawóz" eh="f31197fb" />
@@ -541,8 +541,7 @@
          NOTIFICATIONS
          ====================================================== -->
     <e k="sf_notify_welcome" v="Realistyczne Nawożenie &amp; Gleby Włączone | J = HUD | K = Raport glebowy | Użyj 'soilfertility' dla komend" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="Realistyczne Nawożenie &amp; Gleby Włączone" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="System realistycznych gleb i nawożeń z pełnym zestawem funkcji i zdarzeń" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="Mod gleby Opóźnienie w inicjalizacji pola. Próbuję zastosować alternatywną metodę..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Mod gleby: Inicjalizacja pola zakończona sukcesem!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Krytyczne zaniedbanie" eh="3f981d0c" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Verde" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Почва и удобрения" eh="f31197fb" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Grön" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Yeşil" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -498,7 +498,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Грунт та добриво" eh="f31197fb" />
@@ -498,8 +498,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -497,7 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
+    <e k="sf_startup_dialog_footer" v="[EN] Your soil remembers everything 🌱" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_hud_color_1" v="Xanh lá" eh="d382816a" />
@@ -497,8 +497,7 @@
     <e k="sf_sprayer_burn_possible" v="[EN] BURN RISK: POSSIBLE" eh="25b251b6" />
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="[EN] Soil &amp; Fertilizer Mod Active | J = HUD | K = Soil Report | Type 'soilfertility' for commands" eh="3fde93cd" />
-    <e k="sf_notify_mod_active_title" v="[EN] Soil &amp; Fertilizer Mod Active" eh="15edc102" />
-    <e k="sf_notify_mod_active_body" v="[EN] Real soil system with full event hooks" eh="901e2106" />
+    <e k="sf_startup_dialog_footer" v="[EN] Happy farming!" />
     <e k="sf_notify_init_delayed" v="[EN] Soil Mod: Field initialization delayed. Trying alternative method..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="[EN] Soil Mod: Field initialization successful!" eh="46214360" />
     <e k="sf_notify_critical_title" v="[EN] Critical Care Alert" eh="3f981d0c" />


### PR DESCRIPTION
## Summary

- Replaces the blinking warning on mod load with a proper `InfoDialog` popup
- Dialog shows: mod name, live version (read from `g_modManager`), author, changelog, and a footer
- Fixed `v?` bug — was using `g_currentModName` which is nil in deferred callbacks; now uses `self.sfm.modName`
- Author line moved directly under the version header
- Footer updated to: *Your soil remembers everything 🌱*
- Removed orphaned `sf_notify_mod_active_*` translation keys across all 26 languages
- Per-field notifications (fertilizer applied, critical nutrients) unchanged — still blinking warnings

## Test plan

- [ ] Load a save — confirm InfoDialog appears on game load with correct version number
- [ ] Confirm Author: TisonK appears under the version line
- [ ] Confirm footer reads "Your soil remembers everything 🌱"
- [ ] Confirm per-field notifications still show as blinking warnings
- [ ] Confirm dialog does NOT appear if Notifications are disabled in settings