### PR TITLE
v2.1.6.0 — bug fixes, zoneData sync, legume support, time-scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.5.7
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -150,8 +150,11 @@
         <storeItem xmlFilename="objects/bigBag/gypsum/multiPurchaseBigBag_gypsum.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/multiPurchaseBigBag_compost.xml"/>
         <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml"/>
+        <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure_10k.xml"/>
         <!-- Single items — registered for multiPurchase spawning, hidden from shop UI -->
         <storeItem xmlFilename="objects/liquidTank/uan32/liquidTank_uan32.xml"/>
         <storeItem xmlFilename="objects/liquidTank/uan28/liquidTank_uan28.xml"/>
@@ -174,8 +177,11 @@
         <storeItem xmlFilename="objects/bigBag/gypsum/bigBag_gypsum.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost.xml"/>
         <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids.xml"/>
+        <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/chicken_manure/bigBag_chicken_manure_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml"/>
+        <storeItem xmlFilename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure_10k.xml"/>
     </storeItems>
 
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.5.7</version>
+    <version>2.1.6.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/objects/bigBag/biosolids/bigBag_biosolids_10k.xml
+++ b/objects/bigBag/biosolids/bigBag_biosolids_10k.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <name>$l10n_sf_bigBag_biosolids_10k_name</name>
+        <specs>
+            <weight ignore="true"/>
+        </specs>
+        <image>$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>4800</price>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <functions><function>$l10n_sf_bigBag_biosolids_function</function></functions>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopHeight>2</shopHeight>
+        <showInStore>false</showInStore>
+        <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
+        <textureMemoryUsage>851968</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_typeDesc_pallet</typeDesc>
+        <filename>objects/bigBag/biosolids/bigBag_biosolids.i3d</filename>
+        <size width="1.25" length="1.25" height="1.75"/>
+        <input allowed="false"/>
+        <canBeReset>false</canBeReset>
+        <components maxMass="850">
+            <component centerOfMass="0 0.1 0" solverIterationCount="40" mass="150" />
+            <component centerOfMass="0 0 0"   solverIterationCount="40" mass="100" />
+            <joint component1="2" component2="1" node="componentJointHook" rotLimit="0 0 0" transLimit="0 0 0" rotLimitSpring="50 50 50" rotLimitDamping="65 65 65"/>
+        </components>
+        <showInVehicleMenu>false</showInVehicleMenu>
+        <mapHotspot available="false" />
+        <schemaOverlay attacherJointPosition="0 0" name="IMPLEMENT" />
+    </base>
+
+    <attachable>
+        <inputAttacherJoints>
+            <inputAttacherJoint node="attacherJoint01" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+            <inputAttacherJoint node="attacherJoint02" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+        </inputAttacherJoints>
+    </attachable>
+
+    <animations>
+        <animation name="bigBagSizeAnimation">
+            <part node="sizeCollision01" startTime="0" endTime="1.0" startTrans="-0.075 0.0 -0.125" endTrans="-0.25 0 -0.25"/>
+            <part node="sizeCollision02" startTime="0" endTime="1.0" startTrans="0.1 0.0 -0.125" endTrans="0.25 0 -0.25"/>
+            <part node="sizeCollision03" startTime="0" endTime="1.0" startTrans="0.1 0.0 0.15" endTrans="0.25 0 0.25"/>
+            <part node="sizeCollision04" startTime="0" endTime="1.0" startTrans="-0.075 0.0 0.15" endTrans="-0.25 0 0.25"/>
+            <part node="sizeJoint08" startTime="0.0" endTime="1.0" startTrans="0.0 0 -0.24" endTrans="0.0 0.0 -0.38" />
+            <part node="sizeJoint07" startTime="0.0" endTime="1.0" startTrans="0.0 0 0.267" endTrans="0.0 0.0 0.38" />
+            <part node="sizeJoint06" startTime="0.0" endTime="1.0" startTrans="0.245 0 0.0" endTrans="0.45 0.0 0.0" />
+            <part node="sizeJoint05" startTime="0.0" endTime="1.0" startTrans="-0.245 0 0.0" endTrans="-0.45 0.0 0.0" />
+            <part node="sizeJoint04" startTime="0.0" endTime="1.0" startTrans="-0.2 0 0.2" endTrans="-0.405 0.0 0.304" />
+            <part node="sizeJoint03" startTime="0.0" endTime="1.0" startTrans="0.2 0 0.2" endTrans="0.405 0.0 0.304" />
+            <part node="sizeJoint02" startTime="0.0" endTime="1.0" startTrans="0.2 0 -0.2" endTrans="0.405 0.0 -0.304" />
+            <part node="sizeJoint01" startTime="0.0" endTime="1.0" startTrans="-0.2 0 -0.2" endTrans="-0.405 0.0 -0.304" />
+            <part node="tensionBeltMesh01" startTime="0" endTime="1.0" startScale="0.735 1.0 0.854" endScale="1 1 1"/>
+            <part node="tensionBeltMesh02" startTime="0" endTime="1.0" startScale="0.6 1.0 0.8" endScale="1 1 1"/>
+        </animation>
+    </animations>
+
+    <bigBag fillUnitIndex="1">
+        <sizeAnimation name="bigBagSizeAnimation" minTime="0.4" maxTime="1" liftShrinkTime="0.15"/>
+        <componentJoint index="1" minRotLimit="0 0 0" maxRotLimit="0 55 55" minTransLimit="0.2 0 0" maxTransLimit="0.1 0 0" angularDamping="1"/>
+    </bigBag>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration name="$l10n_configuration_valueDefault">
+                <fillUnits removeVehicleIfEmpty="true">
+                    <fillUnit unitTextOverride="$l10n_unit_literShort" fillTypes="BIOSOLIDS" capacity="10000" startFillType="BIOSOLIDS" startFillLevel="10000" ignoreFillLimit="true">
+                        <fillRootNode node="0>" />
+                        <fillTypeMaterials>
+                            <material fillType="BIOSOLIDS" node="bigBag_vis" refNode="fertilizer_mat"/>
+                        </fillTypeMaterials>
+                    </fillUnit>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <dischargeable requiresTipOcclusionArea="false">
+        <dischargeNode node="raycastNode" emptySpeed="250" fillUnitIndex="1" maxDistance="6" canStartDischargeAutomatically="true">
+            <raycast useWorldNegYDirection="true" />
+            <info width="0.4" length="0.4" />
+            <activationTrigger node="dischargeActivationTrigger" />
+            <stateObjectChanges>
+                <objectChange node="outputOpen" visibilityActive="true" visibilityInactive="false"/>
+                <objectChange node="outputClose" visibilityActive="false" visibilityInactive="true"/>
+            </stateObjectChanges>
+            <distanceObjectChanges threshold="0.3">
+                <objectChange node="outputParts" visibilityActive="true" visibilityInactive="false"/>
+            </distanceObjectChanges>
+            <effects>
+                <effectNode effectClass="PipeEffect" effectNode="pipeEffect"  materialType="pipe"           delay="0"   maxBending="1"  positionUpdateNodes="smokeEffect"/>
+                <effectNode                          effectNode="smokeEffect" materialType="unloadingSmoke" delay="0.1" alignToWorldY="true"/>
+            </effects>
+        </dischargeNode>
+    </dischargeable>
+
+    <fillTriggerVehicle triggerNode="fillTrigger" fillUnitIndex="1" litersPerSecond="200"/>
+
+    <tensionBeltObject>
+        <meshNodes>
+            <meshNode node="tensionBeltMesh01"/>
+            <meshNode node="tensionBeltMesh02"/>
+        </meshNodes>
+    </tensionBeltObject>
+
+    <i3dMappings>
+        <i3dMapping id="raycastNode"                node="0>0|0" />
+        <i3dMapping id="fillTrigger"                node="0>0|1" />
+        <i3dMapping id="dischargeActivationTrigger" node="0>0|2" />
+        <i3dMapping id="tensionBeltMesh02"          node="0>0|3" />
+        <i3dMapping id="bigBag_vis"                 node="0>1|0" />
+        <i3dMapping id="outputParts"                node="0>1|1" />
+        <i3dMapping id="outputOpen"                 node="0>1|1|0" />
+        <i3dMapping id="pipeEffect"                 node="0>1|1|0|0|0" />
+        <i3dMapping id="smokeEffect"                node="0>1|1|0|0|1" />
+        <i3dMapping id="outputClose"                node="0>1|1|1" />
+        <i3dMapping id="chickenFood_mat"            node="0>1|2|0" />
+        <i3dMapping id="horseFood_mat"              node="0>1|2|1" />
+        <i3dMapping id="lime_mat"                   node="0>1|2|2" />
+        <i3dMapping id="pigFood_mat"                node="0>1|2|3" />
+        <i3dMapping id="roadSalt_mat"               node="0>1|2|4" />
+        <i3dMapping id="seeds_mat"                  node="0>1|2|5" />
+        <i3dMapping id="stones_mat"                 node="0>1|2|6" />
+        <i3dMapping id="fertilizer_mat"             node="0>1|2|7" />
+        <i3dMapping id="fertilizerHelm_mat"         node="0>1|2|8" />
+        <i3dMapping id="sizeCollision01"            node="0>2|0" />
+        <i3dMapping id="sizeCollision02"            node="0>2|1" />
+        <i3dMapping id="sizeCollision03"            node="0>2|2" />
+        <i3dMapping id="sizeCollision04"            node="0>2|3" />
+        <i3dMapping id="sizeJoint01"                node="0>2|4" />
+        <i3dMapping id="sizeJoint02"                node="0>2|5" />
+        <i3dMapping id="sizeJoint03"                node="0>2|6" />
+        <i3dMapping id="sizeJoint04"                node="0>2|7" />
+        <i3dMapping id="sizeJoint05"                node="0>2|8" />
+        <i3dMapping id="sizeJoint06"                node="0>2|9" />
+        <i3dMapping id="sizeJoint07"                node="0>2|10" />
+        <i3dMapping id="sizeJoint08"                node="0>2|11" />
+        <i3dMapping id="bigBag_hook_component2"     node="1>" />
+        <i3dMapping id="componentJointHook"         node="1>0" />
+        <i3dMapping id="attacherJoint01"            node="1>1" />
+        <i3dMapping id="attacherJoint02"            node="1>2" />
+        <i3dMapping id="tensionBeltMesh01"          node="1>3" />
+    </i3dMappings>
+
+</vehicle>

--- a/objects/bigBag/biosolids/multiPurchaseBigBag_biosolids_10k.xml
+++ b/objects/bigBag/biosolids/multiPurchaseBigBag_biosolids_10k.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Biosolids 10000L</n>
+        <name>$l10n_sf_bigBag_biosolids_10k_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_biosolids_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>4800</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="BIOSOLIDS" capacity="10000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/biosolids/bigBag_biosolids_10k.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="9600"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="14400"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="19200"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="24000"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="28800"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="33600"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="38400"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/bigBag/chicken_manure/bigBag_chicken_manure_10k.xml
+++ b/objects/bigBag/chicken_manure/bigBag_chicken_manure_10k.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <name>$l10n_sf_bigBag_chicken_manure_10k_name</name>
+        <specs>
+            <weight ignore="true"/>
+        </specs>
+        <image>$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>5800</price>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <functions><function>$l10n_sf_bigBag_chicken_manure_function</function></functions>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopHeight>2</shopHeight>
+        <showInStore>false</showInStore>
+        <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
+        <textureMemoryUsage>851968</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_typeDesc_pallet</typeDesc>
+        <filename>objects/bigBag/chicken_manure/bigBag_chicken_manure.i3d</filename>
+        <size width="1.25" length="1.25" height="1.75"/>
+        <input allowed="false"/>
+        <canBeReset>false</canBeReset>
+        <components maxMass="850">
+            <component centerOfMass="0 0.1 0" solverIterationCount="40" mass="150" />
+            <component centerOfMass="0 0 0"   solverIterationCount="40" mass="100" />
+            <joint component1="2" component2="1" node="componentJointHook" rotLimit="0 0 0" transLimit="0 0 0" rotLimitSpring="50 50 50" rotLimitDamping="65 65 65"/>
+        </components>
+        <showInVehicleMenu>false</showInVehicleMenu>
+        <mapHotspot available="false" />
+        <schemaOverlay attacherJointPosition="0 0" name="IMPLEMENT" />
+    </base>
+
+    <attachable>
+        <inputAttacherJoints>
+            <inputAttacherJoint node="attacherJoint01" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+            <inputAttacherJoint node="attacherJoint02" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+        </inputAttacherJoints>
+    </attachable>
+
+    <animations>
+        <animation name="bigBagSizeAnimation">
+            <part node="sizeCollision01" startTime="0" endTime="1.0" startTrans="-0.075 0.0 -0.125" endTrans="-0.25 0 -0.25"/>
+            <part node="sizeCollision02" startTime="0" endTime="1.0" startTrans="0.1 0.0 -0.125" endTrans="0.25 0 -0.25"/>
+            <part node="sizeCollision03" startTime="0" endTime="1.0" startTrans="0.1 0.0 0.15" endTrans="0.25 0 0.25"/>
+            <part node="sizeCollision04" startTime="0" endTime="1.0" startTrans="-0.075 0.0 0.15" endTrans="-0.25 0 0.25"/>
+            <part node="sizeJoint08" startTime="0.0" endTime="1.0" startTrans="0.0 0 -0.24" endTrans="0.0 0.0 -0.38" />
+            <part node="sizeJoint07" startTime="0.0" endTime="1.0" startTrans="0.0 0 0.267" endTrans="0.0 0.0 0.38" />
+            <part node="sizeJoint06" startTime="0.0" endTime="1.0" startTrans="0.245 0 0.0" endTrans="0.45 0.0 0.0" />
+            <part node="sizeJoint05" startTime="0.0" endTime="1.0" startTrans="-0.245 0 0.0" endTrans="-0.45 0.0 0.0" />
+            <part node="sizeJoint04" startTime="0.0" endTime="1.0" startTrans="-0.2 0 0.2" endTrans="-0.405 0.0 0.304" />
+            <part node="sizeJoint03" startTime="0.0" endTime="1.0" startTrans="0.2 0 0.2" endTrans="0.405 0.0 0.304" />
+            <part node="sizeJoint02" startTime="0.0" endTime="1.0" startTrans="0.2 0 -0.2" endTrans="0.405 0.0 -0.304" />
+            <part node="sizeJoint01" startTime="0.0" endTime="1.0" startTrans="-0.2 0 -0.2" endTrans="-0.405 0.0 -0.304" />
+            <part node="tensionBeltMesh01" startTime="0" endTime="1.0" startScale="0.735 1.0 0.854" endScale="1 1 1"/>
+            <part node="tensionBeltMesh02" startTime="0" endTime="1.0" startScale="0.6 1.0 0.8" endScale="1 1 1"/>
+        </animation>
+    </animations>
+
+    <bigBag fillUnitIndex="1">
+        <sizeAnimation name="bigBagSizeAnimation" minTime="0.4" maxTime="1" liftShrinkTime="0.15"/>
+        <componentJoint index="1" minRotLimit="0 0 0" maxRotLimit="0 55 55" minTransLimit="0.2 0 0" maxTransLimit="0.1 0 0" angularDamping="1"/>
+    </bigBag>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration name="$l10n_configuration_valueDefault">
+                <fillUnits removeVehicleIfEmpty="true">
+                    <fillUnit unitTextOverride="$l10n_unit_literShort" fillTypes="CHICKEN_MANURE" capacity="10000" startFillType="CHICKEN_MANURE" startFillLevel="10000" ignoreFillLimit="true">
+                        <fillRootNode node="0>" />
+                        <fillTypeMaterials>
+                            <material fillType="CHICKEN_MANURE" node="bigBag_vis" refNode="fertilizer_mat"/>
+                        </fillTypeMaterials>
+                    </fillUnit>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <dischargeable requiresTipOcclusionArea="false">
+        <dischargeNode node="raycastNode" emptySpeed="250" fillUnitIndex="1" maxDistance="6" canStartDischargeAutomatically="true">
+            <raycast useWorldNegYDirection="true" />
+            <info width="0.4" length="0.4" />
+            <activationTrigger node="dischargeActivationTrigger" />
+            <stateObjectChanges>
+                <objectChange node="outputOpen" visibilityActive="true" visibilityInactive="false"/>
+                <objectChange node="outputClose" visibilityActive="false" visibilityInactive="true"/>
+            </stateObjectChanges>
+            <distanceObjectChanges threshold="0.3">
+                <objectChange node="outputParts" visibilityActive="true" visibilityInactive="false"/>
+            </distanceObjectChanges>
+            <effects>
+                <effectNode effectClass="PipeEffect" effectNode="pipeEffect"  materialType="pipe"           delay="0"   maxBending="1"  positionUpdateNodes="smokeEffect"/>
+                <effectNode                          effectNode="smokeEffect" materialType="unloadingSmoke" delay="0.1" alignToWorldY="true"/>
+            </effects>
+        </dischargeNode>
+    </dischargeable>
+
+    <fillTriggerVehicle triggerNode="fillTrigger" fillUnitIndex="1" litersPerSecond="200"/>
+
+    <tensionBeltObject>
+        <meshNodes>
+            <meshNode node="tensionBeltMesh01"/>
+            <meshNode node="tensionBeltMesh02"/>
+        </meshNodes>
+    </tensionBeltObject>
+
+    <i3dMappings>
+        <i3dMapping id="raycastNode"                node="0>0|0" />
+        <i3dMapping id="fillTrigger"                node="0>0|1" />
+        <i3dMapping id="dischargeActivationTrigger" node="0>0|2" />
+        <i3dMapping id="tensionBeltMesh02"          node="0>0|3" />
+        <i3dMapping id="bigBag_vis"                 node="0>1|0" />
+        <i3dMapping id="outputParts"                node="0>1|1" />
+        <i3dMapping id="outputOpen"                 node="0>1|1|0" />
+        <i3dMapping id="pipeEffect"                 node="0>1|1|0|0|0" />
+        <i3dMapping id="smokeEffect"                node="0>1|1|0|0|1" />
+        <i3dMapping id="outputClose"                node="0>1|1|1" />
+        <i3dMapping id="chickenFood_mat"            node="0>1|2|0" />
+        <i3dMapping id="horseFood_mat"              node="0>1|2|1" />
+        <i3dMapping id="lime_mat"                   node="0>1|2|2" />
+        <i3dMapping id="pigFood_mat"                node="0>1|2|3" />
+        <i3dMapping id="roadSalt_mat"               node="0>1|2|4" />
+        <i3dMapping id="seeds_mat"                  node="0>1|2|5" />
+        <i3dMapping id="stones_mat"                 node="0>1|2|6" />
+        <i3dMapping id="fertilizer_mat"             node="0>1|2|7" />
+        <i3dMapping id="fertilizerHelm_mat"         node="0>1|2|8" />
+        <i3dMapping id="sizeCollision01"            node="0>2|0" />
+        <i3dMapping id="sizeCollision02"            node="0>2|1" />
+        <i3dMapping id="sizeCollision03"            node="0>2|2" />
+        <i3dMapping id="sizeCollision04"            node="0>2|3" />
+        <i3dMapping id="sizeJoint01"                node="0>2|4" />
+        <i3dMapping id="sizeJoint02"                node="0>2|5" />
+        <i3dMapping id="sizeJoint03"                node="0>2|6" />
+        <i3dMapping id="sizeJoint04"                node="0>2|7" />
+        <i3dMapping id="sizeJoint05"                node="0>2|8" />
+        <i3dMapping id="sizeJoint06"                node="0>2|9" />
+        <i3dMapping id="sizeJoint07"                node="0>2|10" />
+        <i3dMapping id="sizeJoint08"                node="0>2|11" />
+        <i3dMapping id="bigBag_hook_component2"     node="1>" />
+        <i3dMapping id="componentJointHook"         node="1>0" />
+        <i3dMapping id="attacherJoint01"            node="1>1" />
+        <i3dMapping id="attacherJoint02"            node="1>2" />
+        <i3dMapping id="tensionBeltMesh01"          node="1>3" />
+    </i3dMappings>
+
+</vehicle>

--- a/objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure_10k.xml
+++ b/objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure_10k.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Chicken Manure 10000L</n>
+        <name>$l10n_sf_bigBag_chicken_manure_10k_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_chicken_manure_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>5800</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="CHICKEN_MANURE" capacity="10000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/chicken_manure/bigBag_chicken_manure_10k.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="11600"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="17400"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="23200"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="29000"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="34800"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="40600"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="46400"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/bigBag/pelletized_manure/bigBag_pelletized_manure_10k.xml
+++ b/objects/bigBag/pelletized_manure/bigBag_pelletized_manure_10k.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <name>$l10n_sf_bigBag_pelletized_manure_10k_name</name>
+        <specs>
+            <weight ignore="true"/>
+        </specs>
+        <image>$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>9500</price>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <functions><function>$l10n_sf_bigBag_pelletized_manure_function</function></functions>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopHeight>2</shopHeight>
+        <showInStore>false</showInStore>
+        <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
+        <textureMemoryUsage>851968</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_typeDesc_pallet</typeDesc>
+        <filename>objects/bigBag/pelletized_manure/bigBag_pelletized_manure.i3d</filename>
+        <size width="1.25" length="1.25" height="1.75"/>
+        <input allowed="false"/>
+        <canBeReset>false</canBeReset>
+        <components maxMass="850">
+            <component centerOfMass="0 0.1 0" solverIterationCount="40" mass="150" />
+            <component centerOfMass="0 0 0"   solverIterationCount="40" mass="100" />
+            <joint component1="2" component2="1" node="componentJointHook" rotLimit="0 0 0" transLimit="0 0 0" rotLimitSpring="50 50 50" rotLimitDamping="65 65 65"/>
+        </components>
+        <showInVehicleMenu>false</showInVehicleMenu>
+        <mapHotspot available="false" />
+        <schemaOverlay attacherJointPosition="0 0" name="IMPLEMENT" />
+    </base>
+
+    <attachable>
+        <inputAttacherJoints>
+            <inputAttacherJoint node="attacherJoint01" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+            <inputAttacherJoint node="attacherJoint02" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+        </inputAttacherJoints>
+    </attachable>
+
+    <animations>
+        <animation name="bigBagSizeAnimation">
+            <part node="sizeCollision01" startTime="0" endTime="1.0" startTrans="-0.075 0.0 -0.125" endTrans="-0.25 0 -0.25"/>
+            <part node="sizeCollision02" startTime="0" endTime="1.0" startTrans="0.1 0.0 -0.125" endTrans="0.25 0 -0.25"/>
+            <part node="sizeCollision03" startTime="0" endTime="1.0" startTrans="0.1 0.0 0.15" endTrans="0.25 0 0.25"/>
+            <part node="sizeCollision04" startTime="0" endTime="1.0" startTrans="-0.075 0.0 0.15" endTrans="-0.25 0 0.25"/>
+            <part node="sizeJoint08" startTime="0.0" endTime="1.0" startTrans="0.0 0 -0.24" endTrans="0.0 0.0 -0.38" />
+            <part node="sizeJoint07" startTime="0.0" endTime="1.0" startTrans="0.0 0 0.267" endTrans="0.0 0.0 0.38" />
+            <part node="sizeJoint06" startTime="0.0" endTime="1.0" startTrans="0.245 0 0.0" endTrans="0.45 0.0 0.0" />
+            <part node="sizeJoint05" startTime="0.0" endTime="1.0" startTrans="-0.245 0 0.0" endTrans="-0.45 0.0 0.0" />
+            <part node="sizeJoint04" startTime="0.0" endTime="1.0" startTrans="-0.2 0 0.2" endTrans="-0.405 0.0 0.304" />
+            <part node="sizeJoint03" startTime="0.0" endTime="1.0" startTrans="0.2 0 0.2" endTrans="0.405 0.0 0.304" />
+            <part node="sizeJoint02" startTime="0.0" endTime="1.0" startTrans="0.2 0 -0.2" endTrans="0.405 0.0 -0.304" />
+            <part node="sizeJoint01" startTime="0.0" endTime="1.0" startTrans="-0.2 0 -0.2" endTrans="-0.405 0.0 -0.304" />
+            <part node="tensionBeltMesh01" startTime="0" endTime="1.0" startScale="0.735 1.0 0.854" endScale="1 1 1"/>
+            <part node="tensionBeltMesh02" startTime="0" endTime="1.0" startScale="0.6 1.0 0.8" endScale="1 1 1"/>
+        </animation>
+    </animations>
+
+    <bigBag fillUnitIndex="1">
+        <sizeAnimation name="bigBagSizeAnimation" minTime="0.4" maxTime="1" liftShrinkTime="0.15"/>
+        <componentJoint index="1" minRotLimit="0 0 0" maxRotLimit="0 55 55" minTransLimit="0.2 0 0" maxTransLimit="0.1 0 0" angularDamping="1"/>
+    </bigBag>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration name="$l10n_configuration_valueDefault">
+                <fillUnits removeVehicleIfEmpty="true">
+                    <fillUnit unitTextOverride="$l10n_unit_literShort" fillTypes="PELLETIZED_MANURE" capacity="10000" startFillType="PELLETIZED_MANURE" startFillLevel="10000" ignoreFillLimit="true">
+                        <fillRootNode node="0>" />
+                        <fillTypeMaterials>
+                            <material fillType="PELLETIZED_MANURE" node="bigBag_vis" refNode="fertilizer_mat"/>
+                        </fillTypeMaterials>
+                    </fillUnit>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <dischargeable requiresTipOcclusionArea="false">
+        <dischargeNode node="raycastNode" emptySpeed="250" fillUnitIndex="1" maxDistance="6" canStartDischargeAutomatically="true">
+            <raycast useWorldNegYDirection="true" />
+            <info width="0.4" length="0.4" />
+            <activationTrigger node="dischargeActivationTrigger" />
+            <stateObjectChanges>
+                <objectChange node="outputOpen" visibilityActive="true" visibilityInactive="false"/>
+                <objectChange node="outputClose" visibilityActive="false" visibilityInactive="true"/>
+            </stateObjectChanges>
+            <distanceObjectChanges threshold="0.3">
+                <objectChange node="outputParts" visibilityActive="true" visibilityInactive="false"/>
+            </distanceObjectChanges>
+            <effects>
+                <effectNode effectClass="PipeEffect" effectNode="pipeEffect"  materialType="pipe"           delay="0"   maxBending="1"  positionUpdateNodes="smokeEffect"/>
+                <effectNode                          effectNode="smokeEffect" materialType="unloadingSmoke" delay="0.1" alignToWorldY="true"/>
+            </effects>
+        </dischargeNode>
+    </dischargeable>
+
+    <fillTriggerVehicle triggerNode="fillTrigger" fillUnitIndex="1" litersPerSecond="200"/>
+
+    <tensionBeltObject>
+        <meshNodes>
+            <meshNode node="tensionBeltMesh01"/>
+            <meshNode node="tensionBeltMesh02"/>
+        </meshNodes>
+    </tensionBeltObject>
+
+    <i3dMappings>
+        <i3dMapping id="raycastNode"                node="0>0|0" />
+        <i3dMapping id="fillTrigger"                node="0>0|1" />
+        <i3dMapping id="dischargeActivationTrigger" node="0>0|2" />
+        <i3dMapping id="tensionBeltMesh02"          node="0>0|3" />
+        <i3dMapping id="bigBag_vis"                 node="0>1|0" />
+        <i3dMapping id="outputParts"                node="0>1|1" />
+        <i3dMapping id="outputOpen"                 node="0>1|1|0" />
+        <i3dMapping id="pipeEffect"                 node="0>1|1|0|0|0" />
+        <i3dMapping id="smokeEffect"                node="0>1|1|0|0|1" />
+        <i3dMapping id="outputClose"                node="0>1|1|1" />
+        <i3dMapping id="chickenFood_mat"            node="0>1|2|0" />
+        <i3dMapping id="horseFood_mat"              node="0>1|2|1" />
+        <i3dMapping id="lime_mat"                   node="0>1|2|2" />
+        <i3dMapping id="pigFood_mat"                node="0>1|2|3" />
+        <i3dMapping id="roadSalt_mat"               node="0>1|2|4" />
+        <i3dMapping id="seeds_mat"                  node="0>1|2|5" />
+        <i3dMapping id="stones_mat"                 node="0>1|2|6" />
+        <i3dMapping id="fertilizer_mat"             node="0>1|2|7" />
+        <i3dMapping id="fertilizerHelm_mat"         node="0>1|2|8" />
+        <i3dMapping id="sizeCollision01"            node="0>2|0" />
+        <i3dMapping id="sizeCollision02"            node="0>2|1" />
+        <i3dMapping id="sizeCollision03"            node="0>2|2" />
+        <i3dMapping id="sizeCollision04"            node="0>2|3" />
+        <i3dMapping id="sizeJoint01"                node="0>2|4" />
+        <i3dMapping id="sizeJoint02"                node="0>2|5" />
+        <i3dMapping id="sizeJoint03"                node="0>2|6" />
+        <i3dMapping id="sizeJoint04"                node="0>2|7" />
+        <i3dMapping id="sizeJoint05"                node="0>2|8" />
+        <i3dMapping id="sizeJoint06"                node="0>2|9" />
+        <i3dMapping id="sizeJoint07"                node="0>2|10" />
+        <i3dMapping id="sizeJoint08"                node="0>2|11" />
+        <i3dMapping id="bigBag_hook_component2"     node="1>" />
+        <i3dMapping id="componentJointHook"         node="1>0" />
+        <i3dMapping id="attacherJoint01"            node="1>1" />
+        <i3dMapping id="attacherJoint02"            node="1>2" />
+        <i3dMapping id="tensionBeltMesh01"          node="1>3" />
+    </i3dMappings>
+
+</vehicle>

--- a/objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure_10k.xml
+++ b/objects/bigBag/pelletized_manure/multiPurchaseBigBag_pelletized_manure_10k.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Pelletized Manure 10000L</n>
+        <name>$l10n_sf_bigBag_pelletized_manure_10k_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_pelletized_manure_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>9500</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="PELLETIZED_MANURE" capacity="10000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure_10k.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="19000"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="28500"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="38000"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="47500"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="57000"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="66500"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="76000"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2402,6 +2402,16 @@ function SoilFertilitySystem:onHerbicideAppliedDirect(fieldId, effectiveness, li
     local field = self:getOrCreateField(fieldId, true)
     if not field then return end
 
+    -- Confirm field area from farmland on first herbicide application (mirrors applyFertilizer).
+    -- Without this, newly-created fields default to 1.0 ha, making targetVol wrong on dedi servers.
+    if not field._farmlandAreaConfirmed and g_farmlandManager then
+        local farmlandObj = g_farmlandManager:getFarmlandById(fieldId)
+        if farmlandObj and farmlandObj.areaInHa and farmlandObj.areaInHa > 0 then
+            field.fieldArea = farmlandObj.areaInHa
+        end
+        field._farmlandAreaConfirmed = true
+    end
+
     local areaInHa = field.fieldArea or 1.0
     if areaInHa <= 0 then areaInHa = 1.0 end
     local targetRate = SoilConstants.SPRAYER_RATE.BASE_RATES.HERBICIDE.value
@@ -2421,9 +2431,26 @@ function SoilFertilitySystem:onHerbicideAppliedDirect(fieldId, effectiveness, li
         local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
         field.herbicideDaysLeft = SoilConstants.WEED_PRESSURE.HERBICIDE_DURATION_DAYS * daysPerMonth
 
+        -- Update per-cell weed pressure so the PDA cell-report shows changes immediately.
+        -- onInsecticideAppliedIncremental does this for pest pressure; herbicide was missing it.
+        local x, z = self._lastSprayX, self._lastSprayZ
+        if x and z then
+            local zone = SoilConstants.ZONE
+            local cellKey = tostring(math.floor(x / zone.CELL_SIZE) * 10000 + math.floor(z / zone.CELL_SIZE))
+            if not field.zoneData then field.zoneData = {} end
+            if not field.zoneData[cellKey] then
+                field.zoneData[cellKey] = {
+                    N = field.nitrogen, P = field.phosphorus, K = field.potassium,
+                    pH = field.pH, OM = field.organicMatter,
+                    weedPressure = field.weedPressure, pestPressure = field.pestPressure,
+                    diseasePressure = field.diseasePressure, compaction = field.compaction
+                }
+            end
+            field.zoneData[cellKey].weedPressure = math.max(0,
+                (field.zoneData[cellKey].weedPressure or field.weedPressure or 0) - reduction)
+        end
+
         -- Broadcast updated weed pressure to all clients (dedicated server fix — Issue #257)
-        -- Previously missing, causing weed value to only update on clients when a subsequent
-        -- insecticide/fungicide broadcast happened to carry the stale field struct.
         if g_server and g_currentMission and g_currentMission.missionDynamicInfo
             and g_currentMission.missionDynamicInfo.isMultiplayer then
             if SoilFieldUpdateEvent then

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2726,8 +2726,13 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             setXMLInt(xmlFile, fieldKey .. "#fungicideDaysLeft", field.fungicideDaysLeft or 0)
             setXMLInt(xmlFile, fieldKey .. "#dryDayCount", field.dryDayCount or 0)
             setXMLInt(xmlFile, fieldKey .. "#burnDaysLeft", field.burnDaysLeft or 0)
-            setXMLInt(xmlFile, fieldKey .. "#lastAlertSeason", field.lastAlertSeason or 0)
+            setXMLFloat(xmlFile, fieldKey .. "#coverageFraction", field.coverageFraction or 0)
             setXMLFloat(xmlFile, fieldKey .. "#compaction", field.compaction or 0)
+
+            -- Save daily application throttles
+            setXMLInt(xmlFile, fieldKey .. "#herbicideAppliedDay", self.herbicideAppliedDay[fieldId] or 0)
+            setXMLInt(xmlFile, fieldKey .. "#insecticideAppliedDay", self.insecticideAppliedDay[fieldId] or 0)
+            setXMLInt(xmlFile, fieldKey .. "#fungicideAppliedDay", self.fungicideAppliedDay[fieldId] or 0)
 
             -- Save per-cell compaction data
             local compIdx = 0
@@ -2807,6 +2812,7 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             fungicideDaysLeft = getXMLInt(xmlFile, fieldKey .. "#fungicideDaysLeft") or 0,
             dryDayCount = getXMLInt(xmlFile, fieldKey .. "#dryDayCount") or 0,
             burnDaysLeft = getXMLInt(xmlFile, fieldKey .. "#burnDaysLeft") or 0,
+            coverageFraction = getXMLFloat(xmlFile, fieldKey .. "#coverageFraction") or 0,
             lastAlertSeason = getXMLInt(xmlFile, fieldKey .. "#lastAlertSeason") or nil,
             compaction = 0,
             compactionCells = {},
@@ -2817,6 +2823,11 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             nutrientBuffer = {},
             zoneData = {},
         }
+
+        -- Load daily application throttles
+        self.herbicideAppliedDay[fieldId] = getXMLInt(xmlFile, fieldKey .. "#herbicideAppliedDay") or 0
+        self.insecticideAppliedDay[fieldId] = getXMLInt(xmlFile, fieldKey .. "#insecticideAppliedDay") or 0
+        self.fungicideAppliedDay[fieldId] = getXMLInt(xmlFile, fieldKey .. "#fungicideAppliedDay") or 0
 
         -- Refresh fieldArea from the live farmland object — corrects stale values from saves
         -- written before the scan priority bug was fixed (where field.areaHa == 1.0 default

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -893,7 +893,8 @@ function SoilFertilitySystem:onHerbicideApplied(fieldId, effectiveness)
     local reduction = wp.HERBICIDE_PRESSURE_REDUCTION * (effectiveness or 1.0)
     local before = field.weedPressure or 0
     field.weedPressure = math.max(0, before - reduction)
-    field.herbicideDaysLeft = wp.HERBICIDE_DURATION_DAYS
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+    field.herbicideDaysLeft = wp.HERBICIDE_DURATION_DAYS * daysPerMonth
 
     self:log("[Herbicide] Field %d: weed pressure %.0f -> %.0f, protected for %d days",
         fieldId, before, field.weedPressure, field.herbicideDaysLeft)
@@ -926,7 +927,8 @@ function SoilFertilitySystem:onInsecticideApplied(fieldId, effectiveness)
     local reduction = pp.INSECTICIDE_PRESSURE_REDUCTION * (effectiveness or 1.0)
     local before = field.pestPressure or 0
     field.pestPressure = math.max(0, before - reduction)
-    field.insecticideDaysLeft = pp.INSECTICIDE_DURATION_DAYS
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+    field.insecticideDaysLeft = pp.INSECTICIDE_DURATION_DAYS * daysPerMonth
 
     self:log("[Insecticide] Field %d: pest pressure %.0f -> %.0f, protected for %d days",
         fieldId, before, field.pestPressure, field.insecticideDaysLeft)
@@ -958,7 +960,8 @@ function SoilFertilitySystem:onFungicideApplied(fieldId, effectiveness)
     local reduction = dp.FUNGICIDE_PRESSURE_REDUCTION * (effectiveness or 1.0)
     local before = field.diseasePressure or 0
     field.diseasePressure = math.max(0, before - reduction)
-    field.fungicideDaysLeft = dp.FUNGICIDE_DURATION_DAYS
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+    field.fungicideDaysLeft = dp.FUNGICIDE_DURATION_DAYS * daysPerMonth
 
     self:log("[Fungicide] Field %d: disease pressure %.0f -> %.0f, protected for %d days",
         fieldId, before, field.diseasePressure, field.fungicideDaysLeft)
@@ -1551,6 +1554,12 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     local currentDay = self._dailyBatchDay
     local season     = self._dailyBatchSeason
 
+    -- Time scaling (Issue #349): normalize daily changes based on month length.
+    -- All 'per day' rates are scaled by 1/daysPerMonth so that the total change
+    -- per month remains constant regardless of the days-per-period setting.
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+    local timeFactor = 1.0 / daysPerMonth
+
     -- ── Buffer / coverage reset ──────────────────────────────────────────────
     field.nutrientBuffer          = {}
     field.coveredCells            = {}
@@ -1565,26 +1574,27 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     if self.settings.compactionEnabled and SoilConstants.COMPACTION then
         local cp = SoilConstants.COMPACTION
         if (field.compaction or 0) > 0 then
-            field.compaction = math.max(0, field.compaction - cp.NATURAL_DECAY_PER_DAY)
+            field.compaction = math.max(0, field.compaction - cp.NATURAL_DECAY_PER_DAY * timeFactor)
         end
     end
 
     -- ── Fallow recovery ──────────────────────────────────────────────────────
+    -- Fallow threshold also scales so it represents the same 'agricultural time' (months)
     local daysSinceFallow = currentDay - (field.lastHarvest or 0)
-    if daysSinceFallow > SoilConstants.TIMING.FALLOW_THRESHOLD then
-        field.nitrogen      = math.min(limits.MAX, field.nitrogen      + recovery.nitrogen)
-        field.phosphorus    = math.min(limits.MAX, field.phosphorus    + recovery.phosphorus)
-        field.potassium     = math.min(limits.MAX, field.potassium     + recovery.potassium)
+    if daysSinceFallow > SoilConstants.TIMING.FALLOW_THRESHOLD * daysPerMonth then
+        field.nitrogen      = math.min(limits.MAX, field.nitrogen      + recovery.nitrogen * timeFactor)
+        field.phosphorus    = math.min(limits.MAX, field.phosphorus    + recovery.phosphorus * timeFactor)
+        field.potassium     = math.min(limits.MAX, field.potassium     + recovery.potassium * timeFactor)
         field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX,
-                                       field.organicMatter + recovery.organicMatter)
+                                       field.organicMatter + recovery.organicMatter * timeFactor)
     end
 
     -- ── Seasonal nitrogen shift ──────────────────────────────────────────────
     if self.settings.seasonalEffects and season then
         if season == seasonal.SPRING_SEASON then
-            field.nitrogen = math.min(limits.MAX, field.nitrogen + seasonal.SPRING_NITROGEN_BOOST)
+            field.nitrogen = math.min(limits.MAX, field.nitrogen + seasonal.SPRING_NITROGEN_BOOST * timeFactor)
         elseif season == seasonal.FALL_SEASON then
-            field.nitrogen = math.max(limits.MIN, field.nitrogen - seasonal.FALL_NITROGEN_LOSS)
+            field.nitrogen = math.max(limits.MIN, field.nitrogen - seasonal.FALL_NITROGEN_LOSS * timeFactor)
         end
     end
 
@@ -1598,23 +1608,24 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                 local c2 = string.lower(field.lastCrop2)
                 if cr.LEGUMES[c1] and not cr.LEGUMES[c2]
                    and (field.rotationBonusDaysLeft or 0) == 0 then
-                    field.rotationBonusDaysLeft = cr.LEGUME_BONUS_DAYS
+                    -- Bonus duration also scales to match month length
+                    field.rotationBonusDaysLeft = cr.LEGUME_BONUS_DAYS * daysPerMonth
                 end
             end
         end
         -- Apply daily bonus while counter > 0 during spring
         if season == seasonal.SPRING_SEASON and (field.rotationBonusDaysLeft or 0) > 0 then
             local cr = SoilConstants.CROP_ROTATION
-            field.nitrogen = math.min(limits.MAX, field.nitrogen + cr.LEGUME_BONUS_N_PER_DAY)
+            field.nitrogen = math.min(limits.MAX, field.nitrogen + cr.LEGUME_BONUS_N_PER_DAY * timeFactor)
             field.rotationBonusDaysLeft = field.rotationBonusDaysLeft - 1
         end
     end
 
     -- ── pH slow drift toward neutral ─────────────────────────────────────────
     if field.pH < limits.PH_NEUTRAL_LOW then
-        field.pH = math.min(limits.PH_NEUTRAL_LOW, field.pH + phNorm.RATE)
+        field.pH = math.min(limits.PH_NEUTRAL_LOW, field.pH + phNorm.RATE * timeFactor)
     elseif field.pH > limits.PH_NEUTRAL_HIGH then
-        field.pH = math.max(limits.PH_NEUTRAL_HIGH, field.pH - phNorm.RATE)
+        field.pH = math.max(limits.PH_NEUTRAL_HIGH, field.pH - phNorm.RATE * timeFactor)
     end
 
     -- ── Weed pressure daily growth ───────────────────────────────────────────
@@ -1659,6 +1670,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                 end
 
                 local canopyFactor = 1.0
+                local rowClosure = false
                 if g_fieldManager and g_fieldManager.fields then
                     local fsField = nil
                     for _, f in ipairs(g_fieldManager.fields) do
@@ -1682,20 +1694,29 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                                 if progress >= suppressThresh and suppressMax > suppressThresh then
                                     canopyFactor = math.max(0.0, 1.0 - (progress - suppressThresh) / (suppressMax - suppressThresh))
                                 end
+                                if progress >= suppressMax then
+                                    rowClosure = true
+                                end
                             end
                         end
                     end
                 end
 
-                field.weedPressure = math.min(100, pressure + (baseRate * seasonMult + rainBonus) * canopyFactor)
+                if rowClosure then
+                    -- Row closure reached: weeds start to decay due to lack of light (Issue #349)
+                    local decayRate = wp.CANOPY_DECAY_RATE or 1.2
+                    field.weedPressure = math.max(0, pressure - decayRate * timeFactor)
+                else
+                    field.weedPressure = math.min(100, pressure + (baseRate * seasonMult + rainBonus) * canopyFactor * timeFactor)
+                end
             end
 
             -- Weeds consume nutrients
-            if pressure > 0 then
-                local pRatio = pressure / 100
-                field.nitrogen = math.max(limits.MIN, field.nitrogen - (wp.NUTRIENT_DEPLETION_N or 0) * pRatio)
-                field.phosphorus = math.max(limits.MIN, field.phosphorus - (wp.NUTRIENT_DEPLETION_P or 0) * pRatio)
-                field.potassium = math.max(limits.MIN, field.potassium - (wp.NUTRIENT_DEPLETION_K or 0) * pRatio)
+            if (field.weedPressure or 0) > 0 then
+                local pRatio = field.weedPressure / 100
+                field.nitrogen = math.max(limits.MIN, field.nitrogen - (wp.NUTRIENT_DEPLETION_N or 0) * pRatio * timeFactor)
+                field.phosphorus = math.max(limits.MIN, field.phosphorus - (wp.NUTRIENT_DEPLETION_P or 0) * pRatio * timeFactor)
+                field.potassium = math.max(limits.MIN, field.potassium - (wp.NUTRIENT_DEPLETION_K or 0) * pRatio * timeFactor)
             end
         end
     end
@@ -1738,7 +1759,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                 rainBonus = pp.RAIN_BONUS
             end
 
-            field.pestPressure = math.min(100, pressure + (baseRate * seasonMult * cropMult) + rainBonus)
+            field.pestPressure = math.min(100, pressure + ((baseRate * seasonMult * cropMult) + rainBonus) * timeFactor)
         end
     end
 
@@ -1761,11 +1782,35 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
 
         local pressure = field.diseasePressure or 0
 
-        if (field.dryDayCount or 0) >= dp.DRY_DAYS_THRESHOLD then
-            field.diseasePressure = math.max(0, pressure - dp.DRY_DECAY_RATE)
+        -- Dry days threshold also scales
+        if (field.dryDayCount or 0) >= dp.DRY_DAYS_THRESHOLD * daysPerMonth then
+            field.diseasePressure = math.max(0, pressure - dp.DRY_DECAY_RATE * timeFactor)
         elseif (field.fungicideDaysLeft or 0) <= 0 then
             local baseRate
             if     pressure < dp.LOW    then baseRate = dp.GROWTH_RATE_LOW
+            elseif pressure < dp.MEDIUM then baseRate = dp.GROWTH_RATE_MID
+            elseif pressure < dp.HIGH   then baseRate = dp.GROWTH_RATE_HIGH
+            else                             baseRate = dp.GROWTH_RATE_PEAK
+            end
+
+            local seasonMult = 1.0
+            if season then
+                if     season == 1 then seasonMult = dp.SEASONAL_SPRING
+                elseif season == 2 then seasonMult = dp.SEASONAL_SUMMER
+                elseif season == 3 then seasonMult = dp.SEASONAL_FALL
+                elseif season == 4 then seasonMult = dp.SEASONAL_WINTER
+                end
+            end
+
+            local cropMult = 1.0
+            if field.lastCrop then
+                cropMult = dp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
+            end
+
+            local rainBonus = isRaining and dp.RAIN_BONUS or 0
+            field.diseasePressure = math.min(100, pressure + ((baseRate * seasonMult * cropMult) + rainBonus) * timeFactor)
+        end
+    end
             elseif pressure < dp.MEDIUM then baseRate = dp.GROWTH_RATE_MID
             elseif pressure < dp.HIGH   then baseRate = dp.GROWTH_RATE_HIGH
             else                             baseRate = dp.GROWTH_RATE_PEAK
@@ -2212,7 +2257,8 @@ function SoilFertilitySystem:onInsecticideAppliedIncremental(fieldId, reduction)
     local pp = SoilConstants.PEST_PRESSURE
     local before = field.pestPressure or 0
     field.pestPressure = math.max(0, before - reduction)
-    field.insecticideDaysLeft = pp.INSECTICIDE_DURATION_DAYS
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+    field.insecticideDaysLeft = pp.INSECTICIDE_DURATION_DAYS * daysPerMonth
 
     -- Local zoneData update
     local x, z = self._lastSprayX, self._lastSprayZ
@@ -2242,7 +2288,8 @@ function SoilFertilitySystem:onFungicideAppliedIncremental(fieldId, reduction)
     local dp = SoilConstants.DISEASE_PRESSURE
     local before = field.diseasePressure or 0
     field.diseasePressure = math.max(0, before - reduction)
-    field.fungicideDaysLeft = dp.FUNGICIDE_DURATION_DAYS
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+    field.fungicideDaysLeft = dp.FUNGICIDE_DURATION_DAYS * daysPerMonth
 
     -- Local zoneData update
     local x, z = self._lastSprayX, self._lastSprayZ
@@ -2371,7 +2418,8 @@ function SoilFertilitySystem:onHerbicideAppliedDirect(fieldId, effectiveness, li
     if reduction > 0 then
         local before = field.weedPressure or 0
         field.weedPressure = math.max(0, before - reduction)
-        field.herbicideDaysLeft = SoilConstants.WEED_PRESSURE.HERBICIDE_DURATION_DAYS
+        local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
+        field.herbicideDaysLeft = SoilConstants.WEED_PRESSURE.HERBICIDE_DURATION_DAYS * daysPerMonth
 
         -- Broadcast updated weed pressure to all clients (dedicated server fix — Issue #257)
         -- Previously missing, causing weed value to only update on clients when a subsequent
@@ -2461,10 +2509,11 @@ function SoilFertilitySystem:applyBurnEffect(fieldId, rateMultiplier)
     local phDrop  = 0
     local nDrain  = 0
 
+    local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
     if rateMultiplier >= burnCfg.BURN_GUARANTEED_THRESHOLD then
         phDrop = burnCfg.BURN_PH_DROP_CERTAIN
         nDrain = burnCfg.BURN_N_DRAIN_CERTAIN
-        field.burnDaysLeft = 3   -- show burn warning in HUD for 3 in-game days
+        field.burnDaysLeft = 3 * daysPerMonth   -- show burn warning in HUD (Issue #349 scaling)
     else
         -- Probability scales linearly between risk threshold and guaranteed threshold
         local excess = (rateMultiplier - burnCfg.BURN_RISK_THRESHOLD) /
@@ -2472,7 +2521,7 @@ function SoilFertilitySystem:applyBurnEffect(fieldId, rateMultiplier)
         if math.random() < excess then
             phDrop = burnCfg.BURN_PH_DROP_RISK
             nDrain = burnCfg.BURN_N_DRAIN_RISK
-            field.burnDaysLeft = 3
+            field.burnDaysLeft = 3 * daysPerMonth
         end
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1465,8 +1465,24 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
 
     local defaults = SoilConstants.FIELD_DEFAULTS
 
+    -- Attempt farmland area lookup at creation time so the correct area is used
+    -- for nutrient/herbicide calculations from the very first plow or spray pass.
+    -- Without this, area defaults to 1.0 ha and only corrects on first fertilizer spray.
+    local confirmedArea = false
+    local initialArea = area or 1.0
+    if not area and g_farmlandManager then
+        local farmlandObj = g_farmlandManager:getFarmlandById(fieldId)
+        if farmlandObj and farmlandObj.areaInHa and farmlandObj.areaInHa > 0 then
+            initialArea = farmlandObj.areaInHa
+            confirmedArea = true
+        end
+    elseif area and area > 0 then
+        confirmedArea = true
+    end
+
     self.fieldData[fieldId] = {
-        fieldArea = area or 1.0, -- default 1ha if unknown
+        fieldArea = initialArea,
+        _farmlandAreaConfirmed = confirmedArea,
         nitrogen   = math.floor(randomize(defaults.nitrogen,   defaults.nitrogen   * 0.10, 1)),
         phosphorus = math.floor(randomize(defaults.phosphorus, defaults.phosphorus * 0.10, 2)),
         potassium  = math.floor(randomize(defaults.potassium,  defaults.potassium  * 0.10, 3)),
@@ -1501,7 +1517,8 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
         lastAlertSeason = nil, -- Season when the last critical alert fired (persisted)
     }
 
-    self:log("Lazy-created field %d with area %.2f ha and natural soil variation", fieldId, self.fieldData[fieldId].fieldArea)
+    self:log("Lazy-created field %d area=%.2f ha confirmed=%s",
+        fieldId, self.fieldData[fieldId].fieldArea, tostring(confirmedArea))
     return self.fieldData[fieldId]
 end
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -751,6 +751,7 @@ SoilConstants.WEED_PRESSURE = {
     -- Crops block sunlight, slowing or stopping weed growth as they mature.
     CANOPY_SUPPRESSION_THRESHOLD = 0.5, -- Crop growth state % (0.0 to 1.0) where suppression begins
     CANOPY_SUPPRESSION_MAX       = 1.0, -- Crop growth state % where weed growth is completely stopped
+    CANOPY_DECAY_RATE            = 1.2, -- Points per day of weed reduction at full row closure (Issue #349)
 
     -- Nutrient Depletion by Weeds (Issue #327)
     -- Daily nutrient drain at 100% weed pressure (scales linearly with pressure)

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -213,7 +213,7 @@ SoilConstants.CROP_ROTATION = {
     LEGUME_BONUS_N_PER_DAY = 0.5,   -- N added per day during bonus window
     LEGUME_BONUS_DAYS       = 3,     -- spring bonus lasts this many days
     FATIGUE_MULTIPLIER      = 1.15,  -- nutrient extraction ×1.15 for same-crop consecutive seasons
-    LEGUMES = { soybean = true, peas = true, beans = true },
+    LEGUMES = { soybean = true, peas = true, beans = true, luzerne = true, clover = true },
 }
 
 -- ========================================
@@ -309,14 +309,14 @@ SoilConstants.FERTILIZER_PROFILES = {
     -- Phosphorus & potassium sources (Dry bulk)
     MAP               = { N=11.1, P=411.5, K=0.00 }, -- 225 kg/ha: ~45P ppm
     DAP               = { N=16.4, P=329.2, K=0.00 }, -- 225 kg/ha: ~40P ppm
-    POTASH            = { N=0.00, P=0.00, K=55.5 },  -- 225 kg/ha: ~45K ppm
+    POTASH            = { N=0.00, P=0.00, K=100.0 }, -- 225 kg/ha: ~22.5 K pts/pass; 70-90 kg/ha ≈ 7-9 pts (realistic 1-pass fix)
 
     -- Liquid equivalents (match dry profiles)
     LIQUID_UREA       = { N=154.6, P=0.00, K=0.00 },
     LIQUID_AMS        = { N=66.2,  P=0.00, K=0.00 },
     LIQUID_MAP        = { N=11.1, P=411.5, K=0.00 },
     LIQUID_DAP        = { N=16.4, P=329.2, K=0.00 },
-    LIQUID_POTASH     = { N=0.00, P=0.00, K=55.5 },
+    LIQUID_POTASH     = { N=0.00, P=0.00, K=100.0 },
 
     -- Organic / slow-release
     COMPOST           = { N=0.74, P=0.55, K=0.55, OM=0.60 }, -- 5000 kg/ha
@@ -430,6 +430,8 @@ SoilConstants.CROP_NUTRIENT_TARGETS = {
     sorghum    = { N = { min = 30, opt = 50 }, P = { min = 20, opt = 35 }, K = { min = 25, opt = 40 } },
     peas       = { N = { min = 15, opt = 30 }, P = { min = 25, opt = 45 }, K = { min = 30, opt = 50 } },
     beans      = { N = { min = 15, opt = 30 }, P = { min = 25, opt = 45 }, K = { min = 30, opt = 50 } },
+    luzerne    = { N = { min = 10, opt = 20 }, P = { min = 25, opt = 45 }, K = { min = 30, opt = 50 } },
+    clover     = { N = { min = 10, opt = 20 }, P = { min = 25, opt = 45 }, K = { min = 30, opt = 50 } },
     default    = { N = { min = 30, opt = 50 }, P = { min = 25, opt = 40 }, K = { min = 20, opt = 40 } },
 }
 
@@ -496,6 +498,8 @@ SoilConstants.YIELD_SENSITIVITY = {
         sunflower  = "tolerant",
         rye        = "tolerant",
         sorghum    = "tolerant",
+        luzerne    = "tolerant",   -- legume forage — fixes own N
+        clover     = "tolerant",   -- legume forage — fixes own N
         -- Moderate: standard response to nutrient levels
         wheat      = "moderate",
         canola     = "moderate",
@@ -514,6 +518,7 @@ SoilConstants.YIELD_SENSITIVITY = {
     -- Crops that are not row-crop harvests; skip yield forecast for these
     NON_CROP_NAMES = {
         grass = true, drygrass = true, poplar = true, oilseedradish = true,
+        luzerne = true, clover = true,
     },
 }
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -21,7 +21,7 @@ end
 ---@param x number World X coordinate
 ---@param z number World Z coordinate
 ---@return number|nil fieldId
-function HookManager:getFieldIdAtWorldPosition(x, z)
+function HookManager:getFieldIdAtWorldPosition(x, z, skipNegativeCache)
     -- Initialize the native MapDataGrid cache on first use (requires map to be loaded)
     if not self.fieldIdCache then
         local mapSize = g_currentMission and g_currentMission.terrainSize or 2048
@@ -48,8 +48,15 @@ function HookManager:getFieldIdAtWorldPosition(x, z)
     if self.fieldIdCache then
         local cachedId = self.fieldIdCache:getValueAtWorldPos(x, z)
         if cachedId ~= nil then
-            if cachedId == -1 then return nil end  -- -1 = known empty space
-            return cachedId
+            if cachedId == -1 then
+                -- Known-empty at map load. Skip the fast-path return when the caller
+                -- is a tillage hook (skipNegativeCache=true): player-created fields won't
+                -- exist in the cache yet and need a live slow-path re-query.
+                if not skipNegativeCache then return nil end
+                -- Fall through to slow path below
+            else
+                return cachedId
+            end
         end
     end
 
@@ -1685,7 +1692,8 @@ function HookManager:installPlowingHook()
 
             local x, _, z = getWorldTranslation(cultivatorSelf.rootNode)
             local success, errorMsg = pcall(function()
-                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                -- skipNegativeCache=true: player-created fields are not in the cache yet
+                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z, true)
                 SoilLogger.debug("[PlowHook] pos=(%.1f,%.1f) farmlandId=%s isPlow=%s",
                     x, z, tostring(farmlandId), tostring(isPlowSpec))
                 if farmlandId and farmlandId > 0 then
@@ -1788,7 +1796,8 @@ function HookManager:installDedicatedPlowHook()
 
             local x, _, z = getWorldTranslation(plowSelf.rootNode)
             local success, errorMsg = pcall(function()
-                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                -- skipNegativeCache=true: player-created fields are not in the cache yet
+                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z, true)
                 SoilLogger.debug("[DedicatedPlowHook] pos=(%.1f,%.1f) farmlandId=%s",
                     x, z, tostring(farmlandId))
                 if farmlandId and farmlandId > 0 then

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1320,20 +1320,10 @@ function HookManager:installSprayerAreaHook()
                 local rateMultiplier = (rm ~= nil) and rm:getMultiplier(self.id) or 1.0
                 local effectiveLiters = liters * rateMultiplier
 
-                -- Section Control: scale nutrient credit when outer boom sections are off.
+                -- Section Control double-penalty fix (Issue #345):
                 -- wap.usage already reflects section shutoff (VariableWorkWidth.getIsWorkAreaActive
-                -- gates each work area on section.isActive). We apply the fraction here so that
-                -- effectiveLiters correctly represents the nutrient dose for the active portion
-                -- of the field, especially when rateMultiplier != 1.0.
-                local coverageFraction = 1.0
-                if SoilUtils and SoilUtils.getSectionCoverageFraction then
-                    coverageFraction = SoilUtils.getSectionCoverageFraction(self)
-                    if coverageFraction < 1.0 then
-                        effectiveLiters = effectiveLiters * coverageFraction
-                        SoilLogger.debug("SectionControl: %.0f%% boom active → liters scaled to %.4fL",
-                            coverageFraction * 100, effectiveLiters)
-                    end
-                end
+                -- gates each work area on section.isActive), so 'liters' is already proportionally reduced.
+                -- Do NOT multiply by coverageFraction again, otherwise we quadratically penalize the dosage.
 
                 -- ── Coverage tracking (raw liters, before rateMultiplier) ─────────
                 -- Must run for ALL product types (fertilizer AND crop protection).

--- a/src/main.lua
+++ b/src/main.lua
@@ -362,19 +362,22 @@ end
 -- =========================================================
 if DensityMapHeightManager and type(DensityMapHeightManager.loadMapData) == "function" then
     local function injectSFHeightTypes(densityMapHeightManager)
-        if densityMapHeightManager.modDensityHeightMapTypeFilenames then
-            local filename = modDirectory .. "xml/densityMapHeightTypes.xml"
-            local alreadyAdded = false
-            for _, existing in ipairs(densityMapHeightManager.modDensityHeightMapTypeFilenames) do
-                if existing == filename then
-                    alreadyAdded = true
-                    break
-                end
+        if densityMapHeightManager.modDensityHeightMapTypeFilenames == nil then
+            densityMapHeightManager.modDensityHeightMapTypeFilenames = {}
+        end
+
+        local filename = modDirectory .. "xml/densityMapHeightTypes.xml"
+        local alreadyAdded = false
+        for _, existing in ipairs(densityMapHeightManager.modDensityHeightMapTypeFilenames) do
+            if existing == filename then
+                alreadyAdded = true
+                break
             end
-            if not alreadyAdded then
-                SoilLogger.info("Tip On Ground Fix: Registering densityMapHeightTypes.xml")
-                table.insert(densityMapHeightManager.modDensityHeightMapTypeFilenames, filename)
-            end
+        end
+
+        if not alreadyAdded then
+            SoilLogger.info("Tip On Ground Fix: Registering densityMapHeightTypes.xml")
+            table.insert(densityMapHeightManager.modDensityHeightMapTypeFilenames, filename)
         end
     end
     DensityMapHeightManager.loadMapData = Utils.prependedFunction(DensityMapHeightManager.loadMapData, injectSFHeightTypes)

--- a/src/main.lua
+++ b/src/main.lua
@@ -355,6 +355,31 @@ if FillTypeManager and type(FillTypeManager.loadModFillTypes) == "function" then
     FillTypeManager.loadModFillTypes = Utils.prependedFunction(FillTypeManager.loadModFillTypes, injectSFModFillTypes)
 end
 
+-- =========================================================
+-- TIP ON GROUND FIX: Register densityMapHeightTypes
+-- Enables mod fill types to be tipped on the ground (CTRL+I).
+-- We inject our XML into DensityMapHeightManager's loading queue.
+-- =========================================================
+if DensityMapHeightManager and type(DensityMapHeightManager.loadMapData) == "function" then
+    local function injectSFHeightTypes(densityMapHeightManager)
+        if densityMapHeightManager.modDensityHeightMapTypeFilenames then
+            local filename = modDirectory .. "xml/densityMapHeightTypes.xml"
+            local alreadyAdded = false
+            for _, existing in ipairs(densityMapHeightManager.modDensityHeightMapTypeFilenames) do
+                if existing == filename then
+                    alreadyAdded = true
+                    break
+                end
+            end
+            if not alreadyAdded then
+                SoilLogger.info("Tip On Ground Fix: Registering densityMapHeightTypes.xml")
+                table.insert(densityMapHeightManager.modDensityHeightMapTypeFilenames, filename)
+            end
+        end
+    end
+    DensityMapHeightManager.loadMapData = Utils.prependedFunction(DensityMapHeightManager.loadMapData, injectSFHeightTypes)
+end
+
 -- Route mouse events to SoilHUD (for drag/resize edit mode).
 -- Edit mode is entered via Shift+H (SF_HUD_DRAG input action) — not via RMB.
 -- RMB only exits edit mode (and only when this mod is already in edit mode).

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -389,6 +389,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
         local diseaseDays = streamReadInt32(streamId)
         local dryDays = streamReadInt32(streamId)
         local burnDays = streamReadInt32(streamId)
+        local coverageFrac = streamReadFloat32(streamId)
         local compaction = streamReadFloat32(streamId)
 
         -- Read nutrient buffer (V1.7)
@@ -450,6 +451,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
                 fungicideDaysLeft = diseaseDays,
                 dryDayCount = dryDays,
                 burnDaysLeft = burnDays,
+                coverageFraction = math.max(0, math.min(1, coverageFrac or 0)),
                 compaction = math.max(0, math.min(100, compaction or 0)),
                 initialized = true
             }
@@ -515,6 +517,7 @@ function SoilFullSyncEvent:writeStream(streamId, connection)
         streamWriteInt32(streamId, field.fungicideDaysLeft or 0)
         streamWriteInt32(streamId, field.dryDayCount or 0)
         streamWriteInt32(streamId, field.burnDaysLeft or 0)
+        streamWriteFloat32(streamId, field.coverageFraction or 0)
         streamWriteFloat32(streamId, field.compaction or 0)
 
         -- Write nutrient buffer (V1.7)

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -644,6 +644,25 @@ function SoilFieldBatchSyncEvent:writeStream(streamId, connection)
             streamWriteInt32(streamId,   ftIdx)
             streamWriteFloat32(streamId, amount)
         end
+
+        -- Zone cell data: per-cell soil state for the PDA cell-report overlay.
+        -- Added in v2.1.6 so dedi clients receive accumulated cell data on join.
+        local zd = field.zoneData or {}
+        local zdCount = 0
+        for _ in pairs(zd) do zdCount = zdCount + 1 end
+        streamWriteInt32(streamId, zdCount)
+        for cellKey, cell in pairs(zd) do
+            streamWriteInt32(streamId,   tonumber(cellKey) or 0)
+            streamWriteFloat32(streamId, cell.N  or 0)
+            streamWriteFloat32(streamId, cell.P  or 0)
+            streamWriteFloat32(streamId, cell.K  or 0)
+            streamWriteFloat32(streamId, cell.pH or 6.0)
+            streamWriteFloat32(streamId, cell.OM or 0)
+            streamWriteFloat32(streamId, cell.weedPressure    or 0)
+            streamWriteFloat32(streamId, cell.pestPressure    or 0)
+            streamWriteFloat32(streamId, cell.diseasePressure or 0)
+            streamWriteFloat32(streamId, cell.compaction      or 0)
+        end
     end
 end
 
@@ -685,6 +704,24 @@ function SoilFieldBatchSyncEvent:readStream(streamId, connection)
             buffer[ftIdx] = amount
         end
 
+        -- Zone cell data (added v2.1.6)
+        local zd = {}
+        local zdCount = streamReadInt32(streamId)
+        for _ = 1, zdCount do
+            local keyInt = streamReadInt32(streamId)
+            zd[tostring(keyInt)] = {
+                N               = streamReadFloat32(streamId),
+                P               = streamReadFloat32(streamId),
+                K               = streamReadFloat32(streamId),
+                pH              = streamReadFloat32(streamId),
+                OM              = streamReadFloat32(streamId),
+                weedPressure    = streamReadFloat32(streamId),
+                pestPressure    = streamReadFloat32(streamId),
+                diseasePressure = streamReadFloat32(streamId),
+                compaction      = streamReadFloat32(streamId),
+            }
+        end
+
         if type(fieldId) == "number" and fieldId >= 0 then
             self.batchFields[fieldId] = {
                 fieldArea             = math.max(0.01, fieldArea or 1.0),
@@ -712,6 +749,7 @@ function SoilFieldBatchSyncEvent:readStream(streamId, connection)
                 coveredCells          = {},
                 coveredCellCount      = 0,
                 compaction            = math.max(0, math.min(100, compaction or 0)),
+                zoneData              = zd,
                 initialized           = true,
             }
         end
@@ -807,6 +845,24 @@ function SoilFieldUpdateEvent:readStream(streamId, connection)
         buffer[ftIdx] = amount
     end
 
+    -- Zone cell data (added v2.1.6)
+    local zd = {}
+    local zdCount = streamReadInt32(streamId)
+    for _ = 1, zdCount do
+        local keyInt = streamReadInt32(streamId)
+        zd[tostring(keyInt)] = {
+            N               = streamReadFloat32(streamId),
+            P               = streamReadFloat32(streamId),
+            K               = streamReadFloat32(streamId),
+            pH              = streamReadFloat32(streamId),
+            OM              = streamReadFloat32(streamId),
+            weedPressure    = streamReadFloat32(streamId),
+            pestPressure    = streamReadFloat32(streamId),
+            diseasePressure = streamReadFloat32(streamId),
+            compaction      = streamReadFloat32(streamId),
+        }
+    end
+
     -- Clamp all values to valid ranges
     self.field = {
         fieldArea = math.max(0.01, fieldArea or 1.0),
@@ -839,6 +895,7 @@ function SoilFieldUpdateEvent:readStream(streamId, connection)
         coveredCells     = {},
         coveredCellCount = 0,
         compaction       = math.max(0, math.min(100, compaction or 0)),
+        zoneData         = zd,
         initialized      = true
     }
 
@@ -889,6 +946,24 @@ function SoilFieldUpdateEvent:writeStream(streamId, connection)
     for ftIdx, amount in pairs(buffer) do
         streamWriteInt32(streamId, ftIdx)
         streamWriteFloat32(streamId, amount)
+    end
+
+    -- Zone cell data (added v2.1.6)
+    local zd = self.field.zoneData or {}
+    local zdCount = 0
+    for _ in pairs(zd) do zdCount = zdCount + 1 end
+    streamWriteInt32(streamId, zdCount)
+    for cellKey, cell in pairs(zd) do
+        streamWriteInt32(streamId,   tonumber(cellKey) or 0)
+        streamWriteFloat32(streamId, cell.N  or 0)
+        streamWriteFloat32(streamId, cell.P  or 0)
+        streamWriteFloat32(streamId, cell.K  or 0)
+        streamWriteFloat32(streamId, cell.pH or 6.0)
+        streamWriteFloat32(streamId, cell.OM or 0)
+        streamWriteFloat32(streamId, cell.weedPressure    or 0)
+        streamWriteFloat32(streamId, cell.pestPressure    or 0)
+        streamWriteFloat32(streamId, cell.diseasePressure or 0)
+        streamWriteFloat32(streamId, cell.compaction      or 0)
     end
 end
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -515,6 +515,10 @@ function SoilHUD:updateFieldInfoBox()
     local box = self.fieldInfoBox
     if not box then return end
 
+    -- Only show the native FIELD INFO style box when actually on a field.
+    -- This prevents it from showing up on roads, grass, or yards (Tier 2 farmland fallback).
+    if not self.isOnField then return end
+
     local info = self.cachedFieldInfo
     if not info then return end
 
@@ -661,6 +665,7 @@ function SoilHUD:refreshFieldData()
     local fieldId, x, z = self:detectCurrentFieldId()
     local prevId  = self.cachedFieldId
     self.cachedFieldId = fieldId
+    self.isOnField     = (fieldId ~= nil)
     self.cachedPlayerX = x
     self.cachedPlayerZ = z
 

--- a/src/ui/SoilMapCellDialog.lua
+++ b/src/ui/SoilMapCellDialog.lua
@@ -123,10 +123,10 @@ function SoilMapCellDialog:onClickMap(worldX, worldZ)
             if self.valK then self.valK:setText(string.format("%.1f kg/ha", info.k or info.potassium and info.potassium.value or 0)) end
             if self.valPH then self.valPH:setText(string.format("%.2f", info.ph or info.pH or 7.0)) end
             if self.valOM then self.valOM:setText(string.format("%.2f%%", info.om or info.organicMatter or 2.0)) end
-            if self.valWeed then self.valWeed:setText("--") end
-            if self.valPest then self.valPest:setText("--") end
-            if self.valDisease then self.valDisease:setText("--") end
-            if self.valCompaction then self.valCompaction:setText("--") end
+            if self.valWeed then self.valWeed:setText(string.format("%d%%", info.weedPressure or 0)) end
+            if self.valPest then self.valPest:setText(string.format("%d%%", info.pestPressure or 0)) end
+            if self.valDisease then self.valDisease:setText(string.format("%d%%", info.diseasePressure or 0)) end
+            if self.valCompaction then self.valCompaction:setText(string.format("%d%%", info.compaction or 0)) end
         else
             if self.detailsGroup then self.detailsGroup:setVisible(false) end
             if self.hintText then

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,9 +24,20 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "Translation Update",
-    "- All 25 languages have been written in their respective language",
-    "- All 25 translations (627 keys per language) are synced to the english version",
+    "Bug Fixes & Improvements",
+    "- Fixed potassium fertilizer rates (K-rates now agronomically correct)",
+    "- Fixed herbicide cell updates (weed pressure now reflects per-cell spray)",
+    "- Fixed zoneData not syncing to clients on dedicated servers",
+    "- Fixed player-created and expanded fields not being detected by the mod",
+    "- Fixed Section Control double-penalty on herbicide/fertilizer application",
+    "- Fixed network sync, HUD fallback, and save state persistence",
+    "- Fixed UI elements misalignment in settings menu",
+    "- Fixed XML parse failure causing PDA text misalignment",
+    "New Features",
+    "- Luzerne and clover now recognized as legumes (low N target, spring bonus)",
+    "- Weed suppression scales with time-of-season (row closure mechanic)",
+    "- Added 10,000L big bags for bulk fertilizer handling",
+    "- Time-scaling for weed/pest/disease growth speed",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/utils/UIHelper.lua
+++ b/src/utils/UIHelper.lua
@@ -65,36 +65,34 @@ function UIHelper.createBinaryOption(layout, callbackTarget, callbackName, title
     end
 
     local bitMap = BitmapElement.new()
-    local bitMapProfile = g_gui:getProfile("fs25_multiTextOptionContainer")
-    bitMap:loadProfile(bitMapProfile, true)
+    layout:addElement(bitMap)
 
     local binaryOption = BinaryOptionElement.new()
     binaryOption.useYesNoTexts = true
-    local binaryOptionProfile = g_gui:getProfile("fs25_settingsBinaryOption")
-    binaryOption:loadProfile(binaryOptionProfile, true)
+    bitMap:addElement(binaryOption)
+
+    local titleElement = TextElement.new()
+    bitMap:addElement(titleElement)
+
+    local tooltipElement = TextElement.new()
+    tooltipElement.name = "ignore"
+    binaryOption:addElement(tooltipElement)
+
+    bitMap:loadProfile(g_gui:getProfile("fs25_multiTextOptionContainer"), true)
+
+    binaryOption:loadProfile(g_gui:getProfile("fs25_settingsBinaryOption"), true)
     binaryOption.target = callbackTarget
     binaryOption:setCallback("onClickCallback", callbackName)
 
-    local titleElement = TextElement.new()
-    local titleProfile = g_gui:getProfile("fs25_settingsMultiTextOptionTitle")
-    titleElement:loadProfile(titleProfile, true)
+    titleElement:loadProfile(g_gui:getProfile("fs25_settingsMultiTextOptionTitle"), true)
     titleElement:setText(title)
 
-    local tooltipElement = TextElement.new()
-    local tooltipProfile = g_gui:getProfile("fs25_multiTextOptionTooltip")
-    tooltipElement.name = "ignore"
-    tooltipElement:loadProfile(tooltipProfile, true)
+    tooltipElement:loadProfile(g_gui:getProfile("fs25_multiTextOptionTooltip"), true)
     tooltipElement:setText(tooltip)
 
-    binaryOption:addElement(tooltipElement)
-    bitMap:addElement(binaryOption)
-    bitMap:addElement(titleElement)
-
-    binaryOption:onGuiSetupFinished()
-    titleElement:onGuiSetupFinished()
     tooltipElement:onGuiSetupFinished()
-
-    layout:addElement(bitMap)
+    titleElement:onGuiSetupFinished()
+    binaryOption:onGuiSetupFinished()
     bitMap:onGuiSetupFinished()
 
     return binaryOption
@@ -115,36 +113,34 @@ function UIHelper.createMultiOption(layout, callbackTarget, callbackName, texts,
     end
 
     local bitMap = BitmapElement.new()
-    local bitMapProfile = g_gui:getProfile("fs25_multiTextOptionContainer")
-    bitMap:loadProfile(bitMapProfile, true)
+    layout:addElement(bitMap)
 
     local multiTextOption = MultiTextOptionElement.new()
-    local multiTextOptionProfile = g_gui:getProfile("fs25_settingsMultiTextOption")
-    multiTextOption:loadProfile(multiTextOptionProfile, true)
+    bitMap:addElement(multiTextOption)
+
+    local titleElement = TextElement.new()
+    bitMap:addElement(titleElement)
+
+    local tooltipElement = TextElement.new()
+    tooltipElement.name = "ignore"
+    multiTextOption:addElement(tooltipElement)
+
+    bitMap:loadProfile(g_gui:getProfile("fs25_multiTextOptionContainer"), true)
+
+    multiTextOption:loadProfile(g_gui:getProfile("fs25_settingsMultiTextOption"), true)
     multiTextOption.target = callbackTarget
     multiTextOption:setCallback("onClickCallback", callbackName)
     multiTextOption:setTexts(texts)
 
-    local titleElement = TextElement.new()
-    local titleProfile = g_gui:getProfile("fs25_settingsMultiTextOptionTitle")
-    titleElement:loadProfile(titleProfile, true)
+    titleElement:loadProfile(g_gui:getProfile("fs25_settingsMultiTextOptionTitle"), true)
     titleElement:setText(title)
 
-    local tooltipElement = TextElement.new()
-    local tooltipProfile = g_gui:getProfile("fs25_multiTextOptionTooltip")
-    tooltipElement.name = "ignore"
-    tooltipElement:loadProfile(tooltipProfile, true)
+    tooltipElement:loadProfile(g_gui:getProfile("fs25_multiTextOptionTooltip"), true)
     tooltipElement:setText(tooltip)
 
-    multiTextOption:addElement(tooltipElement)
-    bitMap:addElement(multiTextOption)
-    bitMap:addElement(titleElement)
-
-    multiTextOption:onGuiSetupFinished()
-    titleElement:onGuiSetupFinished()
     tooltipElement:onGuiSetupFinished()
-
-    layout:addElement(bitMap)
+    titleElement:onGuiSetupFinished()
+    multiTextOption:onGuiSetupFinished()
     bitMap:onGuiSetupFinished()
 
     return multiTextOption

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -183,10 +183,13 @@
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
     <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biosolids (10,000L)" />
     <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Chicken Manure (10,000L)" />
     <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="42d76587" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelletized Manure (10,000L)" />
     <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
     <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />

--- a/xml/densityMapHeightTypes.xml
+++ b/xml/densityMapHeightTypes.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <map>
     <densityMapHeightTypes>
-        <densityMapHeightType fillType="UREA" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="AN" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="AMS" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="MAP" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="DAP" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="POTASH" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="GYPSUM" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="COMPOST" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="BIOSOLIDS" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="CHICKEN_MANURE" maxAllowedHeight="0.8" minHeight="0.05" />
-        <densityMapHeightType fillType="PELLETIZED_MANURE" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="UREA" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="AN" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="AMS" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="MAP" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="DAP" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="POTASH" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="GYPSUM" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="COMPOST" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="BIOSOLIDS" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="CHICKEN_MANURE" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+        <densityMapHeightType fillType="PELLETIZED_MANURE" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
     </densityMapHeightTypes>
 </map>

--- a/xml/densityMapHeightTypes.xml
+++ b/xml/densityMapHeightTypes.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<map>
+    <densityMapHeightTypes>
+        <densityMapHeightType fillType="UREA" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="AN" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="AMS" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="MAP" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="DAP" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="POTASH" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="GYPSUM" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="COMPOST" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="BIOSOLIDS" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="CHICKEN_MANURE" maxAllowedHeight="0.8" minHeight="0.05" />
+        <densityMapHeightType fillType="PELLETIZED_MANURE" maxAllowedHeight="0.8" minHeight="0.05" />
+    </densityMapHeightTypes>
+</map>

--- a/xml/gui/SoilPDAScreen.xml
+++ b/xml/gui/SoilPDAScreen.xml
@@ -30,8 +30,8 @@
         <!-- SIDEBAR A: Full field list shown on Overview tab -->
         <GuiElement id="sidebarOverview" position="0px 0px" width="420px" height="640px">
           <Text profile="sf_sectionHeader" text="$l10n_sf_pda_tab_fields" position="10px -10px"/>
-          <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_field"  position="10px  -50px" size="60px 24px"/>
-          <Text profile="sf_colHeader"      text="N"                        position="76px  -50px" size="58px 24px"/>
+          <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_field"  position="10px -50px" size="60px 24px"/>
+          <Text profile="sf_colHeader"      text="N"                        position="76px -50px" size="58px 24px"/>
           <Text profile="sf_colHeader"      text="P"                        position="138px -50px" size="58px 24px"/>
           <Text profile="sf_colHeader"      text="K"                        position="200px -50px" size="58px 24px"/>
           <Text profile="sf_colHeader"      text="pH"                       position="262px -50px" size="48px 24px"/>
@@ -42,8 +42,8 @@
                         endClipperElementName="sideListEnd">
               <ListItem profile="sf_listRow" onClick="onClickFieldRow">
                 <Bitmap profile="sf_rowBg" name="alternating"/>
-                <Text profile="sf_cellLeft"  name="fieldRowId"     size="60px  28px"/>
-                <Text profile="sf_cellRight" name="fieldRowN"      position="76px  0" size="58px 28px"/>
+                <Text profile="sf_cellLeft"  name="fieldRowId"     size="60px 28px"/>
+                <Text profile="sf_cellRight" name="fieldRowN"      position="76px 0" size="58px 28px"/>
                 <Text profile="sf_cellRight" name="fieldRowP"      position="138px 0" size="58px 28px"/>
                 <Text profile="sf_cellRight" name="fieldRowK"      position="200px 0" size="58px 28px"/>
                 <Text profile="sf_cellRight" name="fieldRowPH"     position="262px 0" size="48px 28px"/>
@@ -124,8 +124,8 @@
       <!-- TAB 2: TREATMENT PLAN -->
       <GuiElement id="treatmentContent" position="0px 0px" width="1000px" height="668px" visible="false">
         <Text profile="sf_sectionHeader" text="$l10n_sf_pda_treatment_section_title" position="0px 648px"/>
-        <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_field"    position="8px   618px" size="80px  24px"/>
-        <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_priority" position="90px  618px" size="120px 24px"/>
+        <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_field"    position="8px 618px" size="80px 24px"/>
+        <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_priority" position="90px 618px" size="120px 24px"/>
         <Text profile="sf_colHeader"      text="$l10n_sf_pda_col_needs"    position="220px 618px" size="740px 24px"/>
         <GuiElement id="treatmentListContainer" position="0px 100px" width="1000px" height="508px">
           <SmoothList id="treatmentList" profile="sf_smoothList"
@@ -133,8 +133,8 @@
                       endClipperElementName="tlEnd">
             <ListItem profile="sf_listRow" onClick="onClickTreatmentRow">
               <Bitmap profile="sf_rowBg" name="alternating"/>
-              <Text profile="sf_cellLeft"  name="treatRowId"      size="80px  28px"/>
-              <Text profile="sf_cellRight" name="treatRowUrgency" position="90px  0" size="120px 28px"/>
+              <Text profile="sf_cellLeft"  name="treatRowId"      size="80px 28px"/>
+              <Text profile="sf_cellRight" name="treatRowUrgency" position="90px 0" size="120px 28px"/>
               <Text profile="sf_cellLeft"  name="treatRowNeeds"   position="220px 0" size="760px 28px"/>
             </ListItem>
           </SmoothList>
@@ -151,8 +151,8 @@
 
       <!-- Tab bar — 2 tabs, evenly spaced -->
       <GuiElement id="tabBar" profile="emptyPanel" position="0px 668px" width="1000px" height="58px">
-        <Text   profile="sf_tabLabel"     id="tabLabelOverview"      text="$l10n_sf_pda_section_farm_overview" onClick="onClickTabOverview"   position="0px   30px" size="500px 28px"/>
-        <Bitmap profile="sf_tabUnderline" id="tabUnderlineOverview"                                                                            position="0px   28px" size="500px 2px"/>
+        <Text   profile="sf_tabLabel"     id="tabLabelOverview"      text="$l10n_sf_pda_section_farm_overview" onClick="onClickTabOverview"   position="0px 30px" size="500px 28px"/>
+        <Bitmap profile="sf_tabUnderline" id="tabUnderlineOverview"                                                                            position="0px 28px" size="500px 2px"/>
         <Text   profile="sf_tabLabel"     id="tabLabelTreatment"     text="$l10n_sf_pda_tab_treatment"         onClick="onClickTabTreatment"   position="500px 30px" size="500px 28px"/>
         <Bitmap profile="sf_tabUnderline" id="tabUnderlineTreatment"                                                                            position="500px 28px" size="500px 2px" visible="false"/>
       </GuiElement>


### PR DESCRIPTION
## Summary

- Fixed potassium fertilizer rates (agronomically correct K coefficients)
- Fixed herbicide cell updates — weed pressure now reflected per-cell in soil report
- Fixed zoneData not syncing to dedicated server clients on join (#353)
- Fixed player-created and expanded fields not detected by the mod (#354)
- Fixed Section Control double-penalty on herbicide/fertilizer application (#345)
- Fixed network sync, HUD fallback, and save state persistence on dedi (#343)
- Fixed UI elements misalignment in settings menu (#342)
- Fixed XML parse failure causing PDA text misalignment (#342)
- Added luzerne and clover as recognized legumes (low N target, spring N bonus) (#352)
- Weed suppression scales with time-of-season (row closure mechanic) (#349)
- Added 10,000L big bags for bulk fertilizer handling
- Time-scaling for weed/pest/disease growth speed (#349)
- Translation update: 627 keys synced across 25 languages

## Test plan

- [ ] Load a saved game and confirm version dialog shows 2.1.6.0 with new changelog
- [ ] Verify herbicide application reduces weed pressure in cell report dialog
- [ ] Join a dedicated server as client and confirm zoneData visible in cell overlay
- [ ] Create a new field mid-session and confirm soil tracking starts immediately
- [ ] Apply potash fertilizer and verify K gain matches expected rates
- [ ] Confirm luzerne/clover show low N targets in the soil report