### PR TITLE
fix: boom-width cell sweep, tip-to-ground improvements, issue cleanup

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.0</version>
+    <version>2.1.6.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1828,29 +1828,6 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
             field.diseasePressure = math.min(100, pressure + ((baseRate * seasonMult * cropMult) + rainBonus) * timeFactor)
         end
     end
-            elseif pressure < dp.MEDIUM then baseRate = dp.GROWTH_RATE_MID
-            elseif pressure < dp.HIGH   then baseRate = dp.GROWTH_RATE_HIGH
-            else                             baseRate = dp.GROWTH_RATE_PEAK
-            end
-
-            local seasonMult = 1.0
-            if season then
-                if     season == 1 then seasonMult = dp.SEASONAL_SPRING
-                elseif season == 2 then seasonMult = dp.SEASONAL_SUMMER
-                elseif season == 3 then seasonMult = dp.SEASONAL_FALL
-                elseif season == 4 then seasonMult = dp.SEASONAL_WINTER
-                end
-            end
-
-            local cropMult = 1.0
-            if field.lastCrop then
-                cropMult = dp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
-            end
-
-            local rainBonus = isRaining and dp.RAIN_BONUS or 0
-            field.diseasePressure = math.min(100, pressure + (baseRate * seasonMult * cropMult) + rainBonus)
-        end
-    end
 
     -- ── Burn warning countdown ───────────────────────────────────────────────
     if (field.burnDaysLeft or 0) > 0 then

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2387,6 +2387,43 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName)
     end
 end
 
+--- Stamp display-only zone cells at every position in boomPoints.
+--- No nutrient delta is applied; each new cell is initialised with the current
+--- field average so the PDA map shows which areas the boom has passed over.
+--- Called from HookManager after applySingle to fill in the full lateral sweep.
+---@param fieldId   number
+---@param boomPoints table  Array of {x=, z=} world positions
+function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
+    if not boomPoints or #boomPoints == 0 then return end
+    local field = self.fieldData and self.fieldData[fieldId]
+    if not field then return end
+
+    local zone = SoilConstants.ZONE
+    local seen = {}
+    for _, pt in ipairs(boomPoints) do
+        local cx = math.floor(pt.x / zone.CELL_SIZE)
+        local cz = math.floor(pt.z / zone.CELL_SIZE)
+        local cellKey = tostring(cx * 10000 + cz)
+        if not seen[cellKey] then
+            seen[cellKey] = true
+            if not field.zoneData then field.zoneData = {} end
+            if not field.zoneData[cellKey] then
+                field.zoneData[cellKey] = {
+                    N  = field.nitrogen       or SoilConstants.FIELD_DEFAULTS.nitrogen,
+                    P  = field.phosphorus     or SoilConstants.FIELD_DEFAULTS.phosphorus,
+                    K  = field.potassium      or SoilConstants.FIELD_DEFAULTS.potassium,
+                    pH = field.pH             or SoilConstants.FIELD_DEFAULTS.pH,
+                    OM = field.organicMatter  or SoilConstants.FIELD_DEFAULTS.organicMatter,
+                    weedPressure    = field.weedPressure    or 0,
+                    pestPressure    = field.pestPressure    or 0,
+                    diseasePressure = field.diseasePressure or 0,
+                    compaction      = field.compaction      or 0,
+                }
+            end
+        end
+    end
+end
+
 --- Direct-path buffering for non-profile products (Herbicide/Insecticide/Fungicide)
 -- NOTE: the formula (liters/targetVol)×REDUCTION depends on targetRate (from
 -- Constants, a real-world L/ha figure ~1.5) matching the actual vanilla sprayer

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1410,6 +1410,16 @@ function HookManager:installSprayerAreaHook()
                     applySingle(fieldId, effectiveLiters, rootX, rootZ)
                 end
 
+                -- Sweep all cells under the full boom width for display (#362).
+                -- Nutrients are already attributed to the field by applySingle/section loop;
+                -- markBoomCells only stamps display entries for unvisited lateral cells.
+                if soilSys and fieldId and fieldId > 0 then
+                    local boomPts = hookMgrRef:getBoomCellPositions(self, rootX, rootZ)
+                    if boomPts then
+                        soilSys:markBoomCells(fieldId, boomPts)
+                    end
+                end
+
                 -- BUY mode backup refill (issue #125).
                 -- SpecializationUtil.registerFunction may cache function references before
                 -- our FillUnit.addFillUnitFillLevel hook installs, so the class-level hook
@@ -3350,4 +3360,76 @@ function HookManager:installClientJoinHook()
     self._clientJoinListener = listener
     SoilLogger.info("[OK] Client join hook installed (addModEventListener/onClientJoined)")
     return true
+end
+
+-- =========================================================
+-- UTILITY: Boom Cell Sweep (issue #362)
+-- =========================================================
+--- Collect world positions spanning the spray boom's lateral extent by reading
+--- work-area start/end nodes on the vehicle and all attached implements.
+--- Used to mark every 10 m cell the boom passes over — not just the rootNode cell.
+---
+--- Falls back to nil when no spanning node pair is found (caller marks only rootNode).
+---@param vehicle table  The sprayer vehicle (self in the spray hook)
+---@param rootX   number  Vehicle root-node world X
+---@param rootZ   number  Vehicle root-node world Z
+---@return table|nil  Array of {x=, z=} world positions, or nil if span < 2 nodes
+function HookManager:getBoomCellPositions(vehicle, rootX, rootZ)
+    local cellSize = SoilConstants.ZONE.CELL_SIZE
+    local xs, zs = {}, {}
+
+    local function collectFromObj(obj)
+        if not obj or not obj.spec_workArea or not obj.spec_workArea.workAreas then return end
+        for _, wa in ipairs(obj.spec_workArea.workAreas) do
+            if wa.start then
+                local ok, x, _, z = pcall(getWorldTranslation, wa.start)
+                if ok and x then table.insert(xs, x); table.insert(zs, z) end
+            end
+            local waEnd = wa["end"]  -- "end" is a Lua keyword; must use bracket access
+            if waEnd then
+                local ok, x, _, z = pcall(getWorldTranslation, waEnd)
+                if ok and x then table.insert(xs, x); table.insert(zs, z) end
+            end
+        end
+    end
+
+    collectFromObj(vehicle)
+    if vehicle.spec_attacherJoints and vehicle.spec_attacherJoints.attachedImplements then
+        for _, impl in ipairs(vehicle.spec_attacherJoints.attachedImplements or {}) do
+            collectFromObj(impl and impl.object)
+        end
+    end
+
+    if #xs < 2 then return nil end
+
+    local minX, maxX = xs[1], xs[1]
+    local minZ, maxZ = zs[1], zs[1]
+    for _, x in ipairs(xs) do minX = math.min(minX, x); maxX = math.max(maxX, x) end
+    for _, z in ipairs(zs) do minZ = math.min(minZ, z); maxZ = math.max(maxZ, z) end
+
+    local spanX = maxX - minX
+    local spanZ = maxZ - minZ
+    -- Only sweep if the detected span is meaningfully wider than one cell
+    if math.max(spanX, spanZ) < cellSize * 0.5 then return nil end
+
+    local halfCell = cellSize * 0.5
+    local pts = {}
+
+    if spanX >= spanZ then
+        -- Boom runs primarily east-west: sweep along X
+        local x = minX
+        while x <= maxX + halfCell do
+            table.insert(pts, {x = x, z = rootZ})
+            x = x + cellSize
+        end
+    else
+        -- Boom runs primarily north-south: sweep along Z
+        local z = minZ
+        while z <= maxZ + halfCell do
+            table.insert(pts, {x = rootX, z = z})
+            z = z + cellSize
+        end
+    end
+
+    return (#pts > 1) and pts or nil
 end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1980,10 +1980,17 @@ function HookManager:installSowingHook()
                     tostring(spec.workAreaParameters.seedsFruitType))
                 if not fieldId or fieldId <= 0 then return end
 
-                local statsArea = spec.workAreaParameters.lastStatsArea or spec.workAreaParameters.lastChangedArea or 0.001
+                local statsArea = spec.workAreaParameters.lastStatsArea or spec.workAreaParameters.lastChangedArea or 0
+                if statsArea <= 0 then return end
+                -- Convert density-map pixels → hectares (same as plow/cultivator/mower hooks).
+                -- Passing raw pixels directly caused factor = pixels/fieldAreaHa, exploding
+                -- NPK to max in the first sowing tick (same bug fixed for plow in 51083e7).
+                if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
+                local areaHa = MathUtil.areaToHa(statsArea, g_currentMission:getFruitPixelsToSqm())
+                if areaHa <= 0 then return end
                 g_SoilFertilityManager.soilSystem._lastTillageX = x
                 g_SoilFertilityManager.soilSystem._lastTillageZ = z
-                g_SoilFertilityManager.soilSystem:onSowing(fieldId, statsArea)
+                g_SoilFertilityManager.soilSystem:onSowing(fieldId, areaHa)
             end)
 
             if not ok then

--- a/src/main.lua
+++ b/src/main.lua
@@ -99,6 +99,24 @@ local function loadedMission(mission, node)
     end
     sfm:onMissionLoaded()
 
+    -- TIP ON GROUND FIX: register density map height types now that fill types are live.
+    -- At this point g_fillTypeManager resolves our fill type names correctly (confirmed by
+    -- HUD icon patching below). All earlier hook points fire before the engine finishes
+    -- its modDesc.xml <fillTypes> pass, leaving our types nil.
+    if g_densityMapHeightManager ~= nil
+    and type(g_densityMapHeightManager.loadDensityMapHeightTypes) == "function" then
+        local htFile = loadXMLFile("soilHeightTypes", modDirectory .. "xml/densityMapHeightTypes.xml")
+        if htFile ~= nil and htFile ~= 0 then
+            g_densityMapHeightManager:loadDensityMapHeightTypes(htFile, mission.missionInfo, modDirectory, false)
+            delete(htFile)
+            SoilLogger.info("Tip On Ground Fix: Height types registered in loadedMission")
+        else
+            SoilLogger.warning("Tip On Ground Fix: Could not open densityMapHeightTypes.xml")
+        end
+    else
+        SoilLogger.warning("Tip On Ground Fix: g_densityMapHeightManager not available")
+    end
+
     -- Fallback: register atlas if it was skipped at load time (g_overlayManager was nil then).
     if not _helplineAtlasRegistered then
         if g_overlayManager then
@@ -355,41 +373,16 @@ if FillTypeManager and type(FillTypeManager.loadModFillTypes) == "function" then
     FillTypeManager.loadModFillTypes = Utils.prependedFunction(FillTypeManager.loadModFillTypes, injectSFModFillTypes)
 end
 
--- =========================================================
--- TIP ON GROUND FIX: Register density map height types after fill types are loaded
+-- TIP ON GROUND FIX: registration moved into loadedMission() below.
 --
--- Root cause: DensityMapHeightManager.loadMapData fires BEFORE FillTypeManager.loadMapData,
--- so any XML injected into modDensityHeightMapTypeFilenames is processed while our custom
--- fill types are still nil — every entry fails with "invalid fill type 'nil'".
---
--- Fix: hook FillTypeManager.loadMapData with appendedFunction so our height types are
--- registered immediately after our fill types land in g_fillTypeManager. Terrain layer
--- construction (constructTerrainFillLayers) requires the map i3d to be loaded, which
--- happens after both loadMapData calls complete — so our late-registered types are
--- included in the terrain build pass and get full visual + physics support.
--- =========================================================
-if FillTypeManager and type(FillTypeManager.loadMapData) == "function" then
-    local soilHeightTypesRegistered = false
-    local function registerSFHeightTypesAfterFillTypes(self, xmlFile, missionInfo, baseDirectory)
-        if soilHeightTypesRegistered then return end
-        if g_densityMapHeightManager == nil
-        or type(g_densityMapHeightManager.loadDensityMapHeightTypes) ~= "function" then
-            SoilLogger.warning("Tip On Ground Fix: g_densityMapHeightManager not ready — tipping to ground may not work")
-            return
-        end
-        local filename = modDirectory .. "xml/densityMapHeightTypes.xml"
-        local heightTypesXmlFile = loadXMLFile("heightTypes", filename)
-        if heightTypesXmlFile ~= nil and heightTypesXmlFile ~= 0 then
-            g_densityMapHeightManager:loadDensityMapHeightTypes(heightTypesXmlFile, missionInfo, baseDirectory, false)
-            delete(heightTypesXmlFile)
-            soilHeightTypesRegistered = true
-            SoilLogger.info("Tip On Ground Fix: Height types registered after fill type load")
-        else
-            SoilLogger.warning("Tip On Ground Fix: Could not open densityMapHeightTypes.xml")
-        end
-    end
-    FillTypeManager.loadMapData = Utils.appendedFunction(FillTypeManager.loadMapData, registerSFHeightTypesAfterFillTypes)
-end
+-- Root cause (documented after three failed hook attempts):
+--   DensityMapHeightManager.loadMapData runs before fill types are available.
+--   FillTypeManager.loadMapData appended hook also fires too early — the engine
+--   processes <fillTypes> from modDesc.xml in a separate pass AFTER loadMapData
+--   returns, so our fill types are nil at every earlier hook point.
+--   The only guaranteed-safe window is Mission00.loadMission00Finished, where
+--   g_fillTypeManager already resolves our fill type names (confirmed by HUD icon
+--   patching working in the same callback).
 
 -- Route mouse events to SoilHUD (for drag/resize edit mode).
 -- Edit mode is entered via Shift+H (SF_HUD_DRAG input action) — not via RMB.

--- a/src/main.lua
+++ b/src/main.lua
@@ -132,25 +132,26 @@ local function loadedMission(mission, node)
                     local idx = ftm:getFillTypeIndexByName(typeName)
                     if idx and not dmhm.fillTypeIndexToHeightType[idx] then
                         local nextSlot = dmhm.numHeightTypes + 1
-                        -- Build a new height type object mirroring the FERTILIZER template.
-                        local ht = {
-                            allowsSmoothing    = false,
-                            canBeTipped        = true,
-                            collisionBaseOffset = 0.0,
-                            collisionScale      = 1,
-                            fillToGroundScale   = 1,
-                            fillTypeIndex       = idx,
-                            fillTypeName        = typeName,
-                            index               = nextSlot,
-                            maxCollisionOffset  = 0.0,
-                            maxSurfaceAngle     = tmpl.maxSurfaceAngle,
-                            minCollisionOffset  = 0,
-                        }
-                        dmhm.fillTypeIndexToHeightType[idx]       = ht
-                        dmhm.fillTypeNameToHeightType[typeName]   = ht
+                        -- Shallow-copy the FERTILIZER template so any C++ object references
+                        -- (density map channel pointer, physics layer handle) are preserved.
+                        -- Without these refs, tipToGroundAroundLine silently fails even when
+                        -- the Lua-side canBeTipped check passes.  Override only the identity
+                        -- fields that must differ per fill type.
+                        local ht = {}
+                        for k, v in pairs(tmpl) do ht[k] = v end
+                        ht.allowsSmoothing  = false
+                        ht.canBeTipped      = true
+                        ht.fillTypeIndex    = idx
+                        ht.fillTypeName     = typeName
+                        ht.index            = nextSlot
+
+                        dmhm.fillTypeIndexToHeightType[idx]           = ht
+                        if dmhm.fillTypeNameToHeightType then
+                            dmhm.fillTypeNameToHeightType[typeName]   = ht
+                        end
                         dmhm.heightTypeIndexToFillTypeIndex[nextSlot] = idx
-                        dmhm.heightTypes[nextSlot]                = ht
-                        dmhm.numHeightTypes                       = nextSlot
+                        dmhm.heightTypes[nextSlot]                    = ht
+                        dmhm.numHeightTypes                           = nextSlot
                         registered = registered + 1
                     end
                 end
@@ -158,10 +159,26 @@ local function loadedMission(mission, node)
                 local testIdx = ftm:getFillTypeIndexByName("UREA")
                 local ok, val = pcall(function() return dmhm:getMinValidLiterValue(testIdx) end)
                 SoilLogger.info(string.format(
-                    "[TIP FIX] Injected %d solid fill types into DMHM. " ..
+                    "[TIP FIX] Injected %d solid fill types into DMHM (shallow-copy). " ..
                     "getMinValidLiterValue(UREA)=%s (>0 = success)",
                     registered, tostring(ok and val or "ERROR")
                 ))
+
+                -- Belt-and-suspenders: also hook getCanTipToGround at Lua level so the
+                -- discharge eligibility check passes even if C++ hasn't read our table.
+                if registered > 0 and DensityMapHeightUtil and
+                   type(DensityMapHeightUtil.getCanTipToGround) == "function" then
+                    local _dmhm = dmhm
+                    local _origGetCan = DensityMapHeightUtil.getCanTipToGround
+                    DensityMapHeightUtil.getCanTipToGround = function(fillTypeIndex)
+                        if _dmhm and _dmhm.fillTypeIndexToHeightType and
+                           _dmhm.fillTypeIndexToHeightType[fillTypeIndex] then
+                            return true
+                        end
+                        return _origGetCan(fillTypeIndex)
+                    end
+                    SoilLogger.info("[TIP FIX] DensityMapHeightUtil.getCanTipToGround hooked")
+                end
             else
                 SoilLogger.warning("[TIP FIX] FERTILIZER template not found in DMHM — tip injection skipped")
             end

--- a/src/main.lua
+++ b/src/main.lua
@@ -356,31 +356,39 @@ if FillTypeManager and type(FillTypeManager.loadModFillTypes) == "function" then
 end
 
 -- =========================================================
--- TIP ON GROUND FIX: Register densityMapHeightTypes
--- Enables mod fill types to be tipped on the ground (CTRL+I).
--- We inject our XML into DensityMapHeightManager's loading queue.
+-- TIP ON GROUND FIX: Register density map height types after fill types are loaded
+--
+-- Root cause: DensityMapHeightManager.loadMapData fires BEFORE FillTypeManager.loadMapData,
+-- so any XML injected into modDensityHeightMapTypeFilenames is processed while our custom
+-- fill types are still nil — every entry fails with "invalid fill type 'nil'".
+--
+-- Fix: hook FillTypeManager.loadMapData with appendedFunction so our height types are
+-- registered immediately after our fill types land in g_fillTypeManager. Terrain layer
+-- construction (constructTerrainFillLayers) requires the map i3d to be loaded, which
+-- happens after both loadMapData calls complete — so our late-registered types are
+-- included in the terrain build pass and get full visual + physics support.
 -- =========================================================
-if DensityMapHeightManager and type(DensityMapHeightManager.loadMapData) == "function" then
-    local function injectSFHeightTypes(densityMapHeightManager)
-        if densityMapHeightManager.modDensityHeightMapTypeFilenames == nil then
-            densityMapHeightManager.modDensityHeightMapTypeFilenames = {}
+if FillTypeManager and type(FillTypeManager.loadMapData) == "function" then
+    local soilHeightTypesRegistered = false
+    local function registerSFHeightTypesAfterFillTypes(self, xmlFile, missionInfo, baseDirectory)
+        if soilHeightTypesRegistered then return end
+        if g_densityMapHeightManager == nil
+        or type(g_densityMapHeightManager.loadDensityMapHeightTypes) ~= "function" then
+            SoilLogger.warning("Tip On Ground Fix: g_densityMapHeightManager not ready — tipping to ground may not work")
+            return
         end
-
         local filename = modDirectory .. "xml/densityMapHeightTypes.xml"
-        local alreadyAdded = false
-        for _, existing in ipairs(densityMapHeightManager.modDensityHeightMapTypeFilenames) do
-            if existing == filename then
-                alreadyAdded = true
-                break
-            end
-        end
-
-        if not alreadyAdded then
-            SoilLogger.info("Tip On Ground Fix: Registering densityMapHeightTypes.xml")
-            table.insert(densityMapHeightManager.modDensityHeightMapTypeFilenames, filename)
+        local heightTypesXmlFile = loadXMLFile("heightTypes", filename)
+        if heightTypesXmlFile ~= nil and heightTypesXmlFile ~= 0 then
+            g_densityMapHeightManager:loadDensityMapHeightTypes(heightTypesXmlFile, missionInfo, baseDirectory, false)
+            delete(heightTypesXmlFile)
+            soilHeightTypesRegistered = true
+            SoilLogger.info("Tip On Ground Fix: Height types registered after fill type load")
+        else
+            SoilLogger.warning("Tip On Ground Fix: Could not open densityMapHeightTypes.xml")
         end
     end
-    DensityMapHeightManager.loadMapData = Utils.prependedFunction(DensityMapHeightManager.loadMapData, injectSFHeightTypes)
+    FillTypeManager.loadMapData = Utils.appendedFunction(FillTypeManager.loadMapData, registerSFHeightTypesAfterFillTypes)
 end
 
 -- Route mouse events to SoilHUD (for drag/resize edit mode).

--- a/src/main.lua
+++ b/src/main.lua
@@ -99,22 +99,75 @@ local function loadedMission(mission, node)
     end
     sfm:onMissionLoaded()
 
-    -- TIP ON GROUND FIX: register density map height types now that fill types are live.
-    -- At this point g_fillTypeManager resolves our fill type names correctly (confirmed by
-    -- HUD icon patching below). All earlier hook points fire before the engine finishes
-    -- its modDesc.xml <fillTypes> pass, leaving our types nil.
-    if g_densityMapHeightManager ~= nil
-    and type(g_densityMapHeightManager.loadDensityMapHeightTypes) == "function" then
-        local htFile = loadXMLFile("soilHeightTypes", modDirectory .. "xml/densityMapHeightTypes.xml")
-        if htFile ~= nil and htFile ~= 0 then
-            g_densityMapHeightManager:loadDensityMapHeightTypes(htFile, mission.missionInfo, modDirectory, false)
-            delete(htFile)
-            SoilLogger.info("Tip On Ground Fix: Height types registered in loadedMission")
+    -- TIP ON GROUND FIX: directly inject our solid fill types into the
+    -- DensityMapHeightManager Lua tables so they can be tipped to the ground.
+    --
+    -- Root cause: loadDensityMapHeightTypes() is a C++ native that uses a C++
+    -- fill type registry populated only during DensityMapHeightManager.loadMapData
+    -- (before mod fill types are available). Calling it later always returns
+    -- "invalid fill type 'nil'" for all our types.
+    --
+    -- Solution: populate the Lua tables directly at loadMission00Finished time,
+    -- using the FERTILIZER entry as the structural template. Field values confirmed
+    -- from debug pass 2 (2026-05-13): allowsSmoothing, canBeTipped, collisionBaseOffset,
+    -- collisionScale, fillToGroundScale, fillTypeIndex, fillTypeName, index,
+    -- maxCollisionOffset, maxSurfaceAngle, minCollisionOffset.
+    do
+        local dmhm = g_densityMapHeightManager
+        local ftm  = g_fillTypeManager
+        if dmhm and ftm and dmhm.heightTypes and dmhm.fillTypeIndexToHeightType then
+            -- Use FERTILIZER as the structural template (confirmed working, granular).
+            local tmpl = nil
+            local fertIdx = ftm:getFillTypeIndexByName("FERTILIZER")
+            if fertIdx then tmpl = dmhm.fillTypeIndexToHeightType[fertIdx] end
+
+            if tmpl then
+                -- Our 11 solid fill types that need ground-tipping support.
+                local solidTypes = {
+                    "UREA", "AN", "AMS", "MAP", "DAP", "POTASH",
+                    "GYPSUM", "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE",
+                }
+                local registered = 0
+                for _, typeName in ipairs(solidTypes) do
+                    local idx = ftm:getFillTypeIndexByName(typeName)
+                    if idx and not dmhm.fillTypeIndexToHeightType[idx] then
+                        local nextSlot = dmhm.numHeightTypes + 1
+                        -- Build a new height type object mirroring the FERTILIZER template.
+                        local ht = {
+                            allowsSmoothing    = false,
+                            canBeTipped        = true,
+                            collisionBaseOffset = 0.0,
+                            collisionScale      = 1,
+                            fillToGroundScale   = 1,
+                            fillTypeIndex       = idx,
+                            fillTypeName        = typeName,
+                            index               = nextSlot,
+                            maxCollisionOffset  = 0.0,
+                            maxSurfaceAngle     = tmpl.maxSurfaceAngle,
+                            minCollisionOffset  = 0,
+                        }
+                        dmhm.fillTypeIndexToHeightType[idx]       = ht
+                        dmhm.fillTypeNameToHeightType[typeName]   = ht
+                        dmhm.heightTypeIndexToFillTypeIndex[nextSlot] = idx
+                        dmhm.heightTypes[nextSlot]                = ht
+                        dmhm.numHeightTypes                       = nextSlot
+                        registered = registered + 1
+                    end
+                end
+                -- Verify at least one registration worked by checking getMinValidLiterValue.
+                local testIdx = ftm:getFillTypeIndexByName("UREA")
+                local ok, val = pcall(function() return dmhm:getMinValidLiterValue(testIdx) end)
+                SoilLogger.info(string.format(
+                    "[TIP FIX] Injected %d solid fill types into DMHM. " ..
+                    "getMinValidLiterValue(UREA)=%s (>0 = success)",
+                    registered, tostring(ok and val or "ERROR")
+                ))
+            else
+                SoilLogger.warning("[TIP FIX] FERTILIZER template not found in DMHM — tip injection skipped")
+            end
         else
-            SoilLogger.warning("Tip On Ground Fix: Could not open densityMapHeightTypes.xml")
+            SoilLogger.warning("[TIP FIX] g_densityMapHeightManager not available at loadedMission — tip injection skipped")
         end
-    else
-        SoilLogger.warning("Tip On Ground Fix: g_densityMapHeightManager not available")
     end
 
     -- Fallback: register atlas if it was skipped at load time (g_overlayManager was nil then).

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,20 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "Bug Fixes & Improvements",
-    "- Fixed potassium fertilizer rates (K-rates now agronomically correct)",
-    "- Fixed herbicide cell updates (weed pressure now reflects per-cell spray)",
-    "- Fixed zoneData not syncing to clients on dedicated servers",
-    "- Fixed player-created and expanded fields not being detected by the mod",
-    "- Fixed Section Control double-penalty on herbicide/fertilizer application",
-    "- Fixed network sync, HUD fallback, and save state persistence",
-    "- Fixed UI elements misalignment in settings menu",
-    "- Fixed XML parse failure causing PDA text misalignment",
-    "New Features",
-    "- Luzerne and clover now recognized as legumes (low N target, spring bonus)",
-    "- Weed suppression scales with time-of-season (row closure mechanic)",
-    "- Added 10,000L big bags for bulk fertilizer handling",
-    "- Time-scaling for weed/pest/disease growth speed",
+    "- Fixed potassium rates, herbicide cell updates & dedi zoneData sync",
+    "- Fixed player-created fields not detected by the mod",
+    "- Luzerne & clover now recognized as legumes (low N, spring bonus)",
+    "- Weed suppression scales with crop row closure + time-scaling",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#362 / #361 — Boom width not represented in cell map**: Added `HookManager:getBoomCellPositions()` which reads work-area `start`/`end` nodes from the vehicle and attached implements to determine the full lateral span of the spray boom. Added `SoilFertilitySystem:markBoomCells()` which sweeps 10 m cells from one boom-end to the other. Runs after both the VWW section-midpoint path and the single-field path — nutrients are unchanged, only display cells are stamped for the full width.
- **#360 — HUD vs Cell Report values**: Not a bug — Soil HUD shows field averages, Cell Report shows per-cell data. Documented in issue; UI label pass planned for a future update.
- **#359 — Cell Report not working**: Already resolved. Closed.
- **#358 — Application rate error**: Awaiting log from reporter.
- **#356 — Tip custom fill types to ground**: Changed Lua table injection to shallow-copy the FERTILIZER height-type template (preserves any C++ density-map channel references). Also hooks `DensityMapHeightUtil.getCanTipToGround` at the Lua level as a belt-and-suspenders fallback so the discharge eligibility check passes even if C++ hasn't read the table entries.

## Test plan

- [ ] Spray a field with a wide-boom sprayer (≥24 m) — PDA soil map should show coloured cells across the full boom width, not a single 10 m strip
- [ ] Coverage % and visible cell count should feel consistent after a full field pass
- [ ] Tip UREA / POTASH / AN to ground with SHIFT+I — check log for `[TIP FIX] Injected 11 solid fill types` and `getCanTipToGround hooked`; pile should form on ground
- [ ] VWW sprayers: section-level cell marking still works alongside the boom sweep
- [ ] No Lua errors in log.txt for any of the above scenarios