### PR TITLE
v2.1.6.2 hotfix: fix organic fill type pile rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.2
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.1</version>
+    <version>2.1.6.2</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/main.lua
+++ b/src/main.lua
@@ -67,6 +67,27 @@ source(modDirectory .. "src/network/NetworkEvents.lua")
 -- 6. Integrations
 source(modDirectory .. "src/integrations/SectionControlIntegration.lua")
 
+-- Register our custom density map height types with the DMHM mod file list.
+-- DensityMapHeightManager:loadMapData iterates modDensityHeightMapTypeFilenames and
+-- calls loadDensityMapHeightTypes for each, which registers C++ height types.  This
+-- must happen before loadMapData runs (i.e. at module load time, not in a hook).
+-- When C++ handles the registration, physical pile height and tipping work correctly
+-- without any Lua injection.  The Lua injection in loadedMission() remains as a
+-- fallback and is a no-op if C++ already populated fillTypeIndexToHeightType.
+do
+    local dmhm = g_densityMapHeightManager
+    if dmhm ~= nil then
+        if dmhm.modDensityHeightMapTypeFilenames == nil then
+            dmhm.modDensityHeightMapTypeFilenames = {}
+        end
+        local xmlPath = Utils.getFilename("xml/densityMapHeightTypes.xml", modDirectory)
+        table.insert(dmhm.modDensityHeightMapTypeFilenames, xmlPath)
+        SoilLogger.info("[HEIGHT] Registered xml/densityMapHeightTypes.xml with DMHM mod file list")
+    else
+        SoilLogger.warning("[HEIGHT] g_densityMapHeightManager not available at load time — height types will rely on Lua fallback")
+    end
+end
+
 -- Register helpline icon atlas as early as possible (at module load time).
 -- g_overlayManager exists from game startup, so this works before any mission loads.
 -- The loadedMission hook below retries if the manager wasn't available yet.
@@ -179,22 +200,16 @@ local function loadedMission(mission, node)
                     registered, tostring(ok and val or "ERROR")
                 ))
 
-                -- Rebuild the terrain fill layer GPU texture array so our custom fill
-                -- types get valid textureArrayIndex slots and their DDS textures are
-                -- uploaded.  constructTerrainFillLayers already ran during initial
-                -- mission load (before our height types existed), so our fill types
-                -- have textureArrayIndex=nil and render with missing/broken textures.
-                -- Calling it again: clears the GPU array, rebuilds in the same
-                -- height-type order (base game first, our 11 appended at the end),
-                -- and sets textureArrayIndex on every FillTypeDesc that has valid
-                -- layerTextures.  At loadMission00Finished there are no tipped piles
-                -- visible yet, so the momentary GPU clear is harmless.
+                -- If C++ registered our types via modDensityHeightMapTypeFilenames (the
+                -- preferred path), registered == 0 here and nothing else is needed.
+                -- If Lua injection ran as fallback, rebuild the GPU texture array so
+                -- the newly injected types get valid textureArrayIndex slots.
                 if registered > 0 and g_terrainNode then
                     local ctfl_ok, ctfl_err = pcall(function()
                         ftm:constructTerrainFillLayers(dmhm.heightTypes, g_terrainNode)
                     end)
                     if ctfl_ok then
-                        SoilLogger.info("[TIP FIX] constructTerrainFillLayers rebuilt — custom fill types now have GPU texture slots")
+                        SoilLogger.info("[TIP FIX] constructTerrainFillLayers rebuilt (Lua fallback path)")
                     else
                         SoilLogger.warning("[TIP FIX] constructTerrainFillLayers failed: " .. tostring(ctfl_err))
                     end

--- a/src/main.lua
+++ b/src/main.lua
@@ -179,6 +179,27 @@ local function loadedMission(mission, node)
                     registered, tostring(ok and val or "ERROR")
                 ))
 
+                -- Rebuild the terrain fill layer GPU texture array so our custom fill
+                -- types get valid textureArrayIndex slots and their DDS textures are
+                -- uploaded.  constructTerrainFillLayers already ran during initial
+                -- mission load (before our height types existed), so our fill types
+                -- have textureArrayIndex=nil and render with missing/broken textures.
+                -- Calling it again: clears the GPU array, rebuilds in the same
+                -- height-type order (base game first, our 11 appended at the end),
+                -- and sets textureArrayIndex on every FillTypeDesc that has valid
+                -- layerTextures.  At loadMission00Finished there are no tipped piles
+                -- visible yet, so the momentary GPU clear is harmless.
+                if registered > 0 and g_terrainNode then
+                    local ctfl_ok, ctfl_err = pcall(function()
+                        ftm:constructTerrainFillLayers(dmhm.heightTypes, g_terrainNode)
+                    end)
+                    if ctfl_ok then
+                        SoilLogger.info("[TIP FIX] constructTerrainFillLayers rebuilt — custom fill types now have GPU texture slots")
+                    else
+                        SoilLogger.warning("[TIP FIX] constructTerrainFillLayers failed: " .. tostring(ctfl_err))
+                    end
+                end
+
                 -- Belt-and-suspenders: also hook getCanTipToGround at Lua level so the
                 -- discharge eligibility check passes even if C++ hasn't read our table.
                 if registered > 0 and DensityMapHeightUtil and

--- a/src/main.lua
+++ b/src/main.lua
@@ -116,10 +116,25 @@ local function loadedMission(mission, node)
         local dmhm = g_densityMapHeightManager
         local ftm  = g_fillTypeManager
         if dmhm and ftm and dmhm.heightTypes and dmhm.fillTypeIndexToHeightType then
-            -- Use FERTILIZER as the structural template (confirmed working, granular).
-            local tmpl = nil
-            local fertIdx = ftm:getFillTypeIndexByName("FERTILIZER")
-            if fertIdx then tmpl = dmhm.fillTypeIndexToHeightType[fertIdx] end
+            -- Two templates: FERTILIZER (light granular) for mineral types,
+            -- MANURE (dark organic) for compost/biosolids/chicken manure/pelletized manure.
+            -- Using the wrong template causes black/unlit pile rendering because the
+            -- C++ material reference from the shallow copy drives the visual output.
+            local tmplFert   = nil
+            local tmplManure = nil
+            local fertIdx    = ftm:getFillTypeIndexByName("FERTILIZER")
+            local manureIdx  = ftm:getFillTypeIndexByName("MANURE")
+            if fertIdx  then tmplFert   = dmhm.fillTypeIndexToHeightType[fertIdx]   end
+            if manureIdx then tmplManure = dmhm.fillTypeIndexToHeightType[manureIdx] end
+
+            -- Fall back to the other template if one is missing
+            local tmpl = tmplFert or tmplManure
+
+            -- Which types use the organic (MANURE) template
+            local organicSet = {
+                COMPOST = true, BIOSOLIDS = true,
+                CHICKEN_MANURE = true, PELLETIZED_MANURE = true,
+            }
 
             if tmpl then
                 -- Our 11 solid fill types that need ground-tipping support.
@@ -132,13 +147,13 @@ local function loadedMission(mission, node)
                     local idx = ftm:getFillTypeIndexByName(typeName)
                     if idx and not dmhm.fillTypeIndexToHeightType[idx] then
                         local nextSlot = dmhm.numHeightTypes + 1
-                        -- Shallow-copy the FERTILIZER template so any C++ object references
-                        -- (density map channel pointer, physics layer handle) are preserved.
-                        -- Without these refs, tipToGroundAroundLine silently fails even when
-                        -- the Lua-side canBeTipped check passes.  Override only the identity
-                        -- fields that must differ per fill type.
+                        -- Shallow-copy the appropriate template so C++ object references
+                        -- (density map channel pointer, material, physics layer handle) are
+                        -- preserved. Organic types use MANURE to get the correct dark pile
+                        -- visual; mineral types use FERTILIZER for the light granular look.
+                        local srcTmpl = (organicSet[typeName] and tmplManure) or tmplFert or tmpl
                         local ht = {}
-                        for k, v in pairs(tmpl) do ht[k] = v end
+                        for k, v in pairs(srcTmpl) do ht[k] = v end
                         ht.allowsSmoothing  = false
                         ht.canBeTipped      = true
                         ht.fillTypeIndex    = idx

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,10 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed potassium rates, herbicide cell updates & dedi zoneData sync",
-    "- Fixed player-created fields not detected by the mod",
-    "- Luzerne & clover now recognized as legumes (low N, spring bonus)",
-    "- Weed suppression scales with crop row closure + time-scaling",
+    "- Fixed: sowing no longer instantly maxes out NPK",
+    "- Fixed: soil map cell display now covers full boom width",
+    "- Fixed: custom fill types work correctly with ground tipping",
+    "- Fixed: density map type load order stability improvement",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,10 +24,9 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: sowing no longer instantly maxes out NPK",
-    "- Fixed: soil map cell display now covers full boom width",
-    "- Fixed: custom fill types work correctly with ground tipping",
-    "- Fixed: density map type load order stability improvement",
+    "- Fixed: organic fill type piles no longer render black",
+    "- Fixed: pile textures now apply correctly after map load",
+    "- Fixed: pile height now uses correct density map height type",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/xml/densityMapHeightTypes.xml
+++ b/xml/densityMapHeightTypes.xml
@@ -1,16 +1,43 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <map>
     <densityMapHeightTypes>
-        <densityMapHeightType fillType="UREA" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="AN" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="AMS" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="MAP" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="DAP" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="POTASH" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="GYPSUM" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="COMPOST" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="BIOSOLIDS" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="CHICKEN_MANURE" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
-        <densityMapHeightType fillType="PELLETIZED_MANURE" maxAllowedHeight="0.8" minHeight="0.05" collisionScale="1.0" collisionBaseOffset="0.0" />
+
+        <!-- Mineral granular fertilizers — flat pile, similar to base FERTILIZER/LIME -->
+        <densityMapHeightType fillTypeName="UREA" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="AN" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="AMS" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="MAP" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="DAP" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="POTASH" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="GYPSUM" maxSurfaceAngle="25" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.15" />
+        </densityMapHeightType>
+
+        <!-- Organic bulk amendments — taller pile, similar to WOODCHIPS -->
+        <densityMapHeightType fillTypeName="COMPOST" maxSurfaceAngle="35" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.10" minOffset="0.0" maxOffset="0.50" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="BIOSOLIDS" maxSurfaceAngle="30" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.10" minOffset="0.0" maxOffset="0.40" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="CHICKEN_MANURE" maxSurfaceAngle="35" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.10" minOffset="0.0" maxOffset="0.50" />
+        </densityMapHeightType>
+        <densityMapHeightType fillTypeName="PELLETIZED_MANURE" maxSurfaceAngle="20" fillToGroundScale="1.0" allowsSmoothing="false">
+            <collision scale="1.0" baseOffset="0.05" minOffset="0.0" maxOffset="0.20" />
+        </densityMapHeightType>
+
     </densityMapHeightTypes>
 </map>


### PR DESCRIPTION
## Summary
- Fixed organic fill type piles rendering black (was using wrong template)
- Fixed pile textures not applying correctly after map load (constructTerrainFillLayers timing)
- Fixed pile height using incorrect density map height type (densityMapHeightTypes.xml registration)

## Test plan
- [ ] Load a save with organic fill types (compost, biosolids, chicken manure, pelletized manure)
- [ ] Verify piles render with correct textures and color (not black)
- [ ] Verify pile height looks correct when dumped on ground
- [ ] Test on a fresh map load and a reloaded save