### PR TITLE
v2.1.6.3: fix soil map tile refresh + realistic fill textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.2
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.3
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -40,11 +40,15 @@
 
         <!-- ── SOLID GRANULAR SOURCES ─────────────────────────── -->
 
+        <!-- UREA, AN, AMS: white/cream mineral prills — vanilla fertilizer texture is the correct match -->
         <fillType name="UREA" title="$l10n_sf_urea_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.77" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.65"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/urea_diffuse.dds" normal="textures/fillPlanes/urea_normal.dds" height="textures/fillPlanes/urea_height.dds" displacement="textures/fillPlanes/urea_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/urea/bigBag_urea.xml" />
         </fillType>
@@ -53,7 +57,10 @@
             <physics massPerLiter="0.92" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.55"/>
             <image hud="$moddir$textures/hud/fillTypes/hud_fill_AN.dds"/>
-            <textures diffuse="textures/fillPlanes/urea_diffuse.dds" normal="textures/fillPlanes/urea_normal.dds" height="textures/fillPlanes/urea_height.dds" displacement="textures/fillPlanes/urea_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/an/bigBag_an.xml" />
         </fillType>
@@ -62,16 +69,23 @@
             <physics massPerLiter="0.87" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.40"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/AMS_diffuse.dds" normal="textures/fillPlanes/AMS_normal.dds" height="textures/fillPlanes/AMS_height.dds" displacement="textures/fillPlanes/AMS_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
         </fillType>
 
+        <!-- MAP, DAP: off-white/gray mineral granules — vanilla fertilizer texture is a close match -->
         <fillType name="MAP" title="$l10n_sf_map_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.95"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/MAP_diffuse.dds" normal="textures/fillPlanes/MAP_normal.dds" height="textures/fillPlanes/MAP_height.dds" displacement="textures/fillPlanes/MAP_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/map/bigBag_map.xml" />
         </fillType>
@@ -80,7 +94,10 @@
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.75"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/DAP_diffuse.dds" normal="textures/fillPlanes/DAP_normal.dds" height="textures/fillPlanes/DAP_height.dds" displacement="textures/fillPlanes/DAP_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/dap/bigBag_dap.xml" />
         </fillType>
@@ -158,20 +175,28 @@
         <!-- and can be routed by our sprayer hook when obtained from other mods  -->
         <!-- or production lines.                                                 -->
 
+        <!-- GYPSUM: fine white powder — vanilla lime texture is the correct match -->
         <fillType name="GYPSUM" title="$l10n_sf_gypsum_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="1.10" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.55"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/gypsum_diffuse.dds" normal="textures/fillPlanes/gypsum_normal.dds" height="textures/fillPlanes/gypsum_height.dds" displacement="textures/fillPlanes/gypsum_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/lime_diffuse.png" unitSize="0.4" blendContrast="0.15" noiseScale="0.4" porosityAtZeroRoughness="0.95" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/lime_normal.png"
+                      height="$data/fillPlanes/lime_height.png"
+                      displacement="$data/fillPlanes/lime_displacement.png" displacementMaxHeight="0.15" firmness="0.2" viscosity="0.4"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/gypsum/bigBag_gypsum.xml" />
         </fillType>
 
+        <!-- COMPOST: dark brown organic matter — vanilla manure texture is the correct match -->
         <fillType name="COMPOST" title="$l10n_sf_compost_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.60" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.35"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/compost_diffuse.dds" normal="textures/fillPlanes/compost_normal.dds" height="textures/fillPlanes/compost_height.dds" displacement="textures/fillPlanes/compost_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/manure_diffuse.png" unitSize="0.5" blendContrast="0.3" noiseScale="0.6" porosityAtZeroRoughness="0.8" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/manure_normal.png"
+                      height="$data/fillPlanes/manure_height.png"
+                      displacement="$data/fillPlanes/manure_displacement.png" displacementMaxHeight="0.25" firmness="0.4" viscosity="0.6"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/compost/bigBag_compost.xml" />
         </fillType>
@@ -185,21 +210,29 @@
             <pallet filename="objects/bigBag/biosolids/bigBag_biosolids.xml" />
         </fillType>
 
+        <!-- CHICKEN_MANURE: dry tan/light-brown litter — vanilla fertilizer texture (lighter, granular) -->
         <!-- Fill type name is CHICKEN_MANURE; icon file is hud_fill_chickenlitter.dds -->
         <fillType name="CHICKEN_MANURE" title="$l10n_sf_chicken_manure_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.65" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.45"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/chickenlitter_diffuse.dds" normal="textures/fillPlanes/chickenlitter_normal.dds" height="textures/fillPlanes/chickenlitter_height.dds" displacement="textures/fillPlanes/chickenlitter_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.5" blendContrast="0.25" noiseScale="0.6" porosityAtZeroRoughness="0.85" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.35" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml" />
         </fillType>
 
+        <!-- PELLETIZED_MANURE: dark brown compact pellets — vanilla manure base with tighter surface angle -->
         <fillType name="PELLETIZED_MANURE" title="$l10n_sf_pelletized_manure_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.75" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="1.10"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="textures/fillPlanes/PelletizedManure_diffuse.dds" normal="textures/fillPlanes/PelletizedManure_normal.dds" height="textures/fillPlanes/PelletizedManure_height.dds" displacement="textures/fillPlanes/PelletizedManure_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/manure_diffuse.png" unitSize="0.4" blendContrast="0.25" noiseScale="0.5" porosityAtZeroRoughness="0.85" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/manure_normal.png"
+                      height="$data/fillPlanes/manure_height.png"
+                      displacement="$data/fillPlanes/manure_displacement.png" displacementMaxHeight="0.2" firmness="0.45" viscosity="0.5"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml" />
         </fillType>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.2</version>
+    <version>2.1.6.3</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -375,6 +375,16 @@ function SoilFertilitySystem:onFertilizerApplied(fieldId, fillTypeIndex, liters)
 
     SoilLogger.debug("Fertilizer: Field %d, %s, %.4fL", fieldId, fillType and fillType.name or "unknown", liters)
 
+    -- Trigger overlay refresh so the map tile color updates promptly after spraying.
+    -- Throttled to once every 2 seconds to avoid rebuilding samplePoints every frame.
+    local now = (g_currentMission and g_currentMission.time) or 0
+    if not self._fertOverlayRefreshTime then self._fertOverlayRefreshTime = 0 end
+    if (now - self._fertOverlayRefreshTime) >= 2000 then
+        self._fertOverlayRefreshTime = now
+        local overlay = g_SoilFertilityManager and g_SoilFertilityManager.soilMapOverlay
+        if overlay then overlay:requestRefresh() end
+    end
+
     -- Broadcast to clients in multiplayer, throttled to once every 5 seconds per field
     -- to avoid flooding the network with 30+ events/second while a sprayer is running.
     if g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -974,6 +974,10 @@ function SoilFieldUpdateEvent:run(connection)
     if g_SoilFertilityManager and g_SoilFertilityManager.soilSystem then
         g_SoilFertilityManager.soilSystem.fieldData[self.fieldId] = self.field
 
+        -- Refresh overlay so the map tile updates on the client without waiting for the 4.5-s timer
+        local overlay = g_SoilFertilityManager.soilMapOverlay
+        if overlay then overlay:requestRefresh() end
+
         if g_SoilFertilityManager.settings.debugMode then
             SoilLogger.debug("Client: Field %d synced from server (N=%.1f, P=%.1f, K=%.1f)",
                 self.fieldId, self.field.nitrogen, self.field.phosphorus, self.field.potassium)

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -22,7 +22,7 @@ SoilMapOverlay.LAYER_COUNT    = 10
 SoilMapOverlay.ALPHA          = 0.72
 
 -- Sampling constants
-SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 4500
+SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS = 2000
 SoilMapOverlay.POLYGON_STEP     = 10     -- world-unit grid spacing for polygon sampling (meters)
 -- Point budgets per density level (1=Low, 2=Medium, 3=High).
 -- These are the BASE values for a standard 2048m map. At runtime the budget is

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,9 +24,9 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: organic fill type piles no longer render black",
-    "- Fixed: pile textures now apply correctly after map load",
-    "- Fixed: pile height now uses correct density map height type",
+    "- Fixed: soil map tile color now updates promptly after spraying",
+    "- Fixed: multiplayer clients see map tile changes immediately",
+    "- Improved: fill type pile textures now use realistic base-game materials",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Fixed**: soil map tile color now updates within ~2 seconds of spraying instead of up to 4.5 seconds (was: stale overlay cache showed old color even though field data was already updated)
- **Fixed**: multiplayer/dedicated server clients now see tile color changes immediately after receiving a field update event
- **Improved**: fill type pile textures replaced with vanilla base-game materials for visual realism

## Root Cause (tile not updating)
`applyFertilizer` updated `field.phosphorus` and `zoneData[cellKey].P` correctly, but the overlay's `samplePoints` cache (used to draw tile colors) wasn't invalidated. With a 4.5-second refresh timer, the user would see the old tile color for up to 4.5s after spraying. Fix: throttled `requestRefresh()` call in `onFertilizerApplied` + reduced interval from 4500 → 2000ms.

## Texture changes
| Fill type | Before | After |
|---|---|---|
| UREA, AN, AMS, MAP, DAP | Custom DDS | `$data/fillPlanes/fertilizer_diffuse.png` (white/cream granules) |
| GYPSUM | Custom DDS | `$data/fillPlanes/lime_diffuse.png` (white powder) |
| COMPOST | Custom DDS | `$data/fillPlanes/manure_diffuse.png` (dark organic) |
| CHICKEN_MANURE | Custom DDS | `$data/fillPlanes/fertilizer_diffuse.png` (dry, lighter) |
| PELLETIZED_MANURE | Custom DDS | `$data/fillPlanes/manure_diffuse.png` (dark organic) |
| BIOSOLIDS, POTASH | Custom DDS | **Unchanged** (already correct) |

## Test plan
- [ ] Spray any fertilizer → open PDA soil map → tile color updates within 2 seconds
- [ ] Multiplayer: client player sees map tile update promptly after host sprays
- [ ] Ground-tip each organic fill type → verify piles look realistic (compost = dark, chicken litter = lighter)
- [ ] Ground-tip mineral fill types → verify white/cream granule appearance
- [ ] GYPSUM pile should look like white powder (lime-like)
- [ ] POTASH pile still pink/distinct (unchanged)