### PR TITLE
v2.1.6.5 — Colorblind Mode + dedicated server crash fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.3
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.4
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.4
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.5
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -40,15 +40,11 @@
 
         <!-- ── SOLID GRANULAR SOURCES ─────────────────────────── -->
 
-        <!-- UREA, AN, AMS: white/cream mineral prills — vanilla fertilizer texture is the correct match -->
         <fillType name="UREA" title="$l10n_sf_urea_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.77" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.65"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/fertilizer_normal.png"
-                      height="$data/fillPlanes/fertilizer_height.png"
-                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/urea/bigBag_urea.xml" />
         </fillType>
@@ -69,23 +65,16 @@
             <physics massPerLiter="0.87" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.40"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/fertilizer_normal.png"
-                      height="$data/fillPlanes/fertilizer_height.png"
-                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
         </fillType>
 
-        <!-- MAP, DAP: off-white/gray mineral granules — vanilla fertilizer texture is a close match -->
         <fillType name="MAP" title="$l10n_sf_map_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.95"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/fertilizer_normal.png"
-                      height="$data/fillPlanes/fertilizer_height.png"
-                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
+            <textures diffuse="textures/fillPlanes/MAP_diffuse.dds" normal="textures/fillPlanes/MAP_normal.dds" height="textures/fillPlanes/MAP_height.dds" displacement="textures/fillPlanes/MAP_displacement.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/map/bigBag_map.xml" />
         </fillType>
@@ -94,10 +83,7 @@
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.75"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/fertilizer_normal.png"
-                      height="$data/fillPlanes/fertilizer_height.png"
-                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
+            <textures diffuse="textures/fillPlanes/DAP_diffuse.dds" normal="textures/fillPlanes/DAP_normal.dds" height="textures/fillPlanes/DAP_height.dds" displacement="textures/fillPlanes/DAP_displacement.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/dap/bigBag_dap.xml" />
         </fillType>
@@ -175,28 +161,20 @@
         <!-- and can be routed by our sprayer hook when obtained from other mods  -->
         <!-- or production lines.                                                 -->
 
-        <!-- GYPSUM: fine white powder — vanilla lime texture is the correct match -->
         <fillType name="GYPSUM" title="$l10n_sf_gypsum_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="1.10" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.55"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/lime_diffuse.png" unitSize="0.4" blendContrast="0.15" noiseScale="0.4" porosityAtZeroRoughness="0.95" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/lime_normal.png"
-                      height="$data/fillPlanes/lime_height.png"
-                      displacement="$data/fillPlanes/lime_displacement.png" displacementMaxHeight="0.15" firmness="0.2" viscosity="0.4"/>
+            <textures diffuse="textures/fillPlanes/gypsum_diffuse.dds" normal="textures/fillPlanes/gypsum_normal.dds" height="textures/fillPlanes/gypsum_height.dds" displacement="textures/fillPlanes/gypsum_displacement.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/gypsum/bigBag_gypsum.xml" />
         </fillType>
 
-        <!-- COMPOST: dark brown organic matter — vanilla manure texture is the correct match -->
         <fillType name="COMPOST" title="$l10n_sf_compost_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.60" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.35"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/manure_diffuse.png" unitSize="0.5" blendContrast="0.3" noiseScale="0.6" porosityAtZeroRoughness="0.8" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/manure_normal.png"
-                      height="$data/fillPlanes/manure_height.png"
-                      displacement="$data/fillPlanes/manure_displacement.png" displacementMaxHeight="0.25" firmness="0.4" viscosity="0.6"/>
+            <textures diffuse="textures/fillPlanes/compost_diffuse.dds" normal="textures/fillPlanes/compost_normal.dds" height="textures/fillPlanes/compost_height.dds" displacement="textures/fillPlanes/compost_displacement.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/compost/bigBag_compost.xml" />
         </fillType>
@@ -210,29 +188,20 @@
             <pallet filename="objects/bigBag/biosolids/bigBag_biosolids.xml" />
         </fillType>
 
-        <!-- CHICKEN_MANURE: dry tan/light-brown litter — vanilla fertilizer texture (lighter, granular) -->
-        <!-- Fill type name is CHICKEN_MANURE; icon file is hud_fill_chickenlitter.dds -->
         <fillType name="CHICKEN_MANURE" title="$l10n_sf_chicken_manure_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.65" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.45"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.5" blendContrast="0.25" noiseScale="0.6" porosityAtZeroRoughness="0.85" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/fertilizer_normal.png"
-                      height="$data/fillPlanes/fertilizer_height.png"
-                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.35" viscosity="0.5"/>
+            <textures diffuse="textures/fillPlanes/chickenlitter_diffuse.dds" normal="textures/fillPlanes/chickenlitter_normal.dds" height="textures/fillPlanes/chickenlitter_height.dds" displacement="textures/fillPlanes/chickenlitter_displacement.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml" />
         </fillType>
 
-        <!-- PELLETIZED_MANURE: dark brown compact pellets — vanilla manure base with tighter surface angle -->
         <fillType name="PELLETIZED_MANURE" title="$l10n_sf_pelletized_manure_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
             <physics massPerLiter="0.75" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="1.10"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/manure_diffuse.png" unitSize="0.4" blendContrast="0.25" noiseScale="0.5" porosityAtZeroRoughness="0.85" porosityAtFullRoughness="1"
-                      normal="$data/fillPlanes/manure_normal.png"
-                      height="$data/fillPlanes/manure_height.png"
-                      displacement="$data/fillPlanes/manure_displacement.png" displacementMaxHeight="0.2" firmness="0.45" viscosity="0.5"/>
+            <textures diffuse="textures/fillPlanes/PelletizedManure_diffuse.dds" normal="textures/fillPlanes/PelletizedManure_normal.dds" height="textures/fillPlanes/PelletizedManure_height.dds" displacement="textures/fillPlanes/PelletizedManure_displacement.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml" />
         </fillType>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.3</version>
+    <version>2.1.6.4</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.4</version>
+    <version>2.1.6.5</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2131,6 +2131,18 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         if entry.pH then field.pH        = math.max(limits.PH_MIN, math.min(limits.PH_MAX, field.pH + entry.pH * factor)) end
         if entry.OM then field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor) end
 
+        -- Sync all existing zone cells to the updated field values so cells stamped
+        -- by previous tillage operations reflect the fertilizer that was just applied.
+        if field.zoneData then
+            for _, cell in pairs(field.zoneData) do
+                if entry.N  then cell.N  = field.nitrogen end
+                if entry.P  then cell.P  = field.phosphorus end
+                if entry.K  then cell.K  = field.potassium end
+                if entry.pH then cell.pH = field.pH end
+                if entry.OM then cell.OM = field.organicMatter end
+            end
+        end
+
         -- Throttled per-field diagnostic (debug mode, lime types always logged; nutrients every 4 s).
         -- Validates that pH shift and nutrient deltas are agronomically sensible.
         -- For LIME/LIQUIDLIME: target ~0.40 pH over a full 1-ha pass at BASE_RATES volume.
@@ -2417,19 +2429,19 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
         if not seen[cellKey] then
             seen[cellKey] = true
             if not field.zoneData then field.zoneData = {} end
-            if not field.zoneData[cellKey] then
-                field.zoneData[cellKey] = {
-                    N  = field.nitrogen       or SoilConstants.FIELD_DEFAULTS.nitrogen,
-                    P  = field.phosphorus     or SoilConstants.FIELD_DEFAULTS.phosphorus,
-                    K  = field.potassium      or SoilConstants.FIELD_DEFAULTS.potassium,
-                    pH = field.pH             or SoilConstants.FIELD_DEFAULTS.pH,
-                    OM = field.organicMatter  or SoilConstants.FIELD_DEFAULTS.organicMatter,
-                    weedPressure    = field.weedPressure    or 0,
-                    pestPressure    = field.pestPressure    or 0,
-                    diseasePressure = field.diseasePressure or 0,
-                    compaction      = field.compaction      or 0,
-                }
-            end
+            -- Always sync to current field values so lateral boom cells reflect the
+            -- fertilizer that was just applied, not stale values from a previous pass.
+            field.zoneData[cellKey] = {
+                N  = field.nitrogen       or SoilConstants.FIELD_DEFAULTS.nitrogen,
+                P  = field.phosphorus     or SoilConstants.FIELD_DEFAULTS.phosphorus,
+                K  = field.potassium      or SoilConstants.FIELD_DEFAULTS.potassium,
+                pH = field.pH             or SoilConstants.FIELD_DEFAULTS.pH,
+                OM = field.organicMatter  or SoilConstants.FIELD_DEFAULTS.organicMatter,
+                weedPressure    = field.weedPressure    or 0,
+                pestPressure    = field.pestPressure    or 0,
+                diseasePressure = field.diseasePressure or 0,
+                compaction      = field.compaction      or 0,
+            }
         end
     end
 end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2033,6 +2033,10 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     )
 end
 
+-- Maximum zone cells stored per field. Prevents unbounded memory growth and network
+-- packet overflow on large/intensively-farmed fields (see markBoomCells, applyFertilizer).
+local MAX_ZONE_CELLS = 1000
+
 -- Apply fertilizer
 function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     if not self.settings.enabled then return end
@@ -2201,17 +2205,21 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
 
             if not field.zoneData then field.zoneData = {} end
             if not field.zoneData[cellKey] then
-                field.zoneData[cellKey] = {
-                    N  = field.nitrogen,
-                    P  = field.phosphorus,
-                    K  = field.potassium,
-                    pH = field.pH,
-                    OM = field.organicMatter,
-                    weedPressure = field.weedPressure,
-                    pestPressure = field.pestPressure,
-                    diseasePressure = field.diseasePressure,
-                    compaction = field.compaction,
-                }
+                local zdCount = 0
+                for _ in pairs(field.zoneData) do zdCount = zdCount + 1 end
+                if zdCount < MAX_ZONE_CELLS then
+                    field.zoneData[cellKey] = {
+                        N  = field.nitrogen,
+                        P  = field.phosphorus,
+                        K  = field.potassium,
+                        pH = field.pH,
+                        OM = field.organicMatter,
+                        weedPressure = field.weedPressure,
+                        pestPressure = field.pestPressure,
+                        diseasePressure = field.diseasePressure,
+                        compaction = field.compaction,
+                    }
+                end
             end
             local cell = field.zoneData[cellKey]
             -- cellFactor must use areaInHa (not zone.CELL_AREA_HA) so that each cell
@@ -2429,19 +2437,30 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
         if not seen[cellKey] then
             seen[cellKey] = true
             if not field.zoneData then field.zoneData = {} end
-            -- Always sync to current field values so lateral boom cells reflect the
-            -- fertilizer that was just applied, not stale values from a previous pass.
-            field.zoneData[cellKey] = {
-                N  = field.nitrogen       or SoilConstants.FIELD_DEFAULTS.nitrogen,
-                P  = field.phosphorus     or SoilConstants.FIELD_DEFAULTS.phosphorus,
-                K  = field.potassium      or SoilConstants.FIELD_DEFAULTS.potassium,
-                pH = field.pH             or SoilConstants.FIELD_DEFAULTS.pH,
-                OM = field.organicMatter  or SoilConstants.FIELD_DEFAULTS.organicMatter,
-                weedPressure    = field.weedPressure    or 0,
-                pestPressure    = field.pestPressure    or 0,
-                diseasePressure = field.diseasePressure or 0,
-                compaction      = field.compaction      or 0,
-            }
+            -- Enforce cell cap: existing cells are always synced via applyFertilizer,
+            -- so skipping new ones beyond the cap only affects sub-field visual detail,
+            -- not correctness of the aggregate nutrient values.
+            local canWrite = true
+            if field.zoneData[cellKey] == nil then
+                local count = 0
+                for _ in pairs(field.zoneData) do count = count + 1 end
+                if count >= MAX_ZONE_CELLS then canWrite = false end
+            end
+            if canWrite then
+                -- Always sync to current field values so lateral boom cells reflect the
+                -- fertilizer that was just applied, not stale values from a previous pass.
+                field.zoneData[cellKey] = {
+                    N  = field.nitrogen       or SoilConstants.FIELD_DEFAULTS.nitrogen,
+                    P  = field.phosphorus     or SoilConstants.FIELD_DEFAULTS.phosphorus,
+                    K  = field.potassium      or SoilConstants.FIELD_DEFAULTS.potassium,
+                    pH = field.pH             or SoilConstants.FIELD_DEFAULTS.pH,
+                    OM = field.organicMatter  or SoilConstants.FIELD_DEFAULTS.organicMatter,
+                    weedPressure    = field.weedPressure    or 0,
+                    pestPressure    = field.pestPressure    or 0,
+                    diseasePressure = field.diseasePressure or 0,
+                    compaction      = field.compaction      or 0,
+                }
+            end
         end
     end
 end

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -223,6 +223,13 @@ SettingsSchema.definitions = {
         uiId = "sf_overlay_density",
         localOnly = true,  -- per-player render preference, not synced to server
     },
+    {
+        id = "colorblindMode",
+        type = "boolean",
+        default = false,
+        uiId = "sf_colorblind_mode",
+        localOnly = true,  -- per-player accessibility preference, not synced to server
+    },
 }
 
 -- Build lookup table by id for fast access

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -646,12 +646,17 @@ function SoilFieldBatchSyncEvent:writeStream(streamId, connection)
         end
 
         -- Zone cell data: per-cell soil state for the PDA cell-report overlay.
-        -- Added in v2.1.6 so dedi clients receive accumulated cell data on join.
+        -- Capped at 500 cells per field to prevent packet overflow on large fields.
         local zd = field.zoneData or {}
-        local zdCount = 0
-        for _ in pairs(zd) do zdCount = zdCount + 1 end
-        streamWriteInt32(streamId, zdCount)
+        local ZONE_SYNC_MAX = 500
+        local zdSent = {}
         for cellKey, cell in pairs(zd) do
+            if #zdSent >= ZONE_SYNC_MAX then break end
+            table.insert(zdSent, {key = cellKey, cell = cell})
+        end
+        streamWriteInt32(streamId, #zdSent)
+        for _, entry in ipairs(zdSent) do
+            local cellKey, cell = entry.key, entry.cell
             streamWriteInt32(streamId,   tonumber(cellKey) or 0)
             streamWriteFloat32(streamId, cell.N  or 0)
             streamWriteFloat32(streamId, cell.P  or 0)
@@ -948,23 +953,13 @@ function SoilFieldUpdateEvent:writeStream(streamId, connection)
         streamWriteFloat32(streamId, amount)
     end
 
-    -- Zone cell data (added v2.1.6)
-    local zd = self.field.zoneData or {}
-    local zdCount = 0
-    for _ in pairs(zd) do zdCount = zdCount + 1 end
-    streamWriteInt32(streamId, zdCount)
-    for cellKey, cell in pairs(zd) do
-        streamWriteInt32(streamId,   tonumber(cellKey) or 0)
-        streamWriteFloat32(streamId, cell.N  or 0)
-        streamWriteFloat32(streamId, cell.P  or 0)
-        streamWriteFloat32(streamId, cell.K  or 0)
-        streamWriteFloat32(streamId, cell.pH or 6.0)
-        streamWriteFloat32(streamId, cell.OM or 0)
-        streamWriteFloat32(streamId, cell.weedPressure    or 0)
-        streamWriteFloat32(streamId, cell.pestPressure    or 0)
-        streamWriteFloat32(streamId, cell.diseasePressure or 0)
-        streamWriteFloat32(streamId, cell.compaction      or 0)
-    end
+    -- Zone cell data: send 0 cells in per-update broadcasts.
+    -- All zone cells are already synced to the field aggregate after each apply, so
+    -- sending them here is redundant — and on large fields with wide-boom spreaders
+    -- the cell count can reach thousands, overflowing the FS25 packet size limit and
+    -- crashing the dedicated server. Clients fall back to getLayerColor() (aggregate)
+    -- for any cells not in their local zoneData, so the overlay is still correct.
+    streamWriteInt32(streamId, 0)
 end
 
 function SoilFieldUpdateEvent:run(connection)
@@ -972,15 +967,38 @@ function SoilFieldUpdateEvent:run(connection)
     if g_client == nil then return end
 
     if g_SoilFertilityManager and g_SoilFertilityManager.soilSystem then
-        g_SoilFertilityManager.soilSystem.fieldData[self.fieldId] = self.field
+        local soilSys = g_SoilFertilityManager.soilSystem
+        local newField = self.field
 
-        -- Refresh overlay so the map tile updates on the client without waiting for the 4.5-s timer
+        -- Preserve the client's local zoneData and sync all existing cells to the
+        -- new aggregate values. The broadcast no longer ships zone cells (packet
+        -- overflow risk on wide-boom spreaders), so we reconstruct per-cell display
+        -- from the field aggregate — same as what applyFertilizer does server-side.
+        local existing = soilSys.fieldData[self.fieldId]
+        if existing and existing.zoneData then
+            newField.zoneData = existing.zoneData
+            for _, cell in pairs(newField.zoneData) do
+                cell.N  = newField.nitrogen
+                cell.P  = newField.phosphorus
+                cell.K  = newField.potassium
+                cell.pH = newField.pH
+                cell.OM = newField.organicMatter
+                cell.weedPressure    = newField.weedPressure    or cell.weedPressure
+                cell.pestPressure    = newField.pestPressure    or cell.pestPressure
+                cell.diseasePressure = newField.diseasePressure or cell.diseasePressure
+                cell.compaction      = newField.compaction      or cell.compaction
+            end
+        end
+
+        soilSys.fieldData[self.fieldId] = newField
+
+        -- Refresh overlay so the map tile updates on the client without waiting for the timer
         local overlay = g_SoilFertilityManager.soilMapOverlay
         if overlay then overlay:requestRefresh() end
 
         if g_SoilFertilityManager.settings.debugMode then
             SoilLogger.debug("Client: Field %d synced from server (N=%.1f, P=%.1f, K=%.1f)",
-                self.fieldId, self.field.nitrogen, self.field.phosphorus, self.field.potassium)
+                self.fieldId, newField.nitrogen, newField.phosphorus, newField.potassium)
         end
     end
 end

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -22,13 +22,18 @@ local SF_DETAIL_MOD_DIR  = g_currentModDirectory
 SoilFieldDetailDialog.INSTANCE = nil
 SoilFieldDetailDialog.xmlPath  = nil
 
--- Status colors
-local COLOR_GOOD  = {0.25, 0.85, 0.25, 1.0}
-local COLOR_FAIR  = {0.90, 0.82, 0.18, 1.0}
-local COLOR_POOR  = {0.88, 0.25, 0.25, 1.0}
+-- Status colors (static defaults; overridden per-call when colorblind mode is on)
 local COLOR_WHITE = {1.00, 1.00, 1.00, 1.0}
 local COLOR_GREEN = {0.35, 0.85, 0.40, 1.0}
 local COLOR_DIM   = {0.60, 0.60, 0.60, 1.0}
+
+local function getStatusColors()
+    local cb = g_SoilFertilityManager and g_SoilFertilityManager.settings and g_SoilFertilityManager.settings.colorblindMode
+    if cb then
+        return {0.90, 0.37, 0.00, 1.0}, {0.94, 0.86, 0.00, 1.0}, {0.00, 0.45, 0.70, 1.0}
+    end
+    return {0.88, 0.25, 0.25, 1.0}, {0.90, 0.82, 0.18, 1.0}, {0.25, 0.85, 0.25, 1.0}
+end
 
 -- ── i18n helper ───────────────────────────────────────────
 
@@ -172,6 +177,7 @@ end
 -- ── Data population ───────────────────────────────────────
 
 function SoilFieldDetailDialog:_populateData()
+    local COLOR_POOR, COLOR_FAIR, COLOR_GOOD = getStatusColors()
     local fieldId = self._fieldId
     local sfm = g_SoilFertilityManager
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -39,6 +39,10 @@ SoilHUD.C_BAR_BG     = {0.18, 0.18, 0.18, 0.90}   -- neutral bar track
 SoilHUD.C_GOOD       = {0.25, 0.85, 0.25, 1.00}   -- green  — data color, keep
 SoilHUD.C_FAIR       = {0.90, 0.82, 0.18, 1.00}   -- yellow — data color, keep
 SoilHUD.C_POOR       = {0.88, 0.25, 0.25, 1.00}   -- red    — data color, keep
+-- Okabe-Ito colorblind-safe palette (orange / yellow / blue)
+SoilHUD.CB_GOOD      = {0.00, 0.45, 0.70, 1.00}   -- blue
+SoilHUD.CB_FAIR      = {0.94, 0.86, 0.00, 1.00}   -- yellow
+SoilHUD.CB_POOR      = {0.90, 0.37, 0.00, 1.00}   -- vermillion/orange
 SoilHUD.C_LABEL      = {0.72, 0.72, 0.72, 1.00}   -- neutral gray, no green tint
 SoilHUD.C_VALUE      = {1.00, 1.00, 1.00, 1.00}
 SoilHUD.C_DIM        = {0.52, 0.52, 0.52, 0.85}   -- neutral dim
@@ -770,22 +774,34 @@ function SoilHUD:toggleVisibility()
 end
 
 -- ── Color helpers ────────────────────────────────────────
+
+-- Returns poor, fair, good color tables based on colorblind setting.
+function SoilHUD:palette()
+    if self.settings and self.settings.colorblindMode then
+        return SoilHUD.CB_POOR, SoilHUD.CB_FAIR, SoilHUD.CB_GOOD
+    end
+    return SoilHUD.C_POOR, SoilHUD.C_FAIR, SoilHUD.C_GOOD
+end
+
 function SoilHUD:statusColor(status)
-    if status == "Good" then return SoilHUD.C_GOOD
-    elseif status == "Fair" then return SoilHUD.C_FAIR
-    else return SoilHUD.C_POOR end
+    local poor, fair, good = self:palette()
+    if status == "Good" then return good
+    elseif status == "Fair" then return fair
+    else return poor end
 end
 
 function SoilHUD:pHColor(pH)
-    if pH >= 6.5 and pH <= 7.0 then return SoilHUD.C_GOOD
-    elseif pH >= 5.5 and pH <= 7.5 then return SoilHUD.C_FAIR
-    else return SoilHUD.C_POOR end
+    local poor, fair, good = self:palette()
+    if pH >= 6.5 and pH <= 7.0 then return good
+    elseif pH >= 5.5 and pH <= 7.5 then return fair
+    else return poor end
 end
 
 function SoilHUD:omColor(om)
-    if om >= 4.0 then return SoilHUD.C_GOOD
-    elseif om >= 2.5 then return SoilHUD.C_FAIR
-    else return SoilHUD.C_POOR end
+    local poor, fair, good = self:palette()
+    if om >= 4.0 then return good
+    elseif om >= 2.5 then return fair
+    else return poor end
 end
 
 function SoilHUD:overallStatus(info)
@@ -796,18 +812,20 @@ function SoilHUD:overallStatus(info)
         local r = rank[info[key].status] or 3
         if r > worst then worst = r end
     end
-    -- pH
+    -- pH (threshold-based, palette-independent)
     if info.pH then
-        local r = rank[self:pHColor(info.pH) == SoilHUD.C_POOR and "Poor"
-                    or self:pHColor(info.pH) == SoilHUD.C_FAIR and "Fair"
-                    or "Good"] or 1
+        local s = (info.pH >= 6.5 and info.pH <= 7.0) and "Good"
+               or (info.pH >= 5.5 and info.pH <= 7.5) and "Fair"
+               or "Poor"
+        local r = rank[s] or 1
         if r > worst then worst = r end
     end
-    -- OM
+    -- OM (threshold-based, palette-independent)
     if info.organicMatter then
-        local r = rank[self:omColor(info.organicMatter) == SoilHUD.C_POOR and "Poor"
-                    or self:omColor(info.organicMatter) == SoilHUD.C_FAIR and "Fair"
-                    or "Good"] or 1
+        local s = (info.organicMatter >= 4.0) and "Good"
+               or (info.organicMatter >= 2.5) and "Fair"
+               or "Poor"
+        local r = rank[s] or 1
         if r > worst then worst = r end
     end
     -- Weed / pest / disease pressures (0-100, 3-level: <25 Good, <60 Fair, else Poor)
@@ -818,9 +836,10 @@ function SoilHUD:overallStatus(info)
             if r > worst then worst = r end
         end
     end
-    if worst == 1 then return "Good", SoilHUD.C_GOOD
-    elseif worst == 2 then return "Fair", SoilHUD.C_FAIR
-    else return "Poor", SoilHUD.C_POOR end
+    local poor, fair, good = self:palette()
+    if worst == 1 then return "Good", good
+    elseif worst == 2 then return "Fair", fair
+    else return "Poor", poor end
 end
 
 -- ── Draw helper ──────────────────────────────────────────
@@ -1089,8 +1108,9 @@ function SoilHUD:drawPanel()
                 local covPct = math.floor(cov * 100 + 0.5)
                 local minPct = math.floor(minCov * 100 + 0.5)
                 local covText = string.format(g_i18n:getText("sf_hud_coverage"), covPct, minPct)
-                local cr, cg, cb = 0.90, 0.35, 0.15  -- amber-red: below threshold
-                if cov >= minCov then cr, cg, cb = 0.32, 0.88, 0.44 end  -- green: at/above
+                local covPoor, _, covGood = self:palette()
+                local cr, cg, cb = covPoor[1], covPoor[2], covPoor[3]
+                if cov >= minCov then cr, cg, cb = covGood[1], covGood[2], covGood[3] end
                 local pad = SoilHUD.PAD * s
                 setTextAlignment(RenderText.ALIGN_LEFT)
                 setTextColor(cr, cg, cb, 1.0)
@@ -1565,16 +1585,17 @@ function SoilHUD:drawMiniReport()
 
             -- Status color: thresholds at 33% / 66% of range
             local col
+            local barPoor, barFair, barGood = self:palette()
             if row.label == "pH" then
                 -- pH sweet-spot 6.0-7.0; outside is worse
                 local norm = (row.val - 5.0) / 2.5  -- 0=5.0, 1=7.5
-                if norm >= 0.40 and norm <= 0.80 then col = SoilHUD.C_GOOD
-                elseif norm >= 0.20 and norm <= 0.90 then col = SoilHUD.C_FAIR
-                else col = SoilHUD.C_POOR end
+                if norm >= 0.40 and norm <= 0.80 then col = barGood
+                elseif norm >= 0.20 and norm <= 0.90 then col = barFair
+                else col = barPoor end
             else
-                if frac >= 0.66 then col = SoilHUD.C_GOOD
-                elseif frac >= 0.33 then col = SoilHUD.C_FAIR
-                else col = SoilHUD.C_POOR end
+                if frac >= 0.66 then col = barGood
+                elseif frac >= 0.33 then col = barFair
+                else col = barPoor end
             end
 
             -- Bar track

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -34,6 +34,10 @@ SoilMapOverlay.DENSITY_POINTS   = {8000, 20000, 40000}
 SoilMapOverlay.C_POOR = {0.88, 0.25, 0.25}
 SoilMapOverlay.C_FAIR = {0.90, 0.82, 0.18}
 SoilMapOverlay.C_GOOD = {0.25, 0.85, 0.25}
+-- Okabe-Ito colorblind-safe palette (orange / yellow / blue)
+SoilMapOverlay.CB_POOR = {0.90, 0.37, 0.00}
+SoilMapOverlay.CB_FAIR = {0.94, 0.86, 0.00}
+SoilMapOverlay.CB_GOOD = {0.00, 0.45, 0.70}
 
 -- Per-layer accent color
 SoilMapOverlay.LAYER_ACCENT = {
@@ -687,28 +691,29 @@ function SoilMapOverlay:drawCellTooltip(ingameMap, mapX, mapY, mapWidth, mapHeig
         renderText(bx + boxW - padX, midY, textSz, value)
     end
 
+    local ttPOOR, ttFAIR, ttGOOD = self:statusColors()
     local function nColor(status)
-        if status == "Good" then return 0.25, 0.85, 0.25
-        elseif status == "Fair" then return 0.90, 0.82, 0.18
-        else return 0.88, 0.25, 0.25 end
+        if status == "Good" then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif status == "Fair" then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
     end
     local function phColor(ph)
         local rc = SoilConstants.REPORT_COLORS
-        if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return 0.25, 0.85, 0.25
-        elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return 0.90, 0.82, 0.18
-        else return 0.88, 0.25, 0.25 end
+        if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
     end
     local function omColor(om)
         local rc = SoilConstants.REPORT_COLORS
-        if om >= rc.OM_GOOD then return 0.25, 0.85, 0.25
-        elseif om >= rc.OM_FAIR then return 0.90, 0.82, 0.18
-        else return 0.88, 0.25, 0.25 end
+        if om >= rc.OM_GOOD then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif om >= rc.OM_FAIR then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
     end
     local function pressureColor(pct)
         local wp = SoilConstants.WEED_PRESSURE
-        if pct < wp.LOW then return 0.25, 0.85, 0.25
-        elseif pct < wp.MEDIUM then return 0.90, 0.82, 0.18
-        else return 0.88, 0.25, 0.25 end
+        if pct < wp.LOW then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif pct < wp.MEDIUM then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
     end
 
     -- Rows step downward from just below the title divider
@@ -925,12 +930,13 @@ function SoilMapOverlay:drawLegend(panelX, bottomY, panelWidth)
     drawFilledRect(panelX, legendY, panelWidth, legendH, 0.04, 0.04, 0.04, 0.80)
     self:drawThinBorder(panelX, legendY, panelWidth, legendH, 0.35, 0.35, 0.35, 0.5)
 
+    local lPOOR, lFAIR, lGOOD = self:statusColors()
     local items = {
-        { r = SoilMapOverlay.C_POOR[1], g = SoilMapOverlay.C_POOR[2], b = SoilMapOverlay.C_POOR[3],
+        { r = lPOOR[1], g = lPOOR[2], b = lPOOR[3],
           key = "sf_pda_map_legend_poor", label = "Poor" },
-        { r = SoilMapOverlay.C_FAIR[1], g = SoilMapOverlay.C_FAIR[2], b = SoilMapOverlay.C_FAIR[3],
+        { r = lFAIR[1], g = lFAIR[2], b = lFAIR[3],
           key = "sf_pda_map_legend_fair", label = "Fair" },
-        { r = SoilMapOverlay.C_GOOD[1], g = SoilMapOverlay.C_GOOD[2], b = SoilMapOverlay.C_GOOD[3],
+        { r = lGOOD[1], g = lGOOD[2], b = lGOOD[3],
           key = "sf_pda_map_legend_good", label = "Good" },
     }
 
@@ -1005,15 +1011,21 @@ local LAYER_GRLE_NAME = {
     [5] = "infoLayer_soilOM",
 }
 
+-- Returns poor, fair, good color tables based on colorblind setting.
+function SoilMapOverlay:statusColors()
+    if self.settings and self.settings.colorblindMode then
+        return SoilMapOverlay.CB_POOR, SoilMapOverlay.CB_FAIR, SoilMapOverlay.CB_GOOD
+    end
+    return SoilMapOverlay.C_POOR, SoilMapOverlay.C_FAIR, SoilMapOverlay.C_GOOD
+end
+
 -- Convert a raw decoded value (from the density map layer) to a colour.
 -- Mirrors the same thresholds used in getLayerColor so the per-pixel path
 -- matches the per-field fallback path exactly.
 ---@param layerIdx integer  1-5 (soil nutrient layers)
 ---@param val      number   Decoded semantic float from readValueAtWorld
 function SoilMapOverlay:valueToLayerColor(layerIdx, val)
-    local POOR = SoilMapOverlay.C_POOR
-    local FAIR = SoilMapOverlay.C_FAIR
-    local GOOD = SoilMapOverlay.C_GOOD
+    local POOR, FAIR, GOOD = self:statusColors()
     local T    = SoilConstants.STATUS_THRESHOLDS
 
     if layerIdx == 1 then
@@ -1044,9 +1056,7 @@ end
 -- ── Layer color logic ─────────────────────────────────────
 
 function SoilMapOverlay:getLayerColor(layerIdx, info, farmlandId)
-    local POOR = SoilMapOverlay.C_POOR
-    local FAIR = SoilMapOverlay.C_FAIR
-    local GOOD = SoilMapOverlay.C_GOOD
+    local POOR, FAIR, GOOD = self:statusColors()
     local T    = SoilConstants.STATUS_THRESHOLDS
 
     if layerIdx == 1 then

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -32,12 +32,20 @@ SoilReportDialog.MAX_ROWS = 10
 SoilReportDialog.instance = nil
 SoilReportDialog.xmlPath = nil
 
--- Status colors
+-- Status colors (static; only used as fallbacks — see getStatusColors() for runtime palette)
 SoilReportDialog.COLOR_GOOD  = {0.25, 0.85, 0.25, 1.0}
 SoilReportDialog.COLOR_FAIR  = {0.90, 0.82, 0.18, 1.0}
 SoilReportDialog.COLOR_POOR  = {0.88, 0.25, 0.25, 1.0}
 SoilReportDialog.COLOR_WHITE = {1.00, 1.00, 1.00, 1.0}
 SoilReportDialog.COLOR_DIM   = {0.60, 0.60, 0.60, 1.0}
+
+local function getStatusColors()
+    local cb = g_SoilFertilityManager and g_SoilFertilityManager.settings and g_SoilFertilityManager.settings.colorblindMode
+    if cb then
+        return {0.90, 0.37, 0.00, 1.0}, {0.94, 0.86, 0.00, 1.0}, {0.00, 0.45, 0.70, 1.0}
+    end
+    return SoilReportDialog.COLOR_POOR, SoilReportDialog.COLOR_FAIR, SoilReportDialog.COLOR_GOOD
+end
 
 function SoilReportDialog.getInstance(modDirectory)
     if SoilReportDialog.instance == nil then
@@ -267,35 +275,38 @@ end
 -- ── Status color helpers ──────────────────────────────────────────────
 
 local function getStatusColor(status)
-    if status == "Good" then return SoilReportDialog.COLOR_GOOD
-    elseif status == "Fair" then return SoilReportDialog.COLOR_FAIR
-    elseif status == "Poor" then return SoilReportDialog.COLOR_POOR
+    local poor, fair, good = getStatusColors()
+    if status == "Good" then return good
+    elseif status == "Fair" then return fair
+    elseif status == "Poor" then return poor
     end
     return SoilReportDialog.COLOR_WHITE
 end
 
 local function getPHColor(ph)
     local rc = SoilConstants.REPORT_COLORS
-    if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return SoilReportDialog.COLOR_GOOD
-    elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return SoilReportDialog.COLOR_FAIR
+    local poor, fair, good = getStatusColors()
+    if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return good
+    elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return fair
     end
-    return SoilReportDialog.COLOR_POOR
+    return poor
 end
 
 local function getOMColor(om)
     local rc = SoilConstants.REPORT_COLORS
-    if om >= rc.OM_GOOD then return SoilReportDialog.COLOR_GOOD
-    elseif om >= rc.OM_FAIR then return SoilReportDialog.COLOR_FAIR
+    local poor, fair, good = getStatusColors()
+    if om >= rc.OM_GOOD then return good
+    elseif om >= rc.OM_FAIR then return fair
     end
-    return SoilReportDialog.COLOR_POOR
+    return poor
 end
 
 local function getPressureColor(pct)
-    -- Aligned with SoilConstants.WEED_PRESSURE thresholds (LOW=20, MEDIUM=50, same for pest/disease)
     local wp = SoilConstants.WEED_PRESSURE
-    if pct < wp.LOW    then return SoilReportDialog.COLOR_GOOD
-    elseif pct < wp.MEDIUM then return SoilReportDialog.COLOR_FAIR
-    else return SoilReportDialog.COLOR_POOR end
+    local poor, fair, good = getStatusColors()
+    if pct < wp.LOW    then return good
+    elseif pct < wp.MEDIUM then return fair
+    else return poor end
 end
 
 -- ── Overall status helpers ────────────────────────────────────────────
@@ -305,38 +316,42 @@ end
 ---@return string "Good"|"Fair"|"Poor"
 ---@return table color RGBA
 local function getOverallStatus(info)
-    local function colorRank(c)
-        if c == SoilReportDialog.COLOR_POOR then return 3
-        elseif c == SoilReportDialog.COLOR_FAIR then return 2
-        else return 1 end
-    end
+    local rc = SoilConstants.REPORT_COLORS
+    local wp = SoilConstants.WEED_PRESSURE
     local worst = 1
-    -- N / P / K
+    -- N / P / K (status strings)
     for _, key in ipairs({"nitrogen", "phosphorus", "potassium"}) do
         local s = info[key].status
         local r = (s == "Poor") and 3 or (s == "Fair") and 2 or 1
         if r > worst then worst = r end
     end
-    -- pH and OM
+    -- pH (threshold-based)
     if info.pH then
-        local r = colorRank(getPHColor(info.pH))
+        local ph = info.pH
+        local r = (ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH) and 1
+               or (ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH) and 2
+               or 3
         if r > worst then worst = r end
     end
+    -- OM (threshold-based)
     if info.organicMatter then
-        local r = colorRank(getOMColor(info.organicMatter))
+        local om = info.organicMatter
+        local r = (om >= rc.OM_GOOD) and 1 or (om >= rc.OM_FAIR) and 2 or 3
         if r > worst then worst = r end
     end
     -- Weed / pest / disease pressures (stored as 0-100)
     for _, key in ipairs({"weedPressure", "pestPressure", "diseasePressure"}) do
         local val = info[key]
         if val and val > 0 then
-            local r = colorRank(getPressureColor(math.floor(val + 0.5)))
+            local pct = math.floor(val + 0.5)
+            local r = (pct >= wp.MEDIUM) and 3 or (pct >= wp.LOW) and 2 or 1
             if r > worst then worst = r end
         end
     end
-    if worst == 3 then return "Poor", SoilReportDialog.COLOR_POOR
-    elseif worst == 2 then return "Fair", SoilReportDialog.COLOR_FAIR
-    else return "Good", SoilReportDialog.COLOR_GOOD end
+    local poor, fair, good = getStatusColors()
+    if worst == 3 then return "Poor", poor
+    elseif worst == 2 then return "Fair", fair
+    else return "Good", good end
 end
 
 --- Compute average farm health across all owned fields.

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -130,7 +130,7 @@ local CATEGORIES = {
         sections = {
             {
                 headerKey = "sf_panel_hdr_visibility",
-                items     = { "showHUD", "showMiniReport", "useImperialUnits" }
+                items     = { "showHUD", "showMiniReport", "useImperialUnits", "colorblindMode" }
             },
             {
                 headerKey = "sf_panel_hdr_hud_style",
@@ -202,6 +202,7 @@ local SETTING_DESCS = {
     hudPosition       = "sf_desc_hudPosition",
     activeMapLayer    = "sf_desc_activeMapLayer",
     overlayDensity    = "sf_desc_overlayDensity",
+    colorblindMode    = "sf_desc_colorblindMode",
     enabled           = "sf_desc_enabled",
     debugMode         = "sf_desc_debugMode",
     showNotifications = "sf_desc_showNotifications",

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -23,11 +23,16 @@ SoilTreatmentDialog.INSTANCE = nil
 SoilTreatmentDialog.xmlPath  = nil
 
 -- Colors
-local COLOR_GOOD  = {0.25, 0.85, 0.25, 1.0}
-local COLOR_FAIR  = {0.90, 0.82, 0.18, 1.0}
-local COLOR_POOR  = {0.88, 0.25, 0.25, 1.0}
 local COLOR_WHITE = {1.00, 1.00, 1.00, 1.0}
 local COLOR_DIM   = {0.60, 0.60, 0.60, 1.0}
+
+local function getStatusColors()
+    local cb = g_SoilFertilityManager and g_SoilFertilityManager.settings and g_SoilFertilityManager.settings.colorblindMode
+    if cb then
+        return {0.90, 0.37, 0.00, 1.0}, {0.94, 0.86, 0.00, 1.0}, {0.00, 0.45, 0.70, 1.0}
+    end
+    return {0.88, 0.25, 0.25, 1.0}, {0.90, 0.82, 0.18, 1.0}, {0.25, 0.85, 0.25, 1.0}
+end
 
 -- ── i18n helper ───────────────────────────────────────────
 
@@ -132,6 +137,7 @@ end
 -- ── Data Population ───────────────────────────────────────
 
 function SoilTreatmentDialog:_populateData()
+    local COLOR_POOR, COLOR_FAIR, COLOR_GOOD = getStatusColors()
     local fieldId = self._fieldId
     local sfm = g_SoilFertilityManager
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,9 +24,9 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: soil map tile color now updates promptly after spraying",
-    "- Fixed: multiplayer clients see map tile changes immediately",
-    "- Improved: fill type pile textures now use realistic base-game materials",
+    "- Fixed: soil map tiles now update correctly after applying fertilizer",
+    "- Fixed: tiles pre-stamped by tillage (plow, sow) no longer stay stale after spraying",
+    "- Fixed: full boom width cell coverage reflects applied nutrients immediately",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,9 +24,9 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: soil map tiles now update correctly after applying fertilizer",
-    "- Fixed: tiles pre-stamped by tillage (plow, sow) no longer stay stale after spraying",
-    "- Fixed: full boom width cell coverage reflects applied nutrients immediately",
+    "- Fixed: server crash with dry fertilizer (urea spreader) — zone cell packet overflow",
+    "- Fixed: soil map tiles now update after fertilizer on dedicated server clients",
+    "- Added: Colorblind Mode toggle in Display settings (orange/blue palette for deuteranopia)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Camada de nutrientes mostrada como sobreposição no mapa do PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detalhe do Mapa" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Orçamento de pontos de amostragem para a sobreposição de solo do PDA. Baixo = melhor FPS, Alto = cobertura mais completa em mapas grandes." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Abrir Configurações de Solo" eh="2e31c0dd" />
     <e k="sf_reset" v="Restaurar configurações solo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de solo" eh="f0224a10" />
@@ -632,6 +634,7 @@
     <e k="sf_desc_cropRotation" v="Benefícios e penalidades de rotação" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Camada de nutrientes mostrada no mapa do PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Orçamento de pontos (Baixo=8k, Méd=20k, Alto=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Capa de nutrients mostrada com a superposició al mapa de la PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detall del mapa" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Pressupost de punts de mostra per a la superposició de sòl de la PDA. Baix = millors FPS, Alt = cobertura més completa en mapes grans." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Obrir configuració de sòl" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablir configuració del sòl" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD del sòl" eh="f0224a10" />
@@ -631,6 +633,7 @@
     <e k="sf_desc_cropRotation" v="Beneficis i penalitzacions per rotació" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Capa de nutrients mostrada al mapa de la PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Pressupost de punts (Baix=8k, Mitjà=20k, Alt=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Živinová vrstva zobrazená jako překryv v PDA mapě" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detail mapy" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Rozpočet vzorkovacích bodů pro půdní překryv PDA. Nízký = lepší FPS, Vysoký = plnější pokrytí na velkých mapách." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Otevřít nastavení půdy" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetovat nastavení půdy" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Přepnout HUD půdy" eh="f0224a10" />
@@ -631,6 +633,7 @@
     <e k="sf_desc_cropRotation" v="Výhody a postihy střídání plodin" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Živinová vrstva zobrazená v PDA mapě" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Rozpočet bodů (Nízký=8k, Střední=20k, Vysoký=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Næringsstoflag vist som overlejring på PDA-kortet" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kortdetalje" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Prøvepunktsbudget for PDA-jordoverlejringen. Lav = bedre FPS, Høj = bedre dækning på store kort." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Åbn jordindstillinger" eh="2e31c0dd" />
     <e k="sf_reset" v="Nulstil jordindstillinger" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Slå jord-HUD til/fra" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Sædskiftefordele og -ulemper" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Næringslag vist på PDA-kortet" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Antal datapunkter (Lav=8k, Mid=20k, Høj=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Meget langsom (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Langsom (0.5x)" eh="db69874d" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Nährstoffebene, die als Overlay in der PDA-Karte angezeigt wird" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kartendetails" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Abtastpunktbudget für das PDA-Bodenoverlay. Niedrig = bessere FPS, Hoch = vollständigere Abdeckung auf großen Karten." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Bodeneinstellungen öffnen" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeneinstellungen zurücksetzen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Boden-HUD umschalten" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Vorteile und Nachteile der Fruchtfolge" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Nährstoffebene in der PDA-Karte" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Abtastpunktbudget (Niedrig=8k, Mittel=20k, Hoch=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Sehr langsam (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Langsam (0.5x)" eh="db69874d" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Capa de nutrientes mostrada en el mapa PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detalle del Mapa" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Presupuesto de puntos de muestreo para el mapa de suelo. Bajo = mejor FPS, Alto = cobertura total." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Abrir Ajustes de Suelo" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablecer Ajustes de Suelo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de Suelo" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Beneficios y penalizaciones de rotación" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Capa de nutriente en el mapa PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Puntos de muestreo (Bajo=8k, Med=20k, Alto=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Muy Lento (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Lento (0.5x)" eh="db69874d" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Reset Soil Settings" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Toggle Soil HUD" eh="f0224a10" />
@@ -634,6 +636,7 @@
     <e k="sf_desc_cropRotation" v="Rotation benefits and penalties" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Nutrient layer shown in PDA map" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Sample point budget (Low=8k, Med=20k, High=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Capa de nutrientes mostrada en el mapa PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detalle de mapa" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Presupuesto de puntos de muestreo para el mapa de suelo. Bajo = mejor FPS, Alto = cobertura total." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Abrir ajustes de suelo" eh="2e31c0dd" />
     <e k="sf_reset" v="Restablecer ajustes de suelo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD de suelo" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Beneficios y penalizaciones de rotación" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Capa de nutriente en el mapa PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Puntos de muestreo (Bajo=8k, Med=20k, Alto=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Muy lento (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Lento (0.5x)" eh="db69874d" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Couche de nutriments affichée en surimpression sur la carte PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Détails de la carte" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Budget de points d'échantillonnage pour l'incrustation du sol PDA. Bas = meilleur FPS, Haut = couverture plus complète." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Ouvrir réglages du sol" eh="2e31c0dd" />
     <e k="sf_reset" v="Réinitialiser réglages du sol" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Basculer HUD sol" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Avantages et pénalités de rotation" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Couche affichée sur la carte PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Budget points (Bas=8k, Moyen=20k, Haut=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Très lent (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Lent (0.5x)" eh="db69874d" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Ravinnokerros, joka näytetään PDA-kartalla" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kartan yksityiskohdat" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Näytepisteiden määrä PDA:n maaperäkartalle. Matala = parempi FPS, Korkea = kattavampi peitto." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Avaa maaperän asetukset" eh="2e31c0dd" />
     <e k="sf_reset" v="Nollaa maaperän asetukset" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Vaihda maaperän HUD" eh="f0224a10" />
@@ -594,6 +596,7 @@
     <e k="sf_desc_cropRotation" v="Viljelykierron hyödyt ja haitat" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="PDA-kartalla näkyvä ravinnokerros" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Näytepisteiden määrä (Matala=8k, Keski=20k, Korkea=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Erittäin hidas (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Hidas (0.5x)" eh="db69874d" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Couche de nutriments affichée en superposition sur la carte PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Détail de la carte" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Budget de points d'échantillonnage pour la superposition du sol sur la PDA. Faible = meilleures performances, Élevé = couverture plus complète sur les grandes cartes." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Ouvrir les paramètres du sol" eh="2e31c0dd" />
     <e k="sf_reset" v="Réinitialiser les paramètres du sol" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Activer/désactiver le HUD du sol" eh="f0224a10" />
@@ -622,6 +624,7 @@
     <e k="sf_desc_cropRotation" v="Avantages et pénalités de la rotation des cultures" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Couche de nutriments affichée sur la carte PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Budget des points d'échantillonnage (Bas=8k, Moyen=20k, Élevé=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- Valeurs multi-options -->
     <e k="sf_rr_1" v="Très lent (0.25x)" eh="b681a1b4" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Tápanyagréteg megjelenítése átfedésként a PDA térképen" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Térkép részletesség" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Mintavételi pontok kerete a PDA talajátfedéshez. Alacsony = jobb FPS, Magas = teljesebb lefedettség nagy térképeken." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Talaj beállítások megnyitása" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />
@@ -612,6 +614,7 @@
     <e k="sf_desc_cropRotation" v="Vetésforgó előnyök és büntetések" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Tápanyagréteg a PDA térképen" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Mintapont keret (Alacsony=8k, Közepes=20k, Magas=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Nagyon lassú (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Lassú (0.5x)" eh="db69874d" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Lapisan nutrisi ditampilkan sebagai overlay di peta PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detail Peta" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Anggaran titik sampel untuk overlay tanah PDA. Rendah = FPS lebih baik, Tinggi = cakupan lebih penuh pada peta besar." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Buka Pengaturan Tanah" eh="2e31c0dd" />
     <e k="sf_reset" v="Atur Ulang Pengaturan Tanah" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Beralih HUD Tanah" eh="f0224a10" />
@@ -631,6 +633,7 @@
     <e k="sf_desc_cropRotation" v="Manfaat dan penalti rotasi" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Lapisan nutrisi ditunjukkan di peta PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Anggaran titik sampel (Rendah=8k, Sed=20k, Tinggi=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Livello nutrienti mostrato come overlay nella mappa PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Dettaglio Mappa" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Budget punti campionamento per overlay suolo. Basso = FPS migliori, Alto = copertura totale." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Apri impostazioni suolo" eh="2e31c0dd" />
     <e k="sf_reset" v="Ripristina impostazioni suolo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Attiva/disattiva HUD suolo" eh="f0224a10" />
@@ -631,6 +633,7 @@
     <e k="sf_desc_cropRotation" v="Benefici e penalità della rotazione colturale" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Livello nutrienti visualizzato nella mappa PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Budget punti campionamento (Basso=8k, Medio=20k, Alto=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="PDAマップにオーバーレイ表示される養分レイヤー" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="マップの詳細度" eh="a525859a" />
     <e k="sf_overlay_density_long" v="PDA土壌オーバーレイのサンプルポイント予算。低 = FPS向上、高 = 大規模マップでの網羅性向上。" eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="土壌設定を開く" eh="2e31c0dd" />
     <e k="sf_reset" v="土壌設定をリセット" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="土壌HUDの切替" eh="f0224a10" />
@@ -617,6 +619,7 @@
     <e k="sf_desc_cropRotation" v="輪作によるメリットとデメリット" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="PDA マップに表示する養分レイヤー" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="サンプルポイント予算 (低=8k, 中=20k, 高=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- 多肢選択値 -->
     <e k="sf_rr_1" v="極めて遅い (0.25x)" eh="b681a1b4" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="PDA 지도에 오버레이로 표시될 영양분 레이어" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="지도 상세도" eh="a525859a" />
     <e k="sf_overlay_density_long" v="PDA 토양 오버레이를 위한 샘플 지점 수 설정. 낮음 = FPS 향상, 높음 = 대형 지도에서 더 촘촘한 표시." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="토양 설정 열기" eh="2e31c0dd" />
     <e k="sf_reset" v="토양 설정 초기화" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="토양 HUD 전환" eh="f0224a10" />
@@ -618,6 +620,7 @@
     <e k="sf_desc_cropRotation" v="작물 순환 혜택 및 불이익" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="PDA 지도에 표시될 영양분 레이어" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="샘플 지점 수 (낮음=8k, 중간=20k, 높음=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="매우 느림 (0.25x)" eh="b681a1b4" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Voedingsstoffenlaag getoond als overlay op de PDA-kaart" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kaartdetail" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Steekproefpunten voor de PDA-bodemoverlay. Laag = betere FPS, Hoog = volledigere dekking op grote kaarten." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Bodeminstellingen openen" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeminstellingen herstellen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bodem HUD in-/uitschakelen" eh="f0224a10" />
@@ -619,6 +621,7 @@
     <e k="sf_desc_cropRotation" v="Rotatievoordelen en -straffen" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Voedingsstoffenlaag getoond in PDA-kaart" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Steekproefpuntenbudget (Laag=8k, Gem=20k, Hoog=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Zeer langzaam (0,25x)" eh="b681a1b4" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Næringslaget som vises som overlegg i PDA-kartet" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kartdetaljer" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Prøvepunktbudsjett for PDA-jordoverlegget. Lav = bedre FPS, Høy = fyldigere dekning på store kart." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Åpne jordinnstillinger" eh="2e31c0dd" />
     <e k="sf_reset" v="Nullstill jordinnstillinger" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Veksle jord-HUD" eh="f0224a10" />
@@ -619,6 +621,7 @@
     <e k="sf_desc_cropRotation" v="Fordeler og straffer ved vekstskifte" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Næringslag som vises i PDA-kartet" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Prøvepunktbudsjett (Lav=8k, Med=20k, Høy=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Veldig sakte (0,25x)" eh="b681a1b4" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Warstwa składników wyświetlana jako nakładka na mapie PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Szczegółowość mapy" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Budżet punktów próbkowania dla nakładki gleby PDA. Niski = lepsze FPS, Wysoki = pełniejsze pokrycie na dużych mapach." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Otwórz ustawienia gleby" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetuj ustawienia gleby" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Przełącz HUD gleby" eh="f0224a10" />
@@ -619,6 +621,7 @@
     <e k="sf_desc_cropRotation" v="Korzyści i kary za płodozmian" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Warstwa składników pokazywana na mapie PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Budżet punktów próbkowania (Niski=8k, Śr=20k, Wys=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Bardzo wolno (0.25x)" eh="b681a1b4" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Camada de nutrientes mostrada como sobreposição no mapa PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detalhe do Mapa" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Orçamento de pontos de amostragem para a sobreposição de solo do PDA. Baixo = melhor FPS, Alto = cobertura total em mapas grandes." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Abrir Definições do Solo" eh="2e31c0dd" />
     <e k="sf_reset" v="Redefinir Definições do Solo" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Alternar HUD do Solo" eh="f0224a10" />
@@ -632,6 +634,7 @@
     <e k="sf_desc_cropRotation" v="Benefícios e penalidades de rotação" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Camada de nutrientes mostrada no mapa PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Orçamento de pontos (Baixo=8k, Méd=20k, Alto=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          PAINEL DE DEFINIÇÕES — VALORES MULTI-OPÇÃO

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Stratul de nutrienți afișat pe harta PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Detaliu Hartă" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Bugetul de puncte de probă pentru stratul de sol PDA. Scăzut = FPS mai bun, Ridicat = acoperire mai completă pe hărți mari." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Deschide Setări Sol" eh="2e31c0dd" />
     <e k="sf_reset" v="Resetează Setările de Sol" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Comutare HUD Sol" eh="f0224a10" />
@@ -632,6 +634,7 @@
     <e k="sf_desc_cropRotation" v="Beneficii și penalizări la rotația culturilor" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Stratul de nutrienți afișat pe harta PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Bugetul de puncte de probă (Scăzut=8k, Med=20k, Ridicat=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Слой питательных веществ, отображенный в виде наложения на карте PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Детали карты" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Бюджет точек выборки для наложения почвы в PDA. Низкий = лучший FPS, Высокий = более полное покрытие на больших картах." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Настройки почвы" eh="2e31c0dd" />
     <e k="sf_reset" v="Сбросить настройки почвы" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Переключить HUD почвы" eh="f0224a10" />
@@ -587,6 +589,7 @@
     <e k="sf_desc_cropRotation" v="Бонусы/штрафы севооборота" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Слой на карте PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Бюджет точек (Низкий=8k, Средний=20k, Высокий=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
     <e k="sf_rr_1" v="Очень медленно (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Медленно (0.5x)" eh="db69874d" />
     <e k="sf_rr_3" v="Нормально (1.0x)" eh="930452c1" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Näringslager som visas som överlagring på PDA-kartan" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kartdetaljer" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Punktbudget för PDA-marköverlagringen. Låg = bättre FPS, Hög = fullständigare täckning på stora kartor." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Öppna markinställningar" eh="2e31c0dd" />
     <e k="sf_reset" v="Återställ markinställningar" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Växla mark-HUD" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Fördelar och straff vid växtföljd" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Näringslager som visas på PDA-kartan" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Punktbudget (Låg=8k, Med=20k, Hög=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Mycket långsamt (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Långsamt (0.5x)" eh="db69874d" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="PDA haritasında katman olarak gösterilen besin katmanı" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Harita Detayı" eh="a525859a" />
     <e k="sf_overlay_density_long" v="PDA toprak katmanı için örnek nokta bütçesi. Düşük = daha iyi FPS, Yüksek = büyük haritalarda tam kapsam." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Toprak Ayarlarını Aç" eh="2e31c0dd" />
     <e k="sf_reset" v="Toprak Ayarlarını Sıfırla" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Toprak HUD'ını Aç/Kapat" eh="f0224a10" />
@@ -594,6 +596,7 @@
     <e k="sf_desc_cropRotation" v="Münavebe faydaları ve cezaları" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="PDA haritasında gösterilen besin katmanı" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Örnek nokta bütçesi (Düşük=8k, Orta=20k, Yüksek=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Çok Yavaş (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Yavaş (0.5x)" eh="db69874d" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Шар поживних речовин, що відображається на PDA-карті" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Деталізація карти" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Бюджет точок для накладення ґрунту в PDA. Низька = кращий FPS, Висока = повніше покриття на великих картах." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Відкрити налаштування ґрунту" eh="2e31c0dd" />
     <e k="sf_reset" v="Скинути налаштування ґрунту" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Увімкнути/вимкнути HUD ґрунту" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Бонуси та штрафи сівозміни" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Шар речовин на PDA-карті" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Бюджет точок (Low=8k, Med=20k, High=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Дуже повільно (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Повільно (0.5x)" eh="db69874d" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -83,6 +83,8 @@
     <e k="sf_active_map_layer_long" v="Lớp dinh dưỡng được hiển thị trên bản đồ PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Chi tiết bản đồ" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Ngân sách điểm lấy mẫu cho lớp phủ đất PDA. Thấp = FPS tốt hơn, Cao = độ phủ đầy đủ hơn trên bản đồ lớn." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
     <e k="input_SF_OPEN_SETTINGS" v="Mở cài đặt đất" eh="2e31c0dd" />
     <e k="sf_reset" v="Đặt lại cài đặt đất" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bật/Tắt HUD đất" eh="f0224a10" />
@@ -593,6 +595,7 @@
     <e k="sf_desc_cropRotation" v="Lợi ích và hình phạt khi luân canh" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Lớp dinh dưỡng hiển thị trong bản đồ PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Ngân sách điểm lấy mẫu (Thấp=8k, Vừa=20k, Cao=40k)" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
 
     <e k="sf_rr_1" v="Rất chậm (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Chậm (0.5x)" eh="db69874d" />


### PR DESCRIPTION
## Summary

- **Fixed**: Server crash when using a dry fertilizer spreader (urea/spreader) on dedicated servers — zone cell data was being serialized without a size cap, causing packet overflow when a wide-boom spreader stamped thousands of cells
- **Fixed**: Dedicated server clients now correctly see soil map tile color updates after fertilizer application (per-update broadcast now syncs local zone cells from field aggregate instead of re-shipping all cells)
- **Added**: Colorblind Mode setting in Display → Visibility — replaces the red/green status palette with an orange/blue Okabe-Ito palette for deuteranopia and protanopia accessibility; applies to map overlay, HUD, PDA dialogs, and cell tooltip

## Technical Details

- `SoilFieldUpdateEvent:writeStream` no longer serializes `zoneData` (was unbounded, caused packet overflow on large fields); clients now sync their existing zone cells from the new field aggregate in `run()`
- `SoilFieldBatchSyncEvent` (join sync) zone data capped at 500 cells per field
- `markBoomCells` and `applyFertilizer` both enforce `MAX_ZONE_CELLS = 1000` cap per field
- `colorblindMode` setting (localOnly boolean) drives dynamic palette selection via `palette()` / `statusColors()` methods in `SoilHUD` and `SoilMapOverlay`; dialog files use `getStatusColors()` helpers
- Fixed fragile color-reference comparisons in `overallStatus` and `getOverallStatus` (now threshold-based, not palette-dependent)

## Save Compatibility

✅ Fully compatible — no save migration required. Existing saves load normally.

## Test Plan

- [ ] Dedicated server: apply urea with a spreader, no crash, clients see map tile color update
- [ ] Colorblind Mode toggle in Display settings changes map overlay and HUD colors
- [ ] Join a dedicated server mid-session: zone cells appear correctly (capped at 500)
- [ ] Existing saves load and display correctly