### PR TITLE
v2.1.6.6 — Fix sprayer rate network event crash (nil vehicle network ID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.5
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.6
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.5</version>
+    <version>2.1.6.6</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -767,7 +767,7 @@ function SoilFertilityManager:onSprayerRateUpInput()
         SoilLogger.debug("Rate UP input: vehicle %d, new index %d (multiplier %.2f)",
             vehicle.id, newIdx, rm:getMultiplier(vehicle.id))
         if SoilNetworkEvents_SendSprayerRate then
-            SoilNetworkEvents_SendSprayerRate(vehicle.id, newIdx)
+            SoilNetworkEvents_SendSprayerRate(vehicle, newIdx)
         end
     end
 end
@@ -781,7 +781,7 @@ function SoilFertilityManager:onSprayerRateDownInput()
         SoilLogger.debug("Rate DOWN input: vehicle %d, new index %d (multiplier %.2f)",
             vehicle.id, newIdx, rm:getMultiplier(vehicle.id))
         if SoilNetworkEvents_SendSprayerRate then
-            SoilNetworkEvents_SendSprayerRate(vehicle.id, newIdx)
+            SoilNetworkEvents_SendSprayerRate(vehicle, newIdx)
         end
     end
 end
@@ -793,7 +793,7 @@ function SoilFertilityManager:onToggleAutoInput()
     local rm = self.sprayerRateManager
     if rm then
         local newState = rm:toggleAutoMode(vehicle.id)
-        SoilNetworkEvents_SendSprayerAutoMode(vehicle.id, newState)
+        SoilNetworkEvents_SendSprayerAutoMode(vehicle, newState)
     end
 end
 
@@ -1052,7 +1052,7 @@ function SoilFertilityManager:updateAutoRates(dt)
     if newIdx ~= currentIdx then
         rm:setIndex(vehicle.id, newIdx)
         if SoilNetworkEvents_SendSprayerRate then
-            SoilNetworkEvents_SendSprayerRate(vehicle.id, newIdx)
+            SoilNetworkEvents_SendSprayerRate(vehicle, newIdx)
         end
         SoilLogger.debug(
             "Auto-rate: vehicle %d → index %d (%.2fx) [%s on field %d]",

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1116,23 +1116,24 @@ function SoilSprayerRateEvent.emptyNew()
     return Event.new(SoilSprayerRateEvent_mt)
 end
 
-function SoilSprayerRateEvent.new(vehicleId, rateIndex)
+-- vehicleNetId is the FS25 network object ID (from NetworkUtil.getObjectId).
+-- Using the network ID on the wire avoids the streamWriteInt32(nil) crash that
+-- occurs when a local i3d node handle is passed to NetworkUtil.getObjectId.
+function SoilSprayerRateEvent.new(vehicleNetId, rateIndex)
     local self = SoilSprayerRateEvent.emptyNew()
-    self.vehicleId = vehicleId
-    self.rateIndex = rateIndex
+    self.vehicleNetId = vehicleNetId
+    self.rateIndex    = rateIndex
     return self
 end
 
 function SoilSprayerRateEvent:readStream(streamId, connection)
-    local networkId = streamReadInt32(streamId)
-    local vehicle   = NetworkUtil.getObject(networkId)
-    self.vehicleId  = vehicle and vehicle.id or nil
-    self.rateIndex = streamReadUInt8(streamId)
+    self.vehicleNetId = streamReadInt32(streamId)
+    self.rateIndex    = streamReadUInt8(streamId)
     self:run(connection)
 end
 
 function SoilSprayerRateEvent:writeStream(streamId, connection)
-    streamWriteInt32(streamId, NetworkUtil.getObjectId(self.vehicleId))
+    streamWriteInt32(streamId, self.vehicleNetId)
     streamWriteUInt8(streamId, self.rateIndex)
 end
 
@@ -1140,36 +1141,37 @@ function SoilSprayerRateEvent:run(connection)
     local rm = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
     if rm == nil then return end
 
-    if self.vehicleId == nil then return end
+    local vehicle = NetworkUtil.getObject(self.vehicleNetId)
+    if not vehicle then return end
 
     local steps = SoilConstants.SPRAYER_RATE.STEPS
     if self.rateIndex < 1 or self.rateIndex > #steps then return end
 
-    rm:setIndex(self.vehicleId, self.rateIndex)
+    rm:setIndex(vehicle.id, self.rateIndex)
 
-    -- Server rebroadcasts to all other clients
     if g_server ~= nil then
         g_server:broadcastEvent(
-            SoilSprayerRateEvent.new(self.vehicleId, self.rateIndex),
-            nil,        -- send to all
-            connection  -- except original sender
+            SoilSprayerRateEvent.new(self.vehicleNetId, self.rateIndex),
+            nil,
+            connection
         )
     end
 end
 
 --- Send a sprayer rate change. Works in SP, MP client, and MP server.
----@param vehicleId number
+---@param vehicle table  The vehicle object (not vehicle.id)
 ---@param rateIndex number 1-based index into SPRAYER_RATE.STEPS
-function SoilNetworkEvents_SendSprayerRate(vehicleId, rateIndex)
+function SoilNetworkEvents_SendSprayerRate(vehicle, rateIndex)
     if g_client then
+        local vehicleNetId = NetworkUtil.getObjectId(vehicle)
+        if not vehicleNetId then return end
         g_client:getServerConnection():sendEvent(
-            SoilSprayerRateEvent.new(vehicleId, rateIndex)
+            SoilSprayerRateEvent.new(vehicleNetId, rateIndex)
         )
     else
-        -- Singleplayer or dedicated server console: apply directly
         local rm = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
         if rm then
-            rm:setIndex(vehicleId, rateIndex)
+            rm:setIndex(vehicle.id, rateIndex)
         end
     end
 end
@@ -1186,23 +1188,21 @@ function SoilSprayerAutoModeEvent.emptyNew()
     return Event.new(SoilSprayerAutoModeEvent_mt)
 end
 
-function SoilSprayerAutoModeEvent.new(vehicleId, enabled)
+function SoilSprayerAutoModeEvent.new(vehicleNetId, enabled)
     local self = SoilSprayerAutoModeEvent.emptyNew()
-    self.vehicleId = vehicleId
-    self.enabled = enabled
+    self.vehicleNetId = vehicleNetId
+    self.enabled      = enabled
     return self
 end
 
 function SoilSprayerAutoModeEvent:readStream(streamId, connection)
-    local networkId = streamReadInt32(streamId)
-    local vehicle   = NetworkUtil.getObject(networkId)
-    self.vehicleId  = vehicle and vehicle.id or nil
-    self.enabled = streamReadBool(streamId)
+    self.vehicleNetId = streamReadInt32(streamId)
+    self.enabled      = streamReadBool(streamId)
     self:run(connection)
 end
 
 function SoilSprayerAutoModeEvent:writeStream(streamId, connection)
-    streamWriteInt32(streamId, NetworkUtil.getObjectId(self.vehicleId))
+    streamWriteInt32(streamId, self.vehicleNetId)
     streamWriteBool(streamId, self.enabled)
 end
 
@@ -1210,28 +1210,32 @@ function SoilSprayerAutoModeEvent:run(connection)
     local rm = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
     if rm == nil then return end
 
-    if self.vehicleId == nil then return end
+    local vehicle = NetworkUtil.getObject(self.vehicleNetId)
+    if not vehicle then return end
 
-    rm:setAutoMode(self.vehicleId, self.enabled)
+    rm:setAutoMode(vehicle.id, self.enabled)
 
-    -- Server rebroadcasts
     if g_server then
         g_server:broadcastEvent(
-            SoilSprayerAutoModeEvent.new(self.vehicleId, self.enabled),
+            SoilSprayerAutoModeEvent.new(self.vehicleNetId, self.enabled),
             nil, connection
         )
     end
 end
 
-function SoilNetworkEvents_SendSprayerAutoMode(vehicleId, enabled)
+---@param vehicle table  The vehicle object (not vehicle.id)
+---@param enabled boolean
+function SoilNetworkEvents_SendSprayerAutoMode(vehicle, enabled)
     if g_client then
+        local vehicleNetId = NetworkUtil.getObjectId(vehicle)
+        if not vehicleNetId then return end
         g_client:getServerConnection():sendEvent(
-            SoilSprayerAutoModeEvent.new(vehicleId, enabled)
+            SoilSprayerAutoModeEvent.new(vehicleNetId, enabled)
         )
     else
         local rm = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
         if rm then
-            rm:setAutoMode(vehicleId, enabled)
+            rm:setAutoMode(vehicle.id, enabled)
         end
     end
 end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,7 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: server crash during sprayer rate sync (nil network ID in writeStream)",
     "- Fixed: server crash with dry fertilizer (urea spreader) — zone cell packet overflow",
     "- Fixed: soil map tiles now update after fertilizer on dedicated server clients",
     "- Added: Colorblind Mode toggle in Display settings (orange/blue palette for deuteranopia)",


### PR DESCRIPTION
## Summary
- Fixed `SoilSprayerRateEvent` and `SoilSprayerAutoModeEvent` passing an i3d node handle (local integer) to `NetworkUtil.getObjectId` in `writeStream` — always returned nil, causing a `streamWriteInt32: Argument 1 has wrong type. Expected: Int. Actual: Nil` crash on dedicated servers during auto-rate updates
- All call sites in `SoilFertilityManager` updated to pass the vehicle object (not `vehicle.id`) to the send functions, which now resolve the network ID at the boundary

## Root cause
`vehicle.id` is an i3d scene-graph node handle. `NetworkUtil.getObjectId` expects a Lua object reference (table). Passing the integer handle returned nil, which then crashed `streamWriteInt32`.

## Test plan
- [ ] Apply fertilizer with dry spreader (urea) on dedicated server — no crash
- [ ] Rate up/down input in MP — no crash, rate syncs to server
- [ ] Auto-mode toggle in MP — no crash, auto-mode syncs correctly