### PR TITLE
fix: HUD layout persistence on dedicated servers (#375)

### DIFF
--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -83,7 +83,7 @@ function SettingsManager:getLocalSettingsPath()
         if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
             profilePath = profilePath .. "/"
         end
-        local dir = profilePath .. "modsSettings"
+        local dir = profilePath .. "modSettings"
         createFolder(dir)
         return dir .. "/" .. SettingsManager.MOD_NAME .. "_local.xml"
     end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -227,7 +227,7 @@ function SoilHUD:getLayoutPath()
         if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
             profilePath = profilePath .. "/"
         end
-        local dir = profilePath .. "modsSettings"
+        local dir = profilePath .. "modSettings"
         createFolder(dir)
         return dir .. "/" .. (g_currentModName or "FS25_SoilFertilizer") .. "_hud.xml"
     end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -219,6 +219,19 @@ end
 
 -- ── HUD layout persistence ────────────────────────────────
 function SoilHUD:getLayoutPath()
+    -- Per-player UI state must live in the user profile, not the savegame.
+    -- Savegame paths are inaccessible to clients on dedicated servers and may
+    -- resolve to "Savegame0" on first load before the save directory exists.
+    local ok, profilePath = pcall(getUserProfileAppPath)
+    if ok and profilePath and profilePath ~= "" then
+        if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
+            profilePath = profilePath .. "/"
+        end
+        local dir = profilePath .. "modsSettings"
+        createFolder(dir)
+        return dir .. "/" .. (g_currentModName or "FS25_SoilFertilizer") .. "_hud.xml"
+    end
+    -- Fallback for self-hosted / singleplayer environments without a profile path.
     if g_currentMission and g_currentMission.missionInfo and g_currentMission.missionInfo.savegameDirectory then
         return g_currentMission.missionInfo.savegameDirectory .. "/FS25_SoilFertilizer_hud.xml"
     end
@@ -766,6 +779,7 @@ function SoilHUD:toggleVisibility()
     if g_currentMission and g_currentMission.hud and g_currentMission.hud.showBlinkingWarning then
         g_currentMission.hud:showBlinkingWarning(msg, 2000)
     end
+    self:saveLayout()
 end
 
 -- ── Color helpers ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`SoilHUD:getLayoutPath()`** now writes `_hud.xml` to `modSettings/` in the user profile directory instead of the savegame directory. Savegame paths are inaccessible to clients on dedicated servers and resolve to a non-existent `Savegame0` path before the first save is made.
- **`SoilHUD:toggleVisibility()`** now calls `saveLayout()` immediately so the shown/hidden state is persisted at toggle time, not only on game close.
- **`SettingsManager:getLocalSettingsPath()`** corrected folder name from `modsSettings` to `modSettings` (FS25 standard). Same correction applied to `SoilHUD:getLayoutPath()`.

Fixes #375

## Test plan

- [ ] Toggle HUD visibility with J key on a dedicated server — state should persist after reconnect
- [ ] Custom HUD position (drag in edit mode) should persist across sessions on a dedicated server
- [ ] Local settings (color theme, font size, imperial units, etc.) should land in `modSettings/` in the game profile folder
- [ ] Singleplayer: HUD visibility and position still persist correctly