### PR TITLE
release: 2.1.6.9 — HUD persistence fixes, modSettings layout, debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.1.6.9] - 2026-05-14
+
+### Fixed
+- **HUD layout file moved to `modSettings/` (was savegame directory)** (Issue [#375](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/375)) — `_hud.xml` was written to the savegame directory, which is inaccessible to clients on dedicated servers and resolves to a non-existent `Savegame0` path before the first save. Now written to `modSettings/FS25_SoilFertilizer/HUD/hud.xml` (per-player, always writable).
+- **HUD visibility toggle now saves immediately** — Pressing J to show/hide the HUD only persisted on game close; if the save failed (e.g., dedicated server), the state was lost. Now saved immediately on toggle.
+- **`modSettings` folder name corrected** (was `modsSettings`) — Both `SettingsManager` and `SoilHUD` were writing to the wrong directory name, meaning per-player settings and HUD layout were never landing in the correct FS25 folder.
+
+### Changed
+- **`modSettings/` folder structure reorganized** — Files now grouped under `modSettings/FS25_SoilFertilizer/{Settings,HUD,Debug}/` for a cleaner per-mod layout.
+
+### Added
+- **Debug output files** — When debug mode is active, three files are written to `modSettings/FS25_SoilFertilizer/Debug/`:
+  - `debug.xml` — buffered `SoilLogger.debug()` messages (flushed when debug mode is toggled off or the game session ends)
+  - `field_dump.xml` — full nutrient snapshot for a single field (written each time `SoilFieldInfo <id>` is run)
+  - `soil_export.xml` — snapshot of all tracked field data (written each time `SoilSaveData` is run)
+
+---
+
 ## [2.1.6.8] - 2026-05-14
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **2.0.8.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
+**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **2.1.6.9**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 2.1.6.8
+**Version**: 2.1.6.9
 **Last Updated**: 2026-05-14
 
 ---

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.8
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.9
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.8</version>
+    <version>2.1.6.9</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1179,6 +1179,8 @@ end
 --- Cleanup on mod unload
 --- Saves soil data and uninstalls hooks
 function SoilFertilityManager:delete()
+    -- Flush any buffered debug messages to file before shutdown
+    SoilLogger.flushDebugLog()
     -- Save soil data before shutdown
     self:saveSoilData()
 

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -75,17 +75,29 @@ end
 
 -- ── Local-only settings (per-player, not server-shared) ──────
 -- Saved to the user profile directory so they survive reconnects on dedi servers.
+-- Folder layout: modSettings/FS25_SoilFertilizer/{Settings,HUD,Debug}/
 
-function SettingsManager:getLocalSettingsPath()
+function SettingsManager.getModProfileDir()
     local ok, profilePath = pcall(getUserProfileAppPath)
     if ok and profilePath and profilePath ~= "" then
-        -- Ensure trailing separator (some dedicated server builds omit it)
         if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
             profilePath = profilePath .. "/"
         end
-        local dir = profilePath .. "modSettings"
-        createFolder(dir)
-        return dir .. "/" .. SettingsManager.MOD_NAME .. "_local.xml"
+        local base = profilePath .. "modSettings/" .. SettingsManager.MOD_NAME
+        createFolder(profilePath .. "modSettings")
+        createFolder(base)
+        createFolder(base .. "/Settings")
+        createFolder(base .. "/HUD")
+        createFolder(base .. "/Debug")
+        return base
+    end
+    return nil
+end
+
+function SettingsManager:getLocalSettingsPath()
+    local base = SettingsManager.getModProfileDir()
+    if base then
+        return base .. "/Settings/local.xml"
     end
     -- Fallback: savegame dir with _local suffix (singleplayer / self-hosted)
     local xmlPath = self:getSavegameXmlFilePath()

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -194,6 +194,10 @@ end
 function SoilSettingsGUI:consoleCommandDebug()
     if g_SoilFertilityManager and g_SoilFertilityManager.settings then
         local newVal = not g_SoilFertilityManager.settings.debugMode
+        if not newVal then
+            -- Flush buffered debug messages to Debug/debug.xml before turning off
+            SoilLogger.flushDebugLog()
+        end
         requestSettingChange("debugMode", newVal)
         return string.format("Debug mode %s", newVal and "enabled" or "disabled")
     end
@@ -203,9 +207,43 @@ end
 function SoilSettingsGUI:consoleCommandSaveData()
     if g_SoilFertilityManager then
         g_SoilFertilityManager:saveSoilData()
+        SoilSettingsGUI.writeSoilExport(g_SoilFertilityManager.soilSystem)
         return "Soil data saved"
     end
     return "Error: Soil Mod not initialized"
+end
+
+--- Write a full snapshot of all field nutrient data to Debug/soil_export.xml.
+function SoilSettingsGUI.writeSoilExport(soilSystem)
+    if not soilSystem then return end
+    local base = SettingsManager and SettingsManager.getModProfileDir and SettingsManager.getModProfileDir()
+    if not base then return end
+    local xml = XMLFile.create("sf_soilExport", base .. "/Debug/soil_export.xml", "soilExport")
+    if not xml then return end
+    local day = g_currentMission and g_currentMission.environment and g_currentMission.environment.currentDay or 0
+    xml:setInt("soilExport#day", day)
+    local idx = 0
+    for fieldId, fd in pairs(soilSystem.fieldData or {}) do
+        local key = string.format("soilExport.field(%d)", idx)
+        xml:setInt  (key .. "#id",              fieldId)
+        xml:setInt  (key .. "#nitrogen",         fd.nitrogen        or 0)
+        xml:setInt  (key .. "#phosphorus",       fd.phosphorus      or 0)
+        xml:setInt  (key .. "#potassium",        fd.potassium       or 0)
+        xml:setFloat(key .. "#organicMatter",    fd.organicMatter   or 0)
+        xml:setFloat(key .. "#pH",               fd.pH              or 7.0)
+        xml:setString(key .. "#lastCrop",        fd.lastCrop        or "")
+        xml:setInt  (key .. "#lastHarvest",      fd.lastHarvest     or 0)
+        xml:setFloat(key .. "#fertilizerApplied",fd.fertilizerApplied or 0)
+        xml:setInt  (key .. "#weedPressure",     fd.weedPressure    or 0)
+        xml:setInt  (key .. "#pestPressure",     fd.pestPressure    or 0)
+        xml:setInt  (key .. "#diseasePressure",  fd.diseasePressure or 0)
+        xml:setInt  (key .. "#compaction",       fd.compaction      or 0)
+        idx = idx + 1
+    end
+    xml:setInt("soilExport#fieldCount", idx)
+    xml:save()
+    xml:delete()
+    SoilLogger.info("Soil export written: %s/Debug/soil_export.xml (%d fields)", base, idx)
 end
 
 function SoilSettingsGUI:consoleCommandShowSettings()
@@ -253,12 +291,39 @@ function SoilSettingsGUI:consoleCommandFieldInfo(fieldId)
                 info.needsFertilization and "Yes" or "No"
             )
             print(fInfo)
+            SoilSettingsGUI.writeFieldDump(fid, info)
             return fInfo
         else
             return "Field not found or not initialized"
         end
     end
     return "Error: Soil Mod not initialized"
+end
+
+--- Write a single field's soil data to Debug/field_dump.xml.
+function SoilSettingsGUI.writeFieldDump(fid, info)
+    local base = SettingsManager and SettingsManager.getModProfileDir and SettingsManager.getModProfileDir()
+    if not base then return end
+    local xml = XMLFile.create("sf_fieldDump", base .. "/Debug/field_dump.xml", "fieldDump")
+    if not xml then return end
+    local day = g_currentMission and g_currentMission.environment and g_currentMission.environment.currentDay or 0
+    xml:setInt("fieldDump#fieldId", fid)
+    xml:setInt("fieldDump#day",     day)
+    xml:setInt  ("fieldDump.nutrients#nitrogen",      info.nitrogen.value)
+    xml:setString("fieldDump.nutrients#nitrogenStatus", info.nitrogen.status)
+    xml:setInt  ("fieldDump.nutrients#phosphorus",    info.phosphorus.value)
+    xml:setString("fieldDump.nutrients#phosphorusStatus", info.phosphorus.status)
+    xml:setInt  ("fieldDump.nutrients#potassium",     info.potassium.value)
+    xml:setString("fieldDump.nutrients#potassiumStatus", info.potassium.status)
+    xml:setFloat("fieldDump.nutrients#organicMatter", info.organicMatter)
+    xml:setFloat("fieldDump.nutrients#pH",            info.pH)
+    xml:setString("fieldDump.status#lastCrop",        info.lastCrop or "")
+    xml:setInt  ("fieldDump.status#daysSinceHarvest", info.daysSinceHarvest)
+    xml:setFloat("fieldDump.status#fertilizerApplied",info.fertilizerApplied)
+    xml:setBool ("fieldDump.status#needsFertilization", info.needsFertilization)
+    xml:save()
+    xml:delete()
+    SoilLogger.info("Field dump written: %s/Debug/field_dump.xml", base)
 end
 
 function SoilSettingsGUI:consoleCommandFieldForecast(fieldId)

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -219,17 +219,9 @@ end
 
 -- ── HUD layout persistence ────────────────────────────────
 function SoilHUD:getLayoutPath()
-    -- Per-player UI state must live in the user profile, not the savegame.
-    -- Savegame paths are inaccessible to clients on dedicated servers and may
-    -- resolve to "Savegame0" on first load before the save directory exists.
-    local ok, profilePath = pcall(getUserProfileAppPath)
-    if ok and profilePath and profilePath ~= "" then
-        if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
-            profilePath = profilePath .. "/"
-        end
-        local dir = profilePath .. "modSettings"
-        createFolder(dir)
-        return dir .. "/" .. (g_currentModName or "FS25_SoilFertilizer") .. "_hud.xml"
+    local base = SettingsManager and SettingsManager.getModProfileDir and SettingsManager.getModProfileDir()
+    if base then
+        return base .. "/HUD/hud.xml"
     end
     -- Fallback for self-hosted / singleplayer environments without a profile path.
     if g_currentMission and g_currentMission.missionInfo and g_currentMission.missionInfo.savegameDirectory then

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,10 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: HUD & display settings (position, colorblind mode, field info box) now saved per-player",
-    "- Fixed: dedicated server clients no longer lose HUD preferences on reconnect",
-    "- Fixed: mini-report cell overlay visibility now persists correctly (SP & MP)",
-    "- i18n: French translation updated by native speaker (Seb/Squall39)",
+    "- Fixed: HUD layout now saves to modSettings/ — dedicated server clients keep preferences",
+    "- Fixed: HUD visibility (J key) now saves immediately on toggle",
+    "- Fixed: modSettings folder name corrected (was modsSettings — settings were lost)",
+    "- Added: debug output files in modSettings/FS25_SoilFertilizer/Debug/",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,10 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: HUD layout now saves to modSettings/ — dedicated server clients keep preferences",
-    "- Fixed: HUD visibility (J key) now saves immediately on toggle",
-    "- Fixed: modSettings folder name corrected (was modsSettings — settings were lost)",
-    "- Added: debug output files in modSettings/FS25_SoilFertilizer/Debug/",
+    "- Fixed HUD layout now saves to modSettings/ — dedicated server clients keep preferences",
+    "- Fixed HUD visibility (J key) now saves immediately on toggle",
+    "- Fixed modSettings folder name corrected (was modsSettings — settings were lost)",
+    "- Added debug output files in modSettings/FS25_SoilFertilizer/Debug/",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/utils/Logger.lua
+++ b/src/utils/Logger.lua
@@ -12,16 +12,44 @@ SoilLogger = {}
 
 local PREFIX = "[SoilFertilizer]"
 
+SoilLogger.debugBuffer    = {}
+SoilLogger.DEBUG_BUF_MAX  = 500
+
 --- Log a debug message (only shown when debugMode is enabled)
 function SoilLogger.debug(msg, ...)
     if g_SoilFertilityManager and g_SoilFertilityManager.settings and g_SoilFertilityManager.settings.debugMode then
         local success, formatted = pcall(string.format, PREFIX .. " DEBUG: " .. msg, ...)
-        if success then
-            print(formatted)
-        else
-            print(PREFIX .. " DEBUG: " .. tostring(msg))
+        local line = success and formatted or (PREFIX .. " DEBUG: " .. tostring(msg))
+        print(line)
+        local buf = SoilLogger.debugBuffer
+        buf[#buf + 1] = {
+            t   = g_currentMission and math.floor(g_currentMission.time or 0) or 0,
+            msg = line,
+        }
+        if #buf > SoilLogger.DEBUG_BUF_MAX then
+            table.remove(buf, 1)
         end
     end
+end
+
+--- Flush buffered debug messages to Debug/debug.xml in the mod profile folder.
+--- Called when debug mode is turned off or the game session ends.
+function SoilLogger.flushDebugLog()
+    local buf = SoilLogger.debugBuffer
+    if #buf == 0 then return end
+    local base = SettingsManager and SettingsManager.getModProfileDir and SettingsManager.getModProfileDir()
+    if not base then return end
+    local xml = XMLFile.create("sf_debugLog", base .. "/Debug/debug.xml", "debugLog")
+    if not xml then return end
+    xml:setInt("debugLog#count", #buf)
+    for i, entry in ipairs(buf) do
+        local key = string.format("debugLog.entry(%d)", i - 1)
+        xml:setInt(key .. "#t", entry.t)
+        xml:setString(key .. "#msg", entry.msg)
+    end
+    xml:save()
+    xml:delete()
+    SoilLogger.debugBuffer = {}
 end
 
 --- Log an info message (always shown)

--- a/xml/gui/SoilVersionDialog.xml
+++ b/xml/gui/SoilVersionDialog.xml
@@ -41,18 +41,18 @@
 
       <!-- Bottom separator — anchored from bottom of dialog -->
       <Bitmap profile="sfVer_sep" id="sfVer_bottomSep"
-              position="0px -255px" size="560px 2px"/>
+              position="0px -314px" size="560px 2px"/>
 
       <!-- Footer (set at runtime via i18n) -->
       <Text profile="sfVer_footer" id="sfVer_footer1"
-            text="" position="0px -275px"/>
+            text="" position="0px -334px"/>
       <Text profile="sfVer_footer" id="sfVer_footer2"
-            text="" position="0px -293px"/>
+            text="" position="0px -352px"/>
 
       <Text profile="sfVer_tagline1" id="sfVer_footer3"
-            text="" position="0px -320px"/>
+            text="" position="0px -379px"/>
       <Text profile="sfVer_tagline2" id="sfVer_footer4"
-            text="" position="0px -338px"/>
+            text="" position="0px -397px"/>
 
     </GuiElement>
 
@@ -67,7 +67,7 @@
 
   <GUIProfiles>
     <Profile name="sfVer_bg" extends="fs25_dialogBg">
-      <size value="640px 480px"/>
+      <size value="640px 530px"/>
     </Profile>
     <Profile name="sfVer_author" extends="fs25_dialogText" with="anchorTopCenter">
       <textSize value="13px"/>
@@ -84,7 +84,7 @@
     </Profile>
     <!-- Vertical BoxLayout — Lua adds TextElements here dynamically -->
     <Profile name="sfVer_changelogBox" extends="emptyPanel" with="anchorTopCenter">
-      <size value="560px 130px"/>
+      <size value="560px 180px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
       <alignmentX value="center"/>


### PR DESCRIPTION
## Summary

- **Fixed** HUD layout file moved from savegame directory to `modSettings/FS25_SoilFertilizer/HUD/` — dedicated server clients now keep their HUD position and visibility across reconnects
- **Fixed** HUD visibility (J key toggle) now saves immediately instead of only on game close
- **Fixed** `modSettings` folder name corrected (was `modsSettings` — settings were never landing in the right place)
- **Changed** `modSettings/` files reorganized into `FS25_SoilFertilizer/{Settings,HUD,Debug}/` subfolders
- **Added** Debug output files written to `modSettings/FS25_SoilFertilizer/Debug/` (`debug.xml`, `field_dump.xml`, `soil_export.xml`)
- **Fixed** Version dialog no longer overlaps footer text when changelog lines wrap — dialog height increased (480→530px), changelog box increased (130→180px), footer positions adjusted

Closes #375

## Test plan

- [ ] Dedicated server: toggle HUD (J key), reconnect — visibility state persists
- [ ] Dedicated server: drag HUD to custom position, reconnect — position persists
- [ ] Check `modSettings/FS25_SoilFertilizer/` folder structure exists with Settings/, HUD/, Debug/
- [ ] `SoilDebug` on then off → `Debug/debug.xml` written
- [ ] `SoilFieldInfo 1` → `Debug/field_dump.xml` written
- [ ] `SoilSaveData` → `Debug/soil_export.xml` written
- [ ] Version dialog on first load: no text overlap, footer stays below changelog lines