### PR TITLE
v2.1.7.0 — Harvest nutrient depletion fix, cell report fallback, distance texture errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.1.7.0] - 2026-05-15
+
+### Fixed
+- **Harvest nutrient depletion was silently broken** — `Combine.addCutterArea` passes `liters` as a 0/1 flag (crop present/absent), not actual grain volume. The depletion formula `(liters/1000) / fieldAreaHa` was effectively zero every call, meaning harvesting removed no N/P/K whatsoever. Replaced with an area-based formula: `factor = (areaHa / fieldAreaHa) × HARVEST_HA_FACTOR`, calibrated to the existing extraction-rate scale (8 000 L/ha proxy). Nutrients now correctly deplete across a full harvest.
+- **Swath/windrow harvesting now depletes nutrients** — the swath mode path had a similar calibration mismatch (`× 6.0` factor vs. the required `× 8.0`). Both paths are now unified: area is always used, `liters` is ignored. Straw OM estimate also updated to match (6 000 → 8 000 L/ha proxy).
+- **Oats tracked as a separate crop** — the extraction key `"oats"` did not match `g_fruitTypeManager`'s name `"oat"`, so oat harvests fell through to the generic cereal default. Fixed.
+- **Cell report shows "No Data" on new games** (Issue [#383](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/383)) — `zoneData` cells are only created on fertilize/mow/plow events. On a fresh save every field showed "No cell data found". Now falls back to field-level averages (N/P/K/pH/OM) labelled **"Field avg"**. Once cell data exists from field activity, per-cell values display as normal.
+- **Distance texture errors on dedicated servers** (Issue [#384](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/384)) — All 10 solid fill types registered in `densityMapHeightTypes.xml` were missing the `distance="..."` attribute on their `<textures>` element, causing `Failed to create density height map distance texture array` errors every session. Added appropriate vanilla `$data/fillPlanes/distance/*.dds` references to each affected fill type.
+- **False warning on new careers suppressed** — `SettingsManager:getSavegameXmlFilePath()` logged a `WARNING: Savegame directory not available yet` on every new game load. This is expected behaviour (savegame directory is nil before the first save); downgraded to `DEBUG`.
+- **`SoilDebug` console command now takes effect immediately** — `debugMode` was a server-shared setting, requiring a reconnect before changes propagated to the local client. Marked `localOnly` so the toggle is instant.
+
+### Added
+- **"Field avg" i18n key** — new translation key `sf_field_avg` added across all 26 languages for the cell report fallback label.
+
+---
+
 ## [2.1.6.9] - 2026-05-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **2.1.6.9**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
+**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **2.1.7.0**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 2.1.6.9
+**Version**: 2.1.7.0
 **Last Updated**: 2026-05-14
 
 ---

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.6.9
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.7.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -44,7 +44,7 @@
             <physics massPerLiter="0.77" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.65"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/urea/bigBag_urea.xml" />
         </fillType>
@@ -56,7 +56,8 @@
             <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
                       normal="$data/fillPlanes/fertilizer_normal.png"
                       height="$data/fillPlanes/fertilizer_height.png"
-                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"/>
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"
+                      distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/an/bigBag_an.xml" />
         </fillType>
@@ -65,7 +66,7 @@
             <physics massPerLiter="0.87" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.40"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
         </fillType>
@@ -74,7 +75,7 @@
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.95"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/map/bigBag_map.xml" />
         </fillType>
@@ -83,7 +84,7 @@
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.75"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/dap/bigBag_dap.xml" />
         </fillType>
@@ -92,7 +93,7 @@
             <physics massPerLiter="0.95" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.80"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/potash/bigBag_potash.xml" />
         </fillType>
@@ -165,7 +166,7 @@
             <physics massPerLiter="1.10" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.55"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/lime_diffuse.dds" normal="$data/fillPlanes/lime_normal.dds" height="$data/fillPlanes/lime_height.dds" displacement="$data/fillPlanes/lime_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/lime_diffuse.dds" normal="$data/fillPlanes/lime_normal.dds" height="$data/fillPlanes/lime_height.dds" displacement="$data/fillPlanes/lime_displacement.dds" distance="$data/fillPlanes/distance/limeDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/gypsum/bigBag_gypsum.xml" />
         </fillType>
@@ -174,7 +175,7 @@
             <physics massPerLiter="0.60" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.35"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds" distance="$data/fillPlanes/distance/woodChipsDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/compost/bigBag_compost.xml" />
         </fillType>
@@ -183,7 +184,7 @@
             <physics massPerLiter="0.90" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.50"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds" distance="$data/fillPlanes/distance/manureDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/biosolids/bigBag_biosolids.xml" />
         </fillType>
@@ -192,7 +193,7 @@
             <physics massPerLiter="0.65" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="0.45"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds" distance="$data/fillPlanes/distance/manureDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml" />
         </fillType>
@@ -201,7 +202,7 @@
             <physics massPerLiter="0.75" maxPhysicalSurfaceAngle="20"/>
             <economy pricePerLiter="1.10"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/mineralFeed_diffuse.dds" normal="$data/fillPlanes/mineralFeed_normal.dds" height="$data/fillPlanes/mineralFeed_height.dds" displacement="$data/fillPlanes/mineralFeed_displacement.dds"/>
+            <textures diffuse="$data/fillPlanes/mineralFeed_diffuse.dds" normal="$data/fillPlanes/mineralFeed_normal.dds" height="$data/fillPlanes/mineralFeed_height.dds" displacement="$data/fillPlanes/mineralFeed_displacement.dds" distance="$data/fillPlanes/distance/mineralFeedDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml" />
         </fillType>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.6.9</version>
+    <version>2.1.7.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -951,7 +951,7 @@ function SoilFertilityManager:loadSoilData()
 
     local savegamePath = g_currentMission.missionInfo.savegameDirectory
     if not savegamePath then
-        SoilLogger.error("loadSoilData: savegameDirectory is nil")
+        SoilLogger.warning("loadSoilData: savegameDirectory not set yet (new career or early load) — starting with defaults")
         return
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1998,6 +1998,7 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
         if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
         areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
         factor = (areaHa / fieldAreaHa) * SoilConstants.HARVEST_HA_FACTOR
+        SoilLogger.debug("Harvest factor: area=%.0fpx areaHa=%.6f fieldHa=%.2f factor=%.6f", area, areaHa, fieldAreaHa, factor)
     else
         return
     end
@@ -2063,7 +2064,7 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     field.lastHarvest = (g_currentMission and g_currentMission.environment and g_currentMission.environment.currentDay) or 0
 
     self:log(
-        "Harvest depletion field %d (%s): -N %.1f -P %.1f -K %.1f",
+        "Harvest depletion field %d (%s): -N %.5f -P %.5f -K %.5f",
         fieldId, fruitDesc.name,
         rates.N * factor,
         rates.P * factor,

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1956,9 +1956,9 @@ end
 -- Update field nutrients after harvest
 ---@param fieldId number The field being harvested
 ---@param fruitTypeIndex number FS25 fruit type index
----@param harvestedLiters number Amount harvested in liters
+---@param harvestedLiters number 0/1 flag from addCutterArea (NOT actual grain volume — use area for depletion)
 ---@param strawRatio number 0.0-1.0 fraction of straw chopped back into the field (adds organic matter)
----@param area number Area harvested in pixels (used for swath-mode estimation when liters=0)
+---@param area number Area harvested in pixels — always used for depletion; liters is unreliable
 function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harvestedLiters, strawRatio, area)
     if not self.settings.enabled or not self.settings.nutrientCycles then return end
 
@@ -1987,33 +1987,17 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     local name = string.lower(fruitDesc.name or "unknown")
     local rates = SoilConstants.CROP_EXTRACTION[name] or SoilConstants.CROP_EXTRACTION_DEFAULT
 
-    -- NUTRIENT DEPLETION CALCULATION EXPLAINED:
-    --
-    -- Step 1: Calculate depletion factor, normalized by field area.
-    -- Combine.addCutterArea fires many times during a harvest — harvestedLiters
-    -- is the yield from one small chunk, and the chunks sum to the total field yield.
-    -- Without area normalization, a 5 ha field (5× the liters of a 1 ha field)
-    -- would deplete 5× more nutrients from the same 0-100 nutrient pool, draining
-    -- it to zero in one harvest pass. Dividing by fieldAreaHa makes depletion
-    -- field-size independent: the same yield density (L/ha) always removes the
-    -- same number of nutrient points regardless of field size.
-    --
-    -- SWATH MODE (isSwathActive=true): liters=0 because grain is deposited on the ground
-    -- rather than collected. The soil still lost nutrients growing the crop, so we estimate
-    -- biological liters from the cut area using a conservative yield density (0.6 L/m²).
-    -- Formula (normal): factor = (harvestedLiters / 1000) / fieldAreaHa
-    -- Formula (swath):  factor = (area × pixToSqm × 0.6 / 1000) / fieldAreaHa
+    -- Step 1: Calculate depletion factor from harvested area.
+    -- addCutterArea fires many times per harvest; its liters parameter is a 0/1 flag
+    -- (1 = crop present), NOT actual grain volume. Area is always the reliable value.
+    -- factor = areaHa / fieldAreaHa  =>  proportional slice of field depleted this call.
     local fieldAreaHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
     local factor
-    if harvestedLiters and harvestedLiters > 0 then
-        factor = (harvestedLiters / 1000) / fieldAreaHa
-    elseif area and area > 0 then
-        -- Swath/windrow mode: estimate factor from cut area.
-        -- 0.6 L/m² × 10000 m²/ha / 1000 = 6.0 factor-units per ha harvested.
+    local areaHa = 0
+    if area and area > 0 then
         if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
-        local areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
-        factor = (areaHa * 6.0) / fieldAreaHa
-        SoilLogger.debug("Harvest swath mode field %d: area=%.1fpx areaHa=%.5f factor=%.6f", fieldId, area, areaHa, factor)
+        areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
+        factor = areaHa / fieldAreaHa
     else
         return
     end
@@ -2022,8 +2006,6 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     -- Simple (0.7x): 30% less depletion, easier for new players
     -- Realistic (1.0x): Balanced depletion based on real agricultural rates
     -- Hardcore (1.5x): 50% more depletion, challenging management
-    -- Example: 8000L/ha wheat on a 5ha field → factor = (8000/1000)/5 = 1.6 per chunk
-    -- × 1.0 (Realistic) = 1.6; N removed = 2.00 × 1.6 = 3.2 pts per call
     local diffMultiplier = SoilConstants.DIFFICULTY.MULTIPLIERS[self.settings.difficulty]
     if diffMultiplier then
         factor = factor * diffMultiplier
@@ -2068,13 +2050,12 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
         end
     end
 
-    -- Step 4: Chopped straw/chaff adds organic matter
-    -- When strawRatio > 0 the combine is chopping material back into the field.
-    -- The chopped biomass decomposes and increases soil organic matter.
-    -- Formula: OM gain = (harvestedLiters / 1000) × strawRatio × OM_RATE
+    -- Step 4: Chopped straw/chaff adds organic matter.
+    -- harvestedLiters is unreliable (0/1 flag); estimate biological yield from area instead.
     local sr = strawRatio or 0
-    if sr > 0 then
-        local omGain = (harvestedLiters / 1000) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE
+    if sr > 0 and areaHa > 0 then
+        local estimatedLiters = areaHa * 6000  -- 6000 L/ha average yield density
+        local omGain = (estimatedLiters / 1000) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE
         field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, (field.organicMatter or 0) + omGain)
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1958,9 +1958,8 @@ end
 ---@param fruitTypeIndex number FS25 fruit type index
 ---@param harvestedLiters number Amount harvested in liters
 ---@param strawRatio number 0.0-1.0 fraction of straw chopped back into the field (adds organic matter)
----@param area number Area harvested in m² (unused; reserved for future area-normalised depletion)
+---@param area number Area harvested in pixels (used for swath-mode estimation when liters=0)
 function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harvestedLiters, strawRatio, area)
-    _ = area -- luacheck: ignore area
     if not self.settings.enabled or not self.settings.nutrientCycles then return end
 
     local field = self:getOrCreateField(fieldId, true)
@@ -1998,9 +1997,26 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     -- it to zero in one harvest pass. Dividing by fieldAreaHa makes depletion
     -- field-size independent: the same yield density (L/ha) always removes the
     -- same number of nutrient points regardless of field size.
-    -- Formula: factor = (harvestedLiters / 1000) / fieldAreaHa
+    --
+    -- SWATH MODE (isSwathActive=true): liters=0 because grain is deposited on the ground
+    -- rather than collected. The soil still lost nutrients growing the crop, so we estimate
+    -- biological liters from the cut area using a conservative yield density (0.6 L/m²).
+    -- Formula (normal): factor = (harvestedLiters / 1000) / fieldAreaHa
+    -- Formula (swath):  factor = (area × pixToSqm × 0.6 / 1000) / fieldAreaHa
     local fieldAreaHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
-    local factor = (harvestedLiters / 1000) / fieldAreaHa
+    local factor
+    if harvestedLiters and harvestedLiters > 0 then
+        factor = (harvestedLiters / 1000) / fieldAreaHa
+    elseif area and area > 0 then
+        -- Swath/windrow mode: estimate factor from cut area.
+        -- 0.6 L/m² × 10000 m²/ha / 1000 = 6.0 factor-units per ha harvested.
+        if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
+        local areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
+        factor = (areaHa * 6.0) / fieldAreaHa
+        SoilLogger.debug("Harvest swath mode field %d: area=%.1fpx areaHa=%.5f factor=%.6f", fieldId, area, areaHa, factor)
+    else
+        return
+    end
 
     -- Step 2: Apply difficulty multiplier
     -- Simple (0.7x): 30% less depletion, easier for new players

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1997,7 +1997,7 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     if area and area > 0 then
         if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
         areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
-        factor = areaHa / fieldAreaHa
+        factor = (areaHa / fieldAreaHa) * SoilConstants.HARVEST_HA_FACTOR
     else
         return
     end
@@ -2054,7 +2054,7 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     -- harvestedLiters is unreliable (0/1 flag); estimate biological yield from area instead.
     local sr = strawRatio or 0
     if sr > 0 and areaHa > 0 then
-        local estimatedLiters = areaHa * 6000  -- 6000 L/ha average yield density
+        local estimatedLiters = areaHa * 8000  -- 8000 L/ha average yield density (matches HARVEST_HA_FACTOR)
         local omGain = (estimatedLiters / 1000) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE
         field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, (field.organicMatter or 0) + omGain)
     end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -251,7 +251,7 @@ SoilConstants.CROP_EXTRACTION = {
     sunflower  = { N=2.50, P=1.10, K=2.30 },  -- Moderate-high demand
     potato     = { N=3.80, P=1.70, K=5.40 },  -- Very high K demand (tuber crop)
     sugarbeet  = { N=3.30, P=1.50, K=5.80 },  -- Extreme K demand (root crop)
-    oats       = { N=1.80, P=0.90, K=1.60 },  -- Light feeder
+    oat        = { N=1.80, P=0.90, K=1.60 },  -- Light feeder
     rye        = { N=2.00, P=0.80, K=1.80 },  -- Moderate demand
     triticale  = { N=2.10, P=1.00, K=1.90 },  -- Hybrid characteristics
     sorghum    = { N=2.30, P=0.90, K=1.80 },  -- Efficient nutrient user

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -275,6 +275,14 @@ SoilConstants.CROP_EXTRACTION_FORAGE = { N=1.40, P=0.55, K=1.80 }
 -- Compare: wheat harvest 1ha at 7000L → N=14.7, P=6.3, K=11.9. Forage ~57% of grain.
 SoilConstants.MOWER_HA_FACTOR = 6.0
 
+-- Harvest area calibration factor.
+-- addCutterArea's liters parameter is a 0/1 flag, not actual yield volume.
+-- Area is used instead; this factor scales it to match extraction rate calibration.
+-- Value = typical yield in L/ha / 1000 = 8000/1000 = 8.0.
+-- Formula: factor = (areaHa / fieldAreaHa) * HARVEST_HA_FACTOR
+-- At factor=8.0, wheat 1ha: N=16, P=6.4, K=12 depleted (matches extraction rate comments).
+SoilConstants.HARVEST_HA_FACTOR = 8.0
+
 -- ========================================
 -- FERTILIZER PROFILES (per 1,000 liters applied)
 -- ========================================

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -24,6 +24,7 @@ SettingsSchema.definitions = {
         type = "boolean",
         default = false,
         uiId = "sf_debug",
+        localOnly = true,  -- debug output is per-player; applying via event causes async delay that misses hook messages
     },
     {
         id = "fertilitySystem",

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1078,7 +1078,7 @@ function HookManager:installYieldModifierHook()
                     local yieldModifier = g_SoilFertilityManager.soilSystem:computeYieldModifier(fieldId, fruitType)
                     if yieldModifier ~= 1.0 then
                         modifiedDelta = fillLevelDelta * yieldModifier
-                        SoilLogger.debug("Yield modifier hook: Field %d Fruit %d modifier=%.3f (%.1fL â %.1fL)",
+                        SoilLogger.debug("Yield modifier hook: Field %d Fruit %d modifier=%.3f (%.1fL -- %.1fL)",
                             fieldId, fruitType, yieldModifier, fillLevelDelta, modifiedDelta)
                     end
                 end)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1031,7 +1031,7 @@ function HookManager:installYieldModifierHook()
     -- Hooking Combine.addFillUnitFillLevel therefore always fails (nil check).
     -- Real FS25 signature: addFillUnitFillLevel(self, farmId, fillUnitIndex, fillLevelDelta, fillTypeIndex, toolType, fillPositionData)
     if not FillUnit or type(FillUnit.addFillUnitFillLevel) ~= "function" then
-        SoilLogger.warning("Yield modifier hook: FillUnit.addFillUnitFillLevel not available â yield reduction skipped")
+        SoilLogger.warning("Yield modifier hook: FillUnit.addFillUnitFillLevel not available -- yield reduction skipped")
         return false
     end
 
@@ -1106,7 +1106,7 @@ function HookManager:installYieldModifierHook()
         end
     end
 
-    SoilLogger.info("[OK] Yield modifier hook installed (FillUnit.addFillUnitFillLevel) â %d existing combines patched", patched)
+    SoilLogger.info("[OK] Yield modifier hook installed (FillUnit.addFillUnitFillLevel) -- %d existing combines patched", patched)
     return true
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -919,13 +919,17 @@ function HookManager:installHarvestHook()
             -- Yield modifier is NO LONGER applied here — see installYieldModifierHook.
             local detectedFieldId = nil
 
+            -- NOTE: liters=0 is normal in swath/windrow mode (isSwathActive=true on the combine).
+            -- The crop is deposited on the ground rather than collected in the hopper.
+            -- We still deplete nutrients (the soil grew the biomass regardless of collection method);
+            -- updateFieldNutrients handles the liters=0 case via area-based estimation.
             if combineSelf.isServer
                 and g_SoilFertilityManager
                 and g_SoilFertilityManager.soilSystem
                 and g_SoilFertilityManager.settings.enabled
                 and g_SoilFertilityManager.settings.nutrientCycles
                 and inputFruitType and inputFruitType > 0
-                and liters and liters > 0
+                and area and area > 0
             then
                 local ok, errMsg = pcall(function()
                     local x, _, z = getWorldTranslation(combineSelf.rootNode)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1148,9 +1148,12 @@ function HookManager:installMowerHook()
 
             -- lastStatsArea: density-map pixels processed this tick (same unit as Cutter's lastArea)
             local area = spec.workAreaParameters.lastStatsArea or 0
+            local fruitType = spec.workAreaParameters.lastInputFruitType
+
+            SoilLogger.debug("[MowerHook] fired: area=%.1f fruitType=%s", area, tostring(fruitType))
+
             if area <= 0 then return end
 
-            local fruitType = spec.workAreaParameters.lastInputFruitType
             if not fruitType or fruitType <= 0 then return end
 
             local success, errorMsg = pcall(function()

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -29,7 +29,7 @@ function SettingsManager:getSavegameXmlFilePath()
         return path
     end
 
-    SoilLogger.warning("Savegame directory not available yet")
+    SoilLogger.debug("Savegame directory not available yet (new career or early load)")
     return nil
 end
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1508,33 +1508,46 @@ function SoilHUD:drawMiniReport()
     local samples = nil
     local cellLabel = nil
 
-    -- 1. Try to get internal zoneData (per-cell) first
+    -- 1. Try to get per-cell zoneData first; fall back to field-level averages.
     if wx and wz and self.cachedFieldId and self.cachedFieldId > 0 then
         local soilSys = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
         if soilSys then
             local field = soilSys:getOrCreateField(self.cachedFieldId, false)
-            if field and field.zoneData then
-                local cs = SoilConstants.ZONE.CELL_SIZE
-                local cx = math.floor(wx / cs)
-                local cz = math.floor(wz / cs)
-                local cellKey = tostring(cx * 10000 + cz)
-                local cell = field.zoneData[cellKey]
-                
+            if field then
+                local cell = nil
+                if field.zoneData then
+                    local cs = SoilConstants.ZONE.CELL_SIZE
+                    local cx = math.floor(wx / cs)
+                    local cz = math.floor(wz / cs)
+                    local cellKey = tostring(cx * 10000 + cz)
+                    cell = field.zoneData[cellKey]
+                    if cell then
+                        cellLabel = string.format("C %d\xC2\xB7%d", cx, cz)
+                    end
+                end
+
+                -- Cell uses N/P/K/OM; field uses nitrogen/phosphorus/potassium/organicMatter
+                local n, p, k, ph, om
                 if cell then
+                    n, p, k, ph, om = cell.N, cell.P, cell.K, cell.pH, cell.OM
+                elseif field.nitrogen ~= nil then
+                    n, p, k, ph, om = field.nitrogen, field.phosphorus, field.potassium, field.pH, field.organicMatter
+                    cellLabel = g_i18n:hasText("sf_field_avg") and g_i18n:getText("sf_field_avg") or "Field avg"
+                end
+                if n ~= nil then
                     samples = {
-                        { label="N",  val=cell.N,  min=0,   max=100, unit=""  },
-                        { label="P",  val=cell.P,  min=0,   max=100, unit=""  },
-                        { label="K",  val=cell.K,  min=0,   max=100, unit=""  },
-                        { label="pH", val=cell.pH, min=5.0, max=7.5, unit=""  },
-                        { label="OM", val=cell.OM, min=0,   max=10,  unit="%" },
+                        { label="N",  val=n,  min=0,   max=100, unit=""  },
+                        { label="P",  val=p,  min=0,   max=100, unit=""  },
+                        { label="K",  val=k,  min=0,   max=100, unit=""  },
+                        { label="pH", val=ph, min=5.0, max=7.5, unit=""  },
+                        { label="OM", val=om, min=0,   max=10,  unit="%" },
                     }
-                    cellLabel = string.format("C %d\xC2\xB7%d", cx, cz)
                 end
             end
         end
     end
 
-    -- 2. No fallback! If no cell data is found, samples remains nil.
+    -- 2. If still no data, samples remains nil (player off-field or system not ready).
 
     -- ── Background ───────────────────────────────────────
     local alpha = SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3]

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,12 +24,11 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed HUD layout now saves to modSettings/ — dedicated server clients keep preferences",
-    "- Fixed HUD visibility (J key) now saves immediately on toggle",
-    "- Fixed modSettings folder name corrected (was modsSettings — settings were lost)",
-    "- Added debug output files in modSettings/FS25_SoilFertilizer/Debug/",
-    "- Added current-pass coverage tracker: HUD shows % covered + product name this session",
-    "- Fixed Organic Matter clamped to [0,10] on all write paths — negative OM from corrupted saves no longer shown in HUD",
+    "- Fixed Harvesting now correctly drains nitrogen, phosphorus and potassium from your fields",
+    "- Fixed Swath and windrow harvesting also now properly removes soil nutrients",
+    "- Fixed New fields and new games now show soil readings in the cell report right away",
+    "- Fixed Fertilizer and amendment piles no longer cause rendering errors when viewed from a distance",
+    "- Fixed Oats now tracked as a separate crop for nutrient extraction (was grouped with wheat)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -714,6 +714,7 @@
     <e k="sf_cell_report" v="Relatório de Célula" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nenhum dado de célula encontrado" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Sem dados de solo neste local" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Méd. campo" />
     <e k="sf_cell" v="Célula" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeção de Célula de Solo" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalhes da Célula" eh="6fc5243e" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -713,6 +713,7 @@
     <e k="sf_cell_report" v="Informe de cel·la" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="No s'han trobat dades de la cel·la" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No hi ha dades del sòl en aquesta ubicació" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Cel·la" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspecció de cel·la de sòl" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalls de la cel·la" eh="6fc5243e" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -713,6 +713,7 @@
     <e k="sf_cell_report" v="Zpráva o buňce" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Žádná data buňky nenalezena" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Na tomto místě nejsou žádná data o půdě" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Buňka" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspekce půdní buňky" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detaily buňky" eh="6fc5243e" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Cellerapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Ingen celledata fundet" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ingen jorddata på denne placering" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Mark gns." />
     <e k="sf_cell" v="Celle" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Jordcelle-inspektion" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celledetaljer" eh="6fc5243e" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Zellenbericht" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Keine Zellendaten gefunden" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Keine Bodendaten an dieser Position" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Feld Ø" />
     <e k="sf_cell" v="Zelle" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Bodenellen-Inspektion" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Zellendetails" eh="6fc5243e" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Informe Celda" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Sin datos de celda" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No hay datos de suelo aquí" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Prom. campo" />
     <e k="sf_cell" v="Celda" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspección de Celda" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalles Celda" eh="6fc5243e" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -713,6 +713,7 @@
     <e k="sf_cell_report" v="Cell Report" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="No cell data found" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No soil data at this location" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Cell" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Soil Cell Inspection" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Cell Details" eh="6fc5243e" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Informe celda" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Sin datos de celda" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No hay datos de suelo aquí" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Prom. campo" />
     <e k="sf_cell" v="Celda" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspección de celda" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalles celda" eh="6fc5243e" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Rapport cellule" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Données absentes" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Pas de données sol ici" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Cellule" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspection de cellule" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Détails cellule" eh="6fc5243e" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -667,6 +667,7 @@
     <e k="sf_cell_report" v="Soluraportti" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Solutietoja ei löytynyt" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ei maaperätietoja tässä kohdassa" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Pelto kesk." />
     <e k="sf_cell" v="Solu" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Maaperäsolun tarkastelu" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Solun tiedot" eh="6fc5243e" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -698,6 +698,7 @@
     <e k="sf_cell_report" v="Rapport de cellule" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Aucune donnée de cellule trouvée" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Aucune donnée de sol à cet endroit" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Moy. champ" />
     <e k="sf_cell" v="Cellule" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspection de cellule de sol" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Détails de la cellule" eh="6fc5243e" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -686,6 +686,7 @@
     <e k="sf_cell_report" v="Cella jelentés" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nem található cellaadat" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nincs talajadat ezen a helyen" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Cella" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Talajcella vizsgálat" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Cella részletei" eh="6fc5243e" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -713,6 +713,7 @@
     <e k="sf_cell_report" v="Laporan Sel" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Data sel tidak ditemukan" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Tidak ada data tanah di lokasi ini" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Sel" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeksi Sel Tanah" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detail Sel" eh="6fc5243e" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -713,6 +713,7 @@
     <e k="sf_cell_report" v="Rapporto Cella" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Dati cella non trovati" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nessun dato del suolo in questa posizione" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Media campo" />
     <e k="sf_cell" v="Cella" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Ispezione Cella Suolo" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Dettagli Cella" eh="6fc5243e" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -693,6 +693,7 @@
     <e k="sf_cell_report" v="セルレポート" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="セルデータなし" eh="dc41c753" />
     <e k="sf_cell_no_data" v="この場所には土壌データがありません" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="セル" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="土壌セル検査" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="セル詳細" eh="6fc5243e" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -694,6 +694,7 @@
     <e k="sf_cell_report" v="셀 보고서" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="셀 데이터를 찾을 수 없음" eh="dc41c753" />
     <e k="sf_cell_no_data" v="이 위치에 토양 데이터가 없습니다" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="셀" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="토양 셀 조사" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="셀 상세 정보" eh="6fc5243e" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -695,6 +695,7 @@
     <e k="sf_cell_report" v="Celrapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Geen celgegevens gevonden" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Geen bodemgegevens op deze locatie" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Veld gem." />
     <e k="sf_cell" v="Cel" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Bodemcel-inspectie" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celdetails" eh="6fc5243e" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -695,6 +695,7 @@
     <e k="sf_cell_report" v="Cellerapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Ingen celledata funnet" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ingen jorddata på denne lokasjonen" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Felt gj.snitt" />
     <e k="sf_cell" v="Celle" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeksjon av jordcelle" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celledetaljer" eh="6fc5243e" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -695,6 +695,7 @@
     <e k="sf_cell_report" v="Raport komórki" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Brak danych komórki" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Brak danych glebowych w tej lokalizacji" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Śr. pola" />
     <e k="sf_cell" v="Komórka" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspekcja komórki gleby" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Szczegóły komórki" eh="6fc5243e" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -714,6 +714,7 @@
     <e k="sf_cell_report" v="Relatório de Célula" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Sem dados de célula" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Sem dados de solo nesta localização" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Méd. campo" />
     <e k="sf_cell" v="Célula" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeção de Célula de Solo" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalhes da Célula" eh="6fc5243e" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -714,6 +714,7 @@
     <e k="sf_cell_report" v="Raport Celulă" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nu s-au găsit date despre celulă" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nu există date despre sol la această locație" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Celulă" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspecție Celulă Sol" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalii Celulă" eh="6fc5243e" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -655,6 +655,7 @@
     <e k="sf_cell_report" v="Отчет по ячейке" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Данные не найдены" eh="dc41c753" />
     <e k="sf_cell_no_data" v="В этой точке нет данных почвы" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Ср. поля" />
     <e k="sf_cell" v="Ячейка" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Осмотр ячейки" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Детали ячейки" eh="6fc5243e" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Cellrapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Ingen celldata hittades" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ingen markdata på denna plats" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Fält snitt" />
     <e k="sf_cell" v="Cell" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Markcellsinspektion" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celldetaljer" eh="6fc5243e" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -667,6 +667,7 @@
     <e k="sf_cell_report" v="Hücre Raporu" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Hücre verisi bulunamadı" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Bu konumda toprak verisi yok" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Alan ort." />
     <e k="sf_cell" v="Hücre" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Toprak Hücresi İncelemesi" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Hücre Ayrıntıları" eh="6fc5243e" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Звіт комірки" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Дані комірки відсутні" eh="dc41c753" />
     <e k="sf_cell_no_data" v="В цій точці немає даних ґрунту" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Сер. поля" />
     <e k="sf_cell" v="Комірка" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Інспекція комірки ґрунту" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Деталі комірки" eh="6fc5243e" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -666,6 +666,7 @@
     <e k="sf_cell_report" v="Báo cáo ô" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Không thấy dữ liệu ô" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Không có dữ liệu đất tại vị trí này" eh="5dfa58aa" />
+    <e k="sf_field_avg" v="Field avg" />
     <e k="sf_cell" v="Ô" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Kiểm tra ô đất" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Chi tiết ô" eh="6fc5243e" />


### PR DESCRIPTION
## Summary

- **Critical fix**: Harvest depletion was silently producing zero N/P/K drain. `addCutterArea` passes a 0/1 flag as `liters`, not grain volume. Switched to area-based depletion (`areaHa / fieldAreaHa × HARVEST_HA_FACTOR`) calibrated to match the existing extraction rate scale (8000 L/ha proxy).
- **Swath/windrow mode**: Same fix — now uses the same area-based path as normal harvesting. Also fixed oat extraction key (`oats` → `oat` to match `g_fruitTypeManager` name).
- **Cell report "NO DATA" on new games**: `zoneData` cells are only written on fertilize/mow/plow events. Fresh fields now fall back to field-level averages labelled "Field avg" instead of showing "NO DATA".
- **Distance texture errors (issue #384)**: All 10 solid fill types registered in `densityMapHeightTypes.xml` were missing the `distance="..."` attribute on their `<textures>` element, causing `Failed to create density height map distance texture array` errors on dedicated servers. Added appropriate vanilla `$data/fillPlanes/distance/*.dds` references.
- Minor: `debugMode` made `localOnly` so `SoilDebug` takes effect immediately without restart; false savegame-directory warning downgraded to debug on new careers.

## Test plan

- [ ] Harvest a field, check log for non-zero `-N -P -K` depletion values
- [ ] Harvest in swath mode, confirm depletion fires correctly
- [ ] Start a new game — cell report HUD should show "Field avg" with default values, not "NO DATA"
- [ ] Verify no `distance texture` errors in log on dedicated server
- [ ] Confirm `SoilDebug` console command toggles debug mode immediately