### PR TITLE
v2.2.0 — Precision Farming integration, map overlay overhaul, tooltip redesign

### DIFF
--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -10,7 +10,7 @@
             <physics massPerLiter="1.32" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.60"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/uan32/liquidTank_uan32.xml" />
         </fillType>
 
@@ -18,7 +18,7 @@
             <physics massPerLiter="1.28" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.50"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/uan28/liquidTank_uan28.xml" />
         </fillType>
 
@@ -26,7 +26,7 @@
             <physics massPerLiter="0.61" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.85"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/anhydrous/liquidTank_anhydrous.xml" />
         </fillType>
 
@@ -34,7 +34,7 @@
             <physics massPerLiter="1.10" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.70"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/starter/liquidTank_starter.xml" />
         </fillType>
 
@@ -45,7 +45,7 @@
             <economy pricePerLiter="1.65"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
             <pallet filename="objects/bigBag/urea/bigBag_urea.xml" />
         </fillType>
 
@@ -58,7 +58,7 @@
                       height="$data/fillPlanes/fertilizer_height.png"
                       displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"
                       distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
             <pallet filename="objects/bigBag/an/bigBag_an.xml" />
         </fillType>
 
@@ -71,7 +71,7 @@
                       height="$data/fillPlanes/fertilizer_height.png"
                       displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"
                       distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
             <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
         </fillType>
 
@@ -80,7 +80,7 @@
             <economy pricePerLiter="1.95"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
             <pallet filename="objects/bigBag/map/bigBag_map.xml" />
         </fillType>
 
@@ -89,7 +89,7 @@
             <economy pricePerLiter="1.75"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
             <pallet filename="objects/bigBag/dap/bigBag_dap.xml" />
         </fillType>
 
@@ -98,7 +98,7 @@
             <economy pricePerLiter="1.80"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
             <pallet filename="objects/bigBag/potash/bigBag_potash.xml" />
         </fillType>
 
@@ -108,7 +108,7 @@
             <physics massPerLiter="0.001" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.20"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="HERBICIDE"/>
             <pallet filename="objects/liquidTank/insecticide/liquidTank_insecticide.xml" />
         </fillType>
 
@@ -116,7 +116,7 @@
             <physics massPerLiter="0.001" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.30"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="HERBICIDE"/>
             <pallet filename="objects/liquidTank/fungicide/liquidTank_fungicide.xml" />
         </fillType>
 
@@ -124,7 +124,7 @@
             <physics massPerLiter="1.10" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.70"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/liquid_urea/liquidTank_liquid_urea.xml" />
         </fillType>
 
@@ -132,7 +132,7 @@
             <physics massPerLiter="1.15" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.45"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/liquid_ams/liquidTank_liquid_ams.xml" />
         </fillType>
 
@@ -140,7 +140,7 @@
             <physics massPerLiter="1.20" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="2.00"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/liquid_map/liquidTank_liquid_map.xml" />
         </fillType>
 
@@ -148,7 +148,7 @@
             <physics massPerLiter="1.20" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.80"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/liquid_dap/liquidTank_liquid_dap.xml" />
         </fillType>
 
@@ -156,7 +156,7 @@
             <physics massPerLiter="1.25" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="1.85"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/liquid_potash/liquidTank_liquid_potash.xml" />
         </fillType>
 
@@ -171,7 +171,7 @@
             <economy pricePerLiter="0.55"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/lime_diffuse.dds" normal="$data/fillPlanes/lime_normal.dds" height="$data/fillPlanes/lime_height.dds" displacement="$data/fillPlanes/lime_displacement.dds" distance="$data/fillPlanes/distance/limeDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="LIME"/>
             <pallet filename="objects/bigBag/gypsum/bigBag_gypsum.xml" />
         </fillType>
 
@@ -180,7 +180,7 @@
             <economy pricePerLiter="0.35"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds" distance="$data/fillPlanes/distance/woodChipsDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="MANURE"/>
             <pallet filename="objects/bigBag/compost/bigBag_compost.xml" />
         </fillType>
 
@@ -189,7 +189,7 @@
             <economy pricePerLiter="0.50"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$modDir/textures/fillPlanes/biosolids_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds" distance="$modDir/textures/fillPlanes/distance/biosolidsDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="MANURE"/>
             <pallet filename="objects/bigBag/biosolids/bigBag_biosolids.xml" />
         </fillType>
 
@@ -198,7 +198,7 @@
             <economy pricePerLiter="0.45"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/manure_diffuse.dds" normal="$data/fillPlanes/manure_normal.dds" height="$data/fillPlanes/manure_height.dds" displacement="$data/fillPlanes/manure_displacement.dds" distance="$data/fillPlanes/distance/manureDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="MANURE"/>
             <pallet filename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml" />
         </fillType>
 
@@ -207,7 +207,7 @@
             <economy pricePerLiter="1.10"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
             <textures diffuse="$data/fillPlanes/mineralFeed_diffuse.dds" normal="$data/fillPlanes/mineralFeed_normal.dds" height="$data/fillPlanes/mineralFeed_height.dds" displacement="$data/fillPlanes/mineralFeed_displacement.dds" distance="$data/fillPlanes/distance/mineralFeedDistance_diffuse.dds"/>
-            <sprayType sprayTypeStr="SOLID"/>
+            <sprayType sprayTypeStr="MANURE"/>
             <pallet filename="objects/bigBag/pelletized_manure/bigBag_pelletized_manure.xml" />
         </fillType>
 
@@ -215,7 +215,7 @@
             <physics massPerLiter="1.40" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="0.28"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIQUID"/>
+            <sprayType sprayTypeStr="LIME"/>
             <pallet filename="objects/liquidTank/liquidlime/liquidTank_liquidlime.xml" />
         </fillType>
 

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -66,7 +66,11 @@
             <physics massPerLiter="0.87" maxPhysicalSurfaceAngle="15"/>
             <economy pricePerLiter="1.40"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
-            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" normal="$data/fillPlanes/fertilizer_normal.png" height="$data/fillPlanes/fertilizer_height.png" displacement="$data/fillPlanes/fertilizer_displacement.png" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.png" unitSize="0.4" blendContrast="0.2" noiseScale="0.5" porosityAtZeroRoughness="0.9" porosityAtFullRoughness="1"
+                      normal="$data/fillPlanes/fertilizer_normal.png"
+                      height="$data/fillPlanes/fertilizer_height.png"
+                      displacement="$data/fillPlanes/fertilizer_displacement.png" displacementMaxHeight="0.2" firmness="0.3" viscosity="0.5"
+                      distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
             <sprayType sprayTypeStr="SOLID"/>
             <pallet filename="objects/bigBag/ams/bigBag_ams.xml" />
         </fillType>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -32,7 +32,7 @@
         <vi>Đất &amp; Phân Bón Thực Tế</vi>
     </title>
     <description>
-        <en>Adds realistic per-field soil management to Farming Simulator 25. Tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH for every field on the map. Crops deplete nutrients at harvest; fertilizers, manure, and lime replenish them. Rain causes leaching, seasons shift nitrogen levels, and neglected fields slowly recover on their own. Includes a live soil HUD, a full farm soil report (K key), and 9 custom fertilizer types. Fully multiplayer with server-authoritative settings. Works on multifruit maps — unknown crops use a balanced fallback rate.</en>
+        <en>Adds realistic per-field soil management to Farming Simulator 25. Tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH for every field on the map. Crops deplete nutrients at harvest; fertilizers, manure, and lime replenish them. Rain causes leaching, seasons shift nitrogen levels, and neglected fields slowly recover on their own. Includes a live soil HUD, a full farm soil report (K key), and 9 custom fertilizer types. Fully multiplayer with server-authoritative settings. Works on multifruit maps — unknown crops use a balanced fallback rate. Optional: install the Precision Farming DLC + [TH] Precision Farming Configurator for full integration — custom fertilizers are recognized by PF's nitrogen map.</en>
         <de>Fügt realistisches feldspezifisches Bodenmanagement zu Farming Simulator 25 hinzu. Verfolgt Stickstoff, Phosphor, Kalium, organische Substanz und pH-Wert für jedes Feld. Ernten erschöpfen Nährstoffe; Dünger, Mist und Kalk ergänzen sie. Regen verursacht Auswaschung, Jahreszeiten beeinflussen den Stickstoffgehalt, und brachliegende Felder erholen sich langsam von selbst. Enthält ein Live-Boden-HUD, einen vollständigen Hofbodenbericht (K-Taste) und 9 benutzerdefinierte Düngertypen. Vollständig multiplayer-fähig mit serverautoritativen Einstellungen.</de>
         <fr>Ajoute une gestion réaliste du sol par parcelle à Farming Simulator 25. Suit l'Azote, le Phosphore, le Potassium, la Matière Organique et le pH pour chaque champ. Les récoltes épuisent les nutriments ; les engrais, le fumier et la chaux les reconstituent. La pluie lessive les nutriments, les saisons font varier l'azote, et les champs abandonnés se régénèrent lentement. Comprend un HUD sol en direct, un rapport complet de la ferme (touche K) et 9 types d'engrais personnalisés. Multijoueur complet avec paramètres contrôlés par le serveur.</fr>
         <pl>Dodaje realistyczne zarządzanie glebą per-pole do Farming Simulator 25. Śledzi Azot, Fosfor, Potas, Materię Organiczną i pH dla każdego pola. Zbiory wyczerpują składniki odżywcze; nawozy, obornik i wapno je uzupełniają. Deszcz powoduje wymywanie, pory roku wpływają na poziom azotu, a zaniedbane pola powoli się regenerują. Zawiera HUD gleby, pełny raport gleby (klawisz K) i 9 niestandardowych typów nawozów. Pełna obsługa trybu wieloosobowego.</pl>
@@ -445,5 +445,164 @@
         </category>
 
     </helpLines>
+
+    <!--
+        ══════════════════════════════════════════════════════════════════════
+        [TH] PRECISION FARMING CONFIGURATOR INTEGRATION
+        Requires: FS25_precisionFarming DLC + FS25_0_THPFConfigurator mod.
+        If either is absent this block is silently ignored — all three
+        operating modes (SF-only, SF+PF, SF+PF+THPF) are fully supported.
+
+        <sprayTypes>    — tells THPF the N content and PF application rates
+                          for our N-bearing fill types so PF can paint its
+                          nitrogen density map correctly.
+        <sprayTypeMapping> — tells THPF what group each custom fill type
+                          belongs to (FERTILIZER / MANURE / DIGESTATE /
+                          LIME / HERBICIDE). Enables PF HUD naming and
+                          auto-injection into compatible vehicles/storages.
+        ══════════════════════════════════════════════════════════════════════
+    -->
+    <thPFConfig>
+
+        <sprayTypes>
+            <!-- Liquid nitrogen fertilizers -->
+            <sprayType name="UAN32" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="120">
+                    <soil soilTypeIndex="1" rate="60"/>
+                    <soil soilTypeIndex="2" rate="80"/>
+                    <soil soilTypeIndex="3" rate="100"/>
+                    <soil soilTypeIndex="4" rate="80"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.32"/> <!-- UAN 32% N by weight -->
+            </sprayType>
+
+            <sprayType name="UAN28" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="120">
+                    <soil soilTypeIndex="1" rate="60"/>
+                    <soil soilTypeIndex="2" rate="80"/>
+                    <soil soilTypeIndex="3" rate="100"/>
+                    <soil soilTypeIndex="4" rate="80"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.28"/> <!-- UAN 28% N by weight -->
+            </sprayType>
+
+            <sprayType name="ANHYDROUS" litersPerSecond="0.0081" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="120">
+                    <soil soilTypeIndex="1" rate="40"/>
+                    <soil soilTypeIndex="2" rate="55"/>
+                    <soil soilTypeIndex="3" rate="70"/>
+                    <soil soilTypeIndex="4" rate="55"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.82"/> <!-- Anhydrous ammonia 82% N by weight -->
+            </sprayType>
+
+            <sprayType name="LIQUID_UREA" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="120">
+                    <soil soilTypeIndex="1" rate="60"/>
+                    <soil soilTypeIndex="2" rate="80"/>
+                    <soil soilTypeIndex="3" rate="100"/>
+                    <soil soilTypeIndex="4" rate="80"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.29"/> <!-- Liquid urea ~29% N -->
+            </sprayType>
+
+            <sprayType name="LIQUID_AMS" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="100">
+                    <soil soilTypeIndex="1" rate="50"/>
+                    <soil soilTypeIndex="2" rate="65"/>
+                    <soil soilTypeIndex="3" rate="80"/>
+                    <soil soilTypeIndex="4" rate="65"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.21"/> <!-- AMS solution ~21% N -->
+            </sprayType>
+
+            <sprayType name="LIQUID_DAP" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="60">
+                    <soil soilTypeIndex="1" rate="30"/>
+                    <soil soilTypeIndex="2" rate="40"/>
+                    <soil soilTypeIndex="3" rate="50"/>
+                    <soil soilTypeIndex="4" rate="40"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.18"/> <!-- DAP solution 18-46-0, 18% N -->
+            </sprayType>
+
+            <sprayType name="LIQUID_MAP" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="60">
+                    <soil soilTypeIndex="1" rate="30"/>
+                    <soil soilTypeIndex="2" rate="40"/>
+                    <soil soilTypeIndex="3" rate="50"/>
+                    <soil soilTypeIndex="4" rate="40"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.11"/> <!-- MAP solution 11-52-0, 11% N -->
+            </sprayType>
+
+            <!-- Solid granular nitrogen fertilizers -->
+            <sprayType name="UREA" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="120">
+                    <soil soilTypeIndex="1" rate="60"/>
+                    <soil soilTypeIndex="2" rate="80"/>
+                    <soil soilTypeIndex="3" rate="100"/>
+                    <soil soilTypeIndex="4" rate="80"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.46"/> <!-- Urea 46% N by weight -->
+            </sprayType>
+
+            <sprayType name="AN" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="120">
+                    <soil soilTypeIndex="1" rate="60"/>
+                    <soil soilTypeIndex="2" rate="80"/>
+                    <soil soilTypeIndex="3" rate="100"/>
+                    <soil soilTypeIndex="4" rate="80"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.345"/> <!-- Ammonium nitrate 34.5% N by weight -->
+            </sprayType>
+
+            <sprayType name="AMS" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="100">
+                    <soil soilTypeIndex="1" rate="50"/>
+                    <soil soilTypeIndex="2" rate="65"/>
+                    <soil soilTypeIndex="3" rate="80"/>
+                    <soil soilTypeIndex="4" rate="65"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.21"/> <!-- Ammonium sulfate 21% N by weight -->
+            </sprayType>
+
+            <!-- Lime types (pH amendment — no N content) -->
+            <sprayType name="LIQUIDLIME" litersPerSecond="0.0815" type="LIME" sprayGroundType="LIME"/>
+            <sprayType name="GYPSUM"     litersPerSecond="0.0600" type="LIME" sprayGroundType="LIME"/>
+        </sprayTypes>
+
+        <sprayTypeMapping>
+            <!-- Liquid nitrogen fertilizers -->
+            <sprayType name="UAN32"       group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="UAN28"       group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="ANHYDROUS"   group="FERTILIZER" isLiquid="true" aliasNames="NH3"/>
+            <sprayType name="STARTER"     group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="LIQUID_UREA" group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="LIQUID_AMS"  group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="LIQUID_DAP"  group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="LIQUID_MAP"  group="FERTILIZER" isLiquid="true"/>
+            <sprayType name="LIQUID_POTASH" group="FERTILIZER" isLiquid="true"/>
+            <!-- Solid NPK fertilizers -->
+            <sprayType name="UREA"   group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="AN"     group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="AMS"    group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="MAP"    group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="DAP"    group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="POTASH" group="FERTILIZER" isLiquid="false"/>
+            <!-- Organic amendments -->
+            <sprayType name="COMPOST"           group="MANURE" isLiquid="false"/>
+            <sprayType name="BIOSOLIDS"         group="MANURE" isLiquid="false"/>
+            <sprayType name="CHICKEN_MANURE"    group="MANURE" isLiquid="false"/>
+            <sprayType name="PELLETIZED_MANURE" group="MANURE" isLiquid="false"/>
+            <!-- Lime / pH amendments -->
+            <sprayType name="LIQUIDLIME" group="LIME" isLiquid="true"/>
+            <sprayType name="GYPSUM"     group="LIME" isLiquid="false"/>
+            <!-- Crop protection -->
+            <sprayType name="INSECTICIDE" group="HERBICIDE" isLiquid="true"/>
+            <sprayType name="FUNGICIDE"   group="HERBICIDE" isLiquid="true"/>
+        </sprayTypeMapping>
+
+    </thPFConfig>
 
 </modDesc>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -640,8 +640,8 @@ function SoilFertilityManager:deferredSoilSystemInit()
             local initSuccess, initError = pcall(function()
                 self.sfm.soilSystem:initialize()
 
-                -- Detect Precision Farming and verify its read API.
-                -- Must run after soilSystem:initialize() so g_precisionFarming is guaranteed live.
+                -- Detect Precision Farming via g_modManager (shared C++ object, cross-mod visible).
+                -- Must run after mission is fully loaded so g_modManager has all mod entries.
                 if self.sfm.pfBridge then
                     self.sfm.hasPrecisionFarming = self.sfm.pfBridge:initialize()
                     -- Give soil system a direct reference so it can gate logic without a global lookup

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -25,6 +25,10 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
     self.disableGUI = disableGUI or false
     self.lastSeenVersion = ""
 
+    -- PF bridge (created early so SoilPFDump works before deferred init fires)
+    self.pfBridge = PrecisionFarmingBridge and PrecisionFarmingBridge:new() or nil
+    self.hasPrecisionFarming = false
+
     -- Settings
     if not Settings then
         SoilLogger.error("CRITICAL: Settings not loaded — check source order in main.lua")
@@ -635,6 +639,14 @@ function SoilFertilityManager:deferredSoilSystemInit()
 
             local initSuccess, initError = pcall(function()
                 self.sfm.soilSystem:initialize()
+
+                -- Detect Precision Farming and verify its read API.
+                -- Must run after soilSystem:initialize() so g_precisionFarming is guaranteed live.
+                if self.sfm.pfBridge then
+                    self.sfm.hasPrecisionFarming = self.sfm.pfBridge:initialize()
+                    -- Give soil system a direct reference so it can gate logic without a global lookup
+                    self.sfm.soilSystem.pfBridge = self.sfm.pfBridge
+                end
 
                 -- Load saved soil data now that savegameDirectory is set
                 self.sfm:loadSoilData()

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2013,7 +2013,10 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     local factor
     local areaHa = 0
     if area and area > 0 then
-        if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
+        if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then
+            SoilLogger.debug("updateFieldNutrients: getFruitPixelsToSqm unavailable — skipping depletion for field %d", fieldId)
+            return
+        end
         areaHa = MathUtil.areaToHa(area, g_currentMission:getFruitPixelsToSqm())
         factor = (areaHa / fieldAreaHa) * SoilConstants.HARVEST_HA_FACTOR
         SoilLogger.debug("Harvest factor: area=%.0fpx areaHa=%.6f fieldHa=%.2f factor=%.6f", area, areaHa, fieldAreaHa, factor)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2197,15 +2197,16 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         if entry.pH then field.pH        = math.max(limits.PH_MIN, math.min(limits.PH_MAX, field.pH + entry.pH * factor)) end
         if entry.OM then field.organicMatter = math.max(0, math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor)) end
 
-        -- Sync all existing zone cells to the updated field values so cells stamped
-        -- by previous tillage operations reflect the fertilizer that was just applied.
+        -- Sync N/P/K in all existing zone cells so tillage-created cells immediately
+        -- reflect subsequent fertilizer applications (these nutrients spread uniformly
+        -- and the bulk sync keeps the overlay accurate). pH and OM are excluded so
+        -- that per-zone variation is preserved — only the actual spray path cell
+        -- accumulates pH/OM changes via the cellFactor update below.
         if field.zoneData then
             for _, cell in pairs(field.zoneData) do
-                if entry.N  then cell.N  = field.nitrogen end
-                if entry.P  then cell.P  = field.phosphorus end
-                if entry.K  then cell.K  = field.potassium end
-                if entry.pH then cell.pH = field.pH end
-                if entry.OM then cell.OM = field.organicMatter end
+                if entry.N then cell.N = field.nitrogen end
+                if entry.P then cell.P = field.phosphorus end
+                if entry.K then cell.K = field.potassium end
             end
         end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2275,6 +2275,7 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                 end
             end
             local cell = field.zoneData[cellKey]
+            if not cell then return end
             -- cellFactor must use areaInHa (not zone.CELL_AREA_HA) so that each cell
             -- absorbs nutrients at exactly the same per-frame rate as the whole-field
             -- average.  Using CELL_AREA_HA (0.01 ha) as the denominator made cells

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2197,18 +2197,11 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         if entry.pH then field.pH        = math.max(limits.PH_MIN, math.min(limits.PH_MAX, field.pH + entry.pH * factor)) end
         if entry.OM then field.organicMatter = math.max(0, math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor)) end
 
-        -- Sync N/P/K in all existing zone cells so tillage-created cells immediately
-        -- reflect subsequent fertilizer applications (these nutrients spread uniformly
-        -- and the bulk sync keeps the overlay accurate). pH and OM are excluded so
-        -- that per-zone variation is preserved — only the actual spray path cell
-        -- accumulates pH/OM changes via the cellFactor update below.
-        if field.zoneData then
-            for _, cell in pairs(field.zoneData) do
-                if entry.N then cell.N = field.nitrogen end
-                if entry.P then cell.P = field.phosphorus end
-                if entry.K then cell.K = field.potassium end
-            end
-        end
+        -- No bulk zone-cell sync. Each cell accumulates nutrients only from actual
+        -- spray passes through its position (via the cellFactor path below). This
+        -- preserves per-zone variation on the map overlay — the field-level values
+        -- (field.nitrogen, field.pH, etc.) are the aggregate for HUD and yield;
+        -- zone cells are the per-area record for the overlay.
 
         -- Throttled per-field diagnostic (debug mode, lime types always logged; nutrients every 4 s).
         -- Validates that pH shift and nutrient deltas are agronomically sensible.

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2214,8 +2214,16 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         -- For LIME/LIQUIDLIME: target ~0.40 pH over a full 1-ha pass at BASE_RATES volume.
         -- For nutrients: visible delta per frame should be tiny; cumulative over full pass = profile value.
         if entry.pH then
-            -- pH types (LIME, LIQUIDLIME, GYPSUM): log every application event so you can
-            -- see the per-frame delta and verify it adds up to ~0.40 over a full field pass.
+            -- pH types (LIME, LIQUIDLIME, GYPSUM): log once per ~1000 L milestone at info
+            -- level so it appears in the log without requiring SoilDebug, making it easy to
+            -- confirm the hook is firing and the per-frame delta is accumulating correctly.
+            local phBuf = field.nutrientBuffer and field.nutrientBuffer[fillTypeIndex] or 0
+            local phBufPrev = phBuf - liters
+            if math.floor(phBuf / 1000) ~= math.floor(phBufPrev / 1000) then
+                SoilLogger.info(
+                    "FertApply pH field=%d type=%-12s buf=%.0fL factor=%.4f  pH %.3f -> %.3f (area=%.2fha)",
+                    fieldId, fillType.name, phBuf, factor, dbgPH0, field.pH, areaInHa)
+            end
             SoilLogger.debug(
                 "FertApply pH field=%d type=%-12s liters=%.4f factor=%.6f  pH %.3f -> %.3f (delta=%.4f)",
                 fieldId, fillType.name, liters, factor, dbgPH0, field.pH, field.pH - dbgPH0)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2763,6 +2763,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     local ph = field.pH         or SoilConstants.FIELD_DEFAULTS.pH
     local om = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
 
+    local fromZoneCell = false
     if x and z and field.zoneData then
         local zone = SoilConstants.ZONE
         local cellKey = tostring(math.floor(x / zone.CELL_SIZE) * 10000 + math.floor(z / zone.CELL_SIZE))
@@ -2773,6 +2774,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
             k  = cell.K  or k
             ph = cell.pH or ph
             om = cell.OM or om
+            fromZoneCell = true
         end
     end
 
@@ -2884,6 +2886,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         sessionCoverageFraction = field.sessionCoverageFraction or 0,
         sessionLastProduct      = field.sessionLastProduct,
         compaction = field.compaction or 0,
+        fromZoneCell = fromZoneCell,
         needsFertilization = (
             field.nitrogen < fertThresholds.nitrogen or
             field.phosphorus < fertThresholds.phosphorus or

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -218,14 +218,28 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         local nDef = math.max(0, thresh - field.nitrogen)   / thresh
         local pDef = math.max(0, thresh - field.phosphorus) / thresh
         local kDef = math.max(0, thresh - field.potassium)  / thresh
-        local avgDef = (nDef + pDef + kDef) / 3
+
+        -- When Precision Farming is active its ExtendedCombine already applies an N-based
+        -- yield penalty. Exclude N from SF's average to avoid stacking both penalties on
+        -- the same deficiency. P and K are SF-exclusive (PF does not track them).
+        local avgDef
+        if self.pfBridge and self.pfBridge.isActive then
+            avgDef = (pDef + kDef) / 2
+        else
+            avgDef = (nDef + pDef + kDef) / 3
+        end
 
         local nutrientPenalty = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
         if nutrientPenalty > 0 then
             modifier = modifier * (1.0 - nutrientPenalty)
-            self:log("Nutrient penalty field %d (%s/%s): N=%.0f P=%.0f K=%.0f → -%.0f%%",
-                fieldId, cropName, tier, field.nitrogen, field.phosphorus, field.potassium,
-                nutrientPenalty * 100)
+            if self.pfBridge and self.pfBridge.isActive then
+                self:log("Nutrient penalty field %d (%s/%s) [PF Mode - P/K only]: P=%.0f K=%.0f → -%.0f%%",
+                    fieldId, cropName, tier, field.phosphorus, field.potassium, nutrientPenalty * 100)
+            else
+                self:log("Nutrient penalty field %d (%s/%s): N=%.0f P=%.0f K=%.0f → -%.0f%%",
+                    fieldId, cropName, tier, field.nitrogen, field.phosphorus, field.potassium,
+                    nutrientPenalty * 100)
+            end
         end
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2073,11 +2073,11 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     end
 
     -- Step 4: Chopped straw/chaff adds organic matter.
-    -- harvestedLiters is unreliable (0/1 flag); estimate biological yield from area instead.
+    -- OM is a concentration, so gain scales by fraction of field harvested this call,
+    -- not by absolute area. A full harvest at sr=1.0 adds exactly OM_RATE to the field.
     local sr = strawRatio or 0
     if sr > 0 and areaHa > 0 then
-        local estimatedLiters = areaHa * 8000  -- 8000 L/ha average yield density (matches HARVEST_HA_FACTOR)
-        local omGain = (estimatedLiters / 1000) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE
+        local omGain = (areaHa / fieldAreaHa) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE
         field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, (field.organicMatter or 0) + omGain)
     end
 
@@ -2085,11 +2085,13 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     field.lastHarvest = (g_currentMission and g_currentMission.environment and g_currentMission.environment.currentDay) or 0
 
     self:log(
-        "Harvest depletion field %d (%s): -N %.5f -P %.5f -K %.5f",
+        "Harvest depletion field %d (%s): -N %.5f -P %.5f -K %.5f  straw sr=%.2f +OM %.5f",
         fieldId, fruitDesc.name,
         rates.N * factor,
         rates.P * factor,
-        rates.K * factor
+        rates.K * factor,
+        sr,
+        (sr > 0 and areaHa > 0) and (areaHa / fieldAreaHa) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE or 0
     )
 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -311,6 +311,7 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
     if harvestField then
         harvestField.sessionCoverageHa       = 0
         harvestField.sessionCoverageFraction = 0
+        harvestField.sessionCoverageCells    = {}
         harvestField.sessionLastProduct      = nil
     end
 
@@ -1569,10 +1570,12 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
         coveredCells = {},    -- Legacy: kept for daily reset compat (no longer used for coverage calc)
         coveredCellCount = 0, -- Legacy: kept for daily reset compat
         totalFieldCells = 0,  -- Legacy: kept for daily reset compat
-        coveredAreaHa = 0,    -- Hectares covered today (area-based tracker, reset daily)
+        coveredAreaHa = 0,    -- Hectares covered today (cell-dedup, reset daily)
         coverageFraction = 0, -- Fraction of field covered today (0.0–1.0)
-        sessionCoverageHa = 0,       -- Hectares covered this game session (resets on harvest, not daily)
-        sessionCoverageFraction = 0, -- Derived 0.0–1.0 fraction for current-pass HUD display
+        dailyCoverageCells = {},     -- Unique 10×10 m cells sprayed today (reset daily)
+        sessionCoverageHa = 0,       -- Hectares covered this session (cell-dedup, resets on harvest)
+        sessionCoverageFraction = 0, -- Derived 0.0–1.0 fraction for HUD display
+        sessionCoverageCells = {},   -- Unique 10×10 m cells sprayed this session (resets on harvest)
         sessionLastProduct = nil,    -- Fill type name of last product applied this session
         compaction = 0,            -- field-average compaction 0–100 (derived from cells)
         compactionCells = {},      -- {cellKey → 0-100} per-cell compaction (10×10 m grid)
@@ -1648,6 +1651,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     field.coveredCellCount        = 0
     field.coveredAreaHa           = 0
     field.coverageFraction        = 0
+    field.dailyCoverageCells      = {}
     field._covLastX               = nil
     field._covLastZ               = nil
     field._farmlandAreaConfirmed  = nil
@@ -2437,20 +2441,28 @@ end
 -- Dividing by the product's reference rate (L/ha) converts liters → hectares covered.
 -- This is field-size and boom-size independent and matches real application density.
 --
--- Called from the sprayer hook with raw liters (before rateMultiplier) so that a
--- 1.5× rate setting doesn't inflate coverage beyond actual area worked.
----@param fieldId     number
----@param liters      number  Raw liters consumed this tick (pre-rateMultiplier)
----@param fillTypeName string|nil  Fill type name for base-rate lookup
-function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName)
+-- Called from the sprayer hook with raw liters (before rateMultiplier).
+-- For fertilizer products, updateFractions should be false because markBoomCells
+-- handles coverage via spatial cell deduplication (eliminates overlap inflation).
+-- For crop protection direct paths (herbicide/insecticide/fungicide) where no
+-- boomPoints are available, updateFractions remains true (liter-based fallback).
+---@param fieldId        number
+---@param liters         number   Raw liters consumed this tick (pre-rateMultiplier)
+---@param fillTypeName   string|nil
+---@param updateFractions boolean|nil  false = skip area update, only record product name
+function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName, updateFractions)
     if not liters or liters <= 0 then return end
     local field = self.fieldData[fieldId]
     if not field then return end
 
+    if fillTypeName then field.sessionLastProduct = fillTypeName end
+
+    -- Fertilizer products: coverage is handled by markBoomCells (cell dedup).
+    if updateFractions == false then return end
+
+    -- Crop protection fallback: liter-based area estimate (no boom position available).
     local areaInHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
 
-    -- Look up the reference application rate for this product (L/ha or kg/ha).
-    -- liters / ratePerHa gives the hectares covered this tick.
     local baseRates = SoilConstants.SPRAYER_RATE and SoilConstants.SPRAYER_RATE.BASE_RATES
     local rateEntry = fillTypeName and baseRates and (baseRates[fillTypeName] or baseRates.DEFAULT)
     local ratePerHa = (rateEntry and rateEntry.value and rateEntry.value > 0) and rateEntry.value or 93.5
@@ -2461,10 +2473,8 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName)
     local prevCoverage = field.coverageFraction or 0
     field.coverageFraction = math.min(1.0, field.coveredAreaHa / areaInHa)
 
-    -- Session accumulator: persists across daily resets, clears only on harvest
     field.sessionCoverageHa       = math.min(areaInHa, (field.sessionCoverageHa or 0) + areaThisTick)
     field.sessionCoverageFraction = math.min(1.0, field.sessionCoverageHa / areaInHa)
-    if fillTypeName then field.sessionLastProduct = fillTypeName end
 
     local milestones = { 0.10, 0.25, 0.50, 0.75, 1.0 }
     for _, m in ipairs(milestones) do
@@ -2476,9 +2486,10 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName)
     end
 end
 
---- Stamp display-only zone cells at every position in boomPoints.
---- No nutrient delta is applied; each new cell is initialised with the current
---- field average so the PDA map shows which areas the boom has passed over.
+--- Stamp zone cells at every position in boomPoints and update cell-deduped coverage.
+--- Coverage (session + daily) is incremented only for cells not previously visited,
+--- eliminating overlap inflation from headland turns and second passes.
+--- Also stamps visual overlay entries (zoneData) for the PDA map.
 --- Called from HookManager after applySingle to fill in the full lateral sweep.
 ---@param fieldId   number
 ---@param boomPoints table  Array of {x=, z=} world positions
@@ -2487,7 +2498,14 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
     local field = self.fieldData and self.fieldData[fieldId]
     if not field then return end
 
-    local zone = SoilConstants.ZONE
+    local zone     = SoilConstants.ZONE
+    local cellArea = zone.CELL_AREA_HA  -- 0.01 ha per 10×10 m cell
+    local areaInHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
+
+    if not field.sessionCoverageCells then field.sessionCoverageCells = {} end
+    if not field.dailyCoverageCells   then field.dailyCoverageCells   = {} end
+    if not field.zoneData             then field.zoneData             = {} end
+
     local seen = {}
     for _, pt in ipairs(boomPoints) do
         local cx = math.floor(pt.x / zone.CELL_SIZE)
@@ -2495,10 +2513,19 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
         local cellKey = tostring(cx * 10000 + cz)
         if not seen[cellKey] then
             seen[cellKey] = true
-            if not field.zoneData then field.zoneData = {} end
-            -- Enforce cell cap: existing cells are always synced via applyFertilizer,
-            -- so skipping new ones beyond the cap only affects sub-field visual detail,
-            -- not correctness of the aggregate nutrient values.
+
+            -- ── Coverage deduplication ─────────────────────────────────────────
+            if not field.sessionCoverageCells[cellKey] then
+                field.sessionCoverageCells[cellKey] = true
+                field.sessionCoverageHa = math.min(areaInHa, (field.sessionCoverageHa or 0) + cellArea)
+            end
+            if not field.dailyCoverageCells[cellKey] then
+                field.dailyCoverageCells[cellKey] = true
+                field.coveredAreaHa = math.min(areaInHa, (field.coveredAreaHa or 0) + cellArea)
+            end
+
+            -- ── Visual overlay (zoneData) ──────────────────────────────────────
+            -- Enforce cell cap: only affects sub-field visual detail, not coverage accuracy.
             local canWrite = true
             if field.zoneData[cellKey] == nil then
                 local count = 0
@@ -2506,8 +2533,6 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
                 if count >= MAX_ZONE_CELLS then canWrite = false end
             end
             if canWrite then
-                -- Always sync to current field values so lateral boom cells reflect the
-                -- fertilizer that was just applied, not stale values from a previous pass.
                 field.zoneData[cellKey] = {
                     N  = field.nitrogen       or SoilConstants.FIELD_DEFAULTS.nitrogen,
                     P  = field.phosphorus     or SoilConstants.FIELD_DEFAULTS.phosphorus,
@@ -2522,6 +2547,10 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
             end
         end
     end
+
+    -- Recompute fractions after all cells are processed
+    field.coverageFraction        = math.min(1.0, (field.coveredAreaHa  or 0) / areaInHa)
+    field.sessionCoverageFraction = math.min(1.0, (field.sessionCoverageHa or 0) / areaInHa)
 end
 
 --- Direct-path buffering for non-profile products (Herbicide/Insecticide/Fungicide)
@@ -3031,6 +3060,12 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             initialized = true,
             nutrientBuffer = {},
             zoneData = {},
+            coveredAreaHa = 0,
+            dailyCoverageCells = {},
+            sessionCoverageHa = 0,
+            sessionCoverageFraction = 0,
+            sessionCoverageCells = {},
+            sessionLastProduct = nil,
         }
 
         -- Load daily application throttles

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -758,8 +758,11 @@ SoilConstants.WEED_PRESSURE = {
         HERBICIDE = 1.0,
         PESTICIDE = 0.8,
     },
-    -- Pressure points removed on a single herbicide application
-    HERBICIDE_PRESSURE_REDUCTION = 30,
+    -- Pressure points removed on a single herbicide application.
+    -- One full-field pass at the reference rate (BASE_RATES.HERBICIDE = 1.5 L/ha) removes this
+    -- many points. 50 ensures MEDIUM tier (0–50) is fully cleared in one pass, while PEAK (75–100)
+    -- still requires multiple treatments (100−50=50 → MEDIUM; 75−50=25 → below LOW).
+    HERBICIDE_PRESSURE_REDUCTION = 50,
     -- Canopy Suppression (Issue #327)
     -- Crops block sunlight, slowing or stopping weed growth as they mature.
     CANOPY_SUPPRESSION_THRESHOLD = 0.5, -- Crop growth state % (0.0 to 1.0) where suppression begins
@@ -832,8 +835,9 @@ SoilConstants.PEST_PRESSURE = {
     INSECTICIDE_TYPES = {
         INSECTICIDE = 1.0,
     },
-    -- Pressure points removed on a single insecticide application
-    INSECTICIDE_PRESSURE_REDUCTION = 25,
+    -- Pressure points removed on a single insecticide application.
+    -- 50 ensures MEDIUM tier (0–50) is fully cleared in one pass at the reference rate.
+    INSECTICIDE_PRESSURE_REDUCTION = 50,
     -- Days insecticide suppresses pest growth after application
     INSECTICIDE_DURATION_DAYS = 30,
 
@@ -899,8 +903,9 @@ SoilConstants.DISEASE_PRESSURE = {
     FUNGICIDE_TYPES = {
         FUNGICIDE = 1.0,
     },
-    -- Pressure points removed on a single fungicide application
-    FUNGICIDE_PRESSURE_REDUCTION = 20,
+    -- Pressure points removed on a single fungicide application.
+    -- 50 ensures MEDIUM tier (0–50) is fully cleared in one pass at the reference rate.
+    FUNGICIDE_PRESSURE_REDUCTION = 50,
     -- Days fungicide suppresses disease growth after application
     FUNGICIDE_DURATION_DAYS = 35,
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -188,11 +188,12 @@ SoilConstants.FALLOW_RECOVERY = {
 -- ========================================
 -- When a combine chops straw instead of dropping it, the material decomposes
 -- into the soil and adds organic matter (realistic agricultural behaviour).
--- Rate is per 1000L of harvested crop, scaled by strawRatio (0.0-1.0).
--- Example: 5000L wheat, strawRatio=0.5 → 5 × 0.5 × 0.20 = 0.50 OM
--- (comparable to one plowing event on the 0-10 OM scale)
+-- OM is a concentration — gain uses (areaHa / fieldAreaHa) * strawRatio * OM_RATE.
+-- A complete field harvest at strawRatio=1.0 adds exactly OM_RATE to the field,
+-- regardless of field size. Partial passes add a proportional fraction.
+-- Example: full 5ha field, strawRatio=0.5 → 0.5 × 0.20 = 0.10 OM
 SoilConstants.CHOPPED_STRAW = {
-    OM_RATE = 0.20,   -- OM gain per 1000L harvested at full strawRatio=1.0
+    OM_RATE = 0.20,   -- OM gain per full-field harvest at strawRatio=1.0
 }
 
 -- ========================================

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1363,8 +1363,12 @@ function HookManager:installSprayerAreaHook()
                 local x, _, z = getWorldTranslation(self.rootNode)
                 if not x then return end
 
-                -- PHASE 5: route through shared MapDataGrid-backed cache
-                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                -- PHASE 5: route through shared MapDataGrid-backed cache.
+                -- skipNegativeCache=true: if the cache has a stale -1 for this position
+                -- (queried before the field was registered, e.g. freshly-purchased land),
+                -- fall through to the live g_fieldManager slow-path query rather than
+                -- returning nil and silently dropping the fertilizer application.
+                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z, true)
 
                 -- Fallback: try the midpoints of work areas on attached implements
                 if not fieldId or fieldId <= 0 then
@@ -1375,13 +1379,13 @@ function HookManager:installSprayerAreaHook()
                             if obj then
                                 -- Try implement rootNode first
                                 local ix, _, iz = getWorldTranslation(obj.rootNode)
-                                if ix then fieldId = hookMgrRef:getFieldIdAtWorldPosition(ix, iz) end
+                                if ix then fieldId = hookMgrRef:getFieldIdAtWorldPosition(ix, iz, true) end
                                 -- Then try each work area start point
                                 if (not fieldId or fieldId <= 0) and obj.spec_workArea and obj.spec_workArea.workAreas then
                                     for _, wa in ipairs(obj.spec_workArea.workAreas) do
                                         if wa.start then
                                             local sx, _, sz = getWorldTranslation(wa.start)
-                                            if sx then fieldId = hookMgrRef:getFieldIdAtWorldPosition(sx, sz) end
+                                            if sx then fieldId = hookMgrRef:getFieldIdAtWorldPosition(sx, sz, true) end
                                         end
                                         if fieldId and fieldId > 0 then break end
                                     end
@@ -1392,7 +1396,11 @@ function HookManager:installSprayerAreaHook()
                     end
                 end
 
-                if not fieldId or fieldId <= 0 then return end
+                if not fieldId or fieldId <= 0 then
+                    SoilLogger.debug("SprayerHook: no field at rootNode (%.1f,%.1f) — skipping %s apply",
+                        x, z, fillType and fillType.name or "?")
+                    return
+                end
 
                 -- Apply rate multiplier
                 local rm = g_SoilFertilityManager.sprayerRateManager

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1152,11 +1152,9 @@ function HookManager:installMowerHook()
 
             -- lastStatsArea: density-map pixels processed this tick (same unit as Cutter's lastArea)
             local area = spec.workAreaParameters.lastStatsArea or 0
-            local fruitType = spec.workAreaParameters.lastInputFruitType
-
-            SoilLogger.debug("[MowerHook] fired: area=%.1f fruitType=%s", area, tostring(fruitType))
-
             if area <= 0 then return end
+
+            local fruitType = spec.workAreaParameters.lastInputFruitType
 
             if not fruitType or fruitType <= 0 then return end
 
@@ -1451,9 +1449,13 @@ function HookManager:installSprayerAreaHook()
                 -- but PF's nitrogen density map painting is triggered by PF's own hook
                 -- checking workAreaParameters.sprayFillType against its fertilizerFillTypes
                 -- table — and our custom fill types don't pass that check natively.
-                -- By swapping to a scaled LIQUIDFERTILIZER volume we guarantee PF paints
-                -- the correct N amount regardless of THPF presence.
+                -- By swapping to a scaled LIQUIDFERTILIZER volume we signal PF to paint
+                -- the correct N amount for the next frame when PF re-reads workAreaParameters.
                 -- SF's own nutrient accounting already ran above using the real fill type.
+                -- TIMING NOTE: both hooks are appendedFunctions on onEndWorkAreaProcessing.
+                -- PF loads before SF (alphabetical order), so PF's hook fires first this frame.
+                -- The swap is visible to PF on the following frame; the engine resets
+                -- sprayFillType/usage in onStartWorkAreaProcessing so no persistent corruption.
                 do
                     local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
                     if pfBridge and pfBridge.isActive and g_fillTypeManager then

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1228,10 +1228,12 @@ function HookManager:installSprayerAreaHook()
             -- Runs once on the first spray event where a PF extendedSprayer spec is found.
             -- PF adds extendedSprayer to ALL sprayers when active, so any sprayer triggers this.
             local pfBridge = g_SoilFertilityManager.pfBridge
-            if pfBridge and pfBridge.isActive and not pfBridge.fillTypesInjected then
+            -- Fill type injection: only needed when THPF Configurator is absent.
+            -- When THPF is loaded it reads our <thPFConfig> block and handles this natively.
+            if pfBridge and pfBridge.isActive and not pfBridge.thpfActive and not pfBridge.fillTypesInjected then
                 local pfSpec = self["spec_FS25_precisionFarming.extendedSprayer"]
                 if pfSpec then
-                    SoilLogger.info("[PFBridge] Injecting SF fill types into PF nitrogen map...")
+                    SoilLogger.info("[PFBridge] Injecting SF fill types into PF nitrogen map (fallback — THPF absent)...")
                     pfBridge:injectCustomFillTypes(pfSpec.nitrogenMap)
                 end
             end
@@ -1439,10 +1441,13 @@ function HookManager:installSprayerAreaHook()
                     end
                 end
 
-                -- PF N relay: SF's hook fires before PF's (FS25_SoilFertilizer < FS25_precisionFarming
-                -- alphabetically, so SF appended first → runs first).
-                -- For SF custom N-bearing fill types, swap workAreaParameters to an equivalent
-                -- LIQUIDFERTILIZER volume so PF's hook paints the nitrogen map with the right amount.
+                -- PF N relay: fires whenever PF is active (with or without THPF).
+                -- THPF handles HUD recognition and application rate recommendations,
+                -- but PF's nitrogen density map painting is triggered by PF's own hook
+                -- checking workAreaParameters.sprayFillType against its fertilizerFillTypes
+                -- table — and our custom fill types don't pass that check natively.
+                -- By swapping to a scaled LIQUIDFERTILIZER volume we guarantee PF paints
+                -- the correct N amount regardless of THPF presence.
                 -- SF's own nutrient accounting already ran above using the real fill type.
                 do
                     local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1224,6 +1224,18 @@ function HookManager:installSprayerAreaHook()
                 return
             end
 
+            -- Phase 3: Inject SF's custom fill types into PF's nitrogen recognition tables.
+            -- Runs once on the first spray event where a PF extendedSprayer spec is found.
+            -- PF adds extendedSprayer to ALL sprayers when active, so any sprayer triggers this.
+            local pfBridge = g_SoilFertilityManager.pfBridge
+            if pfBridge and pfBridge.isActive and not pfBridge.fillTypesInjected then
+                local pfSpec = self["spec_FS25_precisionFarming.extendedSprayer"]
+                if pfSpec then
+                    SoilLogger.info("[PFBridge] Injecting SF fill types into PF nitrogen map...")
+                    pfBridge:injectCustomFillTypes(pfSpec.nitrogenMap)
+                end
+            end
+
             local spec = self.spec_sprayer
             if not spec or not spec.workAreaParameters then return end
 
@@ -1424,6 +1436,29 @@ function HookManager:installSprayerAreaHook()
                     local boomPts = hookMgrRef:getBoomCellPositions(self, rootX, rootZ)
                     if boomPts then
                         soilSys:markBoomCells(fieldId, boomPts)
+                    end
+                end
+
+                -- PF N relay: SF's hook fires before PF's (FS25_SoilFertilizer < FS25_precisionFarming
+                -- alphabetically, so SF appended first → runs first).
+                -- For SF custom N-bearing fill types, swap workAreaParameters to an equivalent
+                -- LIQUIDFERTILIZER volume so PF's hook paints the nitrogen map with the right amount.
+                -- SF's own nutrient accounting already ran above using the real fill type.
+                do
+                    local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+                    if pfBridge and pfBridge.isActive and g_fillTypeManager then
+                        local nKgPerL = PrecisionFarmingBridge.SF_FILL_TYPE_N_AMOUNTS[fillType.name]
+                        if nKgPerL and nKgPerL > 0 then
+                            local lfFT = g_fillTypeManager:getFillTypeByName("LIQUIDFERTILIZER")
+                            if lfFT then
+                                local scaledLiters = liters * (nKgPerL / PrecisionFarmingBridge.PF_LF_N_KG_PER_L)
+                                spec.workAreaParameters.sprayFillType = lfFT.index
+                                spec.workAreaParameters.usage = scaledLiters
+                                SoilLogger.debug("[PFRelay] %s → LIQUIDFERTILIZER x%.3f (%.2fL → %.2fL)",
+                                    fillType.name, nKgPerL / PrecisionFarmingBridge.PF_LF_N_KG_PER_L,
+                                    liters, scaledLiters)
+                            end
+                        end
                     end
                 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1003,6 +1003,28 @@ function HookManager:installHarvestHook()
         end
     end
 
+    -- Late-patch combines spawned AFTER hook installation.
+    -- FS25's specialization system captures the Combine.addCutterArea reference at
+    -- vehicle-type registration time (before our hook). New vehicles of combine types
+    -- use that captured original as their instance method, bypassing the class-level
+    -- replacement. Hooking VehicleSystem:addVehicle ensures every combine — including
+    -- mod vehicles bought from the shop mid-session — gets the wrapper on first spawn.
+    if type(VehicleSystem) == "table" and type(VehicleSystem.addVehicle) == "function" then
+        local origAddVehicle = VehicleSystem.addVehicle
+        VehicleSystem.addVehicle = function(vsSelf, vehicle)
+            local r = origAddVehicle(vsSelf, vehicle)
+            if vehicle and vehicle.spec_combine and type(vehicle.addCutterArea) == "function" then
+                if vehicle.addCutterArea ~= Combine.addCutterArea then
+                    vehicle.addCutterArea = makeHarvestWrapper(vehicle.addCutterArea)
+                    SoilLogger.debug("[HarvestHook] Late-patched new combine: %s",
+                        tostring(vehicle.configFileName or vehicle.typeName or "?"))
+                end
+            end
+            return r
+        end
+        self:register(VehicleSystem, "addVehicle", origAddVehicle, "VehicleSystem.addVehicle (harvest late-patch)")
+    end
+
     SoilLogger.info("[OK] Harvest hook installed (Combine.addCutterArea) — %d existing combines patched", patched)
     return true
 end
@@ -1301,6 +1323,37 @@ function HookManager:installSprayerAreaHook()
                 local diseaseOnlyDirect = diseaseEffectiveness and not isFertilizer
 
                 if not isFertilizer and not herbOnlyDirect and not pestOnlyDirect and not diseaseOnlyDirect then return end
+
+                -- PF mode: validate fertilizer was actually consumed before crediting nutrients.
+                -- PF's extendedSprayer can block tank drain (when field is at target N) without
+                -- clearing wap.usage. Compare current fill level against sprayFillLevel (captured
+                -- at frame start by vanilla onStartWorkAreaProcessing) — if unchanged, PF skipped
+                -- the application and we must not credit nutrients for product that wasn't used.
+                -- External-fill (BUY) mode is exempt: the tank intentionally stays full there.
+                do
+                    local pfBridgeRef = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+                    if pfBridgeRef and pfBridgeRef.isActive and isFertilizer then
+                        local PF_OWNED = { FERTILIZER=true, LIQUIDFERTILIZER=true, MANURE=true, LIQUIDMANURE=true, DIGESTATE=true }
+                        if PF_OWNED[fillType.name] then
+                            local wap = spec.workAreaParameters
+                            local isExternalFill = wap and (wap.sprayVehicle == nil)
+                            if not isExternalFill then
+                                local fuIdx = nil
+                                pcall(function() fuIdx = self:getSprayerFillUnitIndex() end)
+                                if fuIdx then
+                                    local curLevel = nil
+                                    pcall(function() curLevel = self:getFillUnitFillLevel(fuIdx) end)
+                                    -- 0.01 L tolerance for float rounding in fill level calculations
+                                    if curLevel and curLevel >= sprayFillLevel - 0.01 then
+                                        SoilLogger.debug("[PFBridge] fill unchanged (%.2fL >= %.2fL start) — PF blocked consumption, skipping SF update",
+                                            curLevel, sprayFillLevel)
+                                        return
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
 
                 -- Resolve field from vehicle root position.
                 -- When the tractor body straddles a field boundary (common on edge fields),

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1353,10 +1353,15 @@ function HookManager:installSprayerAreaHook()
                 -- gates each work area on section.isActive), so 'liters' is already proportionally reduced.
                 -- Do NOT multiply by coverageFraction again, otherwise we quadratically penalize the dosage.
 
-                -- ── Coverage tracking (raw liters, before rateMultiplier) ─────────
-                -- Must run for ALL product types (fertilizer AND crop protection).
+                -- ── Coverage tracking ──────────────────────────────────────────────
+                -- updateFractions=false: markBoomCells (called below) owns coverage for
+                -- fertilizers via spatial cell deduplication. trackSprayerCoverage here
+                -- only records the product name for the HUD label.
+                -- Crop protection direct paths (herbicide/insecticide/fungicide) call
+                -- trackSprayerCoverage with default updateFractions=true since they have
+                -- no boomPoints.
                 if g_SoilFertilityManager.soilSystem then
-                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name)
+                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, false)
                 end
 
                 -- ── Sub-field section attribution (issue #300) ────────────────────

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -1,22 +1,23 @@
 -- =========================================================
 -- FS25 Realistic Soil & Fertilizer - Precision Farming Bridge
 -- =========================================================
--- Safe read-only wrapper around g_precisionFarming.
+-- Safe cross-mod wrapper around Precision Farming.
 --
 -- PF's Lua source is compiled/obfuscated. This bridge uses the
--- standard Giants global convention and wraps every call in pcall()
--- so any API change in a PF update silently falls back to SF
--- standalone mode rather than crashing.
+-- g_modManager channel (shared C++ object) for detection and wraps
+-- every API call in pcall() so any PF update silently falls back to
+-- SF standalone mode rather than crashing.
 --
 -- OPERATING MODES
 --   Standalone (PF absent or probe failed):
 --     isActive = false — SF runs exactly as before, full N/P/K/pH/OM
---   PF Mode (PF active + API verified):
---     isActive = true — caller gates N/pH behaviour on this flag
+--   PF Mode (PF active):
+--     isActive = true — SF excludes N from yield-penalty averaging
+--     (PF's ExtendedCombine already applies an N-based penalty)
+--     HookManager relays SF fill types to PF's nitrogen map via
+--     a LIQUIDFERTILIZER volume swap (Phase 3 relay).
 --
--- PHASE 1 SCOPE (detection + diagnostics only)
---   No simulation changes are made here.
---   Use SoilPFDump console command to inspect the live PF global.
+-- Use SoilPFDump console command for live API diagnostics.
 -- =========================================================
 -- Author: TisonK
 -- =========================================================
@@ -41,7 +42,7 @@ function PrecisionFarmingBridge:new()
     o.nitrogenMap = nil
     o.phMap       = nil
     o.soilMap     = nil
-    o.yieldMap    = nil
+    o.yieldMap    = nil     -- reserved: PF does not yet expose yield map via a shared C++ object
     return o
 end
 
@@ -206,9 +207,11 @@ end
 ---@param sampler function(x, z) -> number|nil
 ---@return number|nil average of non-nil samples
 function PrecisionFarmingBridge:_sampleFieldGrid(field, sampler)
-    -- Determine field centre and approximate half-extents
-    local cx = field.posX or (field.worldX) or 0
-    local cz = field.posZ or (field.worldZ) or 0
+    local cx = field.posX or field.worldX or 0
+    local cz = field.posZ or field.worldZ or 0
+    if cx == 0 and cz == 0 then
+        SoilLogger.debug("[PFBridge] _sampleFieldGrid: no position found on field object — sampling around world origin")
+    end
     -- Use a fixed half-size of 30 m; fine for diagnostic/calibration purposes
     local hw = 30
     local sum, count = 0, 0
@@ -264,7 +267,7 @@ function PrecisionFarmingBridge:injectCustomFillTypes(nitrogenMap)
     end
 
     local fillTypes = nitrogenMap.fertilizerFillTypes
-    local ok = pcall(function()
+    local ok, errMsg = pcall(function()
         local injected = 0
         for fillTypeName in pairs(self.SF_FILL_TYPE_N_AMOUNTS) do
             if g_fillTypeManager then
@@ -279,7 +282,7 @@ function PrecisionFarmingBridge:injectCustomFillTypes(nitrogenMap)
     end)
 
     if not ok then
-        SoilLogger.warning("[PFBridge] injectCustomFillTypes: pcall failed")
+        SoilLogger.warning("[PFBridge] injectCustomFillTypes: pcall failed — %s", tostring(errMsg))
     end
     self.fillTypesInjected = true
 end
@@ -309,8 +312,8 @@ end
 -- DIAGNOSTICS
 -- =========================================================
 
---- Dump the full g_precisionFarming global to the game log.
---- Also scans for the actual PF global name if the default is nil.
+--- Dump Precision Farming detection state and API discovery to the game log.
+--- Uses g_modManager and g_specializationManager (shared C++ objects, cross-mod visible).
 --- Run via SoilPFDump console command.
 function PrecisionFarmingBridge:dumpApi()
     print("[SoilPFDump] ===== Precision Farming API discovery =====")

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -37,6 +37,7 @@ function PrecisionFarmingBridge:new()
     local o = setmetatable({}, PrecisionFarmingBridge_mt)
     o.isActive    = false
     o.apiVerified = false
+    o.thpfActive  = false   -- true when FS25_0_THPFConfigurator is also loaded
     o.nitrogenMap = nil
     o.phMap       = nil
     o.soilMap     = nil
@@ -108,9 +109,24 @@ function PrecisionFarmingBridge:initialize()
         end
     end
 
-    if not self.canReadMaps then
-        SoilLogger.info("[PFBridge] PF Mode active (detection only). " ..
-            "N/pH yield penalties suppressed. Map read API not available.")
+    -- Detect [TH] Precision Farming Configurator (FS25_0_THPFConfigurator).
+    -- When present, it reads our <thPFConfig> block from modDesc.xml and injects
+    -- our fill types into PF's nitrogen/pH maps directly — no relay needed.
+    if g_modManager then
+        local ok, thpfMod = pcall(function()
+            return g_modManager:getModByName("FS25_0_THPFConfigurator")
+        end)
+        if ok and thpfMod ~= nil then
+            self.thpfActive = true
+        end
+    end
+
+    if self.thpfActive then
+        SoilLogger.info("[PFBridge] Mode: PF + THPF Configurator — fill type integration via modDesc.xml declarations")
+    elseif self.canReadMaps then
+        SoilLogger.info("[PFBridge] Mode: PF standalone (map read enabled) — relay active for custom fill types")
+    else
+        SoilLogger.info("[PFBridge] Mode: PF standalone (detection only) — relay active for custom fill types")
     end
 
     -- PHASE 5 NOTE: Write-back to PF's nitrogenMap/phMap is not currently possible.

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -112,6 +112,16 @@ function PrecisionFarmingBridge:initialize()
         SoilLogger.info("[PFBridge] PF Mode active (detection only). " ..
             "N/pH yield penalties suppressed. Map read API not available.")
     end
+
+    -- PHASE 5 NOTE: Write-back to PF's nitrogenMap/phMap is not currently possible.
+    -- FS25 mods run in isolated Lua environments; there is no cross-mod write API
+    -- on any shared C++ object. SF changes to N (rain leaching, seasonal effects,
+    -- fallow recovery) cannot propagate to PF's spatial maps in this architecture.
+    -- If a future PF version exposes a write API on g_currentMission, implement
+    -- write-back here: call setValueAtWorldPos(x, z, value) inside a pcall() guard,
+    -- converting SF's 0-100 scale back to kg/ha via (value / 100) * PF_N_MAX_KG_HA.
+    self.canWriteMaps = false
+
     return true
 end
 
@@ -196,6 +206,66 @@ function PrecisionFarmingBridge:_sampleFieldGrid(field, sampler)
         end
     end
     return count > 0 and (sum / count) or nil
+end
+
+-- =========================================================
+-- PF FILL TYPE INJECTION
+-- =========================================================
+
+-- N content (kg N per litre) for SF's custom nitrogen fill types.
+-- Used by the PF relay mechanism: when one of these is sprayed, our hook swaps
+-- workAreaParameters to an equivalent LIQUIDFERTILIZER volume before PF's hook fires,
+-- so PF paints its nitrogen map with the correct N amount.
+-- Calibrated to real-world chemistry relative to PF's baseline:
+--   FERTILIZER       = 0.27 kg N/L
+--   LIQUIDFERTILIZER = 0.39 kg N/L  ← relay reference
+PrecisionFarmingBridge.SF_FILL_TYPE_N_AMOUNTS = {
+    UAN32         = 0.42,   -- UAN 32% N solution, density ~1.32 kg/L
+    UAN28         = 0.37,   -- UAN 28% N solution, density ~1.28 kg/L
+    ANHYDROUS     = 0.50,   -- Anhydrous ammonia 82% N (volume basis)
+    AMS           = 0.21,   -- Ammonium sulfate 21% N
+    UREA          = 0.46,   -- Urea 46% N
+    AN            = 0.34,   -- Ammonium nitrate 34.5% N
+    LIQUID_UREA   = 0.32,   -- Liquid urea solution ~29% N
+    LIQUID_AMS    = 0.24,   -- AMS solution ~21% N
+    LIQUID_DAP    = 0.18,   -- DAP solution 18-46-0
+    LIQUID_MAP    = 0.11,   -- MAP solution 11-52-0
+    -- LIQUID_POTASH: 0% N — not relayed
+}
+
+-- PF's LIQUIDFERTILIZER N content (from PrecisionFarming.xml <nAmount>) used as relay baseline.
+PrecisionFarmingBridge.PF_LF_N_KG_PER_L = 0.39
+
+--- Register SF's custom fill types in PF's recognition set (fertilizerFillTypes).
+--- This makes PF's UI show the type in its sprayer panel.
+--- N map painting is handled by the relay in HookManager, not by PF's internal lookup.
+---@param nitrogenMap table PF nitrogenMap object from extendedSprayer spec
+function PrecisionFarmingBridge:injectCustomFillTypes(nitrogenMap)
+    if not nitrogenMap or not nitrogenMap.fertilizerFillTypes then
+        SoilLogger.warning("[PFBridge] injectCustomFillTypes: fertilizerFillTypes not found — skipping")
+        self.fillTypesInjected = true
+        return
+    end
+
+    local fillTypes = nitrogenMap.fertilizerFillTypes
+    local ok = pcall(function()
+        local injected = 0
+        for fillTypeName in pairs(self.SF_FILL_TYPE_N_AMOUNTS) do
+            if g_fillTypeManager then
+                local ft = g_fillTypeManager:getFillTypeByName(fillTypeName)
+                if ft and ft.index then
+                    fillTypes[ft.index] = ft.index
+                    injected = injected + 1
+                end
+            end
+        end
+        SoilLogger.info("[PFBridge] Registered %d SF fill types in PF recognition set", injected)
+    end)
+
+    if not ok then
+        SoilLogger.warning("[PFBridge] injectCustomFillTypes: pcall failed")
+    end
+    self.fillTypesInjected = true
 end
 
 -- =========================================================

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -1,0 +1,308 @@
+-- =========================================================
+-- FS25 Realistic Soil & Fertilizer - Precision Farming Bridge
+-- =========================================================
+-- Safe read-only wrapper around g_precisionFarming.
+--
+-- PF's Lua source is compiled/obfuscated. This bridge uses the
+-- standard Giants global convention and wraps every call in pcall()
+-- so any API change in a PF update silently falls back to SF
+-- standalone mode rather than crashing.
+--
+-- OPERATING MODES
+--   Standalone (PF absent or probe failed):
+--     isActive = false — SF runs exactly as before, full N/P/K/pH/OM
+--   PF Mode (PF active + API verified):
+--     isActive = true — caller gates N/pH behaviour on this flag
+--
+-- PHASE 1 SCOPE (detection + diagnostics only)
+--   No simulation changes are made here.
+--   Use SoilPFDump console command to inspect the live PF global.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class PrecisionFarmingBridge
+PrecisionFarmingBridge = {}
+local PrecisionFarmingBridge_mt = { __index = PrecisionFarmingBridge }
+
+-- PF nitrogen map range (from PrecisionFarming.xml: 45 states, 0-220 kg/ha)
+PrecisionFarmingBridge.PF_N_MAX_KG_HA = 220
+-- PF pH map range (from PrecisionFarming.xml: 32 states, 4.5-8.25)
+PrecisionFarmingBridge.PF_PH_MIN = 4.5
+PrecisionFarmingBridge.PF_PH_MAX = 8.25
+
+--- Create a new (uninitialised) bridge instance.
+---@return PrecisionFarmingBridge
+function PrecisionFarmingBridge:new()
+    local o = setmetatable({}, PrecisionFarmingBridge_mt)
+    o.isActive    = false
+    o.apiVerified = false
+    o.nitrogenMap = nil
+    o.phMap       = nil
+    o.soilMap     = nil
+    o.yieldMap    = nil
+    return o
+end
+
+--- Detect PF via g_modManager (the only reliable cross-mod channel in FS25).
+--- Each mod runs in its own Lua env, so getfenv(0) globals are NOT visible
+--- cross-mod. g_modManager is a shared C++ object visible to all mods.
+--- Must be called after mission is fully ready (deferred init phase).
+---@return boolean isActive
+function PrecisionFarmingBridge:initialize()
+    -- Primary: check g_modManager for the PF mod entry
+    local pfMod = nil
+    if g_modManager then
+        local ok, result = pcall(function()
+            return g_modManager:getModByName("FS25_precisionFarming")
+        end)
+        if ok then pfMod = result end
+    end
+
+    if pfMod == nil then
+        -- Secondary: check if PF's specializations were registered (vehicle spec check)
+        -- g_specializationManager is shared and populated by all mods at load time
+        local hasPFSpec = false
+        if g_specializationManager then
+            local ok, spec = pcall(function()
+                return g_specializationManager:getSpecializationByName("extendedSprayer")
+            end)
+            hasPFSpec = ok and spec ~= nil
+        end
+
+        if not hasPFSpec then
+            SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
+            return false
+        end
+
+        SoilLogger.info("[PFBridge] PF detected via specialization registry (g_modManager miss)")
+    else
+        SoilLogger.info("[PFBridge] PF detected via g_modManager: %s v%s",
+            tostring(pfMod.modName or pfMod.name or "?"),
+            tostring(pfMod.version or "?"))
+    end
+
+    -- PF is confirmed active. Map API is not cross-mod accessible (PF uses its
+    -- own env). We set isActive for simulation gating; canReadMaps stays false
+    -- unless a future PF version exposes maps on g_currentMission.
+    self.isActive    = true
+    self.apiVerified = false  -- no map API access in this version
+    self.canReadMaps = false
+
+    -- Try to find maps via g_currentMission (in case PF registered them there)
+    local mission = g_currentMission
+    if mission then
+        self.nitrogenMap = mission.nitrogenMap or mission.pfNitrogenMap
+        self.phMap       = mission.phMap       or mission.pfPhMap
+        self.soilMap     = mission.soilMap     or mission.pfSoilMap
+        if self.nitrogenMap or self.phMap then
+            local ok = pcall(function()
+                if self.nitrogenMap then self.nitrogenMap:getValueAtWorldPos(0,0) end
+                if self.phMap       then self.phMap:getValueAtWorldPos(0,0) end
+            end)
+            if ok then
+                self.apiVerified = true
+                self.canReadMaps = true
+                SoilLogger.info("[PFBridge] Map API found on g_currentMission — read enabled")
+            end
+        end
+    end
+
+    if not self.canReadMaps then
+        SoilLogger.info("[PFBridge] PF Mode active (detection only). " ..
+            "N/pH yield penalties suppressed. Map read API not available.")
+    end
+    return true
+end
+
+-- =========================================================
+-- READ API (all calls guarded with pcall)
+-- =========================================================
+
+--- Get nitrogen at world position.
+---@param x number world X
+---@param z number world Z
+---@return number|nil kg/ha (0-220), or nil on error/inactive
+function PrecisionFarmingBridge:getNitrogenAt(x, z)
+    if not self.isActive or not self.nitrogenMap then return nil end
+    local ok, val = pcall(function() return self.nitrogenMap:getValueAtWorldPos(x, z) end)
+    return ok and val or nil
+end
+
+--- Get pH at world position.
+---@param x number world X
+---@param z number world Z
+---@return number|nil pH (4.5-8.25), or nil on error/inactive
+function PrecisionFarmingBridge:getPhAt(x, z)
+    if not self.isActive or not self.phMap then return nil end
+    local ok, val = pcall(function() return self.phMap:getValueAtWorldPos(x, z) end)
+    return ok and val or nil
+end
+
+--- Get soil type at world position.
+---@param x number world X
+---@param z number world Z
+---@return number|nil soil type 1-4, or nil on error/inactive
+function PrecisionFarmingBridge:getSoilTypeAt(x, z)
+    if not self.isActive or not self.soilMap then return nil end
+    local ok, val = pcall(function() return self.soilMap:getValueAtWorldPos(x, z) end)
+    return ok and val or nil
+end
+
+--- Sample field average nitrogen by probing a 3x3 grid across field bounds.
+--- Returns the mean of all successful samples, or nil if no samples succeed.
+---@param field table FS25 field object (has .worldX, .worldZ, .fieldDimensions or similar)
+---@return number|nil average kg/ha
+function PrecisionFarmingBridge:getFieldNitrogenAvg(field)
+    if not self.isActive or not self.nitrogenMap then return nil end
+    if not field then return nil end
+    return self:_sampleFieldGrid(field, function(x, z)
+        local ok, v = pcall(function() return self.nitrogenMap:getValueAtWorldPos(x, z) end)
+        return ok and v or nil
+    end)
+end
+
+--- Sample field average pH by probing a 3x3 grid across field bounds.
+---@param field table FS25 field object
+---@return number|nil average pH (4.5-8.25)
+function PrecisionFarmingBridge:getFieldPhAvg(field)
+    if not self.isActive or not self.phMap then return nil end
+    if not field then return nil end
+    return self:_sampleFieldGrid(field, function(x, z)
+        local ok, v = pcall(function() return self.phMap:getValueAtWorldPos(x, z) end)
+        return ok and v or nil
+    end)
+end
+
+--- Internal: sample a 3x3 grid of world positions across a field and average the results.
+--- Uses field.posX / field.posZ if available, falls back to (0, 0) centre.
+---@param field table
+---@param sampler function(x, z) -> number|nil
+---@return number|nil average of non-nil samples
+function PrecisionFarmingBridge:_sampleFieldGrid(field, sampler)
+    -- Determine field centre and approximate half-extents
+    local cx = field.posX or (field.worldX) or 0
+    local cz = field.posZ or (field.worldZ) or 0
+    -- Use a fixed half-size of 30 m; fine for diagnostic/calibration purposes
+    local hw = 30
+    local sum, count = 0, 0
+    for ox = -1, 1 do
+        for oz = -1, 1 do
+            local v = sampler(cx + ox * hw, cz + oz * hw)
+            if v ~= nil then
+                sum   = sum + v
+                count = count + 1
+            end
+        end
+    end
+    return count > 0 and (sum / count) or nil
+end
+
+-- =========================================================
+-- UNIT CONVERSION HELPERS
+-- =========================================================
+
+--- Convert PF nitrogen (kg/ha) to SF internal scale (0-100).
+--- PF optimal for most crops is ~110-170 kg/ha; SF optimal is 55.
+--- We map 220 kg/ha → 100, so 110 kg/ha → 50 (SF "fair" threshold).
+---@param kgHa number
+---@return number 0-100
+function PrecisionFarmingBridge:nitrogenToSFScale(kgHa)
+    return math.min(100, math.max(0, (kgHa / self.PF_N_MAX_KG_HA) * 100))
+end
+
+--- Convert PF pH (4.5-8.25) to SF internal pH (5.0-7.5).
+--- Clamps to SF range.
+---@param pfPH number
+---@return number SF pH (5.0-7.5)
+function PrecisionFarmingBridge:pfPhToSF(pfPH)
+    return math.min(7.5, math.max(5.0, pfPH))
+end
+
+-- =========================================================
+-- DIAGNOSTICS
+-- =========================================================
+
+--- Dump the full g_precisionFarming global to the game log.
+--- Also scans for the actual PF global name if the default is nil.
+--- Run via SoilPFDump console command.
+function PrecisionFarmingBridge:dumpApi()
+    print("[SoilPFDump] ===== Precision Farming API discovery =====")
+    print(string.format("[SoilPFDump] Bridge status: isActive=%s  apiVerified=%s",
+        tostring(self.isActive), tostring(self.apiVerified)))
+
+    -- 1. g_modManager detection (primary cross-mod channel)
+    print("[SoilPFDump] ----- g_modManager check -----")
+    if g_modManager then
+        local ok, pfMod = pcall(function()
+            return g_modManager:getModByName("FS25_precisionFarming")
+        end)
+        if ok and pfMod then
+            print(string.format("[SoilPFDump]   FOUND: FS25_precisionFarming  name=%s  version=%s  isLoaded=%s",
+                tostring(pfMod.modName or pfMod.name or "?"),
+                tostring(pfMod.version or "?"),
+                tostring(pfMod.isLoaded or "?")))
+        elseif ok then
+            print("[SoilPFDump]   getModByName('FS25_precisionFarming') = nil")
+        else
+            print("[SoilPFDump]   getModByName error: " .. tostring(pfMod))
+        end
+
+        -- List all loaded mod names for reference
+        local ok2, mods = pcall(function() return g_modManager.mods end)
+        if ok2 and mods then
+            print("[SoilPFDump]   Loaded mods:")
+            for _, m in ipairs(mods) do
+                local n = m.modName or m.name or "?"
+                if tostring(n):lower():find("precis") or tostring(n):lower():find("farm") then
+                    print(string.format("[SoilPFDump]     %s  v%s", tostring(n), tostring(m.version or "?")))
+                end
+            end
+        end
+    else
+        print("[SoilPFDump]   g_modManager is nil")
+    end
+
+    -- 2. Specialization registry check
+    print("[SoilPFDump] ----- Specialization registry -----")
+    if g_specializationManager then
+        local pfSpecs = {"extendedSprayer","extendedCombine","extendedMower",
+                         "extendedSowingMachine","soilSampler","cropSensor","weedSpotSpray"}
+        for _, sname in ipairs(pfSpecs) do
+            local ok, spec = pcall(function()
+                return g_specializationManager:getSpecializationByName(sname)
+            end)
+            print(string.format("[SoilPFDump]   spec '%s' = %s", sname,
+                (ok and spec ~= nil) and "FOUND" or "nil"))
+        end
+    else
+        print("[SoilPFDump]   g_specializationManager is nil")
+    end
+
+    -- 3. g_currentMission — broad scan for any non-standard table/userdata fields
+    print("[SoilPFDump] ----- g_currentMission broad scan -----")
+    if g_currentMission then
+        local mOk, mErr = pcall(function()
+            -- Check specific PF candidate field names
+            local candidates = {
+                "precisionFarming","nitrogenMap","phMap","soilMap","yieldMap",
+                "coverMap","seedRateMap","pfMod","pf","precision",
+            }
+            for _, cname in ipairs(candidates) do
+                local v = g_currentMission[cname]
+                if v ~= nil then
+                    print(string.format("[SoilPFDump]   g_currentMission.%s = %s  FOUND", cname, type(v)))
+                end
+            end
+        end)
+        if not mOk then print("[SoilPFDump]   scan error: " .. tostring(mErr)) end
+    else
+        print("[SoilPFDump]   g_currentMission is nil")
+    end
+
+    -- 4. Bridge summary
+    print("[SoilPFDump] ----- Bridge status -----")
+    print(string.format("[SoilPFDump]   isActive=%s  canReadMaps=%s  apiVerified=%s",
+        tostring(self.isActive), tostring(self.canReadMaps or false), tostring(self.apiVerified)))
+    print("[SoilPFDump] ==========================================")
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -564,8 +564,7 @@ function soilStatus()
         local isClient = g_client ~= nil
 
         local pfBridge = g_SoilFertilityManager.pfBridge
-        local pfStatus = pfBridge and pfBridge.isActive and "ACTIVE (N/pH deferred to PF)"
-            or (g_precisionFarming ~= nil and "detected but bridge inactive" or "not detected")
+        local pfStatus = (pfBridge and pfBridge.isActive) and "ACTIVE (N/pH deferred to PF)" or "not detected"
         print(string.format(
             "=== Soil & Fertilizer Status ===\n" ..
             "Mode: %s\n" ..
@@ -643,24 +642,15 @@ function SoilSprayerDebug()
         tostring(spec._soilEffectsActive), tostring(spec._soilManagedFillType)))
 end
 
--- Dump Precision Farming global for API discovery
+-- Dump Precision Farming bridge status and API discovery to the log.
 function SoilPFDump()
     if g_SoilFertilityManager and g_SoilFertilityManager.pfBridge then
         g_SoilFertilityManager.pfBridge:dumpApi()
         return "PF dump written to log (check console output)"
-    else
-        -- Bridge not yet initialised — probe directly
-        if g_precisionFarming == nil then
-            print("[SoilPFDump] g_precisionFarming = nil — Precision Farming is not active")
-        else
-            print("[SoilPFDump] g_precisionFarming found but SF bridge not yet initialised")
-            print("[SoilPFDump] Top-level keys:")
-            for k, v in pairs(g_precisionFarming) do
-                print(string.format("[SoilPFDump]   .%s = %s", tostring(k), type(v)))
-            end
-        end
-        return "PF raw dump written (bridge not initialised yet)"
     end
+    -- Bridge created in SoilFertilityManager.new() so this only happens before mission load.
+    print("[SoilPFDump] SF bridge not yet initialised — load a savegame first, then run SoilPFDump")
+    return "Bridge not ready — load savegame first"
 end
 
 -- Expose global console functions

--- a/src/main.lua
+++ b/src/main.lua
@@ -66,6 +66,7 @@ source(modDirectory .. "src/network/NetworkEvents.lua")
 
 -- 6. Integrations
 source(modDirectory .. "src/integrations/SectionControlIntegration.lua")
+source(modDirectory .. "src/integrations/PrecisionFarmingBridge.lua")
 
 -- Register our custom density map height types with the DMHM mod file list.
 -- DensityMapHeightManager:loadMapData iterates modDensityHeightMapTypeFilenames and
@@ -547,6 +548,7 @@ function soilfertility()
         print("SoilResetSettings - Reset to defaults")
         print("SoilFieldInfo <fieldId> - Show field soil info")
         print("SoilSaveData - Force save soil data")
+        print("SoilPFDump - Dump Precision Farming API (for integration diagnostics)")
         print("")
         print("NOTE: In multiplayer, only server admins can change settings")
         print("================================")
@@ -561,11 +563,15 @@ function soilStatus()
         local isServer = g_server ~= nil
         local isClient = g_client ~= nil
 
+        local pfBridge = g_SoilFertilityManager.pfBridge
+        local pfStatus = pfBridge and pfBridge.isActive and "ACTIVE (N/pH deferred to PF)"
+            or (g_precisionFarming ~= nil and "detected but bridge inactive" or "not detected")
         print(string.format(
             "=== Soil & Fertilizer Status ===\n" ..
             "Mode: %s\n" ..
             "Role: %s\n" ..
             "Enabled: %s\n" ..
+            "Precision Farming: %s\n" ..
             "Fertility System: %s\n" ..
             "Nutrient Cycles: %s\n" ..
             "Fertilizer Costs: %s\n" ..
@@ -578,6 +584,7 @@ function soilStatus()
             isMultiplayer and "Multiplayer" or "Singleplayer",
             isServer and "Server" or (isClient and "Client" or "Unknown"),
             tostring(s.enabled),
+            pfStatus,
             tostring(s.fertilitySystem),
             tostring(s.nutrientCycles),
             tostring(s.fertilizerCosts),
@@ -636,10 +643,31 @@ function SoilSprayerDebug()
         tostring(spec._soilEffectsActive), tostring(spec._soilManagedFillType)))
 end
 
+-- Dump Precision Farming global for API discovery
+function SoilPFDump()
+    if g_SoilFertilityManager and g_SoilFertilityManager.pfBridge then
+        g_SoilFertilityManager.pfBridge:dumpApi()
+        return "PF dump written to log (check console output)"
+    else
+        -- Bridge not yet initialised — probe directly
+        if g_precisionFarming == nil then
+            print("[SoilPFDump] g_precisionFarming = nil — Precision Farming is not active")
+        else
+            print("[SoilPFDump] g_precisionFarming found but SF bridge not yet initialised")
+            print("[SoilPFDump] Top-level keys:")
+            for k, v in pairs(g_precisionFarming) do
+                print(string.format("[SoilPFDump]   .%s = %s", tostring(k), type(v)))
+            end
+        end
+        return "PF raw dump written (bridge not initialised yet)"
+    end
+end
+
 -- Expose global console functions
 getfenv(0)["soilfertility"] = soilfertility
 getfenv(0)["soilStatus"] = soilStatus
 getfenv(0)["SoilSprayerDebug"] = SoilSprayerDebug
+getfenv(0)["SoilPFDump"] = SoilPFDump
 getfenv(0)["soilEnable"] = function()
     if g_SoilFertilityManager and g_SoilFertilityManager.settingsGUI then
         return g_SoilFertilityManager.settingsGUI:consoleCommandSoilEnable()

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -686,14 +686,6 @@ function SoilSettingsGUI:consoleCommandPFDump()
         g_SoilFertilityManager.pfBridge:dumpApi()
         return "PF dump written — check the console output above"
     end
-    -- Bridge not yet initialised — probe directly
-    if g_precisionFarming == nil then
-        print("[SoilPFDump] g_precisionFarming = nil — Precision Farming is not active")
-        return "Precision Farming not detected"
-    end
-    print("[SoilPFDump] g_precisionFarming found but SF bridge not yet initialised")
-    for k, v in pairs(g_precisionFarming) do
-        print(string.format("[SoilPFDump]   .%s = %s", tostring(k), type(v)))
-    end
-    return "PF raw dump written (bridge not initialised yet)"
+    print("[SoilPFDump] SF bridge not yet initialised — load a savegame first, then run SoilPFDump")
+    return "Bridge not ready — load savegame first"
 end

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -43,6 +43,7 @@ function SoilSettingsGUI:registerConsoleCommands()
     addConsoleCommand("SoilSaveData", "Force save soil data", "consoleCommandSaveData", self)
     addConsoleCommand("SoilDebug", "Toggle debug mode", "consoleCommandDebug", self)
     addConsoleCommand("SoilDrainVehicle", "Drain custom fertilizer from current vehicle/implements (50% refund)", "consoleCommandDrainVehicle", self)
+    addConsoleCommand("SoilPFDump", "Dump Precision Farming bridge API for integration diagnostics", "consoleCommandPFDump", self)
     addConsoleCommand("soilfertility", "Show all soil commands", "consoleCommandHelp", self)
 
     SoilLogger.info("Console commands registered")
@@ -68,6 +69,7 @@ function SoilSettingsGUI:consoleCommandHelp()
     print("SoilSaveData - Force save soil data")
     print("SoilDebug - Toggle debug mode")
     print("SoilDrainVehicle - Drain custom fertilizer from vehicle/implements (50% refund)")
+    print("SoilPFDump - Dump Precision Farming API for integration diagnostics")
     print("soilSetState <fieldId> <N> <P> <K> <pH> <OM> - Set state for a field")
     print("soilRecoverField [fieldId] - Recover field to default values")
     print("==============================================")
@@ -677,4 +679,21 @@ function SoilSettingsGUI:consoleCommandRecoverField(fieldId)
     local msg = string.format("Field %d recovered to defaults.", fid)
     if not isServer then msg = msg .. " (Client only! Run on server to persist)" end
     return msg
+end
+
+function SoilSettingsGUI:consoleCommandPFDump()
+    if g_SoilFertilityManager and g_SoilFertilityManager.pfBridge then
+        g_SoilFertilityManager.pfBridge:dumpApi()
+        return "PF dump written — check the console output above"
+    end
+    -- Bridge not yet initialised — probe directly
+    if g_precisionFarming == nil then
+        print("[SoilPFDump] g_precisionFarming = nil — Precision Farming is not active")
+        return "Precision Farming not detected"
+    end
+    print("[SoilPFDump] g_precisionFarming found but SF bridge not yet initialised")
+    for k, v in pairs(g_precisionFarming) do
+        print(string.format("[SoilPFDump]   .%s = %s", tostring(k), type(v)))
+    end
+    return "PF raw dump written (bridge not initialised yet)"
 end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -793,9 +793,10 @@ end
 
 function SoilHUD:pHColor(pH)
     local poor, fair, good = self:palette()
-    if pH >= 6.5 and pH <= 7.0 then return good
-    elseif pH >= 5.5 and pH <= 7.5 then return fair
-    else return poor end
+    if pH >= 6.5 and pH <= 7.0 then return good            -- optimal band
+    elseif pH > 7.0 and pH <= 7.5 then return poor         -- over-limed: treat as poor so players stop adding lime
+    elseif pH >= 5.5 then return fair                       -- slightly acidic: fair
+    else return poor end                                    -- very acidic
 end
 
 function SoilHUD:omColor(om)

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1177,12 +1177,13 @@ end
 -- Returns the new cy after drawing the row.
 -- label must be "N", "P", or "K" — used to look up ppm conversion + thresholds.
 function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
-    local pad    = SoilHUD.PAD * s
-    local rowH   = SoilHUD.ROW_H * s
-    local barH   = SoilHUD.BAR_H * s
-    local barW   = SoilHUD.BAR_W * s
-    local tx     = px + pad
-    local col    = self:statusColor(nutrient.status)
+    local pad       = SoilHUD.PAD * s
+    local rowH      = SoilHUD.ROW_H * s
+    local barH      = SoilHUD.BAR_H * s
+    local barW      = SoilHUD.BAR_W * s
+    local tx        = px + pad
+    local col       = self:statusColor(nutrient.status)
+    local baseLabel = label:match("^%a+") or label   -- strip suffix like "*" from "N*"
 
     cy = cy - rowH
 
@@ -1232,9 +1233,9 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info,
     end
 
     -- Threshold tick marks (global poor/fair)
-    local thresholdKey = label == "N" and "nitrogen"
-                      or label == "P" and "phosphorus"
-                      or label == "K" and "potassium"
+    local thresholdKey = baseLabel == "N" and "nitrogen"
+                      or baseLabel == "P" and "phosphorus"
+                      or baseLabel == "K" and "potassium"
                       or nil
     if thresholdKey then
         local th = SoilConstants.STATUS_THRESHOLDS[thresholdKey]
@@ -1250,7 +1251,7 @@ function SoilHUD:drawNutrientRow(label, nutrient, px, cy, pw, s, fontMult, info,
     end
 
     -- Per-crop target tick at optimal level (bright cyan, taller than status ticks)
-    local cropTarget = info and info.cropTargets and info.cropTargets[label]
+    local cropTarget = info and info.cropTargets and info.cropTargets[baseLabel]
     if cropTarget then
         local tickW = 0.0008 * s
         local tickH = barH + 0.005 * s

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -995,7 +995,10 @@ function SoilHUD:drawPanel()
         local rateMultiplier = (rm and sprayer) and rm:getMultiplier(sprayer.id) or 1.0
 
         -- N / P / K rows
-        cy = self:drawNutrientRow("N", info.nitrogen,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
+        -- When PF is active, N is owned by PF's per-pixel map — label with * so players know
+        local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+        local nLabel = (pfBridge and pfBridge.isActive) and "N*" or "N"
+        cy = self:drawNutrientRow(nLabel, info.nitrogen,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
         cy = self:drawNutrientRow("P", info.phosphorus,  px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
         cy = self:drawNutrientRow("K", info.potassium,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
 

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -1041,9 +1041,10 @@ function SoilMapOverlay:valueToLayerColor(layerIdx, val)
         elseif val < T.potassium.fair then return FAIR[1], FAIR[2], FAIR[3]
         else                               return GOOD[1], GOOD[2], GOOD[3] end
     elseif layerIdx == 4 then
-        if val >= 6.5 and val <= 7.0   then return GOOD[1], GOOD[2], GOOD[3]
-        elseif val >= 5.5 and val <= 7.5 then return FAIR[1], FAIR[2], FAIR[3]
-        else                                  return POOR[1], POOR[2], POOR[3] end
+        if val >= 6.5 and val <= 7.0   then return GOOD[1], GOOD[2], GOOD[3]   -- optimal
+        elseif val > 7.0 and val <= 7.5 then return POOR[1], POOR[2], POOR[3]  -- over-limed: same as poor so the map signals "stop adding lime"
+        elseif val >= 5.5              then return FAIR[1], FAIR[2], FAIR[3]    -- slightly acidic
+        else                                return POOR[1], POOR[2], POOR[3] end
     elseif layerIdx == 5 then
         if val >= 4.0     then return GOOD[1], GOOD[2], GOOD[3]
         elseif val >= 2.5 then return FAIR[1], FAIR[2], FAIR[3]
@@ -1076,9 +1077,10 @@ function SoilMapOverlay:getLayerColor(layerIdx, info, farmlandId)
         else                             return GOOD[1], GOOD[2], GOOD[3] end
     elseif layerIdx == 4 then
         local pH = info.pH or 7.0
-        if pH >= 6.5 and pH <= 7.0 then     return GOOD[1], GOOD[2], GOOD[3]
-        elseif pH >= 5.5 and pH <= 7.5 then return FAIR[1], FAIR[2], FAIR[3]
-        else                                return POOR[1], POOR[2], POOR[3] end
+        if pH >= 6.5 and pH <= 7.0 then     return GOOD[1], GOOD[2], GOOD[3]    -- optimal
+        elseif pH > 7.0 and pH <= 7.5 then  return POOR[1], POOR[2], POOR[3]   -- over-limed
+        elseif pH >= 5.5 then               return FAIR[1], FAIR[2], FAIR[3]    -- slightly acidic
+        else                                return POOR[1], POOR[2], POOR[3] end -- very acidic
     elseif layerIdx == 5 then
         local om = info.organicMatter or 0
         if om >= 4.0     then return GOOD[1], GOOD[2], GOOD[3]

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -408,6 +408,9 @@ function SoilMapOverlay:updateSamplePoints(force)
                         for _, pt in ipairs(polyPts) do
                             if totalPoints < maxPoints then
                                 local r, g, b, a
+                                -- Draw position: use cell centre so the dot on-screen
+                                -- aligns exactly with the zone cell the tooltip reads.
+                                local dotX, dotZ = pt.x, pt.z
                                 if zoneData then
                                     local cx = math.floor(pt.x / zone.CELL_SIZE)
                                     local cz = math.floor(pt.z / zone.CELL_SIZE)
@@ -418,6 +421,9 @@ function SoilMapOverlay:updateSamplePoints(force)
                                         if val then
                                             r, g, b = self:valueToLayerColor(layerIdx, val)
                                             a = 1.0   -- measured: full opacity
+                                            -- Anchor dot at cell centre so it matches tooltip lookup
+                                            dotX = cx * zone.CELL_SIZE + zone.CELL_SIZE * 0.5
+                                            dotZ = cz * zone.CELL_SIZE + zone.CELL_SIZE * 0.5
                                         end
                                     end
                                 end
@@ -425,7 +431,7 @@ function SoilMapOverlay:updateSamplePoints(force)
                                     r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
                                     a = 0.45  -- estimated (field average): dimmed
                                 end
-                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b, a = a})
+                                table.insert(self.samplePoints, {x = dotX, z = dotZ, r = r, g = g, b = b, a = a})
                                 totalPoints = totalPoints + 1
                             end
                         end
@@ -611,18 +617,22 @@ function SoilMapOverlay:onMapClick(ingameMap, screenX, screenY)
     end
 
     self.selectedCell = {
-        cellCX    = cellCX,
-        cellCZ    = cellCZ,
-        worldX    = cellWorldX,
-        worldZ    = cellWorldZ,
-        farmlandId = farmlandId,
-        info      = info,
+        cellCX       = cellCX,
+        cellCZ       = cellCZ,
+        worldX       = cellWorldX,
+        worldZ       = cellWorldZ,
+        farmlandId   = farmlandId,
+        info         = info,
+        fromZoneCell = info.fromZoneCell or false,
     }
+    -- Force overlay refresh so tile colors match the freshly-read tooltip data
+    self.nextSampleUpdateTime = 0
     SoilLogger.debug("SoilMapOverlay: cell selected field=%s cell=[%d,%d]",
         tostring(farmlandId), cellCX, cellCZ)
 end
 
 --- Draw the cell-inspection tooltip over the selected cell on the PDA map.
+--- Content is layer-specific: only data relevant to the active layer is shown.
 ---@param ingameMap table
 ---@param mapX      number  Left edge of map render area (normalized)
 ---@param mapY      number  Bottom edge of map render area (normalized)
@@ -638,46 +648,227 @@ function SoilMapOverlay:drawCellTooltip(ingameMap, mapX, mapY, mapWidth, mapHeig
     sx = math.max(mapX, math.min(mapX + mapWidth,  sx))
     sy = math.max(mapY, math.min(mapY + mapHeight, sy))
 
-    local info = sel.info
-    local ppm  = SoilConstants.PPM_DISPLAY or { N = 1, P = 1, K = 1 }
+    local info     = sel.info
+    local layerIdx = self.settings.activeMapLayer or 1
+    local est      = not sel.fromZoneCell
+    local ppm      = SoilConstants.PPM_DISPLAY or { N = 1, P = 1, K = 1 }
 
-    -- getNormalizedScreenValues(widthPx, heightPx) → normalizedW, normalizedH
-    -- Always capture both return values and use the one that matches the axis.
-    local boxW,  boxH   = getNormalizedScreenValues(200, 168)
-    local padX,  _      = getNormalizedScreenValues(10,  0)
-    local _,     lineH  = getNormalizedScreenValues(0,   15)
-    local _,     titleH = getNormalizedScreenValues(0,   22)
-    local _,     textSz = getNormalizedScreenValues(0,   11)
-    local _,     titSz  = getNormalizedScreenValues(0,   13)
-    local _,     bdrT   = getNormalizedScreenValues(0,   1)
-    local dotSz, _      = getNormalizedScreenValues(5,   0)
+    local ttPOOR, ttFAIR, ttGOOD = self:statusColors()
+    local DIM = { 0.55, 0.55, 0.62 }
+    local NEU = { 0.85, 0.85, 0.90 }
 
-    -- Box position: prefer right of anchor, flip left if it overflows
+    local function fmtV(s) return est and (s .. "~") or s end
+    local function clrStatus(status)
+        if status == "Good" then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif status == "Fair" then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
+    end
+    local function clrPct(pct, low, med)
+        if pct < low then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif pct < med then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
+    end
+    local function cropTitle(name)
+        if not name or name == "" then return nil end
+        return (name:sub(1,1):upper() .. name:sub(2):lower()):gsub("_", " ")
+    end
+
+    -- Build layer-specific row list: each entry { label, value, r, g, b }
+    local rows = {}
+    local function addRow(lbl, val, r, g, b)
+        rows[#rows + 1] = { label = lbl, value = val, r = r, g = g, b = b }
+    end
+
+    if layerIdx >= 1 and layerIdx <= 3 then
+        -- ── Nutrient layer (N / P / K) ──────────────────────────
+        local nInfo, ppmMul, lbl
+        if     layerIdx == 1 then nInfo = info.nitrogen;   ppmMul = ppm.N; lbl = "Nitrogen (N)"
+        elseif layerIdx == 2 then nInfo = info.phosphorus; ppmMul = ppm.P; lbl = "Phosphorus (P)"
+        else                       nInfo = info.potassium;  ppmMul = ppm.K; lbl = "Potassium (K)" end
+
+        local val = (nInfo.value or 0) * ppmMul
+        addRow(lbl, fmtV(string.format("%d ppm", math.floor(val + 0.5))), clrStatus(nInfo.status))
+
+        local targKey = (layerIdx == 1) and "N" or (layerIdx == 2) and "P" or "K"
+        local ct = info.cropTargets
+        if ct and ct[targKey] then
+            local target = ct[targKey] * ppmMul
+            local gap    = val - target
+            local crop   = cropTitle(info.lastCrop) or "Crop"
+            addRow("Target (" .. crop .. ")", string.format("%d ppm", math.floor(target + 0.5)), NEU[1], NEU[2], NEU[3])
+            if gap >= 0 then
+                addRow("Gap", string.format("+%d ppm", math.floor(gap + 0.5)), ttGOOD[1], ttGOOD[2], ttGOOD[3])
+            else
+                addRow("Gap", string.format("%d ppm needed", math.floor(-gap + 0.5)), ttPOOR[1], ttPOOR[2], ttPOOR[3])
+            end
+        else
+            local crop = cropTitle(info.lastCrop)
+            addRow("Target", crop and ("No data: " .. crop) or "No crop planted", DIM[1], DIM[2], DIM[3])
+        end
+
+    elseif layerIdx == 4 then
+        -- ── pH layer ────────────────────────────────────────────
+        local pH = info.pH or 7.0
+        local condLabel, actionLabel, condR, condG, condB
+        if pH >= 6.5 and pH <= 7.0 then
+            condLabel = "Optimal";              actionLabel = "None needed"
+            condR, condG, condB = ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        elseif pH > 7.0 and pH <= 7.5 then
+            condLabel = "Over-limed";           actionLabel = "Allow to normalize"
+            condR, condG, condB = ttPOOR[1], ttPOOR[2], ttPOOR[3]
+        elseif pH > 7.5 then
+            condLabel = "Severely over-limed";  actionLabel = "Apply sulfur"
+            condR, condG, condB = ttPOOR[1], ttPOOR[2], ttPOOR[3]
+        elseif pH >= 5.5 then
+            condLabel = "Slightly acidic";      actionLabel = "Apply lime"
+            condR, condG, condB = ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else
+            condLabel = "Very acidic";          actionLabel = "Apply lime urgently"
+            condR, condG, condB = ttPOOR[1], ttPOOR[2], ttPOOR[3]
+        end
+        addRow("pH",        fmtV(string.format("%.1f", pH)), condR, condG, condB)
+        addRow("Condition", condLabel,   condR, condG, condB)
+        addRow("Treatment", actionLabel, NEU[1], NEU[2], NEU[3])
+
+    elseif layerIdx == 5 then
+        -- ── Organic Matter ──────────────────────────────────────
+        local om = info.organicMatter or 0
+        local rc = SoilConstants.REPORT_COLORS
+        local omR, omG, omB, hint
+        if om >= (rc and rc.OM_GOOD or 4.0) then
+            omR, omG, omB = ttGOOD[1], ttGOOD[2], ttGOOD[3]
+            hint = "Healthy — maintain with straw"
+        elseif om >= (rc and rc.OM_FAIR or 2.5) then
+            omR, omG, omB = ttFAIR[1], ttFAIR[2], ttFAIR[3]
+            hint = "Incorporate straw / manure"
+        else
+            omR, omG, omB = ttPOOR[1], ttPOOR[2], ttPOOR[3]
+            hint = "Low — add manure or digestate"
+        end
+        addRow("Organic Matter", fmtV(string.format("%.1f%%", om)), omR, omG, omB)
+        addRow("Tip",            hint, NEU[1], NEU[2], NEU[3])
+
+    elseif layerIdx == 6 then
+        -- ── Field Urgency ───────────────────────────────────────
+        local urgency = self.soilSystem and self.soilSystem:getFieldUrgency(sel.farmlandId) or 0
+        local uR, uG, uB
+        if urgency > 66 then uR, uG, uB = ttPOOR[1], ttPOOR[2], ttPOOR[3]
+        elseif urgency > 33 then uR, uG, uB = ttFAIR[1], ttFAIR[2], ttFAIR[3]
+        else uR, uG, uB = ttGOOD[1], ttGOOD[2], ttGOOD[3] end
+        addRow("Urgency", string.format("%d / 100", math.floor(urgency + 0.5)), uR, uG, uB)
+
+        local T = SoilConstants.STATUS_THRESHOLDS
+        local limLabel = "Balanced"
+        local limR, limG, limB = ttGOOD[1], ttGOOD[2], ttGOOD[3]
+        local worst = 0
+        local function checkNutrient(val, thresh, name)
+            if val < thresh then
+                local def = thresh - val
+                if def > worst then
+                    worst = def; limLabel = name
+                    limR, limG, limB = ttPOOR[1], ttPOOR[2], ttPOOR[3]
+                end
+            end
+        end
+        checkNutrient(info.nitrogen.value   or 0, (T.nitrogen   and T.nitrogen.fair)   or 50, "Nitrogen (N)")
+        checkNutrient(info.phosphorus.value or 0, (T.phosphorus and T.phosphorus.fair) or 30, "Phosphorus (P)")
+        checkNutrient(info.potassium.value  or 0, (T.potassium  and T.potassium.fair)  or 80, "Potassium (K)")
+        addRow("Limiting", limLabel, limR, limG, limB)
+
+        local crop = cropTitle(info.lastCrop) or "Fallow"
+        addRow("Crop", crop, NEU[1], NEU[2], NEU[3])
+
+    elseif layerIdx == 7 then
+        -- ── Weed Pressure ───────────────────────────────────────
+        local wp     = math.floor((info.weedPressure or 0) + 0.5)
+        local wConst = SoilConstants.WEED_PRESSURE or {}
+        local wLow, wMed = wConst.LOW or 20, wConst.MEDIUM or 50
+        addRow("Weed Pressure", string.format("%d%%", wp), clrPct(wp, wLow, wMed))
+        if info.herbicideActive then
+            addRow("Herbicide", "Active", ttGOOD[1], ttGOOD[2], ttGOOD[3])
+        elseif wp >= wLow then
+            addRow("Herbicide", "Not applied", ttFAIR[1], ttFAIR[2], ttFAIR[3])
+        else
+            addRow("Herbicide", "Not needed", NEU[1], NEU[2], NEU[3])
+        end
+
+    elseif layerIdx == 8 then
+        -- ── Pest Pressure ───────────────────────────────────────
+        local pp = math.floor((info.pestPressure or 0) + 0.5)
+        addRow("Pest Pressure", string.format("%d%%", pp), clrPct(pp, 20, 50))
+        if info.insecticideActive then
+            addRow("Insecticide", "Active", ttGOOD[1], ttGOOD[2], ttGOOD[3])
+        elseif pp >= 20 then
+            addRow("Insecticide", "Not applied", ttFAIR[1], ttFAIR[2], ttFAIR[3])
+        else
+            addRow("Insecticide", "Not needed", NEU[1], NEU[2], NEU[3])
+        end
+
+    elseif layerIdx == 9 then
+        -- ── Disease Pressure ────────────────────────────────────
+        local dp = math.floor((info.diseasePressure or 0) + 0.5)
+        addRow("Disease Pressure", string.format("%d%%", dp), clrPct(dp, 20, 50))
+        if info.fungicideActive then
+            addRow("Fungicide", "Active", ttGOOD[1], ttGOOD[2], ttGOOD[3])
+        elseif dp >= 20 then
+            addRow("Fungicide", "Not applied", ttFAIR[1], ttFAIR[2], ttFAIR[3])
+        else
+            addRow("Fungicide", "Not needed", NEU[1], NEU[2], NEU[3])
+        end
+
+    elseif layerIdx == 10 then
+        -- ── Compaction ──────────────────────────────────────────
+        local comp = math.floor((info.compaction or 0) + 0.5)
+        local cR, cG, cB, action
+        if comp < 25 then
+            cR, cG, cB = ttGOOD[1], ttGOOD[2], ttGOOD[3]; action = "No action needed"
+        elseif comp < 60 then
+            cR, cG, cB = ttFAIR[1], ttFAIR[2], ttFAIR[3]; action = "Subsoiling recommended"
+        else
+            cR, cG, cB = ttPOOR[1], ttPOOR[2], ttPOOR[3]; action = "Subsoiling urgent"
+        end
+        addRow("Compaction", string.format("%d%%", comp), cR, cG, cB)
+        addRow("Treatment",  action, cR, cG, cB)
+    else
+        return
+    end
+
+    if #rows == 0 then return end
+
+    -- ── Box sizing: height grows with row count ───────────────
+    local nRows   = #rows
+    local boxW, _ = getNormalizedScreenValues(200, 0)
+    local padX, _ = getNormalizedScreenValues(10,  0)
+    local _, lineH  = getNormalizedScreenValues(0, 15)
+    local _, titleH = getNormalizedScreenValues(0, 22)
+    local _, textSz = getNormalizedScreenValues(0, 11)
+    local _, titSz  = getNormalizedScreenValues(0, 13)
+    local _, bdrT   = getNormalizedScreenValues(0,  1)
+    local dotSz, _  = getNormalizedScreenValues(5,  0)
+    local boxH = titleH + lineH * nRows + lineH * 0.9
+
+    -- ── Box position ─────────────────────────────────────────
     local gapX = getNormalizedScreenValues(16, 0)
     local bx = sx + gapX
-    if bx + boxW > mapX + mapWidth then
-        bx = sx - boxW - gapX
-    end
+    if bx + boxW > mapX + mapWidth then bx = sx - boxW - gapX end
     local by = sy - boxH * 0.5
     by = math.max(mapY, math.min(mapY + mapHeight - boxH, by))
 
-    -- Highlight dot
+    -- ── Highlight dot + connector ─────────────────────────────
     drawFilledRect(sx - dotSz * 0.5, sy - dotSz * 0.5, dotSz, dotSz, 1, 1, 1, 0.95)
-
-    -- Connector line
     local lineEndX = (bx > sx) and bx or (bx + boxW)
     local _, lineH1 = getNormalizedScreenValues(0, 1)
     drawFilledRect(math.min(sx, lineEndX), sy - lineH1 * 0.5,
                    math.abs(lineEndX - sx), lineH1, 0.6, 0.7, 0.9, 0.5)
 
-    -- Background + borders
+    -- ── Background + borders ──────────────────────────────────
     drawFilledRect(bx, by, boxW, boxH, 0.04, 0.04, 0.07, 0.93)
     drawFilledRect(bx,               by + boxH - bdrT, boxW, bdrT, 0.4, 0.65, 1.0, 0.8)
     drawFilledRect(bx,               by,               boxW, bdrT, 0.4, 0.65, 1.0, 0.4)
     drawFilledRect(bx,               by,               bdrT, boxH, 0.4, 0.65, 1.0, 0.4)
     drawFilledRect(bx + boxW - bdrT, by,               bdrT, boxH, 0.4, 0.65, 1.0, 0.4)
 
-    -- Title bar
+    -- ── Title bar ─────────────────────────────────────────────
     local titleY = by + boxH - titleH
     setTextBold(true)
     setTextColor(0.65, 0.85, 1.0, 1.0)
@@ -688,59 +879,18 @@ function SoilMapOverlay:drawCellTooltip(ingameMap, mapX, mapY, mapWidth, mapHeig
     setTextBold(false)
     drawFilledRect(bx + padX, titleY - bdrT, boxW - padX * 2, bdrT, 0.4, 0.65, 1.0, 0.3)
 
-    -- Row helper: label left, value right, at absolute screen Y
-    local function row(label, value, absY, r, g, b)
-        local midY = absY + lineH * 0.5
-        setTextColor(0.55, 0.55, 0.62, 1.0)
+    -- ── Data rows ─────────────────────────────────────────────
+    local rowY = titleY - lineH * 1.1
+    for _, r in ipairs(rows) do
+        local midY = rowY + lineH * 0.5
+        setTextColor(DIM[1], DIM[2], DIM[3], 1.0)
         setTextAlignment(RenderText.ALIGN_LEFT)
-        renderText(bx + padX, midY, textSz, label)
-        setTextColor(r, g, b, 1.0)
+        renderText(bx + padX, midY, textSz, r.label)
+        setTextColor(r.r, r.g, r.b, 1.0)
         setTextAlignment(RenderText.ALIGN_RIGHT)
-        renderText(bx + boxW - padX, midY, textSz, value)
+        renderText(bx + boxW - padX, midY, textSz, r.value)
+        rowY = rowY - lineH
     end
-
-    local ttPOOR, ttFAIR, ttGOOD = self:statusColors()
-    local function nColor(status)
-        if status == "Good" then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
-        elseif status == "Fair" then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
-        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
-    end
-    local function phColor(ph)
-        local rc = SoilConstants.REPORT_COLORS
-        if ph >= rc.PH_GOOD_LOW and ph <= rc.PH_GOOD_HIGH then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
-        elseif ph >= rc.PH_FAIR_LOW and ph <= rc.PH_FAIR_HIGH then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
-        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
-    end
-    local function omColor(om)
-        local rc = SoilConstants.REPORT_COLORS
-        if om >= rc.OM_GOOD then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
-        elseif om >= rc.OM_FAIR then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
-        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
-    end
-    local function pressureColor(pct)
-        local wp = SoilConstants.WEED_PRESSURE
-        if pct < wp.LOW then return ttGOOD[1], ttGOOD[2], ttGOOD[3]
-        elseif pct < wp.MEDIUM then return ttFAIR[1], ttFAIR[2], ttFAIR[3]
-        else return ttPOOR[1], ttPOOR[2], ttPOOR[3] end
-    end
-
-    -- Rows step downward from just below the title divider
-    local rowY = titleY - lineH * 1.15
-    row("Nitrogen (N)",   string.format("%d ppm", math.floor(info.nitrogen.value   * ppm.N + 0.5)), rowY, nColor(info.nitrogen.status)) ; rowY = rowY - lineH
-    row("Phosphorus (P)", string.format("%d ppm", math.floor(info.phosphorus.value * ppm.P + 0.5)), rowY, nColor(info.phosphorus.status)) ; rowY = rowY - lineH
-    row("Potassium (K)",  string.format("%d ppm", math.floor(info.potassium.value  * ppm.K + 0.5)), rowY, nColor(info.potassium.status)) ; rowY = rowY - lineH
-    row("pH",             string.format("%.1f",   info.pH),                                         rowY, phColor(info.pH)) ; rowY = rowY - lineH
-    row("Organic Matter", string.format("%.1f%%", info.organicMatter),                              rowY, omColor(info.organicMatter)) ; rowY = rowY - lineH * 0.8
-
-    drawFilledRect(bx + padX, rowY + lineH * 0.4, boxW - padX * 2, bdrT, 0.3, 0.3, 0.4, 0.4)
-    rowY = rowY - lineH * 0.6
-
-    local wp = math.floor((info.weedPressure    or 0) + 0.5)
-    local pp = math.floor((info.pestPressure    or 0) + 0.5)
-    local dp = math.floor((info.diseasePressure or 0) + 0.5)
-    row("Weed",    string.format("%d%%", wp), rowY, pressureColor(wp)) ; rowY = rowY - lineH
-    row("Pest",    string.format("%d%%", pp), rowY, pressureColor(pp)) ; rowY = rowY - lineH
-    row("Disease", string.format("%d%%", dp), rowY, pressureColor(dp))
 
     setTextBold(false)
     setTextColor(1, 1, 1, 1)

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -398,14 +398,16 @@ function SoilMapOverlay:updateSamplePoints(force)
                         end
                     elseif layerIdx >= 1 and layerIdx <= 10 then
                         -- zoneData per-cell path: standard maps, layers 1-10.
-                        -- Cells that have been modified show their local value; unvisited cells
-                        -- fall back to the field average so the map is always fully coloured.
+                        -- Cells that have been measured (sprayer/harvester passed) show their
+                        -- real local value at full opacity. Unvisited cells fall back to the
+                        -- field-level average at half opacity so the map stays fully coloured
+                        -- but players can tell measured zones from estimated ones.
                         local fieldEntry = self.soilSystem.fieldData and self.soilSystem.fieldData[farmlandId]
                         local zoneData = fieldEntry and fieldEntry.zoneData
                         local zone = SoilConstants.ZONE
                         for _, pt in ipairs(polyPts) do
                             if totalPoints < maxPoints then
-                                local r, g, b
+                                local r, g, b, a
                                 if zoneData then
                                     local cx = math.floor(pt.x / zone.CELL_SIZE)
                                     local cz = math.floor(pt.z / zone.CELL_SIZE)
@@ -413,11 +415,17 @@ function SoilMapOverlay:updateSamplePoints(force)
                                     local cell = zoneData[cellKey]
                                     if cell then
                                         local val = getCellLayerValue(cell, layerIdx)
-                                        if val then r, g, b = self:valueToLayerColor(layerIdx, val) end
+                                        if val then
+                                            r, g, b = self:valueToLayerColor(layerIdx, val)
+                                            a = 1.0   -- measured: full opacity
+                                        end
                                     end
                                 end
-                                if not r then r, g, b = self:getLayerColor(layerIdx, info, farmlandId) end
-                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b})
+                                if not r then
+                                    r, g, b = self:getLayerColor(layerIdx, info, farmlandId)
+                                    a = 0.45  -- estimated (field average): dimmed
+                                end
+                                table.insert(self.samplePoints, {x = pt.x, z = pt.z, r = r, g = g, b = b, a = a})
                                 totalPoints = totalPoints + 1
                             end
                         end
@@ -496,7 +504,7 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
         if screenX >= mapX and screenX <= mapMaxX
            and screenY >= mapY and screenY <= mapMaxY then
             drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
-                           point.r, point.g, point.b, SoilMapOverlay.ALPHA)
+                           point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
         end
     end
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,11 +24,16 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed Harvesting now correctly drains nitrogen, phosphorus and potassium from your fields",
-    "- Fixed Swath and windrow harvesting also now properly removes soil nutrients",
-    "- Fixed New fields and new games now show soil readings in the cell report right away",
-    "- Fixed Fertilizer and amendment piles no longer cause rendering errors when viewed from a distance",
-    "- Fixed Oats now tracked as a separate crop for nutrient extraction (was grouped with wheat)",
+    "- HUD now shows a session-based current-pass coverage tracker so you can see field progress in real time",
+    "- Fixed Biosolids spread on fields now appears near-black (correct color) instead of brown",
+    "- Fixed Harvest nutrient depletion now calculates correctly using field area (fixes 8x over/under-depletion)",
+    "- Fixed Nutrients now deplete properly when harvesting in swath/windrow mode",
+    "- Fixed Oat nutrient extraction was using the wrong lookup key — corrected",
+    "- Fixed Organic Matter (OM) is now clamped to a valid range on all load and save paths",
+    "- Fixed All solid fill types now have distance textures (fixes visual pop-in at range)",
+    "- Fixed Cell report now shows field averages even when no soil zone cells have been sampled yet",
+    "- Fixed SoilDebug console command now takes effect immediately without requiring a restart",
+    "- Fixed False 'savegame not found' warning no longer appears on brand-new careers",
 }
 
 -- ── i18n helper ───────────────────────────────────────────
@@ -49,7 +54,7 @@ end
 
 function SoilVersionDialog.new(target, customMt)
     local self = ScreenElement.new(target, customMt or SoilVersionDialog_mt)
-    self._changelogLineEls = {}  -- holds dynamically created TextElements
+    self._changelogLineEls = {}
     return self
 end
 

--- a/xml/gui/SoilVersionDialog.xml
+++ b/xml/gui/SoilVersionDialog.xml
@@ -39,20 +39,20 @@
       <BoxLayout profile="sfVer_changelogBox" id="sfVer_changelogBox"
                  position="0px -124px"/>
 
-      <!-- Bottom separator — anchored from bottom of dialog -->
+      <!-- Bottom separator — sits 10px below the changelog box -->
       <Bitmap profile="sfVer_sep" id="sfVer_bottomSep"
-              position="0px -314px" size="560px 2px"/>
+              position="0px -414px" size="560px 2px"/>
 
       <!-- Footer (set at runtime via i18n) -->
       <Text profile="sfVer_footer" id="sfVer_footer1"
-            text="" position="0px -334px"/>
+            text="" position="0px -434px"/>
       <Text profile="sfVer_footer" id="sfVer_footer2"
-            text="" position="0px -352px"/>
+            text="" position="0px -452px"/>
 
       <Text profile="sfVer_tagline1" id="sfVer_footer3"
-            text="" position="0px -379px"/>
+            text="" position="0px -479px"/>
       <Text profile="sfVer_tagline2" id="sfVer_footer4"
-            text="" position="0px -397px"/>
+            text="" position="0px -497px"/>
 
     </GuiElement>
 
@@ -67,7 +67,7 @@
 
   <GUIProfiles>
     <Profile name="sfVer_bg" extends="fs25_dialogBg">
-      <size value="640px 530px"/>
+      <size value="640px 630px"/>
     </Profile>
     <Profile name="sfVer_author" extends="fs25_dialogText" with="anchorTopCenter">
       <textSize value="13px"/>
@@ -84,7 +84,7 @@
     </Profile>
     <!-- Vertical BoxLayout — Lua adds TextElements here dynamically -->
     <Profile name="sfVer_changelogBox" extends="emptyPanel" with="anchorTopCenter">
-      <size value="560px 180px"/>
+      <size value="560px 280px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
       <alignmentX value="center"/>


### PR DESCRIPTION
## Summary

This PR brings the full change set for **v2.2.0**, the largest quality update since initial release. Three main areas:

### Precision Farming Integration
- N/P/K HUD bars now read from PF sensors when the Precision Farming DLC is active — values update live as the player drives
- N bar label becomes `N*` when PF is providing data; tick marks and crop-target lookups correctly strip the suffix so they keep working
- Two harvest/sprayer hook bugs fixed that caused PF-equipped late-spawned combines to skip nutrient depletion

### Map Overlay Overhaul
- **Zone-cell dots now drawn at cell centres** — previously polygon fill offsets meant the colored tile on screen could represent a different zone cell than what the tooltip read on click, causing color/value mismatches
- **Immediate refresh on click** — overlay no longer shows stale tile colors when a cell is clicked; resample fires instantly
- **Bulk zone-cell sync removed** — the old code overwrote all zone cells with the field average on every spray frame, destroying any spatial pH variation. Unsprayed cells now fall back to a dimmed (45% opacity) field-average color so the map always shows something, but measured cells are full opacity
- Over-limed state (pH 7.0–7.5) now correctly renders **red** on both the overlay and the HUD bar — previously it fell into the same yellow band as acidic soil
- `fromZoneCell` flag added to `getFieldInfo` return; tooltip appends `~` to the primary value when showing field-average fallback data

### Tooltip Redesign (all 10 layers)
The cell-inspection tooltip is now **layer-specific** — it only shows data relevant to the layer the player is currently viewing:

| Layer | What you see |
|-------|-------------|
| N / P / K | Value, crop target for the growing crop, gap (+surplus / needed) |
| pH | Value, condition (Optimal / Acidic / Over-limed), treatment hint |
| Organic Matter | Value, improvement tip |
| Field Urgency | Score, most-limiting nutrient, current crop |
| Weed / Pest / Disease | Pressure %, protection status |
| Compaction | %, subsoil recommendation |

Box height is now dynamic — 2-row layers produce a compact box; 3-row layers grow slightly.

### Other Fixes
- Sprayer hook field ID lookup uses `skipNegativeCache=true` to prevent stale -1 entries silently dropping fertilizer applications
- Straw-chopping OM gain now correctly scales by area (was incorrectly using concentration)
- Crop protection pressure reduction raised to 50 across herbicide/insecticide/fungicide
- Spatial cell deduplication replaces liter-based coverage tracking — eliminates headland overlap inflation
- `SoilLayerSystem` GRLE path guarded; nil-cell crash on MAX_ZONE_CELLS guard
- Debug mode is `localOnly` so `SoilDebug` takes effect immediately without reload

## Test plan
- [ ] Standard map (no PF): all 10 tooltip layers show correct layer-specific content
- [ ] pH layer: red tiles for over-limed areas, tooltip shows "Over-limed / Allow to normalize"
- [ ] Apply lime, open map — tile color updates on next click (no stale green)
- [ ] PF active: N bar shows N* label, tick marks still render, crop targets still matched
- [ ] Weed/pest/disease layers: protection status correct when active vs inactive
- [ ] Urgency layer: most-limiting nutrient identified correctly