### PR TITLE
v2.2.0 — Precision Farming compatibility, help dialogs, overlay improvements & bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,32 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 
 ---
 
+## 🆕 What's New in v2.2.0
+
+### Precision Farming DLC Support
+If you run the Precision Farming DLC, the soil HUD bars now read **live sensor data** as you drive. Nitrogen, Phosphorus and Potassium update in real time across different parts of the field — you'll see the variation with your own eyes as you cross from a worked strip into an untouched one.
+
+### The Map Finally Shows What's Happening in Each Spot
+The soil overlay has been rebuilt to show **real per-zone data**, not just a single colour for the whole field. Lime the east half of a field and come back — the east shows green (optimal), the west still shows yellow (acidic). Two halves of the same field, two different stories.
+
+Over-limed areas (pH above 7.0) now correctly show **red**. Too much lime locks out nutrients just like too little does. The map now makes that visible.
+
+### Click a Tile — See Only What Matters
+The info box that pops up when you click a map tile is now **layer-specific**. On the pH layer you see: your pH reading, what that means (*Optimal*, *Acidic*, *Over-limed*), and exactly what to do about it. On the Nitrogen layer you see: your current N level, the target for the crop you're growing, and how many ppm you're over or under. No more scrolling through eight rows of numbers to find the one thing you're looking for.
+
+### "How Much More Does My Crop Actually Need?"
+The N, P and K tooltips now pull in the **nutrient target for your specific crop**. Wheat has different N needs than potatoes. The tooltip shows the target for what's in the ground right now and tells you whether you're above it, hitting it, or short — and by exactly how much.
+
+### Treatment Status at a Glance
+The Weed, Pest and Disease map layers now show whether a protection product is still active on that tile. Green means you're covered. Amber means the pressure is building and nothing's been applied. No guessing whether your herbicide from last week is still doing its job.
+
+### Fixes
+- N bar tick marks and crop targets now work correctly when Precision Farming mod is active
+- Straw chopping now builds Organic Matter correctly based on your field's actual size (was previously using concentration instead of area)
+- Map tiles now refresh immediately when clicked — no more stale colors after applying lime or fertilizer
+
+---
+
 ## ✨ Features
 
 ### 🧪 Per-Field Soil Chemistry
@@ -382,7 +408,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.1.7.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.0.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -567,6 +567,47 @@
                 <fertilizerUsage amount="0.21"/> <!-- Ammonium sulfate 21% N by weight -->
             </sprayType>
 
+            <!-- Phosphorus & potassium products (PF does not manage P/K — fertilizerUsage declares N content only) -->
+            <sprayType name="LIQUID_POTASH" litersPerSecond="0.0300" type="FERTILIZER" sprayGroundType="LIQUIDFERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="100">
+                    <soil soilTypeIndex="1" rate="50"/>
+                    <soil soilTypeIndex="2" rate="70"/>
+                    <soil soilTypeIndex="3" rate="90"/>
+                    <soil soilTypeIndex="4" rate="70"/>
+                </applicationRate>
+                <fertilizerUsage amount="0"/> <!-- 0-0-60 — pure K, zero N -->
+            </sprayType>
+
+            <sprayType name="POTASH" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="200">
+                    <soil soilTypeIndex="1" rate="100"/>
+                    <soil soilTypeIndex="2" rate="140"/>
+                    <soil soilTypeIndex="3" rate="180"/>
+                    <soil soilTypeIndex="4" rate="140"/>
+                </applicationRate>
+                <fertilizerUsage amount="0"/> <!-- 0-0-60 granular — zero N -->
+            </sprayType>
+
+            <sprayType name="MAP" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="225">
+                    <soil soilTypeIndex="1" rate="110"/>
+                    <soil soilTypeIndex="2" rate="150"/>
+                    <soil soilTypeIndex="3" rate="190"/>
+                    <soil soilTypeIndex="4" rate="150"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.11"/> <!-- 11-52-0 granular — 11% N -->
+            </sprayType>
+
+            <sprayType name="DAP" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="225">
+                    <soil soilTypeIndex="1" rate="110"/>
+                    <soil soilTypeIndex="2" rate="150"/>
+                    <soil soilTypeIndex="3" rate="190"/>
+                    <soil soilTypeIndex="4" rate="150"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.18"/> <!-- 18-46-0 granular — 18% N -->
+            </sprayType>
+
             <!-- Lime types (pH amendment — no N content) -->
             <sprayType name="LIQUIDLIME" litersPerSecond="0.0815" type="LIME" sprayGroundType="LIME"/>
             <sprayType name="GYPSUM"     litersPerSecond="0.0600" type="LIME" sprayGroundType="LIME"/>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.7.0</version>
+    <version>2.2.0.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -114,6 +114,18 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             SoilLogger.info("Soil Version dialog registered")
         end
 
+        -- PDA help dialog (X button in PDA footer)
+        if SoilHelpDialog and g_gui then
+            SoilHelpDialog.register(modDirectory)
+            SoilLogger.info("Soil Help dialog registered")
+        end
+
+        -- Overlay help dialog (4th sidebar button on soil map)
+        if SoilOverlayHelpDialog and g_gui then
+            SoilOverlayHelpDialog.register(modDirectory)
+            SoilLogger.info("Soil Overlay Help dialog registered")
+        end
+
         -- Map overlay (client only)
         if SoilMapOverlay then
             self.soilMapOverlay = SoilMapOverlay.new(self.soilSystem, self.settings)

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -238,6 +238,13 @@ SettingsSchema.definitions = {
         uiId = "sf_show_field_info_box",
         localOnly = true,  -- per-player display preference, not synced to server
     },
+    {
+        id = "pfCompatibilityMode",
+        type = "boolean",
+        default = false,
+        uiId = "sf_pf_compat",
+        localOnly = true,  -- per-player; PF presence is client-side, not synced
+    },
 }
 
 -- Build lookup table by id for fast access

--- a/src/main.lua
+++ b/src/main.lua
@@ -58,6 +58,8 @@ source(modDirectory .. "src/ui/SoilPDAScreen.lua")
 source(modDirectory .. "src/ui/SoilFieldDetailDialog.lua")
 source(modDirectory .. "src/ui/SoilTreatmentDialog.lua")
 source(modDirectory .. "src/ui/SoilVersionDialog.lua")
+source(modDirectory .. "src/ui/SoilHelpDialog.lua")
+source(modDirectory .. "src/ui/SoilOverlayHelpDialog.lua")
 source(modDirectory .. "src/ui/SoilSettingsPanel.lua")
 source(modDirectory .. "src/SoilFertilityManager.lua")
 

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -311,6 +311,7 @@ end
 ---@param suffix     string    "%" or ""
 ---@param cropTarget table|nil {min=number, opt=number} per-crop target (internal scale)
 function SoilFieldDetailDialog:_setNutrient(valueEl, statusEl, value, statusStr, suffix, cropTarget)
+    local COLOR_POOR, COLOR_FAIR, COLOR_GOOD = getStatusColors()
     suffix = suffix or ""
     if valueEl then
         valueEl:setText(math.floor(value + 0.5) .. suffix)
@@ -355,6 +356,7 @@ end
 ---@param pressure      number    0-100
 ---@param activeProduct boolean   true if protection product active
 function SoilFieldDetailDialog:_setPressure(valueEl, statusEl, pressure, activeProduct)
+    local COLOR_POOR, COLOR_FAIR, COLOR_GOOD = getStatusColors()
     if valueEl then
         valueEl:setText(string.format("%.0f%%", pressure))
     end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -868,7 +868,14 @@ function SoilHUD:draw()
     end
 
     self:drawPanel()
-    self:drawSprayerRatePanel()
+
+    -- Suppress SF rate panel when PF compat mode is on — PF manages rate control in that case
+    local pfBridgeHud = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+    local pfCompatActive = pfBridgeHud and pfBridgeHud.isActive and self.settings.pfCompatibilityMode
+    if not pfCompatActive then
+        self:drawSprayerRatePanel()
+    end
+
     if self.settings.showMiniReport then
         self:drawMiniReport()
     end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -996,10 +996,16 @@ function SoilHUD:drawPanel()
         local rateMultiplier = (rm and sprayer) and rm:getMultiplier(sprayer.id) or 1.0
 
         -- N / P / K rows
-        -- When PF is active, N is owned by PF's per-pixel map — label with * so players know
-        local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
-        local nLabel = (pfBridge and pfBridge.isActive) and "N*" or "N"
-        cy = self:drawNutrientRow(nLabel, info.nitrogen,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
+        -- When PF is active, N is owned by PF's per-pixel map — label with * so players know.
+        -- When pfCompatibilityMode is also enabled, skip the N row entirely to avoid conflicting displays.
+        local pfBridge  = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+        local settings  = g_SoilFertilityManager and g_SoilFertilityManager.settings
+        local pfActive  = pfBridge and pfBridge.isActive
+        local hideN     = pfActive and settings and settings.pfCompatibilityMode
+        if not hideN then
+            local nLabel = pfActive and "N*" or "N"
+            cy = self:drawNutrientRow(nLabel, info.nitrogen, px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
+        end
         cy = self:drawNutrientRow("P", info.phosphorus,  px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
         cy = self:drawNutrientRow("K", info.potassium,   px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier)
 

--- a/src/ui/SoilHelpDialog.lua
+++ b/src/ui/SoilHelpDialog.lua
@@ -1,0 +1,170 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer — PDA Help Dialog
+-- =========================================================
+-- Opened from the PDA screen X/help button.
+-- Explains nutrients, soil chemistry, crop targets, status
+-- levels, crop pressure, and general tips.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class SoilHelpDialog
+SoilHelpDialog = {}
+local SoilHelpDialog_mt = Class(SoilHelpDialog, ScreenElement)
+
+local SF_HELP_MOD_NAME = g_currentModName
+local SF_HELP_MOD_DIR  = g_currentModDirectory
+
+SoilHelpDialog.INSTANCE = nil
+
+-- Content table: {t="H"|"B"|"S", v="text"}
+-- H = section header (bold, green, uppercase)
+-- B = body line (white, normal)
+-- S = spacer (blank gap)
+SoilHelpDialog.CONTENT = {
+    { t="H", v="NUTRIENTS" },
+    { t="B", v="N  (Nitrogen)     \226\128\148 Depletes every harvest. Apply UAN, Urea, AMS, or Manure." },
+    { t="B", v="P  (Phosphorus)   \226\128\148 Long-lasting. Apply MAP, DAP, Liquid MAP, or Liquid DAP." },
+    { t="B", v="K  (Potassium)    \226\128\148 Apply Potash or Liquid Potash. Critical for root crops." },
+    { t="B", v="OM (Organic Mat.) \226\128\148 Builds slowly. Incorporate Manure, Compost, or Biosolids." },
+    { t="S", v=" " },
+    { t="H", v="SOIL CHEMISTRY" },
+    { t="B", v="pH 6.5 - 7.0 = Ideal. Apply Lime if below 6.5. Apply Gypsum if above 7.5." },
+    { t="B", v="Lime raises pH. Gypsum lowers pH. Allow 1-2 seasons to normalize." },
+    { t="S", v=" " },
+    { t="H", v="CROP TARGETS" },
+    { t="B", v="Each crop has different N/P/K requirements. The map tooltip shows" },
+    { t="B", v="the gap between current levels and the crop's optimal target." },
+    { t="B", v="Green = at or above target. Red = deficit. Hover a cell to inspect." },
+    { t="S", v=" " },
+    { t="H", v="STATUS LEVELS" },
+    { t="B", v="Good  (green)  \226\128\148 Above optimal threshold. No action needed." },
+    { t="B", v="Fair  (yellow) \226\128\148 Below optimal. Monitor or apply a preventive top-up." },
+    { t="B", v="Poor  (red)    \226\128\148 Below minimum. Immediate treatment required." },
+    { t="S", v=" " },
+    { t="H", v="CROP PRESSURE" },
+    { t="B", v="Weed    > 20% \226\128\148 Apply Herbicide or use mechanical weeder / hoe." },
+    { t="B", v="Pest    > 20% \226\128\148 Apply Insecticide." },
+    { t="B", v="Disease > 20% \226\128\148 Apply Fungicide." },
+    { t="S", v=" " },
+    { t="H", v="TIPS" },
+    { t="B", v="* Open the Treatment Plan tab to see which fields need attention most." },
+    { t="B", v="* Use the soil map overlay (press M then Soil Layers) to see per-cell data." },
+    { t="B", v="* Season + rain affect nutrients. Avoid over-applying N in autumn." },
+    { t="B", v="* Crop rotation avoids soil fatigue and can grant a legume N bonus." },
+}
+
+-- ── i18n helper ───────────────────────────────────────────
+
+local function tr(key, fallback)
+    local modEnv = g_modEnvironments and g_modEnvironments[SF_HELP_MOD_NAME]
+    local i18n = (modEnv and modEnv.i18n) or g_i18n
+    if i18n then
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            return text
+        end
+    end
+    return fallback or key
+end
+
+-- ── Constructor ───────────────────────────────────────────
+
+function SoilHelpDialog.new(target, customMt)
+    local self = ScreenElement.new(target, customMt or SoilHelpDialog_mt)
+    self._contentLineEls = {}
+    return self
+end
+
+function SoilHelpDialog.register(modDirectory)
+    if SoilHelpDialog.INSTANCE ~= nil then return end
+
+    SF_HELP_MOD_DIR = modDirectory
+    local xmlPath = modDirectory .. "xml/gui/SoilHelpDialog.xml"
+
+    SoilHelpDialog.INSTANCE = SoilHelpDialog.new()
+    SoilLogger.info("SoilHelpDialog: registering from %s", xmlPath)
+
+    local ok, err = pcall(function()
+        g_gui:loadGui(xmlPath, "SoilHelpDialog", SoilHelpDialog.INSTANCE)
+    end)
+
+    if not ok then
+        SoilLogger.error("SoilHelpDialog: loadGui failed: %s", tostring(err))
+        SoilHelpDialog.INSTANCE = nil
+    else
+        SoilLogger.info("SoilHelpDialog: registered successfully")
+    end
+end
+
+function SoilHelpDialog.show()
+    if SoilHelpDialog.INSTANCE == nil then
+        SoilHelpDialog.register(SF_HELP_MOD_DIR)
+    end
+    if SoilHelpDialog.INSTANCE == nil then return end
+    g_gui:showDialog("SoilHelpDialog")
+end
+
+-- ── Lifecycle ─────────────────────────────────────────────
+
+function SoilHelpDialog:onGuiSetupFinished()
+    SoilHelpDialog:superClass().onGuiSetupFinished(self)
+    self._elContentBox = self:getDescendantById("sfHelp_contentBox")
+end
+
+function SoilHelpDialog:onOpen()
+    SoilHelpDialog:superClass().onOpen(self)
+    self:_buildContent()
+end
+
+function SoilHelpDialog:onClose()
+    SoilHelpDialog:superClass().onClose(self)
+    self:_clearContent()
+end
+
+-- ── Content Builder ───────────────────────────────────────
+
+function SoilHelpDialog:_buildContent()
+    if not self._elContentBox then return end
+
+    local profileH = g_gui:getProfile("sfHelp_header")
+    local profileB = g_gui:getProfile("sfHelp_body")
+    local profileS = g_gui:getProfile("sfHelp_spacer")
+
+    if not profileH or not profileB then
+        SoilLogger.warning("SoilHelpDialog: required profiles not found")
+        return
+    end
+
+    for _, row in ipairs(SoilHelpDialog.CONTENT) do
+        local profile = (row.t == "H") and profileH
+                     or (row.t == "S") and profileS
+                     or profileB
+
+        if profile then
+            local el = TextElement.new()
+            el:loadProfile(profile, true)
+            el:setText(row.v)
+            self._elContentBox:addElement(el)
+            el:onGuiSetupFinished()
+            table.insert(self._contentLineEls, el)
+        end
+    end
+
+    self._elContentBox:invalidateLayout()
+end
+
+function SoilHelpDialog:_clearContent()
+    for _, el in ipairs(self._contentLineEls) do
+        if self._elContentBox then
+            self._elContentBox:removeElement(el)
+        end
+    end
+    self._contentLineEls = {}
+end
+
+-- ── Button ────────────────────────────────────────────────
+
+function SoilHelpDialog:onClickClose()
+    g_gui:closeDialogByName("SoilHelpDialog")
+end

--- a/src/ui/SoilHelpDialog.lua
+++ b/src/ui/SoilHelpDialog.lua
@@ -2,8 +2,7 @@
 -- FS25 Soil & Fertilizer — PDA Help Dialog
 -- =========================================================
 -- Opened from the PDA screen X/help button.
--- Explains nutrients, soil chemistry, crop targets, status
--- levels, crop pressure, and general tips.
+-- Two-column layout: nutrients/chemistry/targets | status/pressure/tips
 -- =========================================================
 -- Author: TisonK
 -- =========================================================
@@ -17,41 +16,61 @@ local SF_HELP_MOD_DIR  = g_currentModDirectory
 
 SoilHelpDialog.INSTANCE = nil
 
--- Content table: {t="H"|"B"|"S", v="text"}
--- H = section header (bold, green, uppercase)
--- B = body line (white, normal)
--- S = spacer (blank gap)
+-- Content table: {t="H"|"B"|"S"|"COL", v="text"}
+-- H   = section header (bold, green, uppercase)
+-- B   = body line (white, normal)
+-- S   = spacer (blank gap)
+-- COL = column break — switch from col1 to col2
 SoilHelpDialog.CONTENT = {
+    -- ── LEFT COLUMN ──────────────────────────────────────
     { t="H", v="NUTRIENTS" },
-    { t="B", v="N  (Nitrogen)     \226\128\148 Depletes every harvest. Apply UAN, Urea, AMS, or Manure." },
-    { t="B", v="P  (Phosphorus)   \226\128\148 Long-lasting. Apply MAP, DAP, Liquid MAP, or Liquid DAP." },
-    { t="B", v="K  (Potassium)    \226\128\148 Apply Potash or Liquid Potash. Critical for root crops." },
-    { t="B", v="OM (Organic Mat.) \226\128\148 Builds slowly. Incorporate Manure, Compost, or Biosolids." },
+    { t="B", v="N  (Nitrogen)    \226\128\148 Depletes every harvest." },
+    { t="B", v="   Apply UAN, Urea, AMS, or Manure." },
+    { t="B", v="P  (Phosphorus)  \226\128\148 Long-lasting." },
+    { t="B", v="   Apply MAP, DAP, Liquid MAP, or Liquid DAP." },
+    { t="B", v="K  (Potassium)   \226\128\148 Critical for root crops." },
+    { t="B", v="   Apply Potash or Liquid Potash." },
+    { t="B", v="OM (Organic Mat.) \226\128\148 Builds slowly." },
+    { t="B", v="   Incorporate Manure, Compost, or Biosolids." },
     { t="S", v=" " },
     { t="H", v="SOIL CHEMISTRY" },
-    { t="B", v="pH 6.5 - 7.0 = Ideal. Apply Lime if below 6.5. Apply Gypsum if above 7.5." },
-    { t="B", v="Lime raises pH. Gypsum lowers pH. Allow 1-2 seasons to normalize." },
+    { t="B", v="pH 6.5 - 7.0 = Ideal range." },
+    { t="B", v="Apply Lime if below 6.5 (too acidic)." },
+    { t="B", v="Apply Gypsum if above 7.5 (over-limed)." },
+    { t="B", v="Allow 1-2 seasons to normalize after treatment." },
     { t="S", v=" " },
     { t="H", v="CROP TARGETS" },
-    { t="B", v="Each crop has different N/P/K requirements. The map tooltip shows" },
-    { t="B", v="the gap between current levels and the crop's optimal target." },
-    { t="B", v="Green = at or above target. Red = deficit. Hover a cell to inspect." },
-    { t="S", v=" " },
+    { t="B", v="Each crop has unique N / P / K requirements." },
+    { t="B", v="The map tooltip shows the gap between your" },
+    { t="B", v="current level and the crop's optimal target." },
+    { t="B", v="Green = at or above target." },
+    { t="B", v="Red = deficit. Hover a map cell to inspect." },
+    -- ── COLUMN BREAK ─────────────────────────────────────
+    { t="COL", v="" },
+    -- ── RIGHT COLUMN ─────────────────────────────────────
     { t="H", v="STATUS LEVELS" },
-    { t="B", v="Good  (green)  \226\128\148 Above optimal threshold. No action needed." },
-    { t="B", v="Fair  (yellow) \226\128\148 Below optimal. Monitor or apply a preventive top-up." },
-    { t="B", v="Poor  (red)    \226\128\148 Below minimum. Immediate treatment required." },
+    { t="B", v="Good  (green)  \226\128\148 At or above optimal." },
+    { t="B", v="   No action needed." },
+    { t="B", v="Fair  (yellow) \226\128\148 Below optimal." },
+    { t="B", v="   Monitor or apply a preventive top-up." },
+    { t="B", v="Poor  (red)    \226\128\148 Below minimum." },
+    { t="B", v="   Immediate treatment required." },
     { t="S", v=" " },
     { t="H", v="CROP PRESSURE" },
-    { t="B", v="Weed    > 20% \226\128\148 Apply Herbicide or use mechanical weeder / hoe." },
+    { t="B", v="Weed    > 20% \226\128\148 Apply Herbicide or use" },
+    { t="B", v="   mechanical weeder / hoe." },
     { t="B", v="Pest    > 20% \226\128\148 Apply Insecticide." },
     { t="B", v="Disease > 20% \226\128\148 Apply Fungicide." },
     { t="S", v=" " },
     { t="H", v="TIPS" },
-    { t="B", v="* Open the Treatment Plan tab to see which fields need attention most." },
-    { t="B", v="* Use the soil map overlay (press M then Soil Layers) to see per-cell data." },
-    { t="B", v="* Season + rain affect nutrients. Avoid over-applying N in autumn." },
-    { t="B", v="* Crop rotation avoids soil fatigue and can grant a legume N bonus." },
+    { t="B", v="* Open Treatment Plan tab — fields sorted" },
+    { t="B", v="  by urgency so you treat the worst first." },
+    { t="B", v="* Soil overlay (M key, Soil Layers tab)" },
+    { t="B", v="  shows per-cell colour-coded data." },
+    { t="B", v="* Rain leaches N. Avoid heavy N application" },
+    { t="B", v="  before forecast rain or in autumn." },
+    { t="B", v="* Legume crops (soy, clover) add a free" },
+    { t="B", v="  N bonus on the next season." },
 }
 
 -- ── i18n helper ───────────────────────────────────────────
@@ -109,7 +128,8 @@ end
 
 function SoilHelpDialog:onGuiSetupFinished()
     SoilHelpDialog:superClass().onGuiSetupFinished(self)
-    self._elContentBox = self:getDescendantById("sfHelp_contentBox")
+    self._elCol1 = self:getDescendantById("sfHelp_col1")
+    self._elCol2 = self:getDescendantById("sfHelp_col2")
 end
 
 function SoilHelpDialog:onOpen()
@@ -125,39 +145,44 @@ end
 -- ── Content Builder ───────────────────────────────────────
 
 function SoilHelpDialog:_buildContent()
-    if not self._elContentBox then return end
-
-    local profileH = g_gui:getProfile("sfHelp_header")
-    local profileB = g_gui:getProfile("sfHelp_body")
-    local profileS = g_gui:getProfile("sfHelp_spacer")
+    local profileH = g_gui:getProfile("sfHelp_colHeader")
+    local profileB = g_gui:getProfile("sfHelp_colBody")
+    local profileS = g_gui:getProfile("sfHelp_colSpacer")
 
     if not profileH or not profileB then
-        SoilLogger.warning("SoilHelpDialog: required profiles not found")
+        SoilLogger.warning("SoilHelpDialog: required column profiles not found")
         return
     end
 
-    for _, row in ipairs(SoilHelpDialog.CONTENT) do
-        local profile = (row.t == "H") and profileH
-                     or (row.t == "S") and profileS
-                     or profileB
+    local currentBox = self._elCol1
 
-        if profile then
-            local el = TextElement.new()
-            el:loadProfile(profile, true)
-            el:setText(row.v)
-            self._elContentBox:addElement(el)
-            el:onGuiSetupFinished()
-            table.insert(self._contentLineEls, el)
+    for _, row in ipairs(SoilHelpDialog.CONTENT) do
+        if row.t == "COL" then
+            if self._elCol1 then self._elCol1:invalidateLayout() end
+            currentBox = self._elCol2
+        elseif currentBox then
+            local profile = (row.t == "H") and profileH
+                         or (row.t == "S") and profileS
+                         or profileB
+
+            if profile then
+                local el = TextElement.new()
+                el:loadProfile(profile, true)
+                el:setText(row.v)
+                currentBox:addElement(el)
+                el:onGuiSetupFinished()
+                table.insert(self._contentLineEls, { box = currentBox, el = el })
+            end
         end
     end
 
-    self._elContentBox:invalidateLayout()
+    if self._elCol2 then self._elCol2:invalidateLayout() end
 end
 
 function SoilHelpDialog:_clearContent()
-    for _, el in ipairs(self._contentLineEls) do
-        if self._elContentBox then
-            self._elContentBox:removeElement(el)
+    for _, entry in ipairs(self._contentLineEls) do
+        if entry.box then
+            entry.box:removeElement(entry.el)
         end
     end
     self._contentLineEls = {}

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -190,6 +190,9 @@ function SoilMapOverlay:onSideBarClick(posX, posY)
             elseif rect.action == "disable" then
                 self:setLayer(0)
                 return true
+            elseif rect.action == "help" then
+                if SoilOverlayHelpDialog then SoilOverlayHelpDialog.show() end
+                return true
             elseif rect.index then
                 -- Toggle: re-clicking the active layer turns the overlay off
                 local newIdx = (self.settings.activeMapLayer == rect.index) and 0 or rect.index
@@ -991,9 +994,10 @@ function SoilMapOverlay:onDrawHud(frame)
     local _, actionMargin = getNormalizedScreenValues(0, 3)
 
     local actionButtons = {
-        { key = "sf_map_btn_report",    label = "Farm Overview",  action = "report"    },
-        { key = "sf_map_btn_treatment", label = "Treatment Plan", action = "treatment" },
-        { key = "sf_map_btn_disable",   label = "Disable Overlay",action = "disable"   },
+        { key = "sf_map_btn_report",    label = "Farm Overview",   action = "report"    },
+        { key = "sf_map_btn_treatment", label = "Treatment Plan",  action = "treatment" },
+        { key = "sf_map_btn_disable",   label = "Disable Overlay", action = "disable"   },
+        { key = "sf_map_btn_help",      label = "Help",            action = "help"      },
     }
 
     for _, btn in ipairs(actionButtons) do

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -681,29 +681,40 @@ function SoilMapOverlay:drawCellTooltip(ingameMap, mapX, mapY, mapWidth, mapHeig
 
     if layerIdx >= 1 and layerIdx <= 3 then
         -- ── Nutrient layer (N / P / K) ──────────────────────────
-        local nInfo, ppmMul, lbl
-        if     layerIdx == 1 then nInfo = info.nitrogen;   ppmMul = ppm.N; lbl = "Nitrogen (N)"
-        elseif layerIdx == 2 then nInfo = info.phosphorus; ppmMul = ppm.P; lbl = "Phosphorus (P)"
-        else                       nInfo = info.potassium;  ppmMul = ppm.K; lbl = "Potassium (K)" end
+        -- When PF compat mode is on and PF is active, suppress the N layer tooltip
+        -- to avoid showing two conflicting nitrogen readings side-by-side.
+        local pfBridge  = layerIdx == 1 and g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+        local sfSettings = layerIdx == 1 and g_SoilFertilityManager and g_SoilFertilityManager.settings
+        local suppressN = pfBridge and pfBridge.isActive and sfSettings and sfSettings.pfCompatibilityMode
 
-        local val = (nInfo.value or 0) * ppmMul
-        addRow(lbl, fmtV(string.format("%d ppm", math.floor(val + 0.5))), clrStatus(nInfo.status))
-
-        local targKey = (layerIdx == 1) and "N" or (layerIdx == 2) and "P" or "K"
-        local ct = info.cropTargets
-        if ct and ct[targKey] then
-            local target = ct[targKey] * ppmMul
-            local gap    = val - target
-            local crop   = cropTitle(info.lastCrop) or "Crop"
-            addRow("Target (" .. crop .. ")", string.format("%d ppm", math.floor(target + 0.5)), NEU[1], NEU[2], NEU[3])
-            if gap >= 0 then
-                addRow("Gap", string.format("+%d ppm", math.floor(gap + 0.5)), ttGOOD[1], ttGOOD[2], ttGOOD[3])
-            else
-                addRow("Gap", string.format("%d ppm needed", math.floor(-gap + 0.5)), ttPOOR[1], ttPOOR[2], ttPOOR[3])
-            end
+        if suppressN then
+            addRow("Nitrogen (N)", "managed by PF", DIM[1], DIM[2], DIM[3])
+            addRow("Tip", "Disable PF Compat Mode to see SF N data", DIM[1], DIM[2], DIM[3])
         else
-            local crop = cropTitle(info.lastCrop)
-            addRow("Target", crop and ("No data: " .. crop) or "No crop planted", DIM[1], DIM[2], DIM[3])
+            local nInfo, ppmMul, lbl
+            if     layerIdx == 1 then nInfo = info.nitrogen;   ppmMul = ppm.N; lbl = "Nitrogen (N)"
+            elseif layerIdx == 2 then nInfo = info.phosphorus; ppmMul = ppm.P; lbl = "Phosphorus (P)"
+            else                       nInfo = info.potassium;  ppmMul = ppm.K; lbl = "Potassium (K)" end
+
+            local val = (nInfo.value or 0) * ppmMul
+            addRow(lbl, fmtV(string.format("%d ppm", math.floor(val + 0.5))), clrStatus(nInfo.status))
+
+            local targKey = (layerIdx == 1) and "N" or (layerIdx == 2) and "P" or "K"
+            local ct = info.cropTargets
+            if ct and ct[targKey] then
+                local target = ct[targKey].opt * ppmMul
+                local gap    = val - target
+                local crop   = cropTitle(info.lastCrop) or "Crop"
+                addRow("Target (" .. crop .. ")", string.format("%d ppm", math.floor(target + 0.5)), NEU[1], NEU[2], NEU[3])
+                if gap >= 0 then
+                    addRow("Gap", string.format("+%d ppm", math.floor(gap + 0.5)), ttGOOD[1], ttGOOD[2], ttGOOD[3])
+                else
+                    addRow("Gap", string.format("%d ppm needed", math.floor(-gap + 0.5)), ttPOOR[1], ttPOOR[2], ttPOOR[3])
+                end
+            else
+                local crop = cropTitle(info.lastCrop)
+                addRow("Target", crop and ("No data: " .. crop) or "No crop planted", DIM[1], DIM[2], DIM[3])
+            end
         end
 
     elseif layerIdx == 4 then

--- a/src/ui/SoilOverlayHelpDialog.lua
+++ b/src/ui/SoilOverlayHelpDialog.lua
@@ -1,0 +1,174 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer — Soil Map Overlay Help Dialog
+-- =========================================================
+-- Opened from the Help button in the overlay sidebar.
+-- Explains how to read the soil map, layer meanings, the
+-- tooltip, the color legend, and sidebar buttons.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class SoilOverlayHelpDialog
+SoilOverlayHelpDialog = {}
+local SoilOverlayHelpDialog_mt = Class(SoilOverlayHelpDialog, ScreenElement)
+
+local SF_OVHELP_MOD_NAME = g_currentModName
+local SF_OVHELP_MOD_DIR  = g_currentModDirectory
+
+SoilOverlayHelpDialog.INSTANCE = nil
+
+-- Content table: {t="H"|"B"|"S", v="text"}
+-- H = section header (bold, green, uppercase)
+-- B = body line (white, normal)
+-- S = spacer (blank gap)
+SoilOverlayHelpDialog.CONTENT = {
+    { t="H", v="HOW TO READ THE SOIL MAP" },
+    { t="B", v="The overlay colours each map cell based on the selected nutrient layer." },
+    { t="B", v="  Red    = Poor  (below minimum, needs immediate attention)" },
+    { t="B", v="  Yellow = Fair  (below optimal, monitor or top-up soon)" },
+    { t="B", v="  Green  = Good  (at or above optimal, no action needed)" },
+    { t="B", v="Unsampled cells appear dim \226\128\148 walk onto the field to sample them." },
+    { t="S", v=" " },
+    { t="H", v="MAP LAYERS" },
+    { t="B", v="Layer 1 \226\128\148 Nitrogen (N)      : Most volatile. Depletes on every harvest." },
+    { t="B", v="Layer 2 \226\128\148 Phosphorus (P)    : Slow-moving. Long-lasting from MAP / DAP." },
+    { t="B", v="Layer 3 \226\128\148 Potassium (K)     : Apply Potash. Important for root crops." },
+    { t="B", v="Layer 4 \226\128\148 pH                : 6.5 - 7.0 ideal. Green = optimal range." },
+    { t="B", v="Layer 5 \226\128\148 Organic Matter    : Higher = better soil structure and retention." },
+    { t="S", v=" " },
+    { t="H", v="CELL TOOLTIP (hover a cell)" },
+    { t="B", v="Shows the exact nutrient value (ppm), its Good / Fair / Poor status," },
+    { t="B", v="and \226\128\148 when a crop is planted \226\128\148 the crop's target value and the gap" },
+    { t="B", v="(how many ppm you are above or below the crop's optimal requirement)." },
+    { t="S", v=" " },
+    { t="H", v="COLOUR LEGEND (sidebar)" },
+    { t="B", v="The gradient bar shows what colour = what status for the active layer." },
+    { t="B", v="All layers use the same Red (poor) to Yellow (fair) to Green (good) scale." },
+    { t="S", v=" " },
+    { t="H", v="SIDEBAR BUTTONS" },
+    { t="B", v="Farm Overview  \226\128\148 Opens the PDA soil report for all your fields." },
+    { t="B", v="Treatment Plan \226\128\148 Opens a prioritised list of fields needing attention." },
+    { t="B", v="Disable Overlay \226\128\148 Turns off the soil overlay (re-enable via sidebar)." },
+    { t="B", v="Help           \226\128\148 You are reading it." },
+    { t="S", v=" " },
+    { t="H", v="TIPS" },
+    { t="B", v="* Click a map cell while the overlay is active to inspect it." },
+    { t="B", v="* The number on each field tile shows the field-average value." },
+    { t="B", v="* Zoom into a field to see per-cell variability within the field." },
+    { t="B", v="* Switch layers with the numbered buttons at the top of the sidebar." },
+}
+
+-- ── i18n helper ───────────────────────────────────────────
+
+local function tr(key, fallback)
+    local modEnv = g_modEnvironments and g_modEnvironments[SF_OVHELP_MOD_NAME]
+    local i18n = (modEnv and modEnv.i18n) or g_i18n
+    if i18n then
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            return text
+        end
+    end
+    return fallback or key
+end
+
+-- ── Constructor ───────────────────────────────────────────
+
+function SoilOverlayHelpDialog.new(target, customMt)
+    local self = ScreenElement.new(target, customMt or SoilOverlayHelpDialog_mt)
+    self._contentLineEls = {}
+    return self
+end
+
+function SoilOverlayHelpDialog.register(modDirectory)
+    if SoilOverlayHelpDialog.INSTANCE ~= nil then return end
+
+    SF_OVHELP_MOD_DIR = modDirectory
+    local xmlPath = modDirectory .. "xml/gui/SoilOverlayHelpDialog.xml"
+
+    SoilOverlayHelpDialog.INSTANCE = SoilOverlayHelpDialog.new()
+    SoilLogger.info("SoilOverlayHelpDialog: registering from %s", xmlPath)
+
+    local ok, err = pcall(function()
+        g_gui:loadGui(xmlPath, "SoilOverlayHelpDialog", SoilOverlayHelpDialog.INSTANCE)
+    end)
+
+    if not ok then
+        SoilLogger.error("SoilOverlayHelpDialog: loadGui failed: %s", tostring(err))
+        SoilOverlayHelpDialog.INSTANCE = nil
+    else
+        SoilLogger.info("SoilOverlayHelpDialog: registered successfully")
+    end
+end
+
+function SoilOverlayHelpDialog.show()
+    if SoilOverlayHelpDialog.INSTANCE == nil then
+        SoilOverlayHelpDialog.register(SF_OVHELP_MOD_DIR)
+    end
+    if SoilOverlayHelpDialog.INSTANCE == nil then return end
+    g_gui:showDialog("SoilOverlayHelpDialog")
+end
+
+-- ── Lifecycle ─────────────────────────────────────────────
+
+function SoilOverlayHelpDialog:onGuiSetupFinished()
+    SoilOverlayHelpDialog:superClass().onGuiSetupFinished(self)
+    self._elContentBox = self:getDescendantById("sfOvHelp_contentBox")
+end
+
+function SoilOverlayHelpDialog:onOpen()
+    SoilOverlayHelpDialog:superClass().onOpen(self)
+    self:_buildContent()
+end
+
+function SoilOverlayHelpDialog:onClose()
+    SoilOverlayHelpDialog:superClass().onClose(self)
+    self:_clearContent()
+end
+
+-- ── Content Builder ───────────────────────────────────────
+
+function SoilOverlayHelpDialog:_buildContent()
+    if not self._elContentBox then return end
+
+    local profileH = g_gui:getProfile("sfOvHelp_header")
+    local profileB = g_gui:getProfile("sfOvHelp_body")
+    local profileS = g_gui:getProfile("sfOvHelp_spacer")
+
+    if not profileH or not profileB then
+        SoilLogger.warning("SoilOverlayHelpDialog: required profiles not found")
+        return
+    end
+
+    for _, row in ipairs(SoilOverlayHelpDialog.CONTENT) do
+        local profile = (row.t == "H") and profileH
+                     or (row.t == "S") and profileS
+                     or profileB
+
+        if profile then
+            local el = TextElement.new()
+            el:loadProfile(profile, true)
+            el:setText(row.v)
+            self._elContentBox:addElement(el)
+            el:onGuiSetupFinished()
+            table.insert(self._contentLineEls, el)
+        end
+    end
+
+    self._elContentBox:invalidateLayout()
+end
+
+function SoilOverlayHelpDialog:_clearContent()
+    for _, el in ipairs(self._contentLineEls) do
+        if self._elContentBox then
+            self._elContentBox:removeElement(el)
+        end
+    end
+    self._contentLineEls = {}
+end
+
+-- ── Button ────────────────────────────────────────────────
+
+function SoilOverlayHelpDialog:onClickClose()
+    g_gui:closeDialogByName("SoilOverlayHelpDialog")
+end

--- a/src/ui/SoilOverlayHelpDialog.lua
+++ b/src/ui/SoilOverlayHelpDialog.lua
@@ -2,8 +2,7 @@
 -- FS25 Soil & Fertilizer — Soil Map Overlay Help Dialog
 -- =========================================================
 -- Opened from the Help button in the overlay sidebar.
--- Explains how to read the soil map, layer meanings, the
--- tooltip, the color legend, and sidebar buttons.
+-- Two-column layout: how-to-read/layers | tooltip/legend/buttons/tips
 -- =========================================================
 -- Author: TisonK
 -- =========================================================
@@ -17,45 +16,58 @@ local SF_OVHELP_MOD_DIR  = g_currentModDirectory
 
 SoilOverlayHelpDialog.INSTANCE = nil
 
--- Content table: {t="H"|"B"|"S", v="text"}
--- H = section header (bold, green, uppercase)
--- B = body line (white, normal)
--- S = spacer (blank gap)
+-- Content table: {t="H"|"B"|"S"|"COL", v="text"}
+-- H   = section header (bold, green, uppercase)
+-- B   = body line (white, normal)
+-- S   = spacer (blank gap)
+-- COL = column break — switch from col1 to col2
 SoilOverlayHelpDialog.CONTENT = {
-    { t="H", v="HOW TO READ THE SOIL MAP" },
-    { t="B", v="The overlay colours each map cell based on the selected nutrient layer." },
-    { t="B", v="  Red    = Poor  (below minimum, needs immediate attention)" },
-    { t="B", v="  Yellow = Fair  (below optimal, monitor or top-up soon)" },
-    { t="B", v="  Green  = Good  (at or above optimal, no action needed)" },
-    { t="B", v="Unsampled cells appear dim \226\128\148 walk onto the field to sample them." },
+    -- ── LEFT COLUMN ──────────────────────────────────────
+    { t="H", v="HOW TO READ THE MAP" },
+    { t="B", v="Each cell is colour-coded for the active layer:" },
+    { t="B", v="  Red    \226\128\148 Poor  (below minimum)" },
+    { t="B", v="  Yellow \226\128\148 Fair  (below optimal)" },
+    { t="B", v="  Green  \226\128\148 Good  (at or above optimal)" },
+    { t="B", v="Dim cells = unsampled. Walk onto the field" },
+    { t="B", v="to collect a soil reading for that area." },
     { t="S", v=" " },
     { t="H", v="MAP LAYERS" },
-    { t="B", v="Layer 1 \226\128\148 Nitrogen (N)      : Most volatile. Depletes on every harvest." },
-    { t="B", v="Layer 2 \226\128\148 Phosphorus (P)    : Slow-moving. Long-lasting from MAP / DAP." },
-    { t="B", v="Layer 3 \226\128\148 Potassium (K)     : Apply Potash. Important for root crops." },
-    { t="B", v="Layer 4 \226\128\148 pH                : 6.5 - 7.0 ideal. Green = optimal range." },
-    { t="B", v="Layer 5 \226\128\148 Organic Matter    : Higher = better soil structure and retention." },
+    { t="B", v="Layer 1 \226\128\148 Nitrogen (N)" },
+    { t="B", v="   Most volatile. Depletes on every harvest." },
+    { t="B", v="Layer 2 \226\128\148 Phosphorus (P)" },
+    { t="B", v="   Slow-moving. Long-lasting from MAP / DAP." },
+    { t="B", v="Layer 3 \226\128\148 Potassium (K)" },
+    { t="B", v="   Apply Potash. Critical for root crops." },
+    { t="B", v="Layer 4 \226\128\148 pH" },
+    { t="B", v="   6.5 - 7.0 ideal. Green = in optimal range." },
+    { t="B", v="Layer 5 \226\128\148 Organic Matter" },
+    { t="B", v="   Higher = better structure and water retention." },
+    -- ── COLUMN BREAK ─────────────────────────────────────
+    { t="COL", v="" },
+    -- ── RIGHT COLUMN ─────────────────────────────────────
+    { t="H", v="CELL TOOLTIP (HOVER A CELL)" },
+    { t="B", v="Shows the exact nutrient value (ppm)," },
+    { t="B", v="its Good / Fair / Poor status, and —" },
+    { t="B", v="when a crop is planted — the crop's target" },
+    { t="B", v="and the gap above or below it." },
     { t="S", v=" " },
-    { t="H", v="CELL TOOLTIP (hover a cell)" },
-    { t="B", v="Shows the exact nutrient value (ppm), its Good / Fair / Poor status," },
-    { t="B", v="and \226\128\148 when a crop is planted \226\128\148 the crop's target value and the gap" },
-    { t="B", v="(how many ppm you are above or below the crop's optimal requirement)." },
-    { t="S", v=" " },
-    { t="H", v="COLOUR LEGEND (sidebar)" },
-    { t="B", v="The gradient bar shows what colour = what status for the active layer." },
-    { t="B", v="All layers use the same Red (poor) to Yellow (fair) to Green (good) scale." },
+    { t="H", v="COLOUR LEGEND (SIDEBAR)" },
+    { t="B", v="The gradient bar shows what colour = what" },
+    { t="B", v="status for the active layer." },
+    { t="B", v="All layers: Red (poor) \226\128\148 Yellow \226\128\148 Green (good)." },
     { t="S", v=" " },
     { t="H", v="SIDEBAR BUTTONS" },
-    { t="B", v="Farm Overview  \226\128\148 Opens the PDA soil report for all your fields." },
-    { t="B", v="Treatment Plan \226\128\148 Opens a prioritised list of fields needing attention." },
-    { t="B", v="Disable Overlay \226\128\148 Turns off the soil overlay (re-enable via sidebar)." },
+    { t="B", v="Farm Overview  \226\128\148 PDA soil report." },
+    { t="B", v="Treatment Plan \226\128\148 Fields by urgency." },
+    { t="B", v="Disable Overlay \226\128\148 Turn off the overlay." },
     { t="B", v="Help           \226\128\148 You are reading it." },
     { t="S", v=" " },
     { t="H", v="TIPS" },
-    { t="B", v="* Click a map cell while the overlay is active to inspect it." },
-    { t="B", v="* The number on each field tile shows the field-average value." },
-    { t="B", v="* Zoom into a field to see per-cell variability within the field." },
-    { t="B", v="* Switch layers with the numbered buttons at the top of the sidebar." },
+    { t="B", v="* Click a cell to inspect it in detail." },
+    { t="B", v="* Number on field tile = field average." },
+    { t="B", v="* Zoom in to see per-cell variability." },
+    { t="B", v="* Layer buttons at top of sidebar switch" },
+    { t="B", v="  between N / P / K / pH / OM views." },
 }
 
 -- ── i18n helper ───────────────────────────────────────────
@@ -113,7 +125,8 @@ end
 
 function SoilOverlayHelpDialog:onGuiSetupFinished()
     SoilOverlayHelpDialog:superClass().onGuiSetupFinished(self)
-    self._elContentBox = self:getDescendantById("sfOvHelp_contentBox")
+    self._elCol1 = self:getDescendantById("sfOvHelp_col1")
+    self._elCol2 = self:getDescendantById("sfOvHelp_col2")
 end
 
 function SoilOverlayHelpDialog:onOpen()
@@ -129,39 +142,44 @@ end
 -- ── Content Builder ───────────────────────────────────────
 
 function SoilOverlayHelpDialog:_buildContent()
-    if not self._elContentBox then return end
-
-    local profileH = g_gui:getProfile("sfOvHelp_header")
-    local profileB = g_gui:getProfile("sfOvHelp_body")
-    local profileS = g_gui:getProfile("sfOvHelp_spacer")
+    local profileH = g_gui:getProfile("sfOvHelp_colHeader")
+    local profileB = g_gui:getProfile("sfOvHelp_colBody")
+    local profileS = g_gui:getProfile("sfOvHelp_colSpacer")
 
     if not profileH or not profileB then
-        SoilLogger.warning("SoilOverlayHelpDialog: required profiles not found")
+        SoilLogger.warning("SoilOverlayHelpDialog: required column profiles not found")
         return
     end
 
-    for _, row in ipairs(SoilOverlayHelpDialog.CONTENT) do
-        local profile = (row.t == "H") and profileH
-                     or (row.t == "S") and profileS
-                     or profileB
+    local currentBox = self._elCol1
 
-        if profile then
-            local el = TextElement.new()
-            el:loadProfile(profile, true)
-            el:setText(row.v)
-            self._elContentBox:addElement(el)
-            el:onGuiSetupFinished()
-            table.insert(self._contentLineEls, el)
+    for _, row in ipairs(SoilOverlayHelpDialog.CONTENT) do
+        if row.t == "COL" then
+            if self._elCol1 then self._elCol1:invalidateLayout() end
+            currentBox = self._elCol2
+        elseif currentBox then
+            local profile = (row.t == "H") and profileH
+                         or (row.t == "S") and profileS
+                         or profileB
+
+            if profile then
+                local el = TextElement.new()
+                el:loadProfile(profile, true)
+                el:setText(row.v)
+                currentBox:addElement(el)
+                el:onGuiSetupFinished()
+                table.insert(self._contentLineEls, { box = currentBox, el = el })
+            end
         end
     end
 
-    self._elContentBox:invalidateLayout()
+    if self._elCol2 then self._elCol2:invalidateLayout() end
 end
 
 function SoilOverlayHelpDialog:_clearContent()
-    for _, el in ipairs(self._contentLineEls) do
-        if self._elContentBox then
-            self._elContentBox:removeElement(el)
+    for _, entry in ipairs(self._contentLineEls) do
+        if entry.box then
+            entry.box:removeElement(entry.el)
         end
     end
     self._contentLineEls = {}

--- a/src/ui/SoilPDAScreen.lua
+++ b/src/ui/SoilPDAScreen.lua
@@ -467,29 +467,8 @@ end
 -- ── Map Tab button ────────────────────────────────────────
 
 function SoilPDAScreen:onClickHelp()
-    if InfoDialog then
-        local t = tr
-        local lines = {
-            t("sf_help_nutrients_header", "NUTRIENTS"),
-            t("sf_help_n",  "N  (Nitrogen)     — Depletes fast. Apply UAN, Urea, or Manure."),
-            t("sf_help_p",  "P  (Phosphorus)   — Long-lasting. Apply MAP or DAP."),
-            t("sf_help_k",  "K  (Potassium)    — Apply Potash. Important for roots."),
-            t("sf_help_om", "OM (Organic Mat.) — Builds slowly. Plow in manure/compost."),
-            "",
-            t("sf_help_soil_header", "SOIL CHEMISTRY"),
-            t("sf_help_ph", "pH  6.5 – 7.0 = Ideal.  < 6.5 apply Lime.  > 7.5 apply Gypsum."),
-            "",
-            t("sf_help_pressure_header", "CROP PRESSURE"),
-            t("sf_help_weed",    "Weed     > 20% — Apply Herbicide or use mechanical weeder/hoe."),
-            t("sf_help_pest",    "Pest     > 20% — Apply Insecticide."),
-            t("sf_help_disease", "Disease  > 20% — Apply Fungicide."),
-            "",
-            t("sf_help_status_header", "STATUS LEVELS"),
-            t("sf_help_good", "Good — No action needed."),
-            t("sf_help_fair", "Fair — Monitor / preventive top-up."),
-            t("sf_help_poor", "Poor — Immediate treatment required."),
-        }
-        InfoDialog.show(table.concat(lines, "\n"), nil, tr("sf_help_title", "Soil Quick Reference"))
+    if SoilHelpDialog then
+        SoilHelpDialog.show()
     end
 end
 

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -130,7 +130,7 @@ local CATEGORIES = {
         sections = {
             {
                 headerKey = "sf_panel_hdr_visibility",
-                items     = { "showHUD", "showMiniReport", "showFieldInfoBox", "useImperialUnits", "colorblindMode" }
+                items     = { "showHUD", "showMiniReport", "showFieldInfoBox", "useImperialUnits", "colorblindMode", "pfCompatibilityMode" }
             },
             {
                 headerKey = "sf_panel_hdr_hud_style",

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -192,7 +192,7 @@ function SoilTreatmentDialog:_populateData()
     if info.phosphorus.value < (thresh.phosphorus.poor or 25) then
         self:_setAction(self.treatPAction, tr("sf_treat_action_p_poor", "Apply MAP or DAP (Phosphorus)."), COLOR_POOR)
     elseif info.phosphorus.value < (thresh.phosphorus.fair or 45) then
-        self:_setAction(self.treatPAction, tr("sf_treat_action_p_fair", "Apply blended FERTILIZER."), COLOR_FAIR)
+        self:_setAction(self.treatPAction, tr("sf_treat_action_p_fair", "Top-up with Liquid MAP, Liquid DAP, or DAP (P)."), COLOR_FAIR)
     else
         self:_setAction(self.treatPAction, tr("sf_treat_action_ok", "OK"), COLOR_GOOD)
     end
@@ -201,7 +201,7 @@ function SoilTreatmentDialog:_populateData()
     if info.potassium.value < (thresh.potassium.poor or 20) then
         self:_setAction(self.treatKAction, tr("sf_treat_action_k_poor", "Apply POTASH (Potassium)."), COLOR_POOR)
     elseif info.potassium.value < (thresh.potassium.fair or 40) then
-        self:_setAction(self.treatKAction, tr("sf_treat_action_k_fair", "Apply blended FERTILIZER."), COLOR_FAIR)
+        self:_setAction(self.treatKAction, tr("sf_treat_action_k_fair", "Top-up with Liquid Potash or Potash (K)."), COLOR_FAIR)
     else
         self:_setAction(self.treatKAction, tr("sf_treat_action_ok", "OK"), COLOR_GOOD)
     end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,16 +24,16 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- HUD now shows a session-based current-pass coverage tracker so you can see field progress in real time",
-    "- Fixed Biosolids spread on fields now appears near-black (correct color) instead of brown",
-    "- Fixed Harvest nutrient depletion now calculates correctly using field area (fixes 8x over/under-depletion)",
-    "- Fixed Nutrients now deplete properly when harvesting in swath/windrow mode",
-    "- Fixed Oat nutrient extraction was using the wrong lookup key — corrected",
-    "- Fixed Organic Matter (OM) is now clamped to a valid range on all load and save paths",
-    "- Fixed All solid fill types now have distance textures (fixes visual pop-in at range)",
-    "- Fixed Cell report now shows field averages even when no soil zone cells have been sampled yet",
-    "- Fixed SoilDebug console command now takes effect immediately without requiring a restart",
-    "- Fixed False 'savegame not found' warning no longer appears on brand-new careers",
+    "- NEW  Precision Farming DLC: N/P/K bars now update live from PF sensors as you drive",
+    "- NEW  Map shows real per-zone variation — lime one half of a field, map shows two different colors",
+    "- NEW  Over-limed soil (pH above 7.0) now correctly shows red on the map instead of yellow",
+    "- NEW  Click any map tile to see focused info for that layer only — no more wall of numbers",
+    "- NEW  pH tile shows your condition (Optimal / Acidic / Over-limed) and what treatment to apply",
+    "- NEW  N, P, K tiles show your crop's target and exactly how far above or below you are",
+    "- NEW  Weed, pest and disease tiles show whether your protection product is still active",
+    "- Fixed Map tile colors now refresh the moment you click — no more stale colors after spraying",
+    "- Fixed N bar tick marks now show correctly when Precision Farming mod is active",
+    "- Fixed Straw chopping now builds Organic Matter correctly based on your field's actual size",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -442,7 +442,7 @@
     <e k="sf_pda_map_unavailable" v="Visualização do mapa indisponível" eh="43983f81" />
     <e k="sf_map_health_overall" v="Saúde Média do Solo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir Visão Geral da Fazenda" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Nota do Dev (NÃO FUNCIONA AINDA)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Mudar camada" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plano de tratamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desativar camada" eh="8e75dec5" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limiar ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Produção ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Vista prèvia del mapa no disponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salut mitjana del sòl" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Obrir resum de la granja" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Nota del dev (ENCARA NO FUNCIONA)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Canviar capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Pla de tractament" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar capa" eh="8e75dec5" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basat en N/P/K vs llindar òptim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Pèrdua de rendiment ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Náhled mapy nedostupný" eh="43983f81" />
     <e k="sf_map_health_overall" v="Průměrné zdraví půdy" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Otevřít přehled farmy" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Poznámka vývojáře (ZATÍM NEFUNGUJE)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Přepnout vrstvu" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plán ošetření" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Vypnout překryv" eh="8e75dec5" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Vysoký" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Založeno na N/P/K vs optimální práh" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Výnos ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Kortvisning ikke tilgængelig" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gennemsnitlig jordsundhed" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Åbn gårdsoversigt" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Udviklernote (VIRKER IKKE ENDNU)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Skift lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver lag" eh="8e75dec5" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Høj" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baseret på N/P/K vs. optimal grænse" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Udbytte ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Oversigt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Kom godt i gang" eh="bf647454" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Karten-Vorschau nicht verfügbar" eh="43983f81" />
     <e k="sf_map_health_overall" v="Durchschn. Bodengesundheit" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Hofübersicht öffnen" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Entwickler-Notiz (FUNKTIONIERT NOCH NICHT)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ebene wechseln" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlungsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay deaktivieren" eh="8e75dec5" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Hoch" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basierend auf N/P/K vs. optimalem Schwellenwert" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Ertrag ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Übersicht" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Erste Schritte" eh="bf647454" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Previsualización no disponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salud Media del Suelo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir Resumen de Granja" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Nota (NO FUNCIONA AÚN)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ciclar Capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de Tratamiento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar Capa" eh="8e75dec5" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Alto" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros Pasos" eh="bf647454" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="43983f81" />
     <e k="sf_map_health_overall" v="Average Soil Health" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Open Farm Overview" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Dev Note (NOT WORKING YET)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Cycle Layer" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Treatment Plan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disable Overlay" eh="8e75dec5" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Previsualización no disponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salud promedio del suelo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir resumen de granja" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Nota (NO FUNCIONA AÚN)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ciclar capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de tratamiento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar capa" eh="8e75dec5" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros pasos" eh="bf647454" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Aperçu indisponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Santé moyenne du sol" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Ouvrir aperçu ferme" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Note (Bientôt disponible)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Changer couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan traitement" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Désactiver couche" eh="8e75dec5" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Haute" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Aperçu" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Mise en route" eh="bf647454" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -426,7 +426,7 @@
     <e k="sf_pda_map_unavailable" v="Kartan esikatselu ei ole käytettävissä" eh="43983f81" />
     <e k="sf_map_health_overall" v="Maaperän keskim. terveys" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Avaa tilan yleiskatsaus" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Kehittäjän huomio (EI TOIMI VIELÄ)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Vaihda tasoa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Hoitosuunnitelma" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Poista peite käytöstä" eh="8e75dec5" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Korkea" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Perustuu N/P/K-tasoihin vs. kynnysarvo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Satohäviö ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Yleiskatsaus" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Aloittaminen" eh="bf647454" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -443,7 +443,7 @@
     <e k="sf_pda_map_unavailable" v="Aperçu de la carte indisponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Santé moyenne du sol" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Ouvrir l'aperçu de la ferme" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Note dev (PAS ENCORE FONCTIONNEL)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Changer de couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de traitement" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Désactiver la superposition" eh="8e75dec5" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Élevé" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basé sur N/P/K par rapport au seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          LIGNES D’AIDE (ESC > Aide > Sol & Fertilisation réalistes)

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -442,7 +442,7 @@
     <e k="sf_pda_map_unavailable" v="Térkép előnézet nem elérhető" eh="43983f81" />
     <e k="sf_map_health_overall" v="Átlagos talaj egészség" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Gazdaság áttekintés" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Dev megjegyzés (MÉG NEM MŰKÖDIK)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Réteg váltás" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kezelési terv" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Átfedés kikapcsolása" eh="8e75dec5" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Magas" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Az N/P/K arány alapján az optimális küszöbhöz képest" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hozam ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Pratinjau peta tidak tersedia" eh="43983f81" />
     <e k="sf_map_health_overall" v="Rata-rata Kesehatan Tanah" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Buka Ikhtisar Pertanian" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Catatan Dev (BELUM BERFUNGSI)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Siklus Lapisan" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Rencana Perawatan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Nonaktifkan Overlay" eh="8e75dec5" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Tinggi" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Berdasarkan N/P/K vs ambang batas optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hasil ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Anteprima mappa non disponibile" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salute Media del Suolo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Apri Panoramica Fattoria" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Nota Dev (NON ANCORA FUNZIONANTE)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Cambia livello" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Piano di trattamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disabilita overlay" eh="8e75dec5" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basato su N/P/K rispetto alla soglia ottimale" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Resa ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="マッププレビュー利用不可" eh="43983f81" />
     <e k="sf_map_health_overall" v="平均土壌健全度" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="農場概要を開く" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="開発ノート (未実装)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="レイヤー切替" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="施肥計画" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="オーバーレイ無効" eh="8e75dec5" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="高" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="窒素/リン/カリの最適閾値に基づきます" eh="022663e0" />
     <e k="sf_report_yield_loss" v="収量予測 ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -440,7 +440,7 @@
     <e k="sf_pda_map_unavailable" v="지도 미리보기를 사용할 수 없음" eh="43983f81" />
     <e k="sf_map_health_overall" v="평균 토양 건강도" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="농장 개요 열기" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="개발자 참고 (아직 작동 안 함)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="레이어 전환" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="처리 계획" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="오버레이 비활성화" eh="8e75dec5" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="높음" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="최적 임계값 대비 N/P/K 기준" eh="022663e0" />
     <e k="sf_report_yield_loss" v="수확량 ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Kaartvoorbeeld niet beschikbaar" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gemiddelde bodemgezondheid" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Open boerderijoverzicht" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Dev Notitie (WERKT NOG NIET)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Laag wisselen" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandelplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay uitschakelen" eh="8e75dec5" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Hoog" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Gebaseerd op N/P/K versus optimale drempel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Opbrengstverlies ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Kartforhåndsvisning utilgjengelig" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gjennomsnittlig jordhelse" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Åpne gårdsoversikt" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Utvikler-notat (VIRKER IKKE ENNÅ)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Bytt lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver overlegg" eh="8e75dec5" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Høy" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basert på N/P/K mot optimal terskel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Avlingstap ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -441,7 +441,7 @@
     <e k="sf_pda_map_unavailable" v="Podgląd mapy niedostępny" eh="43983f81" />
     <e k="sf_map_health_overall" v="Średnie zdrowie gleby" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Otwórz przegląd gospodarstwa" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Notka dewelopera (JESZCZE NIE DZIAŁA)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Przełącz warstwę" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan zabiegów" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Wyłącz nakładkę" eh="8e75dec5" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Wysoka" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Na podstawie N/P/K vs próg optymalny" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Strata plonu ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -442,7 +442,7 @@
     <e k="sf_pda_map_unavailable" v="Pré-visualização do mapa indisponível" eh="43983f81" />
     <e k="sf_map_health_overall" v="Saúde Média do Solo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir Visão Geral da Quinta" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Nota Dev (AINDA NÃO FUNCIONA)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Ciclar Camada" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plano de Tratamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desativar Sobreposição" eh="8e75dec5" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limite ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimento ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          LINHAS DE AJUDA (ESC > Ajuda > Solo e Fertilizante Realista)

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -442,7 +442,7 @@
     <e k="sf_pda_map_unavailable" v="Previzualizare hartă indisponibilă" eh="43983f81" />
     <e k="sf_map_health_overall" v="Sănătatea Medie a Solului" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Deschide Prezentare Fermă" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Notă Dev (NU FUNCȚIONEAZĂ ÎNCĂ)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Schimbă Stratul" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan Tratament" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Dezactivează Suprapunerea" eh="8e75dec5" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Ridicată" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Bazat pe N/P/K vs prag optim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Recoltă ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          LINII DE AJUTOR (ESC > Ajutor > Sol și Îngrășământ Realist)

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -426,7 +426,7 @@
     <e k="sf_pda_map_unavailable" v="Предпросмотр недоступен" eh="43983f81" />
     <e k="sf_map_health_overall" v="Среднее здоровье почвы" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Открыть обзор фермы" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Заметка (В РАЗРАБОТКЕ)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Сменить слой" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="План обработки" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Убрать наложение" eh="8e75dec5" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Высокая" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="На основе N/P/K относительно оптимума" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Потеря урожая ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- Help Lines -->
     <e k="helpLine_sf_cat_overview" v="Обзор" eh="3b878279" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Kartförhandsvisning ej tillgänglig" eh="43983f81" />
     <e k="sf_map_health_overall" v="Genomsnittlig markhälsa" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Öppna gårdsöversikt" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Utvecklarnotis (FUNGERAR INTE ÄNNU)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Byt lager" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Inaktivera överlagring" eh="8e75dec5" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Hög" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baserat på N/P/K mot optimalt tröskelvärde" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Skörd ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Översikt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Komma igång" eh="bf647454" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -426,7 +426,7 @@
     <e k="sf_pda_map_unavailable" v="Harita önizlemesi mevcut değil" eh="43983f81" />
     <e k="sf_map_health_overall" v="Ortalama Toprak Sağlığı" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Çiftlik Özetini Aç" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Geliştirici Notu (HENÜZ ÇALIŞMIYOR)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Katmanı Değiştir" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Tedavi Planı" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Katmanı Kapat" eh="8e75dec5" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Yüksek" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Optimal eşiğe göre N/P/K baz alınmıştır" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Verim ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Genel Bakış" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Başlangıç" eh="bf647454" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Прев'ю карти недоступне" eh="43983f81" />
     <e k="sf_map_health_overall" v="Середній стан ґрунту" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Відкрити огляд ферми" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Примітка розробника (В РОБОТІ)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Змінити шар" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="План обробки" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Вимкнути оверлей" eh="8e75dec5" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Висока" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Базується на N/P/K відносно порогу" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Врожайність ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Огляд" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Початок роботи" eh="bf647454" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -425,7 +425,7 @@
     <e k="sf_pda_map_unavailable" v="Không có xem trước bản đồ" eh="43983f81" />
     <e k="sf_map_health_overall" v="Sức khỏe đất trung bình" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Mở tổng quan trang trại" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Ghi chú Dev (CHƯA HOẠT ĐỘNG)" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Đổi lớp" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kế hoạch xử lý" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Tắt lớp phủ" eh="8e75dec5" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -223,6 +223,8 @@
     <e k="sf_report_pressure_high" v="Cao" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Dựa trên N/P/K so với ngưỡng tối ưu" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Sản lượng ~-%d%%" eh="d64d5d59" />
+    <e k="sf_pf_compat_short" v="PF Compat Mode" />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Tổng quan" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Bắt đầu" eh="bf647454" />

--- a/xml/gui/SoilHelpDialog.xml
+++ b/xml/gui/SoilHelpDialog.xml
@@ -19,12 +19,17 @@
     <Text profile="fs25_dialogTitle" id="sfHelp_title"
           text="Soil &amp; Fertilizer Guide" position="0px -30px"/>
 
-    <!-- Separator -->
-    <Bitmap profile="sfHelp_sep" position="0px -66px" size="620px 2px"/>
+    <!-- Horizontal separator under title -->
+    <Bitmap profile="sfHelp_sep" position="0px -66px" size="900px 2px"/>
 
-    <!-- Dynamic content box — Lua adds header/body TextElements here -->
-    <BoxLayout profile="sfHelp_contentBox" id="sfHelp_contentBox"
-               position="0px -84px"/>
+    <!-- Left column — populated by Lua -->
+    <BoxLayout profile="sfHelp_col" id="sfHelp_col1" position="-230px -84px"/>
+
+    <!-- Vertical divider between columns -->
+    <Bitmap profile="sfHelp_vSep" position="0px -84px" size="2px 580px"/>
+
+    <!-- Right column — populated by Lua -->
+    <BoxLayout profile="sfHelp_col" id="sfHelp_col2" position="230px -84px"/>
 
     <BoxLayout profile="fs25_dialogButtonBox">
       <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
@@ -34,33 +39,36 @@
 
   <GUIProfiles>
     <Profile name="sfHelp_bg" extends="fs25_dialogBg">
-      <size value="680px 720px"/>
+      <size value="960px 720px"/>
     </Profile>
     <Profile name="sfHelp_sep" extends="baseReference" with="anchorTopCenter">
       <imageColor value="1.0 1.0 1.0 0.15"/>
     </Profile>
-    <!-- Vertical BoxLayout — Lua adds elements at runtime -->
-    <Profile name="sfHelp_contentBox" extends="emptyPanel" with="anchorTopCenter">
-      <size value="620px 575px"/>
+    <Profile name="sfHelp_vSep" extends="baseReference" with="anchorTopCenter">
+      <imageColor value="1.0 1.0 1.0 0.15"/>
+    </Profile>
+    <!-- Vertical column — Lua adds TextElements at runtime -->
+    <Profile name="sfHelp_col" extends="emptyPanel" with="anchorTopCenter">
+      <size value="440px 580px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
-      <alignmentX value="center"/>
+      <alignmentX value="left"/>
       <elementSpacing value="3px"/>
     </Profile>
     <!-- Section header: bold, green, uppercase -->
-    <Profile name="sfHelp_header" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfHelp_colHeader" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="14px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
     </Profile>
     <!-- Body line: normal weight, white -->
-    <Profile name="sfHelp_body" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="12px"/>
       <textColor value="$preset_colorWhite"/>
     </Profile>
     <!-- Spacer: invisible placeholder for vertical gap -->
-    <Profile name="sfHelp_spacer" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfHelp_colSpacer" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="6px"/>
       <textColor value="0.0 0.0 0.0 0.0"/>
     </Profile>

--- a/xml/gui/SoilHelpDialog.xml
+++ b/xml/gui/SoilHelpDialog.xml
@@ -55,12 +55,13 @@
       <alignmentX value="left"/>
       <elementSpacing value="3px"/>
     </Profile>
-    <!-- Section header: bold, green, uppercase -->
+    <!-- Section header: bold, green, uppercase, left-aligned -->
     <Profile name="sfHelp_colHeader" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="14px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
+      <textAlignment value="left"/>
     </Profile>
     <!-- Body line: normal weight, white, left-aligned -->
     <Profile name="sfHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">

--- a/xml/gui/SoilHelpDialog.xml
+++ b/xml/gui/SoilHelpDialog.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    Soil & Fertilizer — In-Game Help Guide (PDA)
+    Opened from the PDA X/help button.
+    Content lines are built dynamically in Lua.
+    Controller: SoilHelpDialog (src/ui/SoilHelpDialog.lua)
+-->
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+  <GuiElement profile="newLayer"/>
+  <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+
+  <GuiElement profile="sfHelp_bg" id="dialogElement">
+
+    <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+    <ThreePartBitmap profile="fs25_dialogBgTop"/>
+    <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+
+    <!-- Title -->
+    <Text profile="fs25_dialogTitle" id="sfHelp_title"
+          text="Soil &amp; Fertilizer Guide" position="0px -30px"/>
+
+    <!-- Separator -->
+    <Bitmap profile="sfHelp_sep" position="0px -66px" size="620px 2px"/>
+
+    <!-- Dynamic content box — Lua adds header/body TextElements here -->
+    <BoxLayout profile="sfHelp_contentBox" id="sfHelp_contentBox"
+               position="0px -84px"/>
+
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
+    </BoxLayout>
+
+  </GuiElement>
+
+  <GUIProfiles>
+    <Profile name="sfHelp_bg" extends="fs25_dialogBg">
+      <size value="680px 720px"/>
+    </Profile>
+    <Profile name="sfHelp_sep" extends="baseReference" with="anchorTopCenter">
+      <imageColor value="1.0 1.0 1.0 0.15"/>
+    </Profile>
+    <!-- Vertical BoxLayout — Lua adds elements at runtime -->
+    <Profile name="sfHelp_contentBox" extends="emptyPanel" with="anchorTopCenter">
+      <size value="620px 575px"/>
+      <flowDirection value="vertical"/>
+      <useFullVisibility value="false"/>
+      <alignmentX value="center"/>
+      <elementSpacing value="3px"/>
+    </Profile>
+    <!-- Section header: bold, green, uppercase -->
+    <Profile name="sfHelp_header" extends="fs25_dialogText" with="anchorTopCenter">
+      <textSize value="14px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="0.35 0.85 0.40 1.0"/>
+    </Profile>
+    <!-- Body line: normal weight, white -->
+    <Profile name="sfHelp_body" extends="fs25_dialogText" with="anchorTopCenter">
+      <textSize value="12px"/>
+      <textColor value="$preset_colorWhite"/>
+    </Profile>
+    <!-- Spacer: invisible placeholder for vertical gap -->
+    <Profile name="sfHelp_spacer" extends="fs25_dialogText" with="anchorTopCenter">
+      <textSize value="6px"/>
+      <textColor value="0.0 0.0 0.0 0.0"/>
+    </Profile>
+  </GUIProfiles>
+</GUI>

--- a/xml/gui/SoilHelpDialog.xml
+++ b/xml/gui/SoilHelpDialog.xml
@@ -62,15 +62,17 @@
       <textUpperCase value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
     </Profile>
-    <!-- Body line: normal weight, white -->
+    <!-- Body line: normal weight, white, left-aligned -->
     <Profile name="sfHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="12px"/>
       <textColor value="$preset_colorWhite"/>
+      <textAlignment value="left"/>
     </Profile>
     <!-- Spacer: invisible placeholder for vertical gap -->
     <Profile name="sfHelp_colSpacer" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="6px"/>
       <textColor value="0.0 0.0 0.0 0.0"/>
+      <textAlignment value="left"/>
     </Profile>
   </GUIProfiles>
 </GUI>

--- a/xml/gui/SoilOverlayHelpDialog.xml
+++ b/xml/gui/SoilOverlayHelpDialog.xml
@@ -55,12 +55,13 @@
       <alignmentX value="left"/>
       <elementSpacing value="3px"/>
     </Profile>
-    <!-- Section header: bold, green, uppercase -->
+    <!-- Section header: bold, green, uppercase, left-aligned -->
     <Profile name="sfOvHelp_colHeader" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="14px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
+      <textAlignment value="left"/>
     </Profile>
     <!-- Body line: normal weight, white, left-aligned -->
     <Profile name="sfOvHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">

--- a/xml/gui/SoilOverlayHelpDialog.xml
+++ b/xml/gui/SoilOverlayHelpDialog.xml
@@ -19,12 +19,17 @@
     <Text profile="fs25_dialogTitle" id="sfOvHelp_title"
           text="Soil Map Overlay — Help" position="0px -30px"/>
 
-    <!-- Separator -->
-    <Bitmap profile="sfOvHelp_sep" position="0px -66px" size="620px 2px"/>
+    <!-- Horizontal separator under title -->
+    <Bitmap profile="sfOvHelp_sep" position="0px -66px" size="900px 2px"/>
 
-    <!-- Dynamic content box — Lua adds header/body TextElements here -->
-    <BoxLayout profile="sfOvHelp_contentBox" id="sfOvHelp_contentBox"
-               position="0px -84px"/>
+    <!-- Left column — populated by Lua -->
+    <BoxLayout profile="sfOvHelp_col" id="sfOvHelp_col1" position="-230px -84px"/>
+
+    <!-- Vertical divider between columns -->
+    <Bitmap profile="sfOvHelp_vSep" position="0px -84px" size="2px 580px"/>
+
+    <!-- Right column — populated by Lua -->
+    <BoxLayout profile="sfOvHelp_col" id="sfOvHelp_col2" position="230px -84px"/>
 
     <BoxLayout profile="fs25_dialogButtonBox">
       <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
@@ -34,33 +39,36 @@
 
   <GUIProfiles>
     <Profile name="sfOvHelp_bg" extends="fs25_dialogBg">
-      <size value="680px 720px"/>
+      <size value="960px 720px"/>
     </Profile>
     <Profile name="sfOvHelp_sep" extends="baseReference" with="anchorTopCenter">
       <imageColor value="1.0 1.0 1.0 0.15"/>
     </Profile>
-    <!-- Vertical BoxLayout — Lua adds elements at runtime -->
-    <Profile name="sfOvHelp_contentBox" extends="emptyPanel" with="anchorTopCenter">
-      <size value="620px 575px"/>
+    <Profile name="sfOvHelp_vSep" extends="baseReference" with="anchorTopCenter">
+      <imageColor value="1.0 1.0 1.0 0.15"/>
+    </Profile>
+    <!-- Vertical column — Lua adds TextElements at runtime -->
+    <Profile name="sfOvHelp_col" extends="emptyPanel" with="anchorTopCenter">
+      <size value="440px 580px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
-      <alignmentX value="center"/>
+      <alignmentX value="left"/>
       <elementSpacing value="3px"/>
     </Profile>
     <!-- Section header: bold, green, uppercase -->
-    <Profile name="sfOvHelp_header" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfOvHelp_colHeader" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="14px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
     </Profile>
     <!-- Body line: normal weight, white -->
-    <Profile name="sfOvHelp_body" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfOvHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="12px"/>
       <textColor value="$preset_colorWhite"/>
     </Profile>
     <!-- Spacer: invisible placeholder for vertical gap -->
-    <Profile name="sfOvHelp_spacer" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfOvHelp_colSpacer" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="6px"/>
       <textColor value="0.0 0.0 0.0 0.0"/>
     </Profile>

--- a/xml/gui/SoilOverlayHelpDialog.xml
+++ b/xml/gui/SoilOverlayHelpDialog.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    Soil & Fertilizer — Soil Map Overlay Help Dialog
+    Opened from the Help button in the overlay sidebar.
+    Content lines are built dynamically in Lua.
+    Controller: SoilOverlayHelpDialog (src/ui/SoilOverlayHelpDialog.lua)
+-->
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+  <GuiElement profile="newLayer"/>
+  <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+
+  <GuiElement profile="sfOvHelp_bg" id="dialogElement">
+
+    <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+    <ThreePartBitmap profile="fs25_dialogBgTop"/>
+    <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+
+    <!-- Title -->
+    <Text profile="fs25_dialogTitle" id="sfOvHelp_title"
+          text="Soil Map Overlay — Help" position="0px -30px"/>
+
+    <!-- Separator -->
+    <Bitmap profile="sfOvHelp_sep" position="0px -66px" size="620px 2px"/>
+
+    <!-- Dynamic content box — Lua adds header/body TextElements here -->
+    <BoxLayout profile="sfOvHelp_contentBox" id="sfOvHelp_contentBox"
+               position="0px -84px"/>
+
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
+    </BoxLayout>
+
+  </GuiElement>
+
+  <GUIProfiles>
+    <Profile name="sfOvHelp_bg" extends="fs25_dialogBg">
+      <size value="680px 720px"/>
+    </Profile>
+    <Profile name="sfOvHelp_sep" extends="baseReference" with="anchorTopCenter">
+      <imageColor value="1.0 1.0 1.0 0.15"/>
+    </Profile>
+    <!-- Vertical BoxLayout — Lua adds elements at runtime -->
+    <Profile name="sfOvHelp_contentBox" extends="emptyPanel" with="anchorTopCenter">
+      <size value="620px 575px"/>
+      <flowDirection value="vertical"/>
+      <useFullVisibility value="false"/>
+      <alignmentX value="center"/>
+      <elementSpacing value="3px"/>
+    </Profile>
+    <!-- Section header: bold, green, uppercase -->
+    <Profile name="sfOvHelp_header" extends="fs25_dialogText" with="anchorTopCenter">
+      <textSize value="14px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="0.35 0.85 0.40 1.0"/>
+    </Profile>
+    <!-- Body line: normal weight, white -->
+    <Profile name="sfOvHelp_body" extends="fs25_dialogText" with="anchorTopCenter">
+      <textSize value="12px"/>
+      <textColor value="$preset_colorWhite"/>
+    </Profile>
+    <!-- Spacer: invisible placeholder for vertical gap -->
+    <Profile name="sfOvHelp_spacer" extends="fs25_dialogText" with="anchorTopCenter">
+      <textSize value="6px"/>
+      <textColor value="0.0 0.0 0.0 0.0"/>
+    </Profile>
+  </GUIProfiles>
+</GUI>

--- a/xml/gui/SoilOverlayHelpDialog.xml
+++ b/xml/gui/SoilOverlayHelpDialog.xml
@@ -62,15 +62,17 @@
       <textUpperCase value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
     </Profile>
-    <!-- Body line: normal weight, white -->
+    <!-- Body line: normal weight, white, left-aligned -->
     <Profile name="sfOvHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="12px"/>
       <textColor value="$preset_colorWhite"/>
+      <textAlignment value="left"/>
     </Profile>
     <!-- Spacer: invisible placeholder for vertical gap -->
     <Profile name="sfOvHelp_colSpacer" extends="fs25_dialogText" with="anchorTopLeft">
       <textSize value="6px"/>
       <textColor value="0.0 0.0 0.0 0.0"/>
+      <textAlignment value="left"/>
     </Profile>
   </GUIProfiles>
 </GUI>


### PR DESCRIPTION
## Summary

This PR merges the full **v2.2.0** development cycle into main. It covers three major feature areas and a significant number of bug fixes. Read the sections below before merging — several changes affect behaviour that players may already be familiar with.

---

## ⚠️ Breaking / Behaviour Changes (read before merging)

### Precision Farming N display suppression
When **PF Compatibility Mode** is enabled (new setting, default **off**), the mod hides its own Nitrogen bar, sprayer rate panel, and N row in the map tooltip. This is intentional — PF and SF track nitrogen independently at different scales (kg/ha vs ppm), and showing both simultaneously produced two conflicting readings. Enabling this setting gives PF sole authority over nitrogen display.

**Players upgrading who use Precision Farming should enable this setting.** It is off by default so existing players are not surprised.

### Map overlay now shows per-zone data, not field averages
The soil map overlay previously coloured entire fields using their average nutrient value. It now reads per-zone (per-cell) data, meaning one half of a field can be green and the other red if you limed only part of it. Unsampled zones render dim/transparent instead of faking a colour. This is correct behaviour but will look different to players used to the old solid-colour tiles.

### Treatment dialog — P and K "fair" recommendations changed
The treatment dialog previously showed **"Apply blended FERTILIZER."** for phosphorus and potassium when they were in the fair range. This was vague and caused confusion (several Discord reports of players not knowing what "blended fertilizer" meant). It now shows:
- P fair → **"Top-up with Liquid MAP, Liquid DAP, or DAP (P)."**
- K fair → **"Top-up with Liquid Potash or Potash (K)."**

---

## New Features

### 1. Precision Farming bridge (`src/integrations/PrecisionFarmingBridge.lua`)
Full integration bridge for the Precision Farming DLC:
- Detects PF at runtime — no hard dependency, safe to run without it
- Live N/P/K bar updates from PF sensor readings as you drive
- New **PF Compatibility Mode** setting (Display tab) — hides SF nitrogen data when PF is active to prevent conflicting readings
- Completed all missing `<sprayType>` entries in `thPFConfig` for LIQUID_POTASH, POTASH, MAP, and DAP — previously these fill types had no rate control data in the THPF Configurator block, causing the PF HUD to show 0 kg/ha or disappear entirely for those products

### 2. New help dialogs — two styled dialogs replace the old InfoDialog text dump

**SoilHelpDialog** (PDA → Help / X button):
- Replaces the old `InfoDialog.show()` raw text concat with a proper styled dialog
- Two-column layout: NUTRIENTS / SOIL CHEMISTRY / CROP TARGETS | STATUS LEVELS / CROP PRESSURE / TIPS
- 960px wide, sections separated by a vertical divider line

**SoilOverlayHelpDialog** (Soil Map Overlay → Help button):
- New 4th button added to the overlay sidebar (below "Disable Overlay")
- Same two-column styled layout: HOW TO READ / MAP LAYERS | CELL TOOLTIP / COLOUR LEGEND / SIDEBAR BUTTONS / TIPS
- Gives players in-context guidance without leaving the map

### 3. Soil Map Overlay — major improvements
- **Layer-specific tooltips**: clicking a cell shows tooltip content relevant to the active layer only (N/P/K shows ppm + crop target gap; pH shows condition + treatment advice; OM shows percentage + status)
- **Per-zone rendering**: overlay now reads individual soil zones instead of field averages
- **Unsampled zones**: cells with no data render dim/transparent instead of showing a misleading colour
- **Over-limed state**: pH above 7.0 now correctly shows red (was showing yellow — a longstanding visual bug)
- **Overlay alignment fixes**: sidebar panel and minimap overlay positioning corrected

---

## Bug Fixes

| Area | Fix |
|------|-----|
| Field Detail dialog | `_setNutrient` and `_setPressure` referenced `COLOR_GOOD/FAIR/POOR` locals from `_populateData()` — invisible from those methods, causing `unpack(nil)` crash. Only the N value appeared; everything else showed placeholder dashes. Fixed by calling `getStatusColors()` inside each helper. |
| Precision Farming | N bar tick marks missing when PF mod was active |
| Straw chopping | OM gain was using concentration instead of scaling by actual field size — large fields got same OM as small ones |
| Harvest depletion | Two bugs with PF-controlled combines and late-spawned combines not triggering depletion |
| Sprayer hook | Field ID lookup failing in certain vehicle configurations; pH application not being logged |
| Soil zones | Bulk zone-cell sync removed — was syncing thousands of cells at once on load, causing lag spikes |
| Crop protection | Pressure reduction raised to 50 across weed/pest/disease (was inconsistent) |
| AMS fill plane | Texture too coarse — now matches AN material parameters |

---

## Translation Updates (all 26 languages)

- `sf_map_btn_help`: updated from placeholder "Dev Note (NOT WORKING YET)" → **"Help"** in all 26 files
- `sf_pf_compat_short` / `sf_pf_compat_long`: new keys for the PF Compatibility Mode setting toggle

---

## Test Checklist

- [ ] Load savegame — no Lua errors in log
- [ ] Open soil map overlay → 4 sidebar buttons visible (Farm Overview / Treatment Plan / Disable Overlay / **Help**)
- [ ] Click Help button → SoilOverlayHelpDialog opens with two-column layout, all sections left-aligned
- [ ] PDA → Help (X) button → SoilHelpDialog opens (not old InfoDialog text dump)
- [ ] PDA → click field row → Field Detail dialog opens without crash, all nutrient rows coloured correctly
- [ ] Treatment dialog: field with fair P → shows "Top-up with Liquid MAP, Liquid DAP, or DAP (P)." (not "blended")
- [ ] Treatment dialog: field with fair K → shows "Top-up with Liquid Potash or Potash (K)."
- [ ] Settings → Display → PF Compatibility Mode toggle visible
- [ ] With PF active + PF Compat Mode ON: SF nitrogen bar hidden, APP. RATE panel hidden, N row in map tooltip replaced with "managed by PF"
- [ ] Soil map overlay: liming half a field shows two different colours on that field's tiles
- [ ] Unsampled field tiles appear dim, not a solid colour