### PR TITLE
perf: only draw owned fields on map overlay and minimap

### DIFF
--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -351,11 +351,14 @@ function SoilMapOverlay:updateSamplePoints(force)
     -- We match fields to our soil data via farmland.id (the key fieldData uses).
     -- getFieldFillPoints() handles the grid sampling and caching; it falls back to
     -- a single centroid point for very small fields or when polygon data is absent.
+    -- Only owned fields are sampled — activeFieldIds is maintained by the ownership
+    -- hook and already represents the correct set for both SP and MP.
     local fields = g_fieldManager.fields
     if fields == nil then
         SoilLogger.debug("SoilMapOverlay: g_fieldManager.fields is nil")
         return
     end
+    local activeFieldIds = self.soilSystem and self.soilSystem.activeFieldIds or {}
 
     -- Scale sampling step proportional to terrain size so large maps
     -- (4x, 16x, 64x) get the same screen-pixel density as a standard 2048m map.
@@ -374,7 +377,7 @@ function SoilMapOverlay:updateSamplePoints(force)
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
-            if farmlandId and farmlandId > 0 then
+            if farmlandId and farmlandId > 0 and activeFieldIds[farmlandId] then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
                     local polyPts = self:getFieldFillPoints(fsField, scaledStep)
@@ -1310,11 +1313,12 @@ function SoilMapOverlay:updateMinimapCentroids(force)
     local fields = g_fieldManager.fields
     if not fields then return end
 
+    local activeFieldIds = self.soilSystem and self.soilSystem.activeFieldIds or {}
     local zone = SoilConstants.ZONE
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
-            if farmlandId and farmlandId > 0 then
+            if farmlandId and farmlandId > 0 and activeFieldIds[farmlandId] then
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
                     -- 1. Restore Centroid Dot (Low-res status)


### PR DESCRIPTION
## Summary

- `updateSamplePoints` and `updateMinimapCentroids` previously iterated **all** fields in `g_fieldManager.fields`, including every unowned farmland on the map
- On large maps this caused a measurable FPS drop (reported: 29 → 21 FPS with overlay active)
- Both loops now gate on `soilSystem.activeFieldIds` — an O(1) lookup into the set that the ownership hook already maintains
- Unowned fields are skipped entirely: no polygon fill, no sample points, no minimap dots
- Field buy/sell updates `activeFieldIds` immediately via the existing `FARMLAND_OWNER_CHANGED` hook; the overlay picks up the change on its next 2-second refresh cycle

## Why `activeFieldIds`

- Already computed and maintained — zero new state
- Correctly includes **all** farms in multiplayer (not just local player's fields)
- O(1) hash lookup per field — no extra `g_farmlandManager` API calls

## Test plan

- [ ] Open map overlay with N/P/K/pH/OM layer — only owned fields draw tiles
- [ ] Unowned fields show no color tiles (blank terrain visible underneath)
- [ ] Buy a field mid-session — appears on overlay within ~2 seconds
- [ ] Sell a field mid-session — disappears from overlay within ~2 seconds
- [ ] Minimap dots also limited to owned fields
- [ ] Multiplayer: co-op farm fields all visible; rival farm fields not drawn
- [ ] Check `log.txt` — no errors after a full session with overlay active