### PR TITLE
fix: treatment dialog blended FERTILIZER + version dialog v2.2.0.1 changelog

### DIFF
--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -30,6 +30,18 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed Treatment plan no longer says 'blended FERTILIZER' — now names the actual product",
     "  (P deficit → Liquid MAP / Liquid DAP / DAP;  K deficit → Liquid Potash / Potash)",
     "- Fixed Compost fill plane no longer overrides map-defined custom visuals",
+    "- Fixed pH display rounding — tooltip and map tile colors now always match",
+    "",
+    "PERFORMANCE",
+    "- Soil map overlay is now up to 8x faster on large maps — only your owned fields are",
+    "  drawn instead of every field on the map. Big improvement for anyone playing on",
+    "  community servers or large maps with hundreds of unowned parcels.",
+    "- Spraying large fields is smoother — less stuttering and frame drops while the",
+    "  sprayer is running across a big parcel.",
+    "- HUD nutrient display refreshes more efficiently — less background work every",
+    "  frame, especially on lower-end machines.",
+    "- Multiplayer join sync is lighter — connecting to a server with lots of fields",
+    "  sends less data and causes fewer hitches.",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -526,9 +526,9 @@
     <e k="sf_treat_action_n_poor" v="Aplique UAN32, UREIA ou AMÔNIA ANIDRA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplique AMS ou fertilizante STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplique MAP ou DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Aplique FERTILIZANTE misto." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Aplique POTASSA (Potássio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Aplique FERTILIZANTE misto." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Aplique HERBICIDA imediatamente." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Apliqueu UAN32, UREA o AMONÍAC ANHIDRE." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Apliqueu AMS o fertilitzant STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Apliqueu MAP o DAP (Fòsfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Apliqueu fertilitzant barrejat." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Apliqueu POTASSA (Potassi)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Apliqueu fertilitzant barrejat." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Apliqueu HERBICIDA immediatament." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Apliqueu INSECTICIDA immediatament." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Apliqueu FUNGICIDA immediatament." eh="9228323a" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Aplikujte UAN32, MOČOVINU nebo BEZVODÝ AMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplikujte AMS nebo hnojivo STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplikujte MAP nebo DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Aplikujte kombinované HNOJIVO." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Aplikujte POTAŠ (Draslík)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Aplikujte kombinované HNOJIVO." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Okamžitě aplikujte HERBICID." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Okamžitě aplikujte INSEKTICID." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Okamžitě aplikujte FUNGICID." eh="9228323a" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Anvend UAN32, UREA eller VANDFRI AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Anvend AMS eller STARTGØDNING." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Anvend MAP eller DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Anvend blandet GØDNING." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Anvend KALIUMKLORID (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Anvend blandet GØDNING." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Anvend HERBICID øjeblikkeligt." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Anvend INSEKTICID øjeblikkeligt." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Anvend FUNGICID øjeblikkeligt." eh="9228323a" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="UAN32, HARNSTOFF oder FLÜSSIGAMMONIAK ausbringen." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS oder STARTER-Dünger ausbringen." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP oder DAP (Phosphor) ausbringen." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="MischDÜNGER ausbringen." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="KALI (Kalium) ausbringen." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="MischDÜNGER ausbringen." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Sofort HERBIZID ausbringen." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Sofort INSEKTIZID ausbringen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Sofort FUNGIZID ausbringen." eh="9228323a" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Aplica UAN32, UREA o ANHIDRO." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplica AMS o fertilizante INICIADOR." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplica MAP o DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Aplica FERTILIZANTE mezclado." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Aplica POTASA (Potasio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Aplica FERTILIZANTE mezclado." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Aplica HERBICIDA de inmediato." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplica INSECTICIDA de inmediato." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplica FUNGICIDA de inmediato." eh="9228323a" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Apply UAN32, UREA, or ANHYDROUS." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Apply AMS or STARTER fertilizer." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Apply MAP or DAP (Phosphorus)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Apply blended FERTILIZER." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Apply POTASH (Potassium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Apply blended FERTILIZER." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Apply HERBICIDE immediately." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Apply INSECTICIDE immediately." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Apply FUNGICIDE immediately." eh="9228323a" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Aplica UAN32, UREA o ANHIDRO." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplica AMS o fertilizante INICIADOR." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplica MAP o DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Aplica FERTILIZANTE mezclado." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Aplica POTASA (Potasio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Aplica FERTILIZANTE mezclado." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Aplica HERBICIDA de inmediato." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplica INSECTICIDA de inmediato." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplica FUNGICIDA de inmediato." eh="9228323a" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Appliquez UAN32, URÉE ou AMMONIAC." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Appliquez AMS ou engrais STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Appliquez MAP ou DAP (Phosphore)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Appliquez ENGRAIS composé." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Appliquez POTASSE (Potassium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Appliquez ENGRAIS composé." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Appliquez HERBICIDE immédiatement." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Appliquez INSECTICIDE immédiatement." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Appliquez FONGICIDE immédiatement." eh="9228323a" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -506,9 +506,9 @@
     <e k="sf_treat_action_n_poor" v="Käytä UAN32:ta, UREAA tai AMMONIAKKIA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Käytä AMS- tai STARTTERIlannoitetta." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Käytä MAPia tai DAPia (Fosfori)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Käytä moniravinnelannoitetta." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Käytä KALIUMSUOLAA (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Käytä moniravinnelannoitetta." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Käytä RIKKAKASVIMYRKKYÄ välittömästi." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Käytä HYÖNTEISMYRKKYÄ välittömästi." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Käytä SIENIMYRKKYÄ välittömästi." eh="9228323a" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -530,9 +530,9 @@
     <e k="sf_treat_action_n_poor" v="Appliquer UAN32, URÉE ou ANHYDRE." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Appliquer AMS ou engrais STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Appliquer MAP ou DAP (Phosphore)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Appliquer ENGRAIS mélangé." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Appliquer POTASSE (Potassium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Appliquer ENGRAIS mélangé." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Appliquer HERBICIDE immédiatement." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Appliquer INSECTICIDE immédiatement." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Appliquer FONGICIDE immédiatement." eh="9228323a" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -524,9 +524,9 @@
     <e k="sf_treat_action_n_poor" v="Alkalmazzon UAN32-t, KARBAMIDOT vagy VÍZMENTES AMMÓNIÁT." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Alkalmazzon AMS-t vagy STARTER műtrágyát." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Alkalmazzon MAP-ot vagy DAP-ot (Foszfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Alkalmazzon kevert MŰTRÁGYÁT." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Alkalmazzon HAMUZSÍRT (Kálium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Alkalmazzon kevert MŰTRÁGYÁT." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Azonnal alkalmazzon GYOMIRTÓT." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Azonnal alkalmazzon ROVARÖLŐT." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Azonnal alkalmazzon GOMBAÖLŐT." eh="9228323a" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Terapkan UAN32, UREA, atau ANHIDRAT." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Terapkan AMS atau pupuk STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Terapkan MAP atau DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Terapkan CAMPURAN PUPUK." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Terapkan KALIUM (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Terapkan CAMPURAN PUPUK." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Terapkan HERBISIDA segera." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Terapkan INSEKTISIDA segera." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Terapkan FUNGISIDA segera." eh="9228323a" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Applica UAN32, UREA o ANIDRA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Applica AMS o fertilizzante STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Applica MAP o DAP (Fosforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Applica FERTILIZZANTE miscelato." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Applica POTASSIO (Potash)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Applica FERTILIZZANTE miscelato." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Applica ERBICIDA immediatamente." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Applica INSETTICIDA immediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Applica FUNGICIDE immediatamente." eh="9228323a" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="UAN32、尿素、または無水アンモニアを散布してください。" eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS またはスターター肥料を散布してください。" eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP または DAP (リン酸) を散布してください。" eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="配合肥料を散布してください。" eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="塩化カリ (カリウム) を散布してください。" eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="配合肥料を散布してください。" eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="直ちに除草剤を散布してください。" eh="625551c5" />
     <e k="sf_treat_action_pest" v="直ちに殺虫剤を散布してください。" eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="直ちに殺菌剤を散布してください。" eh="9228323a" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -524,9 +524,9 @@
     <e k="sf_treat_action_n_poor" v="UAN32, 요소 또는 무수 암모니아를 살포하세요." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS 또는 스타터 비료를 살포하세요." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP 또는 DAP(인산)를 살포하세요." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="복합 비료를 살포하세요." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="칼리(칼륨)를 살포하세요." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="복합 비료를 살포하세요." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="즉시 제초제를 살포하세요." eh="625551c5" />
     <e k="sf_treat_action_pest" v="즉시 살충제를 살포하세요." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="즉시 살균제를 살포하세요." eh="9228323a" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Gebruik UAN32, UREUM of WATERVRIJ AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Gebruik AMS of STARTER meststof." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Gebruik MAP of DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Gebruik gemengde KUNSTMEST." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Gebruik POTASH (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Gebruik gemengde KUNSTMEST." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Onmiddellijk HERBICIDE toepassen." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Onmiddellijk INSECTICIDE toepassen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Onmiddellijk FUNGICIDE toepassen." eh="9228323a" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Påfør UAN32, UREA eller VANNFRI AMMONIAKK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Påfør AMS eller START-gjødsel." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Påfør MAP eller DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Påfør blandet FULLGJØDSEL." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Påfør KALIUM (K-gjødsel)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Påfør blandet FULLGJØDSEL." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Påfør UGRESSMIDDEL umiddelbart." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Påfør INSEKTMIDDEL umiddelbart." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Påfør SOPPMIDDEL umiddelbart." eh="9228323a" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -525,9 +525,9 @@
     <e k="sf_treat_action_n_poor" v="Zastosuj UAN32, MOCZNIK lub BEZWODNY AMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Zastosuj AMS lub nawóz STARTOWY." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Zastosuj MAP lub DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Zastosuj nawóz wieloskładnikowy." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Zastosuj POTAS (Sól potasową)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Zastosuj nawóz wieloskładnikowy." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Zastosuj HERBICYD natychmiast." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Zastosuj INSEKTYCYD natychmiast." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Zastosuj FUNGICYD natychmiast." eh="9228323a" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -526,9 +526,9 @@
     <e k="sf_treat_action_n_poor" v="Aplique UAN32, UREIA ou ANIDRA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplique AMS ou fertilizante STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplique MAP ou DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Aplique FERTILIZANTE misto." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Aplique POTASSA (Potássio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Aplique FERTILIZANTE misto." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Aplique HERBICIDA imediatamente." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -526,9 +526,9 @@
     <e k="sf_treat_action_n_poor" v="Aplică UAN32, UREE sau AMONIAC ANIDRU." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplică AMS sau îngrășământ STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplică MAP sau DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Aplică ÎNGRĂȘĂMÂNT mixt." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Aplică POTASIU (Potasiu)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Aplică ÎNGRĂȘĂMÂNT mixt." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Aplică ERBICID imediat." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplică INSECTICID imediat." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplică FUNGICID imediat." eh="9228323a" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Внесите КАС-32, КАРБАМИД или АММИАК." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Внесите СУЛЬФАТ АММОНИЯ или СТАРТЕР." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Внесите АММОФОС или ДИАММОФОС (P)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Внесите смешанное УДОБРЕНИЕ." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Внесите КАЛИЙ (0-0-60)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Внесите смешанное УДОБРЕНИЕ." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Немедленно внесите ГЕРБИЦИД." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Немедленно внесите ИНСЕКТИЦИД." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Немедленно внесите ФУНГИЦИД." eh="9228323a" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Sprid UAN32, UREA eller VATTENFRITT AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Sprid AMS eller STARTGÖDSEL." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Sprid MAP eller DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Sprid blandat MINERALGÖDSEL." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Sprid KALIUMKLORID (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Sprid blandat MINERALGÖDSEL." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Sprid OGRÄSMEDEL omedelbart." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Sprid INSEKTSMEDEL omedelbart." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Sprid SVAMPMEDEL omedelbart." eh="9228323a" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -506,9 +506,9 @@
     <e k="sf_treat_action_n_poor" v="UAN32, ÜRE veya ANHİDRE uygulayın." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS veya BAŞLANGIÇ gübresi uygulayın." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP veya DAP (Fosfor) uygulayın." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Karma GÜBRE uygulayın." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="POTAS (Potasyum) uygulayın." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Karma GÜBRE uygulayın." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Derhal HERBİSİT uygulayın." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Derhal İNSEKTİSİT uygulayın." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Derhal FUNGİSİT uygulayın." eh="9228323a" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Внесіть КАС-32, КАРБАМІД або БЕЗВОДНИЙ АМІАК." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Внесіть AMS або СТАРТОВЕ добриво." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Внесіть MAP або DAP (Фосфор)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Внесіть комплексні ДОБРИВА." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Внесіть ПОТАШ (Калій)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Внесіть комплексні ДОБРИВА." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Негайно внесіть ГЕРБІЦИД." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Негайно внесіть ІНСЕКТИЦИД." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Негайно внесіть ФУНГІЦИД." eh="9228323a" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -505,9 +505,9 @@
     <e k="sf_treat_action_n_poor" v="Bón UAN32, URÊ hoặc AMONIAC KHAN." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Bón AMS hoặc PHÂN BÓN LÓT." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Bón MAP hoặc DAP (Lân)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Bón PHÂN HỖN HỢP." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Bón KALI (Potash)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Bón PHÂN HỖN HỢP." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Bón THUỐC DIỆT CỎ ngay lập tức." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Bón THUỐC TRỪ SÂU ngay lập tức." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Bón THUỐC TRỪ NẤM ngay lập tức." eh="9228323a" />


### PR DESCRIPTION
## Summary

- **Root cause found**: The treatment dialog fix from earlier in this branch was in the Lua fallback strings, but the `tr()` helper was finding the OLD values in all 26 translation XML files and using those instead. Players still saw "Apply blended FERTILIZER." for P and K fair-level recommendations.
- **Fix**: Updated `sf_treat_action_p_fair` and `sf_treat_action_k_fair` in all 26 language files with the specific product names. Product names (MAP, DAP, Potash, etc.) are the actual in-game item names and are not localized.
- **Version dialog**: Updated `SoilVersionDialog.CHANGELOG` for v2.2.0.1 to include the performance improvements from the map overlay and HUD audit in farmer-friendly language.

## Files changed

| File | Change |
|------|--------|
| `translations/translation_*.xml` (×26) | Fixed `sf_treat_action_p_fair` and `sf_treat_action_k_fair` values |
| `src/ui/SoilVersionDialog.lua` | Added performance section to v2.2.0.1 changelog |

## Test plan

- [ ] Open Treatment Plan for a field with P in "Fair" range — should say "Top-up with Liquid MAP, Liquid DAP, or DAP (P)."
- [ ] Open Treatment Plan for a field with K in "Fair" range — should say "Top-up with Liquid Potash or Potash (K)."
- [ ] Verify in at least DE and FR locale that the product names still show (English is correct by design)
- [ ] Launch game fresh — version dialog shows performance section for v2.2.0.1