### PR TITLE
Bug fixes + PF integration setting (weed penalties, canopy lookup, PF gate)

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -587,7 +587,11 @@ function SoilFertilityManager:onMissionStarted()
         self.soilSystem:initialize()
 
         if self.pfBridge then
-            self.hasPrecisionFarming = self.pfBridge:initialize()
+            self.pfBridge:initialize()
+            if not self.settings.pfCompatibilityMode then
+                self.pfBridge.isActive = false
+            end
+            self.hasPrecisionFarming = self.pfBridge.isActive
             self.soilSystem.pfBridge = self.pfBridge
         end
 

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -551,7 +551,6 @@ function SoilFertilityManager:onMissionLoaded()
     local success, errorMsg = pcall(function()
         if self.soilHUD then
             self.soilHUD:initialize()
-            self.soilHUD:loadLayout()
         end
 
         if self.settingsPanel then

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -543,14 +543,12 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
     return self
 end
 
---- Called after mission is loaded
---- Initializes HUD and sets up deferred hook installation
+--- Called after mission is loaded (loadMission00Finished).
+--- Initializes HUD and settings panel — fields not yet guaranteed populated at this point.
 function SoilFertilityManager:onMissionLoaded()
     if not self.settings.enabled then return end
 
     local success, errorMsg = pcall(function()
-        -- Initialize HUD immediately (client-side only)
-        -- Input binding (J key) is registered via PlayerInputComponent hook in new(), not here
         if self.soilHUD then
             self.soilHUD:initialize()
             self.soilHUD:loadLayout()
@@ -559,10 +557,6 @@ function SoilFertilityManager:onMissionLoaded()
         if self.settingsPanel then
             self.settingsPanel:initialize()
         end
-
-        -- Defer soil system initialization (hook installation) until game is ready
-        -- This fixes the timing issue where FruitUtil, Sprayer, g_farmlandManager aren't loaded yet
-        self:deferredSoilSystemInit()
     end)
 
     if not success then
@@ -572,127 +566,45 @@ function SoilFertilityManager:onMissionLoaded()
     end
 end
 
---- Deferred initialization of soil system using updater pattern
---- Waits for game to be fully ready before installing hooks
-function SoilFertilityManager:deferredSoilSystemInit()
+--- Called when mission actually starts (Mission00.onStartMission).
+--- At this point the loading screen is gone, the player is in the world, and
+--- g_fieldManager.fields is fully populated — safe to initialize the soil system.
+function SoilFertilityManager:onMissionStarted()
     if not self.soilSystem then return end
 
-    SoilLogger.info("Scheduling deferred soil system initialization...")
+    -- Reload settings: savegameDirectory is guaranteed set by onStartMission time.
+    -- The load() call in new() fires during Mission00.load before savegameDirectory
+    -- is available on fresh saves, so it falls back to defaults.
+    self.settings:load()
 
-    local hookInstaller = {
-        sfm = self,
-        installed = false,
-        attempts = 0,
-        maxAttempts = 3000,  -- ~50s at 60fps — covers very heavy modded servers
+    if not self.settings.enabled then
+        SoilLogger.info("Mod disabled in settings — skipping soil system init")
+        return
+    end
 
-        update = function(self, dt)
-            if self.installed then
-                g_currentMission:removeUpdateable(self)
-                return
-            end
+    SoilLogger.info("Mission started — initializing soil system (fields guaranteed populated)...")
 
-            self.attempts = self.attempts + 1
-
-            -- Guard 1: Mission must exist and be in a started state.
-            -- FS25 does not reliably expose isMissionStarted; instead check missionDynamicInfo.isStarted
-            -- which is set once the loading screen completes, with a fallback to checking that hud
-            -- exists (initialized late in the load sequence) for older or modded builds.
-            local missionReady = g_currentMission ~= nil and (
-                (g_currentMission.missionDynamicInfo ~= nil and g_currentMission.missionDynamicInfo.isStarted) or
-                (g_currentMission.hud ~= nil)
-            )
-            if not missionReady then
-                if self.attempts >= self.maxAttempts then
-                    SoilLogger.warning("Deferred init timeout: Mission not ready after %d attempts", self.attempts)
-                    g_currentMission:removeUpdateable(self)
-                end
-                return
-            end
-
-            -- Guard 2: Field manager must be ready AND populated with at least one field.
-            -- On 100+ mod servers, g_fieldManager.fields exists as an empty table for several
-            -- seconds before the game finishes populating it — we must wait for next() to return
-            -- a valid entry, not just check for non-nil.
-            if not g_fieldManager or not g_fieldManager.fields or next(g_fieldManager.fields) == nil then
-                if self.attempts >= self.maxAttempts then
-                    SoilLogger.warning("Deferred init timeout: FieldManager not populated after %d attempts", self.attempts)
-                    g_currentMission:removeUpdateable(self)
-                end
-                return
-            end
-
-            -- Guard 3: FarmlandManager must be available for ownership hook installation.
-            -- Without this, the ownership hook fails on heavily modded servers where
-            -- farmlandManager loads after fieldManager.
-            if not g_farmlandManager then
-                if self.attempts >= self.maxAttempts then
-                    SoilLogger.warning("Deferred init timeout: FarmlandManager not available after %d attempts", self.attempts)
-                    g_currentMission:removeUpdateable(self)
-                end
-                return
-            end
-
-            -- All guards passed - initialize soil system now
-            SoilLogger.info("Game ready after %d update cycles - initializing soil system...", self.attempts)
-
-            -- Reload settings here: savegameDirectory is now guaranteed available.
-            -- The earlier load() in new() fires before savegameDirectory is set on
-            -- dedicated servers (Mission00.load timing), so it falls back to defaults.
-            -- This reload picks up the actual saved XML values.
-            self.sfm.settings:load()
-
-            -- Guard: if settings were saved with enabled=false, respect that.
-            if not self.sfm.settings.enabled then
-                SoilLogger.info("Mod disabled in settings — skipping soil system init")
-                self.installed = true
-                g_currentMission:removeUpdateable(self)
-                return
-            end
-
-            local initSuccess, initError = pcall(function()
-                self.sfm.soilSystem:initialize()
-
-                -- Detect Precision Farming via g_modManager (shared C++ object, cross-mod visible).
-                -- Must run after mission is fully loaded so g_modManager has all mod entries.
-                if self.sfm.pfBridge then
-                    self.sfm.hasPrecisionFarming = self.sfm.pfBridge:initialize()
-                    -- Give soil system a direct reference so it can gate logic without a global lookup
-                    self.sfm.soilSystem.pfBridge = self.sfm.pfBridge
-                end
-
-                -- Load saved soil data now that savegameDirectory is set
-                self.sfm:loadSoilData()
-
-                -- Show version dialog (once per version only).
-                -- The hardcoded changelog values are here for a reason, and will NOT be translated.
-                if self.sfm.settings.showNotifications and SoilVersionDialog and SoilVersionDialog.INSTANCE ~= nil then
-                    local modInfo = g_modManager and g_modManager:getModByName(self.sfm.modName)
-                    local version = (modInfo and modInfo.version) or "?"
-
-                    if self.sfm.lastSeenVersion ~= version then
-                        SoilVersionDialog.show(version)
-                    end
-                end
-            end)
-
-            if not initSuccess then
-                SoilLogger.error("Deferred soil system init failed: %s", tostring(initError))
-            end
-
-            self.installed = true
-            g_currentMission:removeUpdateable(self)
-        end
-    }
-
-    -- Register updater with mission
-    if g_currentMission and g_currentMission.addUpdateable then
-        g_currentMission:addUpdateable(hookInstaller)
-        SoilLogger.info("Deferred init updater registered - waiting for game readiness...")
-    else
-        -- Fallback: try immediate initialization
-        SoilLogger.warning("Mission.addUpdateable not available - attempting immediate init")
+    local ok, err = pcall(function()
         self.soilSystem:initialize()
+
+        if self.pfBridge then
+            self.hasPrecisionFarming = self.pfBridge:initialize()
+            self.soilSystem.pfBridge = self.pfBridge
+        end
+
         self:loadSoilData()
+
+        if self.settings.showNotifications and SoilVersionDialog and SoilVersionDialog.INSTANCE ~= nil then
+            local modInfo = g_modManager and g_modManager:getModByName(self.modName)
+            local version = (modInfo and modInfo.version) or "?"
+            if self.lastSeenVersion ~= version then
+                SoilVersionDialog.show(version)
+            end
+        end
+    end)
+
+    if not ok then
+        SoilLogger.error("onMissionStarted init failed: %s", tostring(err))
     end
 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -187,7 +187,7 @@ end
 ---@param fruitTypeIndex number
 ---@return number modifier  Combined yield multiplier
 function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
-    if not self.settings.enabled or not self.settings.nutrientCycles then return 1.0 end
+    if not self.settings.enabled then return 1.0 end
 
     local field = self.fieldData[fieldId]
     if not field then return 1.0 end
@@ -199,8 +199,8 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
     local ys        = SoilConstants.YIELD_SENSITIVITY
     local isGrass   = ys and ys.NON_CROP_NAMES and ys.NON_CROP_NAMES[cropName]
 
-    -- Nutrient-based modifier (skipped for grass/non-crop)
-    if ys and not isGrass then
+    -- Nutrient-based modifier (only when nutrientCycles enabled, skipped for grass/non-crop)
+    if self.settings.nutrientCycles and ys and not isGrass then
         local tier     = ys.CROP_TIERS[cropName] or ys.DEFAULT_TIER
         local tierData = ys.TIERS[tier]
         local thresh   = ys.OPTIMAL_THRESHOLD
@@ -1679,11 +1679,14 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                 local canopyFactor = 1.0
                 local rowClosure = false
                 if g_fieldManager and g_fieldManager.fields then
-                    local fsField = nil
-                    for _, f in ipairs(g_fieldManager.fields) do
-                        if f and f.farmland and f.farmland.id == fieldId then
-                            fsField = f
-                            break
+                    -- Direct lookup first (fields table is typically indexed by fieldId)
+                    local fsField = g_fieldManager.fields[fieldId]
+                    if not fsField then
+                        for _, f in ipairs(g_fieldManager.fields) do
+                            if f and (f.fieldId == fieldId or f.id == fieldId) then
+                                fsField = f
+                                break
+                            end
                         end
                     end
                     if fsField and fsField.posX and fsField.posZ then

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1048,10 +1048,11 @@ function SoilFertilitySystem:onEnvironmentUpdate(env, dt)
     end
 
     -- Rain effects
-    if self.settings.rainEffects and
-       env.weather and env.weather.rainScale and
-       env.weather.rainScale > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
-        self:applyRainEffects(dt, env.weather.rainScale)
+    if self.settings.rainEffects and env.weather then
+        local rainScale = env.weather:getRainFallScale()
+        if rainScale and rainScale > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
+            self:applyRainEffects(dt, rainScale)
+        end
     end
 end
 
@@ -1752,9 +1753,9 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
 
                 local rainBonus = 0
                 if g_currentMission and g_currentMission.environment and
-                   g_currentMission.environment.weather and
-                   (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
-                    rainBonus = wp.RAIN_BONUS
+                   g_currentMission.environment.weather then
+                    local rs = g_currentMission.environment.weather:getRainFallScale()
+                    if rs and rs > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then rainBonus = wp.RAIN_BONUS end
                 end
 
                 local canopyFactor = 1.0
@@ -1842,9 +1843,9 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
 
             local rainBonus = 0
             if g_currentMission and g_currentMission.environment and
-               g_currentMission.environment.weather and
-               (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then
-                rainBonus = pp.RAIN_BONUS
+               g_currentMission.environment.weather then
+                local rs = g_currentMission.environment.weather:getRainFallScale()
+                if rs and rs > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then rainBonus = pp.RAIN_BONUS end
             end
 
             field.pestPressure = math.min(100, pressure + ((baseRate * seasonMult * cropMult) + rainBonus) * timeFactor)
@@ -1854,9 +1855,11 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     -- ── Disease pressure daily growth ────────────────────────────────────────
     if self.settings.diseasePressure and SoilConstants.DISEASE_PRESSURE then
         local dp = SoilConstants.DISEASE_PRESSURE
-        local isRaining = g_currentMission and g_currentMission.environment and
-                          g_currentMission.environment.weather and
-                          (g_currentMission.environment.weather.rainScale or 0) > SoilConstants.RAIN.MIN_RAIN_THRESHOLD
+        local isRaining = false
+        if g_currentMission and g_currentMission.environment and g_currentMission.environment.weather then
+            local rs = g_currentMission.environment.weather:getRainFallScale()
+            isRaining = rs ~= nil and rs > SoilConstants.RAIN.MIN_RAIN_THRESHOLD
+        end
 
         if isRaining then
             field.dryDayCount = 0

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -64,18 +64,6 @@ function SoilFertilitySystem.new(settings)
     self._dailyBatchSeason   = nil   -- season snapshot taken at batch start
     self.DAILY_BATCH_SIZE    = 25    -- fields per update() call (~0.5 ms budget)
 
-    -- Field scan retry mechanism (for delayed initialization)
-    self.fieldsScanPending = true
-    self.fieldsScanAttempts = 0
-    self.fieldsScanMaxAttempts = 10  -- Try up to 10 times
-    self.fieldsScanNextRetry = 0
-    self.fieldsScanRetryInterval = 2000  -- 2 seconds between attempts
-
-    -- Frame-based fallback (in case g_currentMission.time is frozen)
-    self.fieldsScanStage = 1  -- 1=time-based, 2=frame-based, 3=failed
-    self.fieldsScanFrameCounter = 0
-    self.fieldsScanMaxFrames = 600  -- 600 frames = ~10 seconds at 60fps
-
     return self
 end
 
@@ -1083,76 +1071,6 @@ end
 -- Update function called every frame
 function SoilFertilitySystem:update(dt)
     if not self.settings.enabled then return end
-
-    -- Delayed field scanning retry (3-tier approach: time-based → frame-based → fail gracefully)
-    if self.fieldsScanPending then
-        -- Clients must not run field scans — data arrives via SoilFieldBatchSyncEvent
-        if g_server == nil then
-            self.fieldsScanPending = false
-        elseif self.fieldsScanStage == 1 then
-            -- Stage 1: Time-based retry (10 attempts, 2 sec intervals)
-            if self.fieldsScanAttempts < self.fieldsScanMaxAttempts then
-                local currentTime = g_currentMission and g_currentMission.time or 0
-                if currentTime >= self.fieldsScanNextRetry then
-                    self.fieldsScanAttempts = self.fieldsScanAttempts + 1
-                    self:log("Retrying field scan (attempt %d/%d)...", self.fieldsScanAttempts, self.fieldsScanMaxAttempts)
-
-                    local success = self:scanFields()
-                    if success then
-                        self:info("Delayed field scan successful!")
-                        self.fieldsScanPending = false
-                    else
-                        -- Schedule next retry
-                        self.fieldsScanNextRetry = currentTime + self.fieldsScanRetryInterval
-                        if self.fieldsScanAttempts >= self.fieldsScanMaxAttempts then
-                            self:warning("Time-based retry failed after %d attempts - switching to frame-based fallback", self.fieldsScanMaxAttempts)
-                            self.fieldsScanStage = 2
-                            self.fieldsScanFrameCounter = 0
-                            if g_currentMission and g_currentMission.hud then
-                                g_currentMission.hud:showBlinkingWarning(g_i18n:getText("sf_notify_init_delayed"), 5000)
-                            end
-                        end
-                    end
-                end
-            end
-        elseif self.fieldsScanStage == 2 then
-            -- Stage 2: Frame-based fallback (try every frame for 600 frames = ~10 sec)
-            self.fieldsScanFrameCounter = self.fieldsScanFrameCounter + 1
-
-            -- Try scan every 30 frames (twice per second at 60fps) to avoid spam
-            if self.fieldsScanFrameCounter % 30 == 0 then
-                local success = self:scanFields()
-                if success then
-                    self:info("Frame-based field scan successful after %d frames!", self.fieldsScanFrameCounter)
-                    self.fieldsScanPending = false
-                    -- Show success notification so player knows recovery worked
-                    if g_currentMission and g_currentMission.hud then
-                        g_currentMission.hud:showBlinkingWarning(g_i18n:getText("sf_notify_init_success"), 4000)
-                    end
-                end
-            end
-
-            -- Timeout after max frames
-            if self.fieldsScanFrameCounter >= self.fieldsScanMaxFrames then
-                self:warning("Field initialization failed after all retry attempts (time + frame-based)")
-                self.fieldsScanStage = 3
-
-                -- Show error dialog and disable mod gracefully
-                if g_gui then
-                    g_gui:showInfoDialog({
-                        text = "Soil & Fertilizer Mod: Could not initialize fields.\n\nThe game's field system is not responding.\n\nThe mod has been disabled for this session only.\n\nPlease restart the game to try again.\n\nIf this issue persists, please report it.",
-                        title = "Field Initialization Failed"
-                    })
-                end
-
-                -- Disable mod to prevent half-broken state
-                if self.settings then
-                    self.settings.enabled = false
-                end
-                self.fieldsScanPending = false
-            end
-        end
-    end
 
     self.lastUpdate = self.lastUpdate + dt
 

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -243,7 +243,7 @@ SettingsSchema.definitions = {
         type = "boolean",
         default = false,
         uiId = "sf_pf_compat",
-        localOnly = true,  -- per-player; PF presence is client-side, not synced
+        -- server-synced: controls fill type relay and yield modifier, not just display
     },
 }
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -114,6 +114,13 @@ local function isEnabled()
     return sfm ~= nil
 end
 
+-- Called when mission starts (player enters world, all fields populated)
+local function missionStarted(mission)
+    if sfm then
+        sfm:onMissionStarted()
+    end
+end
+
 -- Called after mission loaded
 local function loadedMission(mission, node)
     if mission.cancelLoading then return end
@@ -431,7 +438,7 @@ local function hookSaveLoadEvents()
         SoilLogger.warning("FSCareerMissionInfo.saveToXMLFile not found — soil data will NOT be saved")
     end
 
-    -- Load is handled in SoilFertilityManager:deferredSoilSystemInit() after soilSystem:initialize().
+    -- Load is handled in SoilFertilityManager:onMissionStarted() after soilSystem:initialize().
     -- This guarantees missionInfo.savegameDirectory is set (it is nil at constructor time
     -- for new careers) before we attempt to read soilData.xml.
 end
@@ -441,6 +448,7 @@ end
 -- mission object is completely set up before our load() accesses it.
 Mission00.load = Utils.appendedFunction(Mission00.load, load)
 Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, loadedMission)
+Mission00.onStartMission = Utils.appendedFunction(Mission00.onStartMission, missionStarted)
 -- Prepend so our cleanup runs before FS25 tears down g_inputBinding/HUD (fixes black screen with AGS)
 FSBaseMission.delete = Utils.prependedFunction(FSBaseMission.delete, unload)
 

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -63,7 +63,7 @@ function SettingsManager:loadSettings(settingsObject)
         end
     end
 
-    SoilLogger.info("No saved settings found, using defaults")
+    SoilLogger.debug("No saved settings found, using defaults")
     self:applyDefaults(settingsObject)
 end
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -31,17 +31,10 @@ SoilVersionDialog.CHANGELOG = {
     "  (P deficit → Liquid MAP / Liquid DAP / DAP;  K deficit → Liquid Potash / Potash)",
     "- Fixed Compost fill plane no longer overrides map-defined custom visuals",
     "- Fixed pH display rounding — tooltip and map tile colors now always match",
-    "",
-    "PERFORMANCE",
-    "- Soil map overlay is now up to 8x faster on large maps — only your owned fields are",
-    "  drawn instead of every field on the map. Big improvement for anyone playing on",
-    "  community servers or large maps with hundreds of unowned parcels.",
-    "- Spraying large fields is smoother — less stuttering and frame drops while the",
-    "  sprayer is running across a big parcel.",
-    "- HUD nutrient display refreshes more efficiently — less background work every",
-    "  frame, especially on lower-end machines.",
-    "- Multiplayer join sync is lighter — connecting to a server with lots of fields",
-    "  sends less data and causes fewer hitches.",
+    "- Soil map overlay only draws your owned fields — big FPS boost on large maps",
+    "- Spraying large fields is smoother — less stuttering while the boom is running",
+    "- HUD nutrient display is lighter on your CPU, especially on lower-end machines",
+    "- Multiplayer join is faster — less data when connecting to a busy server",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limiar ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Produção ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basat en N/P/K vs llindar òptim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Pèrdua de rendiment ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Založeno na N/P/K vs optimální práh" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Výnos ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baseret på N/P/K vs. optimal grænse" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Udbytte ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Oversigt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Kom godt i gang" eh="bf647454" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basierend auf N/P/K vs. optimalem Schwellenwert" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Ertrag ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Übersicht" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Erste Schritte" eh="bf647454" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros Pasos" eh="bf647454" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros pasos" eh="bf647454" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Aperçu" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Mise en route" eh="bf647454" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Perustuu N/P/K-tasoihin vs. kynnysarvo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Satohäviö ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Yleiskatsaus" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Aloittaminen" eh="bf647454" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basé sur N/P/K par rapport au seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          LIGNES D’AIDE (ESC > Aide > Sol & Fertilisation réalistes)

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Az N/P/K arány alapján az optimális küszöbhöz képest" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hozam ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Berdasarkan N/P/K vs ambang batas optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hasil ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basato su N/P/K rispetto alla soglia ottimale" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Resa ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="窒素/リン/カリの最適閾値に基づきます" eh="022663e0" />
     <e k="sf_report_yield_loss" v="収量予測 ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="최적 임계값 대비 N/P/K 기준" eh="022663e0" />
     <e k="sf_report_yield_loss" v="수확량 ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Gebaseerd op N/P/K versus optimale drempel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Opbrengstverlies ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basert på N/P/K mot optimal terskel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Avlingstap ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Na podstawie N/P/K vs próg optymalny" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Strata plonu ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limite ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimento ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          LINHAS DE AJUDA (ESC > Ajuda > Solo e Fertilizante Realista)

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Bazat pe N/P/K vs prag optim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Recoltă ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- ======================================================
          LINII DE AJUTOR (ESC > Ajutor > Sol și Îngrășământ Realist)

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="На основе N/P/K относительно оптимума" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Потеря урожая ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <!-- Help Lines -->
     <e k="helpLine_sf_cat_overview" v="Обзор" eh="3b878279" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baserat på N/P/K mot optimalt tröskelvärde" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Skörd ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Översikt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Komma igång" eh="bf647454" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Optimal eşiğe göre N/P/K baz alınmıştır" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Verim ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Genel Bakış" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Başlangıç" eh="bf647454" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Базується на N/P/K відносно порогу" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Врожайність ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Огляд" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Початок роботи" eh="bf647454" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Dựa trên N/P/K so với ngưỡng tối ưu" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Sản lượng ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
 
     <e k="helpLine_sf_cat_overview" v="Tổng quan" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Bắt đầu" eh="bf647454" />

--- a/xml/gui/SoilFieldDetailDialog.xml
+++ b/xml/gui/SoilFieldDetailDialog.xml
@@ -1,96 +1,83 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<!--
-    Soil Field Detail Dialog
-    Per-field nutrient + pressure details, opened from the Fields tab.
-    Controller: SoilFieldDetailDialog (src/ui/SoilFieldDetailDialog.lua)
--->
 <GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
   <GuiElement profile="newLayer"/>
   <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
 
   <GuiElement profile="sfDetail_bg" id="dialogElement">
-
     <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
     <ThreePartBitmap profile="fs25_dialogBgTop"/>
     <ThreePartBitmap profile="fs25_dialogBgBottom"/>
 
     <GuiElement profile="fs25_dialogContentContainer">
 
-      <!-- Title -->
       <Text profile="fs25_dialogTitle" id="detailTitle"
             text="$l10n_sf_detail_title" position="0px -30px"/>
 
-      <!-- Field ID + urgency (outside sections) -->
-      <Text profile="sfDetail_fieldId" id="detailFieldId"
-            text="" position="-180px -63px" size="340px 24px"/>
-      <Text profile="sfDetail_urgencyLabel" id="detailUrgencyLabel"
-            text="$l10n_sf_detail_urgency_label" position="175px -63px" size="160px 24px"/>
-      <Text profile="sfDetail_urgencyValue" id="detailUrgency"
-            text="--" position="340px -63px" size="100px 24px"/>
+      <!-- Field ID (left) + Urgency (right) — outside sections -->
+      <Text profile="sfDetail_fieldId"      id="detailFieldId"       text="" position="-160px -63px"/>
+      <Text profile="sfDetail_urgencyLabel" id="detailUrgencyLabel"  text="$l10n_sf_detail_urgency_label" position="150px -63px"/>
+      <Text profile="sfDetail_urgencyValue" id="detailUrgency"       text="--" position="290px -63px"/>
 
-      <!-- ─── SOIL NUTRIENTS section ─── -->
-      <GuiElement profile="sfDetail_section" position="0px -95px">
-        <Bitmap profile="sfDetail_sectionBg" position="0px 0px"/>
-        <Text profile="sfDetail_sectionHeader"
-              text="$l10n_sf_detail_section_nutrients" position="0px -5px"/>
+      <!-- ─── SOIL NUTRIENTS ─── -->
+      <GuiElement profile="sfDetail_section5" position="0px -95px">
+        <Bitmap profile="sfDetail_sectionBg5" position="0px 0px"/>
+        <Text profile="sfDetail_sectionHeader" text="$l10n_sf_detail_section_nutrients" position="0px -5px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_n_label"  position="-330px -33px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailN"    text="--"        position="-130px -33px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailNStatus" text=""      position="-20px  -33px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_n_label"  position="-240px -33px"/>
+        <Text profile="sfDetail_value" id="detailN"        text="--"   position="-80px  -33px"/>
+        <Text profile="sfDetail_status" id="detailNStatus" text=""      position=" 90px  -33px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_p_label"  position="-330px -58px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailP"    text="--"        position="-130px -58px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailPStatus" text=""      position="-20px  -58px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_p_label"  position="-240px -58px"/>
+        <Text profile="sfDetail_value" id="detailP"        text="--"   position="-80px  -58px"/>
+        <Text profile="sfDetail_status" id="detailPStatus" text=""      position=" 90px  -58px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_k_label"  position="-330px -83px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailK"    text="--"        position="-130px -83px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailKStatus" text=""      position="-20px  -83px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_k_label"  position="-240px -83px"/>
+        <Text profile="sfDetail_value" id="detailK"        text="--"   position="-80px  -83px"/>
+        <Text profile="sfDetail_status" id="detailKStatus" text=""      position=" 90px  -83px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_ph_label" position="-330px -108px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailPH"   text="--"        position="-130px -108px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailPHStatus" text=""     position="-20px  -108px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_ph_label" position="-240px -108px"/>
+        <Text profile="sfDetail_value" id="detailPH"       text="--"   position="-80px  -108px"/>
+        <Text profile="sfDetail_status" id="detailPHStatus" text=""     position=" 90px  -108px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_om_label" position="-330px -133px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailOM"   text="--"        position="-130px -133px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailOMStatus" text=""     position="-20px  -133px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_om_label" position="-240px -133px"/>
+        <Text profile="sfDetail_value" id="detailOM"       text="--"   position="-80px  -133px"/>
+        <Text profile="sfDetail_status" id="detailOMStatus" text=""     position=" 90px  -133px"/>
       </GuiElement>
 
-      <!-- ─── CROP PRESSURE section ─── -->
-      <GuiElement profile="sfDetail_sectionAlt" position="0px -270px">
-        <Bitmap profile="sfDetail_sectionBgAlt" position="0px 0px"/>
-        <Text profile="sfDetail_sectionHeader"
-              text="$l10n_sf_detail_section_pressure" position="0px -5px"/>
+      <!-- ─── CROP PRESSURE ─── -->
+      <GuiElement profile="sfDetail_section3" position="0px -270px">
+        <Bitmap profile="sfDetail_sectionBg3alt" position="0px 0px"/>
+        <Text profile="sfDetail_sectionHeader" text="$l10n_sf_detail_section_pressure" position="0px -5px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_weed_label"    position="-330px -33px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailWeed"    text="--"          position="-130px -33px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailWeedStatus" text=""        position="-20px  -33px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_weed_label"    position="-240px -33px"/>
+        <Text profile="sfDetail_value" id="detailWeed"     text="--"        position="-80px  -33px"/>
+        <Text profile="sfDetail_status" id="detailWeedStatus" text=""        position=" 90px  -33px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_pest_label"    position="-330px -58px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailPest"    text="--"          position="-130px -58px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailPestStatus" text=""        position="-20px  -58px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_pest_label"    position="-240px -58px"/>
+        <Text profile="sfDetail_value" id="detailPest"     text="--"        position="-80px  -58px"/>
+        <Text profile="sfDetail_status" id="detailPestStatus" text=""        position=" 90px  -58px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_disease_label" position="-330px -83px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailDisease"  text="--"         position="-130px -83px" size="100px 22px"/>
-        <Text profile="sfDetail_status" id="detailDiseaseStatus" text=""     position="-20px  -83px" size="200px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_disease_label" position="-240px -83px"/>
+        <Text profile="sfDetail_value" id="detailDisease"  text="--"        position="-80px  -83px"/>
+        <Text profile="sfDetail_status" id="detailDiseaseStatus" text=""     position=" 90px  -83px"/>
       </GuiElement>
 
-      <!-- ─── HISTORY section ─── -->
-      <GuiElement profile="sfDetail_sectionHistory" position="0px -394px">
-        <Bitmap profile="sfDetail_sectionBgHistory" position="0px 0px"/>
-        <Text profile="sfDetail_sectionHeader"
-              text="$l10n_sf_detail_section_history" position="0px -5px"/>
+      <!-- ─── HISTORY ─── -->
+      <GuiElement profile="sfDetail_section2" position="0px -394px">
+        <Bitmap profile="sfDetail_sectionBg5" position="0px 0px"/>
+        <Text profile="sfDetail_sectionHeader" text="$l10n_sf_detail_section_history" position="0px -5px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_last_crop_label" position="-330px -33px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailLastCrop" text="--"           position="-125px -33px" size="450px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_last_crop_label" position="-240px -33px"/>
+        <Text profile="sfDetail_valueWide" id="detailLastCrop" text="--"      position=" 80px  -33px"/>
 
-        <Text profile="sfDetail_label" text="$l10n_sf_detail_rotation_label"  position="-330px -58px" size="195px 22px"/>
-        <Text profile="sfDetail_value" id="detailRotation"  text="--"          position="-125px -58px" size="450px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_rotation_label"  position="-240px -58px"/>
+        <Text profile="sfDetail_valueWide" id="detailRotation"  text="--"     position=" 80px  -58px"/>
       </GuiElement>
 
       <!-- No data fallback -->
       <Text profile="sfDetail_noData" id="detailNoData"
             text="$l10n_sf_detail_no_field"
-            position="0px -270px" size="700px 80px"
+            position="0px -280px" size="680px 80px"
             wrapText="true" autoFitHeight="true" visible="false"/>
 
     </GuiElement>
@@ -99,7 +86,6 @@
       <Button profile="buttonBack" id="detailCloseBtn"
               text="$l10n_sf_detail_close" onClick="onClickClose"/>
     </BoxLayout>
-
   </GuiElement>
 
   <GUIProfiles>
@@ -108,29 +94,27 @@
       <size value="760px 590px"/>
     </Profile>
 
-    <!-- Section containers -->
-    <Profile name="sfDetail_section" extends="emptyPanel" with="anchorTopCenter">
+    <!-- 5-row section (nutrients) -->
+    <Profile name="sfDetail_section5" extends="emptyPanel" with="anchorTopCenter">
       <size value="700px 166px"/>
     </Profile>
-    <Profile name="sfDetail_sectionBg" extends="baseReference" with="anchorTopCenter">
+    <Profile name="sfDetail_sectionBg5" extends="baseReference" with="anchorTopCenter">
       <size value="700px 166px"/>
       <imageColor value="0.08 0.08 0.12 0.9"/>
     </Profile>
 
-    <Profile name="sfDetail_sectionAlt" extends="emptyPanel" with="anchorTopCenter">
+    <!-- 3-row section (crop pressure, alt color) -->
+    <Profile name="sfDetail_section3" extends="emptyPanel" with="anchorTopCenter">
       <size value="700px 116px"/>
     </Profile>
-    <Profile name="sfDetail_sectionBgAlt" extends="baseReference" with="anchorTopCenter">
+    <Profile name="sfDetail_sectionBg3alt" extends="baseReference" with="anchorTopCenter">
       <size value="700px 116px"/>
       <imageColor value="0.06 0.10 0.14 0.9"/>
     </Profile>
 
-    <Profile name="sfDetail_sectionHistory" extends="emptyPanel" with="anchorTopCenter">
+    <!-- 2-row section (history) -->
+    <Profile name="sfDetail_section2" extends="emptyPanel" with="anchorTopCenter">
       <size value="700px 91px"/>
-    </Profile>
-    <Profile name="sfDetail_sectionBgHistory" extends="baseReference" with="anchorTopCenter">
-      <size value="700px 91px"/>
-      <imageColor value="0.08 0.08 0.12 0.9"/>
     </Profile>
 
     <!-- Section header: gold, bold, centered -->
@@ -142,43 +126,61 @@
       <textAlignment value="center"/>
     </Profile>
 
-    <!-- Field ID sub-title -->
-    <Profile name="sfDetail_fieldId" extends="fs25_textDefault" with="anchorTopLeft">
+    <!-- Row label — gray, left-aligned, anchorTopCenter -->
+    <Profile name="sfDetail_label" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="180px 22px"/>
+      <textSize value="12px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+
+    <!-- Row value — white, bold, left-aligned -->
+    <Profile name="sfDetail_value" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="110px 22px"/>
+      <textSize value="13px"/>
+      <textBold value="true"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+
+    <!-- Wide value for history rows (crop name, rotation) -->
+    <Profile name="sfDetail_valueWide" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="400px 22px"/>
+      <textSize value="13px"/>
+      <textBold value="true"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+
+    <!-- Status text (color set by Lua) -->
+    <Profile name="sfDetail_status" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="190px 22px"/>
+      <textSize value="13px"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+
+    <!-- Field ID sub-title (outside sections) -->
+    <Profile name="sfDetail_fieldId" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="340px 24px"/>
       <textSize value="18px"/>
       <textBold value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
+      <textAlignment value="left"/>
     </Profile>
 
-    <!-- Urgency label/value -->
-    <Profile name="sfDetail_urgencyLabel" extends="fs25_textDefault" with="anchorTopLeft">
+    <Profile name="sfDetail_urgencyLabel" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="160px 24px"/>
       <textSize value="13px"/>
       <textColor value="0.65 0.65 0.65 1"/>
       <textAlignment value="right"/>
     </Profile>
-    <Profile name="sfDetail_urgencyValue" extends="fs25_textDefault" with="anchorTopLeft">
+    <Profile name="sfDetail_urgencyValue" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="120px 24px"/>
       <textSize value="13px"/>
       <textBold value="true"/>
       <textColor value="1 1 1 1"/>
       <textAlignment value="right"/>
-    </Profile>
-
-    <!-- Row label -->
-    <Profile name="sfDetail_label" extends="fs25_textDefault" with="anchorTopLeft">
-      <textSize value="12px"/>
-      <textColor value="0.65 0.65 0.65 1"/>
-    </Profile>
-
-    <!-- Row value -->
-    <Profile name="sfDetail_value" extends="fs25_textDefault" with="anchorTopLeft">
-      <textSize value="13px"/>
-      <textBold value="true"/>
-      <textColor value="1 1 1 1"/>
-    </Profile>
-
-    <!-- Status (color set by Lua) -->
-    <Profile name="sfDetail_status" extends="fs25_textDefault" with="anchorTopLeft">
-      <textSize value="13px"/>
-      <textColor value="1 1 1 1"/>
     </Profile>
 
     <!-- No data hint -->

--- a/xml/gui/SoilFieldDetailDialog.xml
+++ b/xml/gui/SoilFieldDetailDialog.xml
@@ -3,9 +3,6 @@
     Soil Field Detail Dialog
     Per-field nutrient + pressure details, opened from the Fields tab.
     Controller: SoilFieldDetailDialog (src/ui/SoilFieldDetailDialog.lua)
-
-    Pattern: MessageDialog base class.
-    ⚠ Callback names must NOT be onClose/onOpen (reserved by GUI lifecycle).
 -->
 <GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
   <GuiElement profile="newLayer"/>
@@ -13,121 +10,91 @@
 
   <GuiElement profile="sfDetail_bg" id="dialogElement">
 
-    <!-- Required background panels -->
     <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
     <ThreePartBitmap profile="fs25_dialogBgTop"/>
     <ThreePartBitmap profile="fs25_dialogBgBottom"/>
 
-    <!-- Content container: negative Y goes DOWN from top -->
     <GuiElement profile="fs25_dialogContentContainer">
 
-      <!-- Title row -->
+      <!-- Title -->
       <Text profile="fs25_dialogTitle" id="detailTitle"
             text="$l10n_sf_detail_title" position="0px -30px"/>
 
-      <!-- Field ID + Urgency sub-title line -->
+      <!-- Field ID + urgency (outside sections) -->
       <Text profile="sfDetail_fieldId" id="detailFieldId"
-            text="" position="0px -65px" size="340px 24px"/>
+            text="" position="-180px -63px" size="340px 24px"/>
       <Text profile="sfDetail_urgencyLabel" id="detailUrgencyLabel"
-            text="$l10n_sf_detail_urgency_label" position="360px -65px" size="200px 24px"/>
+            text="$l10n_sf_detail_urgency_label" position="175px -63px" size="160px 24px"/>
       <Text profile="sfDetail_urgencyValue" id="detailUrgency"
-            text="--" position="570px -65px" size="120px 24px"/>
+            text="--" position="340px -63px" size="100px 24px"/>
 
       <!-- ─── SOIL NUTRIENTS section ─── -->
-      <Text profile="sfDetail_sectionHeader"
-            text="$l10n_sf_detail_section_nutrients" position="0px -105px"/>
+      <GuiElement profile="sfDetail_section" position="0px -95px">
+        <Bitmap profile="sfDetail_sectionBg" position="0px 0px"/>
+        <Text profile="sfDetail_sectionHeader"
+              text="$l10n_sf_detail_section_nutrients" position="0px -5px"/>
 
-      <!-- N -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_n_label"
-            position="0px -140px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailN"
-            text="--"  position="225px -140px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailNStatus"
-            text=""    position="355px -140px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_n_label"  position="-330px -33px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailN"    text="--"        position="-130px -33px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailNStatus" text=""      position="-20px  -33px" size="200px 22px"/>
 
-      <!-- P -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_p_label"
-            position="0px -165px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailP"
-            text="--"  position="225px -165px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailPStatus"
-            text=""    position="355px -165px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_p_label"  position="-330px -58px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailP"    text="--"        position="-130px -58px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailPStatus" text=""      position="-20px  -58px" size="200px 22px"/>
 
-      <!-- K -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_k_label"
-            position="0px -190px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailK"
-            text="--"  position="225px -190px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailKStatus"
-            text=""    position="355px -190px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_k_label"  position="-330px -83px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailK"    text="--"        position="-130px -83px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailKStatus" text=""      position="-20px  -83px" size="200px 22px"/>
 
-      <!-- pH -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_ph_label"
-            position="0px -215px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailPH"
-            text="--"  position="225px -215px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailPHStatus"
-            text=""    position="355px -215px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_ph_label" position="-330px -108px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailPH"   text="--"        position="-130px -108px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailPHStatus" text=""     position="-20px  -108px" size="200px 22px"/>
 
-      <!-- Organic Matter -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_om_label"
-            position="0px -240px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailOM"
-            text="--"  position="225px -240px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailOMStatus"
-            text=""    position="355px -240px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_om_label" position="-330px -133px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailOM"   text="--"        position="-130px -133px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailOMStatus" text=""     position="-20px  -133px" size="200px 22px"/>
+      </GuiElement>
 
       <!-- ─── CROP PRESSURE section ─── -->
-      <Text profile="sfDetail_sectionHeader"
-            text="$l10n_sf_detail_section_pressure" position="0px -288px"/>
+      <GuiElement profile="sfDetail_sectionAlt" position="0px -270px">
+        <Bitmap profile="sfDetail_sectionBgAlt" position="0px 0px"/>
+        <Text profile="sfDetail_sectionHeader"
+              text="$l10n_sf_detail_section_pressure" position="0px -5px"/>
 
-      <!-- Weed -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_weed_label"
-            position="0px -322px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailWeed"
-            text="--"  position="225px -322px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailWeedStatus"
-            text=""    position="355px -322px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_weed_label"    position="-330px -33px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailWeed"    text="--"          position="-130px -33px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailWeedStatus" text=""        position="-20px  -33px" size="200px 22px"/>
 
-      <!-- Pest -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_pest_label"
-            position="0px -347px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailPest"
-            text="--"  position="225px -347px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailPestStatus"
-            text=""    position="355px -347px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_pest_label"    position="-330px -58px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailPest"    text="--"          position="-130px -58px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailPestStatus" text=""        position="-20px  -58px" size="200px 22px"/>
 
-      <!-- Disease -->
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_disease_label"
-            position="0px -372px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailDisease"
-            text="--"  position="225px -372px" size="120px 22px"/>
-      <Text profile="sfDetail_status" id="detailDiseaseStatus"
-            text=""    position="355px -372px" size="140px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_disease_label" position="-330px -83px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailDisease"  text="--"         position="-130px -83px" size="100px 22px"/>
+        <Text profile="sfDetail_status" id="detailDiseaseStatus" text=""     position="-20px  -83px" size="200px 22px"/>
+      </GuiElement>
 
       <!-- ─── HISTORY section ─── -->
-      <Text profile="sfDetail_sectionHeader"
-            text="$l10n_sf_detail_section_history" position="0px -420px"/>
+      <GuiElement profile="sfDetail_sectionHistory" position="0px -394px">
+        <Bitmap profile="sfDetail_sectionBgHistory" position="0px 0px"/>
+        <Text profile="sfDetail_sectionHeader"
+              text="$l10n_sf_detail_section_history" position="0px -5px"/>
 
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_last_crop_label"
-            position="0px -455px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailLastCrop"
-            text="--"  position="225px -455px" size="460px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_last_crop_label" position="-330px -33px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailLastCrop" text="--"           position="-125px -33px" size="450px 22px"/>
 
-      <Text profile="sfDetail_label" text="$l10n_sf_detail_rotation_label"
-            position="0px -480px"   size="220px 22px"/>
-      <Text profile="sfDetail_value" id="detailRotation"
-            text="--"  position="225px -480px" size="460px 22px"/>
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_rotation_label"  position="-330px -58px" size="195px 22px"/>
+        <Text profile="sfDetail_value" id="detailRotation"  text="--"          position="-125px -58px" size="450px 22px"/>
+      </GuiElement>
 
-      <!-- No data fallback text -->
+      <!-- No data fallback -->
       <Text profile="sfDetail_noData" id="detailNoData"
             text="$l10n_sf_detail_no_field"
-            position="0px -200px" size="700px 80px"
+            position="0px -270px" size="700px 80px"
             wrapText="true" autoFitHeight="true" visible="false"/>
 
     </GuiElement>
 
-    <!-- Button bar -->
     <BoxLayout profile="fs25_dialogButtonBox">
       <Button profile="buttonBack" id="detailCloseBtn"
               text="$l10n_sf_detail_close" onClick="onClickClose"/>
@@ -135,66 +102,89 @@
 
   </GuiElement>
 
-  <!-- Inline profiles -->
   <GUIProfiles>
 
-    <!-- Dialog background: 760px × 600px -->
     <Profile name="sfDetail_bg" extends="fs25_dialogBg">
-      <size value="760px 600px"/>
+      <size value="760px 590px"/>
     </Profile>
 
-    <!-- Field ID sub-title: bright, bold -->
-    <Profile name="sfDetail_fieldId" extends="fs25_dialogText" with="anchorTopLeft">
+    <!-- Section containers -->
+    <Profile name="sfDetail_section" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 166px"/>
+    </Profile>
+    <Profile name="sfDetail_sectionBg" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 166px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
+    </Profile>
+
+    <Profile name="sfDetail_sectionAlt" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 116px"/>
+    </Profile>
+    <Profile name="sfDetail_sectionBgAlt" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 116px"/>
+      <imageColor value="0.06 0.10 0.14 0.9"/>
+    </Profile>
+
+    <Profile name="sfDetail_sectionHistory" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 91px"/>
+    </Profile>
+    <Profile name="sfDetail_sectionBgHistory" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 91px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
+    </Profile>
+
+    <!-- Section header: gold, bold, centered -->
+    <Profile name="sfDetail_sectionHeader" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="660px 22px"/>
+      <textSize value="14px"/>
+      <textBold value="true"/>
+      <textColor value="1 0.8 0.2 1"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <!-- Field ID sub-title -->
+    <Profile name="sfDetail_fieldId" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="18px"/>
       <textBold value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
     </Profile>
 
     <!-- Urgency label/value -->
-    <Profile name="sfDetail_urgencyLabel" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="14px"/>
-      <textColor value="$preset_colorWhite_50"/>
+    <Profile name="sfDetail_urgencyLabel" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
       <textAlignment value="right"/>
     </Profile>
-    <Profile name="sfDetail_urgencyValue" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="14px"/>
-      <textBold value="true"/>
-      <textAlignment value="right"/>
-      <textColor value="$preset_colorWhite"/>
-    </Profile>
-
-    <!-- Section headers -->
-    <Profile name="sfDetail_sectionHeader" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="14px"/>
-      <textBold value="true"/>
-      <textUpperCase value="true"/>
-      <textColor value="0.35 0.85 0.40 1.0"/>
-    </Profile>
-
-    <!-- Row label (dim) -->
-    <Profile name="sfDetail_label" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="13px"/>
-      <textColor value="$preset_colorWhite_50"/>
-    </Profile>
-
-    <!-- Row value (white, bold) -->
-    <Profile name="sfDetail_value" extends="fs25_dialogText" with="anchorTopLeft">
+    <Profile name="sfDetail_urgencyValue" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="13px"/>
       <textBold value="true"/>
-      <textColor value="$preset_colorWhite"/>
+      <textColor value="1 1 1 1"/>
       <textAlignment value="right"/>
     </Profile>
 
-    <!-- Status label (color set in Lua: green/amber/red) -->
-    <Profile name="sfDetail_status" extends="fs25_dialogText" with="anchorTopLeft">
+    <!-- Row label -->
+    <Profile name="sfDetail_label" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="12px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
+    </Profile>
+
+    <!-- Row value -->
+    <Profile name="sfDetail_value" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="13px"/>
-      <textColor value="$preset_colorWhite"/>
+      <textBold value="true"/>
+      <textColor value="1 1 1 1"/>
+    </Profile>
+
+    <!-- Status (color set by Lua) -->
+    <Profile name="sfDetail_status" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
+      <textColor value="1 1 1 1"/>
     </Profile>
 
     <!-- No data hint -->
-    <Profile name="sfDetail_noData" extends="fs25_dialogText" with="anchorTopLeft">
+    <Profile name="sfDetail_noData" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="14px"/>
-      <textColor value="$preset_colorWhite_50"/>
+      <textColor value="0.65 0.65 0.65 1"/>
       <textAlignment value="center"/>
     </Profile>
 

--- a/xml/gui/SoilHelpDialog.xml
+++ b/xml/gui/SoilHelpDialog.xml
@@ -15,21 +15,25 @@
     <ThreePartBitmap profile="fs25_dialogBgTop"/>
     <ThreePartBitmap profile="fs25_dialogBgBottom"/>
 
-    <!-- Title -->
-    <Text profile="fs25_dialogTitle" id="sfHelp_title"
-          text="Soil &amp; Fertilizer Guide" position="0px -30px"/>
+    <GuiElement profile="fs25_dialogContentContainer">
 
-    <!-- Horizontal separator under title -->
-    <Bitmap profile="sfHelp_sep" position="0px -66px" size="900px 2px"/>
+      <!-- Title -->
+      <Text profile="fs25_dialogTitle" id="sfHelp_title"
+            text="Soil &amp; Fertilizer Guide" position="0px -30px"/>
 
-    <!-- Left column — populated by Lua -->
-    <BoxLayout profile="sfHelp_col" id="sfHelp_col1" position="-230px -84px"/>
+      <!-- Left column panel -->
+      <GuiElement profile="sfHelp_columnPanel" position="-231px -68px">
+        <Bitmap profile="sfHelp_columnBg" position="0px 0px"/>
+        <BoxLayout profile="sfHelp_col" id="sfHelp_col1" position="0px -8px"/>
+      </GuiElement>
 
-    <!-- Vertical divider between columns -->
-    <Bitmap profile="sfHelp_vSep" position="0px -84px" size="2px 580px"/>
+      <!-- Right column panel -->
+      <GuiElement profile="sfHelp_columnPanel" position="231px -68px">
+        <Bitmap profile="sfHelp_columnBgAlt" position="0px 0px"/>
+        <BoxLayout profile="sfHelp_col" id="sfHelp_col2" position="0px -8px"/>
+      </GuiElement>
 
-    <!-- Right column — populated by Lua -->
-    <BoxLayout profile="sfHelp_col" id="sfHelp_col2" position="230px -84px"/>
+    </GuiElement>
 
     <BoxLayout profile="fs25_dialogButtonBox">
       <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
@@ -38,42 +42,55 @@
   </GuiElement>
 
   <GUIProfiles>
+
     <Profile name="sfHelp_bg" extends="fs25_dialogBg">
       <size value="960px 720px"/>
     </Profile>
-    <Profile name="sfHelp_sep" extends="baseReference" with="anchorTopCenter">
-      <imageColor value="1.0 1.0 1.0 0.15"/>
+
+    <!-- Column panel container -->
+    <Profile name="sfHelp_columnPanel" extends="emptyPanel" with="anchorTopCenter">
+      <size value="446px 596px"/>
     </Profile>
-    <Profile name="sfHelp_vSep" extends="baseReference" with="anchorTopCenter">
-      <imageColor value="1.0 1.0 1.0 0.15"/>
+    <Profile name="sfHelp_columnBg" extends="baseReference" with="anchorTopCenter">
+      <size value="446px 596px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
     </Profile>
+    <Profile name="sfHelp_columnBgAlt" extends="baseReference" with="anchorTopCenter">
+      <size value="446px 596px"/>
+      <imageColor value="0.06 0.10 0.14 0.9"/>
+    </Profile>
+
     <!-- Vertical column — Lua adds TextElements at runtime -->
     <Profile name="sfHelp_col" extends="emptyPanel" with="anchorTopCenter">
-      <size value="440px 580px"/>
+      <size value="430px 580px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
       <alignmentX value="left"/>
       <elementSpacing value="3px"/>
     </Profile>
-    <!-- Section header: bold, green, uppercase, left-aligned -->
-    <Profile name="sfHelp_colHeader" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="14px"/>
+
+    <!-- Section header: gold, bold, uppercase -->
+    <Profile name="sfHelp_colHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
-      <textColor value="0.35 0.85 0.40 1.0"/>
+      <textColor value="1 0.8 0.2 1"/>
       <textAlignment value="left"/>
     </Profile>
-    <!-- Body line: normal weight, white, left-aligned -->
-    <Profile name="sfHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">
+
+    <!-- Body line -->
+    <Profile name="sfHelp_colBody" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="12px"/>
-      <textColor value="$preset_colorWhite"/>
+      <textColor value="1 1 1 1"/>
       <textAlignment value="left"/>
     </Profile>
-    <!-- Spacer: invisible placeholder for vertical gap -->
-    <Profile name="sfHelp_colSpacer" extends="fs25_dialogText" with="anchorTopLeft">
+
+    <!-- Spacer -->
+    <Profile name="sfHelp_colSpacer" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="6px"/>
       <textColor value="0.0 0.0 0.0 0.0"/>
       <textAlignment value="left"/>
     </Profile>
+
   </GUIProfiles>
 </GUI>

--- a/xml/gui/SoilMapCellDialog.xml
+++ b/xml/gui/SoilMapCellDialog.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    Soil Map Cell Dialog
+    Shows per-cell soil data on map click with full-screen map view.
+    Controller: SoilMapCellDialog (src/ui/SoilMapCellDialog.lua)
+-->
 <GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
     <GuiElement profile="newLayer" />
     <Bitmap profile="dialogFullscreenBg" id="dialogBg" />
@@ -9,65 +14,81 @@
         <ThreePartBitmap profile="fs25_dialogBgBottom" />
 
         <GuiElement profile="fs25_dialogContentContainer">
+
             <!-- Title -->
             <Text profile="fs25_dialogTitle" id="dialogTitleElement" position="0px -30px" text="$l10n_sf_cell_dialog_title"/>
 
-            <!-- Main Content Area: Map + Sidebar -->
+            <!-- Main Content: Map + Sidebar -->
             <GuiElement position="0px -80px" size="1160px 600px">
-                
+
                 <!-- Map Element (Left) -->
-                <IngameMap id="mapElement" profile="fs25_ingameMap" position="0px 0px" size="800px 600px" 
+                <IngameMap id="mapElement" profile="fs25_ingameMap" position="0px 0px" size="800px 600px"
                            onClickMap="onClickMap" onDrawPostIngameMap="onDrawPostIngameMap" />
 
                 <!-- Sidebar (Right) -->
                 <GuiElement id="sidebarContainer" position="820px 0px" size="340px 600px">
                     <ThreePartBitmap profile="fs25_subCategoryContainer" size="340px 600px" position="0px 0px">
                         <GuiElement profile="fs25_subCategoryContainer" width="320px">
+
                             <Text profile="sf_sectionHeader" text="$l10n_sf_cell_sidebar_header" position="10px -10px"/>
-                            
-                            <!-- Detail Fields -->
-                            <GuiElement id="detailsGroup" position="0px -50px" visible="false">
-                                <Text profile="sf_detailLabel" text="$l10n_sf_detail_field_label" position="10px -10px"/>
-                                <Text profile="sf_detailValueLarge" id="valFieldId" text="--" position="200px -10px" textAlignment="right" size="100px 24px"/>
-                                
-                                <Text profile="sf_detailLabel" text="$l10n_sf_cell_coord" position="10px -40px"/>
-                                <Text profile="sf_detailValueLarge" id="valCoords" text="[0, 0]" position="150px -40px" textAlignment="right" size="150px 24px"/>
-                                
-                                <Bitmap profile="sf_tabDivider" position="0px -75px" size="300px 2px"/>
-                                
-                                <Text profile="sf_detailLabel" text="Nitrogen (N)" position="10px -100px"/>
-                                <Text profile="sf_detailValueLarge" id="valN" text="--%" position="200px -100px" textAlignment="right" size="100px 24px"/>
-                                
-                                <Text profile="sf_detailLabel" text="Phosphorus (P)" position="10px -130px"/>
-                                <Text profile="sf_detailValueLarge" id="valP" text="--%" position="200px -130px" textAlignment="right" size="100px 24px"/>
-                                
-                                <Text profile="sf_detailLabel" text="Potassium (K)" position="10px -160px"/>
-                                <Text profile="sf_detailValueLarge" id="valK" text="--%" position="200px -160px" textAlignment="right" size="100px 24px"/>
-                                
-                                <Text profile="sf_detailLabel" text="pH Level" position="10px -190px"/>
-                                <Text profile="sf_detailValueLarge" id="valPH" text="--%" position="200px -190px" textAlignment="right" size="100px 24px"/>
-                                
-                                <Text profile="sf_detailLabel" text="Organic Matter" position="10px -220px"/>
-                                <Text profile="sf_detailValueLarge" id="valOM" text="--%" position="200px -220px" textAlignment="right" size="100px 24px"/>
 
-                                <Bitmap profile="sf_tabDivider" position="0px -255px" size="300px 2px"/>
+                            <!-- Detail Fields (hidden until map click) -->
+                            <GuiElement id="detailsGroup" position="0px -48px" visible="false">
 
-                                <Text profile="sf_detailLabel" text="Weed Pressure" position="10px -280px"/>
-                                <Text profile="sf_detailValueLarge" id="valWeed" text="--%" position="200px -280px" textAlignment="right" size="100px 24px"/>
+                                <!-- Field ID + Coords row -->
+                                <GuiElement profile="sf_infoRow" position="0px 0px">
+                                    <Bitmap profile="sf_infoRowBg" position="0px 0px"/>
+                                    <Text profile="sf_detailLabel" text="$l10n_sf_detail_field_label" position="8px -5px"/>
+                                    <Text profile="sf_detailValue" id="valFieldId" text="--" position="200px -5px" size="100px 22px"/>
+                                    <Text profile="sf_detailLabel" text="$l10n_sf_cell_coord" position="8px -28px"/>
+                                    <Text profile="sf_detailValue" id="valCoords" text="[0, 0]" position="150px -28px" size="140px 22px"/>
+                                </GuiElement>
 
-                                <Text profile="sf_detailLabel" text="Pest Pressure" position="10px -310px"/>
-                                <Text profile="sf_detailValueLarge" id="valPest" text="--%" position="200px -310px" textAlignment="right" size="100px 24px"/>
+                                <!-- Nutrients section -->
+                                <GuiElement profile="sf_nutrientSection" position="0px -62px">
+                                    <Bitmap profile="sf_nutrientBg" position="0px 0px"/>
+                                    <Text profile="sf_sidebarSectionHeader" text="Nutrients" position="8px -5px"/>
 
-                                <Text profile="sf_detailLabel" text="Disease Pressure" position="10px -340px"/>
-                                <Text profile="sf_detailValueLarge" id="valDisease" text="--%" position="200px -340px" textAlignment="right" size="100px 24px"/>
+                                    <Text profile="sf_detailLabel" text="Nitrogen (N)"     position="8px  -30px"/>
+                                    <Text profile="sf_detailValue" id="valN"  text="--%" position="195px -30px" size="100px 22px"/>
 
-                                <Text profile="sf_detailLabel" text="Compaction" position="10px -370px"/>
-                                <Text profile="sf_detailValueLarge" id="valCompaction" text="--%" position="200px -370px" textAlignment="right" size="100px 24px"/>
+                                    <Text profile="sf_detailLabel" text="Phosphorus (P)"   position="8px  -55px"/>
+                                    <Text profile="sf_detailValue" id="valP"  text="--%" position="195px -55px" size="100px 22px"/>
+
+                                    <Text profile="sf_detailLabel" text="Potassium (K)"    position="8px  -80px"/>
+                                    <Text profile="sf_detailValue" id="valK"  text="--%" position="195px -80px" size="100px 22px"/>
+
+                                    <Text profile="sf_detailLabel" text="pH Level"         position="8px  -105px"/>
+                                    <Text profile="sf_detailValue" id="valPH" text="--%" position="195px -105px" size="100px 22px"/>
+
+                                    <Text profile="sf_detailLabel" text="Organic Matter"   position="8px  -130px"/>
+                                    <Text profile="sf_detailValue" id="valOM" text="--%" position="195px -130px" size="100px 22px"/>
+                                </GuiElement>
+
+                                <!-- Pressures section -->
+                                <GuiElement profile="sf_pressureSection" position="0px -230px">
+                                    <Bitmap profile="sf_pressureBg" position="0px 0px"/>
+                                    <Text profile="sf_sidebarSectionHeader" text="Crop Pressure" position="8px -5px"/>
+
+                                    <Text profile="sf_detailLabel" text="Weed Pressure"   position="8px  -30px"/>
+                                    <Text profile="sf_detailValue" id="valWeed"       text="--%" position="195px -30px"  size="100px 22px"/>
+
+                                    <Text profile="sf_detailLabel" text="Pest Pressure"   position="8px  -55px"/>
+                                    <Text profile="sf_detailValue" id="valPest"       text="--%" position="195px -55px"  size="100px 22px"/>
+
+                                    <Text profile="sf_detailLabel" text="Disease Pressure" position="8px -80px"/>
+                                    <Text profile="sf_detailValue" id="valDisease"    text="--%" position="195px -80px"  size="100px 22px"/>
+
+                                    <Text profile="sf_detailLabel" text="Compaction"      position="8px  -105px"/>
+                                    <Text profile="sf_detailValue" id="valCompaction" text="--%" position="195px -105px" size="100px 22px"/>
+                                </GuiElement>
+
                             </GuiElement>
 
-                            <!-- Hint Text -->
+                            <!-- Hint Text (shown before map click) -->
                             <Text profile="sf_hintText" id="hintText" text="$l10n_sf_cell_click_hint"
                                   position="10px -100px" size="300px 200px" wrapText="true" visible="true" textAlignment="center"/>
+
                         </GuiElement>
                     </ThreePartBitmap>
                 </GuiElement>
@@ -75,53 +96,83 @@
 
         </GuiElement>
 
-        <!-- Button bar -->
         <BoxLayout profile="fs25_dialogButtonBox">
             <Button profile="buttonBack" text="$l10n_sf_detail_close" onClick="onCancel"/>
         </BoxLayout>
     </GuiElement>
 
     <GUIProfiles>
-        <!-- Map element profile (IngameMap) -->
+
         <Profile name="fs25_ingameMap" extends="baseReference" with="anchorTopLeft">
             <imageColor value="1 1 1 1"/>
         </Profile>
 
-        <!-- Profile for section headers in sidebar -->
+        <!-- Sidebar section header -->
         <Profile name="sf_sectionHeader" extends="fs25_textDefault" with="anchorTopLeft">
-            <size value="300px 30px"/>
-            <textSize value="16px"/>
+            <size value="300px 28px"/>
+            <textSize value="15px"/>
             <textBold value="true"/>
             <textColor value="0.65 0.80 0.95 1"/>
         </Profile>
 
-        <!-- Profile for detail labels -->
+        <!-- Field ID / coord info row -->
+        <Profile name="sf_infoRow" extends="emptyPanel" with="anchorTopLeft">
+            <size value="310px 58px"/>
+        </Profile>
+        <Profile name="sf_infoRowBg" extends="baseReference" with="anchorTopLeft">
+            <size value="310px 58px"/>
+            <imageColor value="0.08 0.08 0.12 0.9"/>
+        </Profile>
+
+        <!-- Nutrients section -->
+        <Profile name="sf_nutrientSection" extends="emptyPanel" with="anchorTopLeft">
+            <size value="310px 163px"/>
+        </Profile>
+        <Profile name="sf_nutrientBg" extends="baseReference" with="anchorTopLeft">
+            <size value="310px 163px"/>
+            <imageColor value="0.06 0.10 0.14 0.9"/>
+        </Profile>
+
+        <!-- Pressure section -->
+        <Profile name="sf_pressureSection" extends="emptyPanel" with="anchorTopLeft">
+            <size value="310px 138px"/>
+        </Profile>
+        <Profile name="sf_pressureBg" extends="baseReference" with="anchorTopLeft">
+            <size value="310px 138px"/>
+            <imageColor value="0.10 0.07 0.06 0.9"/>
+        </Profile>
+
+        <!-- Sidebar section header (inside panels) -->
+        <Profile name="sf_sidebarSectionHeader" extends="fs25_textDefault" with="anchorTopLeft">
+            <size value="295px 22px"/>
+            <textSize value="12px"/>
+            <textBold value="true"/>
+            <textColor value="1 0.8 0.2 1"/>
+        </Profile>
+
+        <!-- Row label -->
         <Profile name="sf_detailLabel" extends="fs25_textDefault" with="anchorTopLeft">
-            <size value="180px 24px"/>
+            <size value="185px 22px"/>
             <textSize value="12px"/>
             <textColor value="0.65 0.65 0.65 1"/>
         </Profile>
 
-        <!-- Profile for large detail values -->
-        <Profile name="sf_detailValueLarge" extends="fs25_textDefault" with="anchorTopLeft">
-            <size value="120px 24px"/>
+        <!-- Row value -->
+        <Profile name="sf_detailValue" extends="fs25_textDefault" with="anchorTopLeft">
+            <size value="100px 22px"/>
             <textSize value="13px"/>
             <textBold value="true"/>
             <textColor value="1 1 1 1"/>
+            <textAlignment value="right"/>
         </Profile>
 
-        <!-- Profile for dividers -->
-        <Profile name="sf_tabDivider" extends="baseReference" with="anchorTopLeft">
-            <size value="300px 2px"/>
-            <imageColor value="0.2 0.25 0.35 0.5"/>
-        </Profile>
-
-        <!-- Profile for hint text -->
+        <!-- Hint text -->
         <Profile name="sf_hintText" extends="fs25_textDefault" with="anchorTopLeft">
             <size value="300px 200px"/>
             <textSize value="14px"/>
-            <textColor value="0.6 0.6 0.6 1"/>
+            <textColor value="0.65 0.65 0.65 1"/>
             <textAlignment value="center"/>
         </Profile>
+
     </GUIProfiles>
 </GUI>

--- a/xml/gui/SoilOverlayHelpDialog.xml
+++ b/xml/gui/SoilOverlayHelpDialog.xml
@@ -15,21 +15,25 @@
     <ThreePartBitmap profile="fs25_dialogBgTop"/>
     <ThreePartBitmap profile="fs25_dialogBgBottom"/>
 
-    <!-- Title -->
-    <Text profile="fs25_dialogTitle" id="sfOvHelp_title"
-          text="Soil Map Overlay — Help" position="0px -30px"/>
+    <GuiElement profile="fs25_dialogContentContainer">
 
-    <!-- Horizontal separator under title -->
-    <Bitmap profile="sfOvHelp_sep" position="0px -66px" size="900px 2px"/>
+      <!-- Title -->
+      <Text profile="fs25_dialogTitle" id="sfOvHelp_title"
+            text="Soil Map Overlay — Help" position="0px -30px"/>
 
-    <!-- Left column — populated by Lua -->
-    <BoxLayout profile="sfOvHelp_col" id="sfOvHelp_col1" position="-230px -84px"/>
+      <!-- Left column panel -->
+      <GuiElement profile="sfOvHelp_columnPanel" position="-231px -68px">
+        <Bitmap profile="sfOvHelp_columnBg" position="0px 0px"/>
+        <BoxLayout profile="sfOvHelp_col" id="sfOvHelp_col1" position="0px -8px"/>
+      </GuiElement>
 
-    <!-- Vertical divider between columns -->
-    <Bitmap profile="sfOvHelp_vSep" position="0px -84px" size="2px 580px"/>
+      <!-- Right column panel -->
+      <GuiElement profile="sfOvHelp_columnPanel" position="231px -68px">
+        <Bitmap profile="sfOvHelp_columnBgAlt" position="0px 0px"/>
+        <BoxLayout profile="sfOvHelp_col" id="sfOvHelp_col2" position="0px -8px"/>
+      </GuiElement>
 
-    <!-- Right column — populated by Lua -->
-    <BoxLayout profile="sfOvHelp_col" id="sfOvHelp_col2" position="230px -84px"/>
+    </GuiElement>
 
     <BoxLayout profile="fs25_dialogButtonBox">
       <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
@@ -38,42 +42,55 @@
   </GuiElement>
 
   <GUIProfiles>
+
     <Profile name="sfOvHelp_bg" extends="fs25_dialogBg">
       <size value="960px 720px"/>
     </Profile>
-    <Profile name="sfOvHelp_sep" extends="baseReference" with="anchorTopCenter">
-      <imageColor value="1.0 1.0 1.0 0.15"/>
+
+    <!-- Column panel container -->
+    <Profile name="sfOvHelp_columnPanel" extends="emptyPanel" with="anchorTopCenter">
+      <size value="446px 596px"/>
     </Profile>
-    <Profile name="sfOvHelp_vSep" extends="baseReference" with="anchorTopCenter">
-      <imageColor value="1.0 1.0 1.0 0.15"/>
+    <Profile name="sfOvHelp_columnBg" extends="baseReference" with="anchorTopCenter">
+      <size value="446px 596px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
     </Profile>
+    <Profile name="sfOvHelp_columnBgAlt" extends="baseReference" with="anchorTopCenter">
+      <size value="446px 596px"/>
+      <imageColor value="0.06 0.10 0.14 0.9"/>
+    </Profile>
+
     <!-- Vertical column — Lua adds TextElements at runtime -->
     <Profile name="sfOvHelp_col" extends="emptyPanel" with="anchorTopCenter">
-      <size value="440px 580px"/>
+      <size value="430px 580px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
       <alignmentX value="left"/>
       <elementSpacing value="3px"/>
     </Profile>
-    <!-- Section header: bold, green, uppercase, left-aligned -->
-    <Profile name="sfOvHelp_colHeader" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="14px"/>
+
+    <!-- Section header: gold, bold, uppercase -->
+    <Profile name="sfOvHelp_colHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
-      <textColor value="0.35 0.85 0.40 1.0"/>
+      <textColor value="1 0.8 0.2 1"/>
       <textAlignment value="left"/>
     </Profile>
-    <!-- Body line: normal weight, white, left-aligned -->
-    <Profile name="sfOvHelp_colBody" extends="fs25_dialogText" with="anchorTopLeft">
+
+    <!-- Body line -->
+    <Profile name="sfOvHelp_colBody" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="12px"/>
-      <textColor value="$preset_colorWhite"/>
+      <textColor value="1 1 1 1"/>
       <textAlignment value="left"/>
     </Profile>
-    <!-- Spacer: invisible placeholder for vertical gap -->
-    <Profile name="sfOvHelp_colSpacer" extends="fs25_dialogText" with="anchorTopLeft">
+
+    <!-- Spacer -->
+    <Profile name="sfOvHelp_colSpacer" extends="fs25_textDefault" with="anchorTopLeft">
       <textSize value="6px"/>
       <textColor value="0.0 0.0 0.0 0.0"/>
       <textAlignment value="left"/>
     </Profile>
+
   </GUIProfiles>
 </GUI>

--- a/xml/gui/SoilTreatmentDialog.xml
+++ b/xml/gui/SoilTreatmentDialog.xml
@@ -30,11 +30,11 @@
         <Text profile="sfTreat_sectionHeader"
               text="$l10n_sf_treat_section_soil" position="0px -5px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_ph" position="-330px -33px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatPHAction" text="--"  position="-185px -33px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_ph" position="-270px -33px"/>
+        <Text profile="sfTreat_action" id="treatPHAction" text="--"  position="60px -33px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_om" position="-330px -58px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatOMAction" text="--"  position="-185px -58px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_om" position="-270px -58px"/>
+        <Text profile="sfTreat_action" id="treatOMAction" text="--"  position="60px -58px"/>
       </GuiElement>
 
       <!-- ─── FERTILIZATION section ─── -->
@@ -43,14 +43,14 @@
         <Text profile="sfTreat_sectionHeader"
               text="$l10n_sf_treat_section_fert" position="0px -5px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_n" position="-330px -33px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatNAction" text="--"  position="-185px -33px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_n" position="-270px -33px"/>
+        <Text profile="sfTreat_action" id="treatNAction" text="--"  position="60px -33px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_p" position="-330px -58px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatPAction" text="--"  position="-185px -58px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_p" position="-270px -58px"/>
+        <Text profile="sfTreat_action" id="treatPAction" text="--"  position="60px -58px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_k" position="-330px -83px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatKAction" text="--"  position="-185px -83px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_k" position="-270px -83px"/>
+        <Text profile="sfTreat_action" id="treatKAction" text="--"  position="60px -83px"/>
       </GuiElement>
 
       <!-- ─── CROP PROTECTION section ─── -->
@@ -59,14 +59,14 @@
         <Text profile="sfTreat_sectionHeader"
               text="$l10n_sf_treat_section_prot" position="0px -5px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_weed"    position="-330px -33px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatWeedAction"    text="--" position="-185px -33px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_weed"    position="-270px -33px"/>
+        <Text profile="sfTreat_action" id="treatWeedAction"    text="--" position="60px -33px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_pest"    position="-330px -58px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatPestAction"    text="--" position="-185px -58px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_pest"    position="-270px -58px"/>
+        <Text profile="sfTreat_action" id="treatPestAction"    text="--" position="60px -58px"/>
 
-        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_disease" position="-330px -83px" size="140px 22px"/>
-        <Text profile="sfTreat_action" id="treatDiseaseAction" text="--" position="-185px -83px" size="500px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_disease" position="-270px -83px"/>
+        <Text profile="sfTreat_action" id="treatDiseaseAction" text="--" position="60px -83px"/>
       </GuiElement>
 
       <!-- Summary hint (outside sections) -->
@@ -132,12 +132,14 @@
       <textAlignment value="center"/>
     </Profile>
 
-    <Profile name="sfTreat_label" extends="fs25_textDefault" with="anchorTopLeft">
+    <Profile name="sfTreat_label" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="140px 22px"/>
       <textSize value="12px"/>
       <textColor value="0.65 0.65 0.65 1"/>
     </Profile>
 
-    <Profile name="sfTreat_action" extends="fs25_textDefault" with="anchorTopLeft">
+    <Profile name="sfTreat_action" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="500px 22px"/>
       <textSize value="13px"/>
       <textBold value="true"/>
       <textColor value="1 1 1 1"/>

--- a/xml/gui/SoilTreatmentDialog.xml
+++ b/xml/gui/SoilTreatmentDialog.xml
@@ -20,66 +20,59 @@
       <Text profile="fs25_dialogTitle" id="treatTitle"
             text="$l10n_sf_treat_title" position="0px -30px"/>
 
-      <!-- Field ID -->
+      <!-- Field ID (outside sections) -->
       <Text profile="sfTreat_fieldId" id="treatFieldId"
-            text="" position="0px -65px" size="340px 24px"/>
+            text="" position="0px -63px" size="500px 24px"/>
 
-      <!-- ─── SOIL AMELIORATION ─── -->
-      <Text profile="sfTreat_sectionHeader"
-            text="$l10n_sf_treat_section_soil" position="0px -105px"/>
+      <!-- ─── SOIL AMELIORATION section ─── -->
+      <GuiElement profile="sfTreat_section2" position="0px -95px">
+        <Bitmap profile="sfTreat_sectionBg2" position="0px 0px"/>
+        <Text profile="sfTreat_sectionHeader"
+              text="$l10n_sf_treat_section_soil" position="0px -5px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_col_ph"
-            position="0px -140px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatPHAction"
-            text="--"  position="190px -140px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_ph" position="-330px -33px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatPHAction" text="--"  position="-185px -33px" size="500px 22px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_col_om"
-            position="0px -165px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatOMAction"
-            text="--"  position="190px -165px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_om" position="-330px -58px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatOMAction" text="--"  position="-185px -58px" size="500px 22px"/>
+      </GuiElement>
 
-      <!-- ─── FERTILIZATION ─── -->
-      <Text profile="sfTreat_sectionHeader"
-            text="$l10n_sf_treat_section_fert" position="0px -215px"/>
+      <!-- ─── FERTILIZATION section ─── -->
+      <GuiElement profile="sfTreat_section3" position="0px -194px">
+        <Bitmap profile="sfTreat_sectionBg3" position="0px 0px"/>
+        <Text profile="sfTreat_sectionHeader"
+              text="$l10n_sf_treat_section_fert" position="0px -5px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_col_n"
-            position="0px -250px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatNAction"
-            text="--"  position="190px -250px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_n" position="-330px -33px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatNAction" text="--"  position="-185px -33px" size="500px 22px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_col_p"
-            position="0px -275px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatPAction"
-            text="--"  position="190px -275px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_p" position="-330px -58px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatPAction" text="--"  position="-185px -58px" size="500px 22px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_col_k"
-            position="0px -300px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatKAction"
-            text="--"  position="190px -300px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_col_k" position="-330px -83px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatKAction" text="--"  position="-185px -83px" size="500px 22px"/>
+      </GuiElement>
 
-      <!-- ─── CROP PROTECTION ─── -->
-      <Text profile="sfTreat_sectionHeader"
-            text="$l10n_sf_treat_section_prot" position="0px -350px"/>
+      <!-- ─── CROP PROTECTION section ─── -->
+      <GuiElement profile="sfTreat_section3prot" position="0px -319px">
+        <Bitmap profile="sfTreat_sectionBgProt" position="0px 0px"/>
+        <Text profile="sfTreat_sectionHeader"
+              text="$l10n_sf_treat_section_prot" position="0px -5px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_need_weed"
-            position="0px -385px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatWeedAction"
-            text="--"  position="190px -385px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_weed"    position="-330px -33px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatWeedAction"    text="--" position="-185px -33px" size="500px 22px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_need_pest"
-            position="0px -410px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatPestAction"
-            text="--"  position="190px -410px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_pest"    position="-330px -58px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatPestAction"    text="--" position="-185px -58px" size="500px 22px"/>
 
-      <Text profile="sfTreat_label" text="$l10n_sf_pda_need_disease"
-            position="0px -435px"   size="180px 22px"/>
-      <Text profile="sfTreat_action" id="treatDiseaseAction"
-            text="--"  position="190px -435px" size="480px 22px"/>
+        <Text profile="sfTreat_label" text="$l10n_sf_pda_need_disease" position="-330px -83px" size="140px 22px"/>
+        <Text profile="sfTreat_action" id="treatDiseaseAction" text="--" position="-185px -83px" size="500px 22px"/>
+      </GuiElement>
 
-      <!-- Summary hint -->
+      <!-- Summary hint (outside sections) -->
       <Text profile="sfTreat_hint" id="treatHint"
             text="$l10n_sf_treat_hint"
-            position="0px -485px" size="680px 40px" wrapText="true"/>
+            position="0px -450px" size="680px 36px" wrapText="true"/>
 
     </GuiElement>
 
@@ -91,33 +84,70 @@
   </GuiElement>
 
   <GUIProfiles>
+
     <Profile name="sfTreat_bg" extends="fs25_dialogBg">
-      <size value="760px 600px"/>
+      <size value="760px 560px"/>
     </Profile>
-    <Profile name="sfTreat_fieldId" extends="fs25_dialogText" with="anchorTopLeft">
+
+    <!-- 2-row section (soil amelioration) -->
+    <Profile name="sfTreat_section2" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 91px"/>
+    </Profile>
+    <Profile name="sfTreat_sectionBg2" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 91px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
+    </Profile>
+
+    <!-- 3-row section (fertilization) -->
+    <Profile name="sfTreat_section3" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 116px"/>
+    </Profile>
+    <Profile name="sfTreat_sectionBg3" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 116px"/>
+      <imageColor value="0.06 0.10 0.14 0.9"/>
+    </Profile>
+
+    <!-- 3-row section (crop protection — slight warm tint) -->
+    <Profile name="sfTreat_section3prot" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 116px"/>
+    </Profile>
+    <Profile name="sfTreat_sectionBgProt" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 116px"/>
+      <imageColor value="0.10 0.07 0.06 0.9"/>
+    </Profile>
+
+    <!-- Section header: gold, bold, centered -->
+    <Profile name="sfTreat_sectionHeader" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="660px 22px"/>
+      <textSize value="14px"/>
+      <textBold value="true"/>
+      <textColor value="1 0.8 0.2 1"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="sfTreat_fieldId" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="18px"/>
       <textBold value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
-    </Profile>
-    <Profile name="sfTreat_sectionHeader" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="14px"/>
-      <textBold value="true"/>
-      <textUpperCase value="true"/>
-      <textColor value="0.35 0.85 0.40 1.0"/>
-    </Profile>
-    <Profile name="sfTreat_label" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="13px"/>
-      <textColor value="$preset_colorWhite_50"/>
-    </Profile>
-    <Profile name="sfTreat_action" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="13px"/>
-      <textBold value="true"/>
-      <textColor value="$preset_colorWhite"/>
-    </Profile>
-    <Profile name="sfTreat_hint" extends="fs25_dialogText" with="anchorTopLeft">
-      <textSize value="12px"/>
-      <textColor value="$preset_colorWhite_50"/>
       <textAlignment value="center"/>
     </Profile>
+
+    <Profile name="sfTreat_label" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="12px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
+    </Profile>
+
+    <Profile name="sfTreat_action" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
+      <textBold value="true"/>
+      <textColor value="1 1 1 1"/>
+    </Profile>
+
+    <Profile name="sfTreat_hint" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="12px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
+      <textAlignment value="center"/>
+    </Profile>
+
   </GUIProfiles>
 </GUI>

--- a/xml/gui/SoilVersionDialog.xml
+++ b/xml/gui/SoilVersionDialog.xml
@@ -6,7 +6,6 @@
 
     Changelog lines are created dynamically in Lua (no fixed slots).
     sfVer_changelogBox is a vertical BoxLayout — Lua adds TextElements to it.
-    Footer is anchored from the bottom of the dialog, not to changelog content.
 -->
 <GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
   <GuiElement profile="newLayer"/>
@@ -26,33 +25,30 @@
 
       <!-- Author -->
       <Text profile="sfVer_author"
-            text="Author: TisonK" position="0px -62px"/>
+            text="Author: TisonK" position="0px -60px"/>
 
-      <!-- Top separator -->
-      <Bitmap profile="sfVer_sep" position="0px -86px" size="560px 2px"/>
+      <!-- ─── CHANGELOG section ─── -->
+      <GuiElement profile="sfVer_changelogSection" position="0px -85px">
+        <Bitmap profile="sfVer_changelogBg" position="0px 0px"/>
 
-      <!-- "What's new" section header (set at runtime via i18n) -->
-      <Text profile="sfVer_sectionHeader" id="sfVer_changelogHeader"
-            text="" position="0px -104px"/>
+        <!-- "What's new" header (set at runtime via i18n) -->
+        <Text profile="sfVer_sectionHeader" id="sfVer_changelogHeader"
+              text="" position="0px -8px"/>
 
-      <!-- Dynamic changelog lines added here by Lua at onOpen() -->
-      <BoxLayout profile="sfVer_changelogBox" id="sfVer_changelogBox"
-                 position="0px -124px"/>
+        <!-- Dynamic changelog lines added here by Lua at onOpen() -->
+        <BoxLayout profile="sfVer_changelogBox" id="sfVer_changelogBox"
+                   position="0px -36px"/>
+      </GuiElement>
 
-      <!-- Bottom separator — sits 10px below the changelog box -->
-      <Bitmap profile="sfVer_sep" id="sfVer_bottomSep"
-              position="0px -414px" size="560px 2px"/>
+      <!-- ─── FOOTER section ─── -->
+      <GuiElement profile="sfVer_footerSection" position="0px -390px">
+        <Bitmap profile="sfVer_footerBg" position="0px 0px"/>
 
-      <!-- Footer (set at runtime via i18n) -->
-      <Text profile="sfVer_footer" id="sfVer_footer1"
-            text="" position="0px -434px"/>
-      <Text profile="sfVer_footer" id="sfVer_footer2"
-            text="" position="0px -452px"/>
-
-      <Text profile="sfVer_tagline1" id="sfVer_footer3"
-            text="" position="0px -479px"/>
-      <Text profile="sfVer_tagline2" id="sfVer_footer4"
-            text="" position="0px -497px"/>
+        <Text profile="sfVer_footer" id="sfVer_footer1" text="" position="0px -10px"/>
+        <Text profile="sfVer_footer" id="sfVer_footer2" text="" position="0px -28px"/>
+        <Text profile="sfVer_tagline1" id="sfVer_footer3" text="" position="0px -52px"/>
+        <Text profile="sfVer_tagline2" id="sfVer_footer4" text="" position="0px -70px"/>
+      </GuiElement>
 
     </GuiElement>
 
@@ -66,47 +62,74 @@
   </GuiElement>
 
   <GUIProfiles>
+
     <Profile name="sfVer_bg" extends="fs25_dialogBg">
-      <size value="640px 630px"/>
+      <size value="640px 600px"/>
     </Profile>
-    <Profile name="sfVer_author" extends="fs25_dialogText" with="anchorTopCenter">
-      <textSize value="13px"/>
-      <textColor value="$preset_colorWhite_50"/>
+
+    <!-- Changelog section container (dynamic height ~295px for up to ~8 lines) -->
+    <Profile name="sfVer_changelogSection" extends="emptyPanel" with="anchorTopCenter">
+      <size value="580px 295px"/>
     </Profile>
-    <Profile name="sfVer_sep" extends="baseReference" with="anchorTopCenter">
-      <imageColor value="1.0 1.0 1.0 0.15"/>
+    <Profile name="sfVer_changelogBg" extends="baseReference" with="anchorTopCenter">
+      <size value="580px 295px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
     </Profile>
-    <Profile name="sfVer_sectionHeader" extends="fs25_dialogText" with="anchorTopCenter">
+
+    <!-- Footer section -->
+    <Profile name="sfVer_footerSection" extends="emptyPanel" with="anchorTopCenter">
+      <size value="580px 95px"/>
+    </Profile>
+    <Profile name="sfVer_footerBg" extends="baseReference" with="anchorTopCenter">
+      <size value="580px 95px"/>
+      <imageColor value="0.06 0.08 0.10 0.9"/>
+    </Profile>
+
+    <!-- Section header: gold, bold -->
+    <Profile name="sfVer_sectionHeader" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="540px 22px"/>
       <textSize value="13px"/>
       <textBold value="true"/>
       <textUpperCase value="true"/>
-      <textColor value="0.35 0.85 0.40 1.0"/>
+      <textColor value="1 0.8 0.2 1"/>
+      <textAlignment value="center"/>
     </Profile>
+
     <!-- Vertical BoxLayout — Lua adds TextElements here dynamically -->
     <Profile name="sfVer_changelogBox" extends="emptyPanel" with="anchorTopCenter">
-      <size value="560px 280px"/>
+      <size value="540px 250px"/>
       <flowDirection value="vertical"/>
       <useFullVisibility value="false"/>
       <alignmentX value="center"/>
       <elementSpacing value="4px"/>
     </Profile>
+
     <!-- Used by Lua when creating each changelog TextElement -->
-    <Profile name="sfVer_changelogLine" extends="fs25_dialogText" with="anchorTopCenter">
+    <Profile name="sfVer_changelogLine" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="13px"/>
-      <textColor value="$preset_colorWhite"/>
+      <textColor value="1 1 1 1"/>
     </Profile>
-    <Profile name="sfVer_footer" extends="fs25_dialogText" with="anchorTopCenter">
+
+    <Profile name="sfVer_author" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="13px"/>
-      <textColor value="$preset_colorWhite_50"/>
+      <textColor value="0.65 0.65 0.65 1"/>
     </Profile>
-    <Profile name="sfVer_tagline1" extends="fs25_dialogText" with="anchorTopCenter">
+
+    <Profile name="sfVer_footer" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="13px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
+    </Profile>
+
+    <Profile name="sfVer_tagline1" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="12px"/>
-      <textColor value="$preset_colorWhite_50"/>
+      <textColor value="0.65 0.65 0.65 1"/>
     </Profile>
-    <Profile name="sfVer_tagline2" extends="fs25_dialogText" with="anchorTopCenter">
+
+    <Profile name="sfVer_tagline2" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="13px"/>
       <textBold value="true"/>
       <textColor value="0.35 0.85 0.40 1.0"/>
     </Profile>
+
   </GUIProfiles>
 </GUI>


### PR DESCRIPTION
## Summary

- **fix**: `computeYieldModifier` early-returned 1.0 when `nutrientCycles=false`, silently skipping weed, pest, and disease yield penalties even when those settings were enabled. Nutrient block is now gated independently; pressure penalties always fire when their setting is on
- **fix**: Canopy suppression field lookup matched on `f.farmland.id` (farmland ID) instead of field ID, causing the lookup to silently fail on most maps and leaving `canopyFactor=1.0` always. Fixed to use direct `fields[fieldId]` index first with fallback iteration
- **feat**: `pfCompatibilityMode` now fully gates the Precision Farming bridge — when disabled, `pfBridge.isActive` is forced false after detection, so yield calculations, fill type relays, HUD, and overlay all run in standalone mode. Also removed `localOnly` so the setting syncs correctly in MP

## Test plan

- [ ] With `nutrientCycles=false` and `weedPressure=true`: harvest a field with high weed pressure and confirm yield penalty is applied
- [ ] Confirm canopy suppression activates on standard maps (weed growth should slow as crop matures)
- [ ] With PF installed and `pfCompatibilityMode=false`: confirm N is shown in HUD and SF yield calc uses N/P/K (not PF-adjusted P/K only)
- [ ] With PF installed and `pfCompatibilityMode=true`: confirm SF defers N to PF as before
- [ ] No log errors on load