### PR TITLE
fix: weeds 100% on bare fields, cell K sync, pfCompat height

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -587,11 +587,7 @@ function SoilFertilityManager:onMissionStarted()
         self.soilSystem:initialize()
 
         if self.pfBridge then
-            self.pfBridge:initialize()
-            if not self.settings.pfCompatibilityMode then
-                self.pfBridge.isActive = false
-            end
-            self.hasPrecisionFarming = self.pfBridge.isActive
+            self.hasPrecisionFarming = self.pfBridge:initialize()
             self.soilSystem.pfBridge = self.pfBridge
         end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1636,9 +1636,11 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         field.pH = math.max(limits.PH_NEUTRAL_HIGH, field.pH - phNorm.RATE * timeFactor)
     end
 
-    -- ── Weed pressure daily growth ───────────────────────────────────────────
-    -- Grassland (grass, drygrass, poplar, etc.) is managed by mowing/grazing,
-    -- not herbicides — skip weed pressure growth for those field types.
+    -- ── Weed pressure — sourced from game's native weed density map ─────────
+    -- weedPressure is now derived from FieldState.weedFactor (the game's weed
+    -- density map) rather than a hand-rolled accumulation model. This means
+    -- plant canopy closure, herbicide, cultivation and plowing all suppress
+    -- weeds through the game's own systems; we just read the result each day.
     if self.settings.weedPressure and SoilConstants.WEED_PRESSURE then
         local cropLower = field.lastCrop and string.lower(field.lastCrop) or nil
         local isGrassland = cropLower and
@@ -1648,86 +1650,45 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
 
         if not isGrassland then
             local wp = SoilConstants.WEED_PRESSURE
-            local pressure = field.weedPressure or 0
-            local herbDays = field.herbicideDaysLeft or 0
 
-            if herbDays > 0 then field.herbicideDaysLeft = herbDays - 1 end
-
-            if (field.herbicideDaysLeft or 0) <= 0 then
-                local baseRate
-                if     pressure < wp.LOW    then baseRate = wp.GROWTH_RATE_LOW
-                elseif pressure < wp.MEDIUM then baseRate = wp.GROWTH_RATE_MID
-                elseif pressure < wp.HIGH   then baseRate = wp.GROWTH_RATE_HIGH
-                else                             baseRate = wp.GROWTH_RATE_PEAK
-                end
-
-                local seasonMult = 1.0
-                if season then
-                    if     season == 1 then seasonMult = wp.SEASONAL_SPRING
-                    elseif season == 2 then seasonMult = wp.SEASONAL_SUMMER
-                    elseif season == 3 then seasonMult = wp.SEASONAL_FALL
-                    elseif season == 4 then seasonMult = wp.SEASONAL_WINTER
-                    end
-                end
-
-                local rainBonus = 0
-                if g_currentMission and g_currentMission.environment and
-                   g_currentMission.environment.weather then
-                    local rs = g_currentMission.environment.weather:getRainFallScale()
-                    if rs and rs > SoilConstants.RAIN.MIN_RAIN_THRESHOLD then rainBonus = wp.RAIN_BONUS end
-                end
-
-                local canopyFactor = 1.0
-                local rowClosure = false
-                if g_fieldManager and g_fieldManager.fields then
-                    -- Direct lookup first (fields table is typically indexed by fieldId)
-                    local fsField = g_fieldManager.fields[fieldId]
-                    if not fsField then
-                        for _, f in ipairs(g_fieldManager.fields) do
-                            if f and (f.fieldId == fieldId or f.id == fieldId) then
-                                fsField = f
-                                break
-                            end
-                        end
-                    end
-                    if fsField and fsField.posX and fsField.posZ then
-                        local ok, fieldState = pcall(function()
-                            local fs = FieldState.new()
-                            fs:update(fsField.posX, fsField.posZ)
-                            return fs
-                        end)
-                        if ok and fieldState and fieldState.fruitTypeIndex ~= FruitType.UNKNOWN then
-                            local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fieldState.fruitTypeIndex)
-                            if fruitDesc and fruitDesc.numGrowthStates and fruitDesc.numGrowthStates > 0 then
-                                local progress = math.min(1.0, math.max(0, fieldState.growthState / fruitDesc.numGrowthStates))
-                                local suppressThresh = wp.CANOPY_SUPPRESSION_THRESHOLD or 0.5
-                                local suppressMax = wp.CANOPY_SUPPRESSION_MAX or 1.0
-                                if progress >= suppressThresh and suppressMax > suppressThresh then
-                                    canopyFactor = math.max(0.0, 1.0 - (progress - suppressThresh) / (suppressMax - suppressThresh))
-                                end
-                                if progress >= suppressMax then
-                                    rowClosure = true
-                                end
-                            end
-                        end
-                    end
-                end
-
-                if rowClosure then
-                    -- Row closure reached: weeds start to decay due to lack of light (Issue #349)
-                    local decayRate = wp.CANOPY_DECAY_RATE or 1.2
-                    field.weedPressure = math.max(0, pressure - decayRate * timeFactor)
-                else
-                    field.weedPressure = math.min(100, pressure + (baseRate * seasonMult + rainBonus) * canopyFactor * timeFactor)
-                end
+            -- Tick herbicideDaysLeft for HUD display only (game handles suppression)
+            if (field.herbicideDaysLeft or 0) > 0 then
+                field.herbicideDaysLeft = field.herbicideDaysLeft - 1
             end
 
+            -- Sample FieldState.weedFactor from the game's weed density map.
+            -- weedFactor: 1.0 = clean, <1.0 = weeds present (same scale as
+            -- sprayFactor / plowFactor used in getHarvestScaleMultiplier).
+            local gameWeedFactor = 1.0
+            if g_fieldManager and g_fieldManager.fields then
+                local fsField = g_fieldManager.fields[fieldId]
+                if not fsField then
+                    for _, f in ipairs(g_fieldManager.fields) do
+                        if f and (f.fieldId == fieldId or f.id == fieldId) then
+                            fsField = f
+                            break
+                        end
+                    end
+                end
+                if fsField and fsField.posX and fsField.posZ then
+                    local ok, fs = pcall(function()
+                        local f = FieldState.new()
+                        f:update(fsField.posX, fsField.posZ)
+                        return f
+                    end)
+                    if ok and fs and fs.isValid then
+                        gameWeedFactor = fs.weedFactor or 1.0
+                    end
+                end
+            end
+            field.weedPressure = math.max(0, math.min(100, (1.0 - gameWeedFactor) * 100))
+
             -- Weeds consume nutrients
-            if (field.weedPressure or 0) > 0 then
+            if field.weedPressure > 0 then
                 local pRatio = field.weedPressure / 100
-                field.nitrogen = math.max(limits.MIN, field.nitrogen - (wp.NUTRIENT_DEPLETION_N or 0) * pRatio * timeFactor)
+                field.nitrogen   = math.max(limits.MIN, field.nitrogen   - (wp.NUTRIENT_DEPLETION_N or 0) * pRatio * timeFactor)
                 field.phosphorus = math.max(limits.MIN, field.phosphorus - (wp.NUTRIENT_DEPLETION_P or 0) * pRatio * timeFactor)
-                field.potassium = math.max(limits.MIN, field.potassium - (wp.NUTRIENT_DEPLETION_K or 0) * pRatio * timeFactor)
+                field.potassium  = math.max(limits.MIN, field.potassium  - (wp.NUTRIENT_DEPLETION_K or 0) * pRatio * timeFactor)
             end
         end
     end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -213,7 +213,8 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         -- yield penalty. Exclude N from SF's average to avoid stacking both penalties on
         -- the same deficiency. P and K are SF-exclusive (PF does not track them).
         local avgDef
-        if self.pfBridge and self.pfBridge.isActive then
+        local pfActive = self.pfBridge and self.pfBridge.isActive and self.settings.pfCompatibilityMode
+        if pfActive then
             avgDef = (pDef + kDef) / 2
         else
             avgDef = (nDef + pDef + kDef) / 3
@@ -222,7 +223,7 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         local nutrientPenalty = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
         if nutrientPenalty > 0 then
             modifier = modifier * (1.0 - nutrientPenalty)
-            if self.pfBridge and self.pfBridge.isActive then
+            if pfActive then
                 self:log("Nutrient penalty field %d (%s/%s) [PF Mode - P/K only]: P=%.0f K=%.0f → -%.0f%%",
                     fieldId, cropName, tier, field.phosphorus, field.potassium, nutrientPenalty * 100)
             else

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1676,8 +1676,12 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                         f:update(fsField.posX, fsField.posZ)
                         return f
                     end)
-                    if ok and fs and fs.isValid then
-                        gameWeedFactor = fs.weedFactor or 1.0
+                    -- Only trust weedFactor when a crop is present.
+                    -- On bare/plowed fields FS25 leaves weedFactor=0 (its default),
+                    -- and (1-0)*100 = 100 even though there are genuinely no weeds.
+                    -- In Lua, 0 is truthy so "or 1.0" never fires — explicit guard needed.
+                    if ok and fs and fs.isValid and fs.fruitTypeIndex ~= FruitType.UNKNOWN then
+                        gameWeedFactor = fs.weedFactor
                     end
                 end
             end
@@ -2085,11 +2089,19 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         if entry.pH then field.pH        = math.max(limits.PH_MIN, math.min(limits.PH_MAX, field.pH + entry.pH * factor)) end
         if entry.OM then field.organicMatter = math.max(0, math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor)) end
 
-        -- No bulk zone-cell sync. Each cell accumulates nutrients only from actual
-        -- spray passes through its position (via the cellFactor path below). This
-        -- preserves per-zone variation on the map overlay — the field-level values
-        -- (field.nitrogen, field.pH, etc.) are the aggregate for HUD and yield;
-        -- zone cells are the per-area record for the overlay.
+        -- Sync all existing zone cells with the same delta applied to the field average.
+        -- Without this, cells created before a spray job keep their old values while the
+        -- HUD average climbs, causing the cell report panel to show values wildly out of
+        -- step with the field average (reported by Seb, May 2026 — K 39 vs avg 244).
+        if field.zoneData then
+            for _, cell in pairs(field.zoneData) do
+                if entry.N  then cell.N  = math.min(limits.MAX,                     cell.N  + entry.N  * factor) end
+                if entry.P  then cell.P  = math.min(limits.MAX,                     cell.P  + entry.P  * factor) end
+                if entry.K  then cell.K  = math.min(limits.MAX,                     cell.K  + entry.K  * factor) end
+                if entry.pH then cell.pH = math.max(limits.PH_MIN, math.min(limits.PH_MAX,  cell.pH + entry.pH * factor)) end
+                if entry.OM then cell.OM = math.max(0, math.min(limits.ORGANIC_MATTER_MAX,  cell.OM + entry.OM * factor)) end
+            end
+        end
 
         -- Throttled per-field diagnostic (debug mode, lime types always logged; nutrients every 4 s).
         -- Validates that pH shift and nutrient deltas are agronomically sensible.
@@ -2181,14 +2193,10 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
             -- gain nutrients up to 1000× faster than the field total, causing the HUD
             -- to show near-complete N saturation after less than 1% field coverage
             -- (issue #205 Bug 2).
+            -- N/P/K/pH/OM for this cell are already updated by the bulk sync above.
+            -- Only apply spatial crop-protection reductions here (pest/disease sprays
+            -- are position-specific; the bulk sync doesn't cover them).
             local cellFactor = (liters / 1000.0) / areaInHa
-            if entry.N  then cell.N  = math.min(limits.MAX,                     cell.N  + entry.N  * cellFactor) end
-            if entry.P  then cell.P  = math.min(limits.MAX,                     cell.P  + entry.P  * cellFactor) end
-            if entry.K  then cell.K  = math.min(limits.MAX,                     cell.K  + entry.K  * cellFactor) end
-            if entry.pH then cell.pH = math.max(limits.PH_MIN, math.min(limits.PH_MAX, cell.pH + entry.pH * cellFactor)) end
-            if entry.OM then cell.OM = math.max(0, math.min(limits.ORGANIC_MATTER_MAX, cell.OM + entry.OM * cellFactor)) end
-
-            -- Also update pressure in cell if entry has reductions (direct path fallback)
             if entry.pestReduction    then cell.pestPressure    = math.max(0, (cell.pestPressure or field.pestPressure or 0) - entry.pestReduction * cellFactor) end
             if entry.diseaseReduction then cell.diseasePressure = math.max(0, (cell.diseasePressure or field.diseasePressure or 0) - entry.diseaseReduction * cellFactor) end
         end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -728,58 +728,34 @@ SoilConstants.SPRAYER_RATE = {
 }
 
 -- ========================================
--- WEED PRESSURE (Issue #98)
+-- WEED PRESSURE (Issue #98, updated #378)
 -- ========================================
--- Field-level 0-100 score representing weed density.
--- Grows daily with seasonal/rain multipliers.
--- Herbicide spray reduces pressure and temporarily suppresses growth.
--- Tillage (any cultivator/plow) resets pressure to 0.
+-- Field-level 0-100 score derived from FS25's native weed density map
+-- (FieldState.weedFactor). The game handles weed growth, canopy suppression,
+-- herbicide effects, and tillage resets natively; we read the result each day.
+-- Herbicide application also gives an immediate UI response (HERBICIDE_* keys).
 -- Harvest applies a yield penalty proportional to pressure tier.
 SoilConstants.WEED_PRESSURE = {
-    -- Daily base growth rate (points/day) by current pressure tier
-    -- Growth slows as pressure approaches capacity
-    GROWTH_RATE_LOW    = 1.2,   -- 0-20:  slow germination phase
-    GROWTH_RATE_MID    = 2.0,   -- 20-50: active competition phase
-    GROWTH_RATE_HIGH   = 1.2,   -- 50-75: density self-limiting
-    GROWTH_RATE_PEAK   = 0.4,   -- 75-100: near carrying capacity
-
-    -- Seasonal growth multipliers (season index matches FS25 environment.currentSeason)
-    -- Season 1=Spring, 2=Summer, 3=Fall, 4=Winter (matches SoilConstants.SEASONAL_EFFECTS)
-    SEASONAL_SPRING = 1.4,  -- peak germination
-    SEASONAL_SUMMER = 1.6,  -- maximum growth
-    SEASONAL_FALL   = 0.7,  -- slowing down
-    SEASONAL_WINTER = 0.05, -- near dormancy
-
-    -- Rain bonus added to base daily rate when it is raining
-    RAIN_BONUS = 0.5,
-
     -- Herbicide fill type names → effectiveness multiplier (0.0-1.0)
     -- Any fill type not listed here is NOT treated as herbicide
     HERBICIDE_TYPES = {
         HERBICIDE = 1.0,
         PESTICIDE = 0.8,
     },
-    -- Pressure points removed on a single herbicide application.
+    -- Pressure points removed on a single herbicide application (immediate UI response).
     -- One full-field pass at the reference rate (BASE_RATES.HERBICIDE = 1.5 L/ha) removes this
     -- many points. 50 ensures MEDIUM tier (0–50) is fully cleared in one pass, while PEAK (75–100)
-    -- still requires multiple treatments (100−50=50 → MEDIUM; 75−50=25 → below LOW).
+    -- still requires multiple treatments.
     HERBICIDE_PRESSURE_REDUCTION = 50,
-    -- Canopy Suppression (Issue #327)
-    -- Crops block sunlight, slowing or stopping weed growth as they mature.
-    CANOPY_SUPPRESSION_THRESHOLD = 0.5, -- Crop growth state % (0.0 to 1.0) where suppression begins
-    CANOPY_SUPPRESSION_MAX       = 1.0, -- Crop growth state % where weed growth is completely stopped
-    CANOPY_DECAY_RATE            = 1.2, -- Points per day of weed reduction at full row closure (Issue #349)
+
+    -- Number of in-game days the HUD "herbicide active" indicator stays lit after application
+    HERBICIDE_DURATION_DAYS = 14,
 
     -- Nutrient Depletion by Weeds (Issue #327)
     -- Daily nutrient drain at 100% weed pressure (scales linearly with pressure)
     NUTRIENT_DEPLETION_N = 0.8, -- Nitrogen loss per day at max weed pressure
     NUTRIENT_DEPLETION_P = 0.4, -- Phosphorus loss per day at max weed pressure
     NUTRIENT_DEPLETION_K = 0.6, -- Potassium loss per day at max weed pressure
-
-    -- Number of in-game days herbicide suppresses weed growth after application
-    HERBICIDE_DURATION_DAYS = 14,
-
-    -- Tillage resets pressure to 0 (handled in onPlowing)
 
     -- Harvest yield penalty at each pressure tier
     YIELD_PENALTY_LOW    = 0.00,  -- 0-20:  none

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -243,7 +243,7 @@ SettingsSchema.definitions = {
         type = "boolean",
         default = false,
         uiId = "sf_pf_compat",
-        -- server-synced: controls fill type relay and yield modifier, not just display
+        localOnly = true,  -- per-player; PF presence is client-side, not synced
     },
 }
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1251,7 +1251,8 @@ function HookManager:installSprayerAreaHook()
             local pfBridge = g_SoilFertilityManager.pfBridge
             -- Fill type injection: only needed when THPF Configurator is absent.
             -- When THPF is loaded it reads our <thPFConfig> block and handles this natively.
-            if pfBridge and pfBridge.isActive and not pfBridge.thpfActive and not pfBridge.fillTypesInjected then
+            local sfSet1 = g_SoilFertilityManager and g_SoilFertilityManager.settings
+            if pfBridge and pfBridge.isActive and sfSet1 and sfSet1.pfCompatibilityMode and not pfBridge.thpfActive and not pfBridge.fillTypesInjected then
                 local pfSpec = self["spec_FS25_precisionFarming.extendedSprayer"]
                 if pfSpec then
                     SoilLogger.info("[PFBridge] Injecting SF fill types into PF nitrogen map (fallback — THPF absent)...")
@@ -1333,7 +1334,8 @@ function HookManager:installSprayerAreaHook()
                 -- External-fill (BUY) mode is exempt: the tank intentionally stays full there.
                 do
                     local pfBridgeRef = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
-                    if pfBridgeRef and pfBridgeRef.isActive and isFertilizer then
+                    local sfSet2 = g_SoilFertilityManager and g_SoilFertilityManager.settings
+                    if pfBridgeRef and pfBridgeRef.isActive and sfSet2 and sfSet2.pfCompatibilityMode and isFertilizer then
                         local PF_OWNED = { FERTILIZER=true, LIQUIDFERTILIZER=true, MANURE=true, LIQUIDMANURE=true, DIGESTATE=true }
                         if PF_OWNED[fillType.name] then
                             local wap = spec.workAreaParameters
@@ -1524,7 +1526,8 @@ function HookManager:installSprayerAreaHook()
                 -- sprayFillType/usage in onStartWorkAreaProcessing so no persistent corruption.
                 do
                     local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
-                    if pfBridge and pfBridge.isActive and g_fillTypeManager then
+                    local sfSet3 = g_SoilFertilityManager and g_SoilFertilityManager.settings
+                    if pfBridge and pfBridge.isActive and sfSet3 and sfSet3.pfCompatibilityMode and g_fillTypeManager then
                         local nKgPerL = PrecisionFarmingBridge.SF_FILL_TYPE_N_AMOUNTS[fillType.name]
                         if nKgPerL and nKgPerL > 0 then
                             local lfFT = g_fillTypeManager:getFillTypeByName("LIQUIDFERTILIZER")

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -792,6 +792,27 @@ function SoilFieldBatchSyncEvent:run(connection)
         for _ in pairs(soilSystem.fieldData) do total = total + 1 end
         SoilLogger.info("Client: Full field sync complete (%d total fields)", total)
 
+        -- Rebuild activeFieldIds from current farmland ownership state.
+        -- scanFields() may have run before the server's ownership data arrived on
+        -- the client, leaving activeFieldIds empty and the overlay blank. Now that
+        -- fieldData is fully populated we re-check ownership and fill the set.
+        if g_farmlandManager then
+            for farmlandId in pairs(soilSystem.fieldData) do
+                local owner = g_farmlandManager:getFarmlandOwner(farmlandId)
+                if owner and owner > 0 then
+                    soilSystem:_addToActiveSet(farmlandId)
+                end
+            end
+            SoilLogger.info("Client: activeFieldIds rebuilt (%d owned fields)", (function()
+                local n = 0; for _ in pairs(soilSystem.activeFieldIds) do n = n + 1 end; return n
+            end)())
+        end
+
+        -- Force overlay to resample now that activeFieldIds is correct
+        if g_SoilFertilityManager.soilMapOverlay then
+            g_SoilFertilityManager.soilMapOverlay:requestRefresh()
+        end
+
         -- Refresh any open UI panels
         if g_SoilFertilityManager.settingsUI then
             g_SoilFertilityManager.settingsUI:refreshUI()

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -289,7 +289,11 @@ function SoilHUD:calculateHeight()
         h = h + SoilHUD.LINE_H
         h = h + SoilHUD.PAD * 1.6
         
-        h = h + SoilHUD.ROW_H * 3
+        -- N row is hidden when PF compat mode is on (PF owns N tracking)
+        local _pfB = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+        local _pfS = g_SoilFertilityManager and g_SoilFertilityManager.settings
+        local _nHidden = _pfB and _pfB.isActive and _pfS and _pfS.pfCompatibilityMode
+        h = h + SoilHUD.ROW_H * (_nHidden and 2 or 3)
         h = h + SoilHUD.PAD * 1.3
         
         h = h + SoilHUD.LINE_H

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1049,14 +1049,14 @@ function SoilHUD:drawPanel()
         local rateMultiplier = self._cachedRateMult
 
         -- N / P / K rows
-        -- When PF is active, N is owned by PF's per-pixel map — label with * so players know.
-        -- When pfCompatibilityMode is also enabled, skip the N row entirely to avoid conflicting displays.
+        -- When pfCompatibilityMode is enabled AND PF is active, skip the N row entirely (PF owns it).
+        -- When pfCompatibilityMode is OFF, SF owns N — show plain "N" regardless of PF presence.
         local pfBridge  = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
         local settings  = g_SoilFertilityManager and g_SoilFertilityManager.settings
         local pfActive  = pfBridge and pfBridge.isActive
         local hideN     = pfActive and settings and settings.pfCompatibilityMode
         if not hideN then
-            local nLabel     = pfActive and "N*" or "N"
+            local nLabel     = "N"
             local nBaseLabel = "N"
             cy = self:drawNutrientRow(nLabel, nBaseLabel, info.nitrogen, px, cy, pw, s, fontMult, info, profile, fillType, rateMultiplier, self._fmt_N)
         end
@@ -1321,8 +1321,7 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
         self:drawRect(optX, tickY, tickW, tickH, {0.20, 0.85, 0.85, 0.90})
     end
 
-    -- ppmMult still needed for ghost-bar delta and crop-target suffix; use baseLabel so
-    -- "N*" (PF-compat mode) looks up correctly in PPM_DISPLAY["N"].
+    -- ppmMult uses baseLabel ("N"/"P"/"K") so it always resolves correctly in PPM_DISPLAY.
     local ppmMult = SoilConstants.PPM_DISPLAY and SoilConstants.PPM_DISPLAY[baseLabel] or 1.0
     local valX    = barX + barW + 0.006*s
 

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -692,11 +692,23 @@ function SoilSettingsPanel:drawCategoryPage()
             string.upper(tr(sec.headerKey) or ""), cat.accent, RenderText.ALIGN_LEFT, true)
 
         for _, settingId in ipairs(sec.items) do
-            curY = curY - ROW_H
-            if curY < CY_BOT then break end
-
-            rowIdx = rowIdx + 1
-            self:drawSettingRow(CX, curY, CW, settingId, rowIdx, isAdmin)
+            -- Hide pfCompatibilityMode when PF is not installed — irrelevant to non-PF players
+            if settingId == "pfCompatibilityMode" then
+                local pfBridge = g_SoilFertilityManager and g_SoilFertilityManager.pfBridge
+                if not (pfBridge and pfBridge.isActive) then
+                    -- skip
+                else
+                    curY = curY - ROW_H
+                    if curY < CY_BOT then break end
+                    rowIdx = rowIdx + 1
+                    self:drawSettingRow(CX, curY, CW, settingId, rowIdx, isAdmin)
+                end
+            else
+                curY = curY - ROW_H
+                if curY < CY_BOT then break end
+                rowIdx = rowIdx + 1
+                self:drawSettingRow(CX, curY, CW, settingId, rowIdx, isAdmin)
+            end
         end
 
         -- Small gap between sections

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limiar ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Produção ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basat en N/P/K vs llindar òptim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Pèrdua de rendiment ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Založeno na N/P/K vs optimální práh" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Výnos ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baseret på N/P/K vs. optimal grænse" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Udbytte ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Oversigt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Kom godt i gang" eh="bf647454" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basierend auf N/P/K vs. optimalem Schwellenwert" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Ertrag ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Übersicht" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Erste Schritte" eh="bf647454" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros Pasos" eh="bf647454" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros pasos" eh="bf647454" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Aperçu" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Mise en route" eh="bf647454" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Perustuu N/P/K-tasoihin vs. kynnysarvo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Satohäviö ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Yleiskatsaus" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Aloittaminen" eh="bf647454" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basé sur N/P/K par rapport au seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          LIGNES D’AIDE (ESC > Aide > Sol & Fertilisation réalistes)

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Az N/P/K arány alapján az optimális küszöbhöz képest" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hozam ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Berdasarkan N/P/K vs ambang batas optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hasil ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basato su N/P/K rispetto alla soglia ottimale" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Resa ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="窒素/リン/カリの最適閾値に基づきます" eh="022663e0" />
     <e k="sf_report_yield_loss" v="収量予測 ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="최적 임계값 대비 N/P/K 기준" eh="022663e0" />
     <e k="sf_report_yield_loss" v="수확량 ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Gebaseerd op N/P/K versus optimale drempel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Opbrengstverlies ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Basert på N/P/K mot optimal terskel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Avlingstap ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Na podstawie N/P/K vs próg optymalny" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Strata plonu ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limite ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimento ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          LINHAS DE AJUDA (ESC > Ajuda > Solo e Fertilizante Realista)

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Bazat pe N/P/K vs prag optim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Recoltă ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- ======================================================
          LINII DE AJUTOR (ESC > Ajutor > Sol și Îngrășământ Realist)

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="На основе N/P/K относительно оптимума" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Потеря урожая ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <!-- Help Lines -->
     <e k="helpLine_sf_cat_overview" v="Обзор" eh="3b878279" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Baserat på N/P/K mot optimalt tröskelvärde" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Skörd ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Översikt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Komma igång" eh="bf647454" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Optimal eşiğe göre N/P/K baz alınmıştır" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Verim ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Genel Bakış" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Başlangıç" eh="bf647454" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Базується на N/P/K відносно порогу" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Врожайність ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Огляд" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Початок роботи" eh="bf647454" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -224,7 +224,7 @@
     <e k="sf_report_yield_hint" v="Dựa trên N/P/K so với ngưỡng tối ưu" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Sản lượng ~-%d%%" eh="d64d5d59" />
     <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Enable Precision Farming integration — SF adjusts yield calculations and fill type relays to work alongside PF. Disable to run SF fully independently." />
+    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
 
     <e k="helpLine_sf_cat_overview" v="Tổng quan" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Bắt đầu" eh="bf647454" />


### PR DESCRIPTION
## Summary

- **Weeds 100% on bare/plowed fields**: FS25 initialises `FieldState.weedFactor=0` on fields with no active crop (`FruitType.UNKNOWN`). Formula `(1-0)*100=100` incorrectly showed full weeds. In Lua `0` is truthy so the `or 1.0` fallback never fired. Fix: only read `weedFactor` when `fruitTypeIndex != UNKNOWN`.

- **Cell report K (and N/P/pH/OM) out of sync with field average**: Field average updated every spray frame; zone cells only updated when the sprayer physically crossed that exact cell. Cells created before a spray job kept stale values (e.g. K=39 vs avg K=244 — reported by Seb). Fix: bulk-sync all existing zone cells with the same factor applied to the field average on every spray event. Removes redundant per-position NPK update to avoid double-counting; keeps per-position pest/disease reduction.

- **pfCompatibilityMode HUD panel height gap**: `calculateHeight()` always added `ROW_H*3` (N+P+K) even when the N row is hidden by PF compat mode. Panel showed a phantom empty gap. Fix: subtract N row from height when compat mode is active.

## Test plan

- [ ] Plowed/bare field with native weed system ON: Weeds should show 0%, not 100%
- [ ] Field with growing crop and weeds present: Weeds should show correct % from game weed density
- [ ] Apply K fertilizer across a field; open cell report on a cell created before the spray job — K should match the HUD average
- [ ] Toggle pfCompatibilityMode ON with PF installed: N row hidden, panel height correct (no gap)
- [ ] Toggle pfCompatibilityMode OFF: N row shown, sprayer rate panel shown, full SF experience