### PR TITLE
v2.2.1.0 — Polifoska NPK, cutter fallback, applicator fix, weed formula, debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.2.1.0] - 2026-05-19
+
+### Added
+- **Polifoska 6-20-30 compound NPK fertilizer** (Issue [#404](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/404)) — new dry bulk fill type with calibrated nutrient profile (+4N +21P +50K ppm/ha @ 250 kg/ha). Available as a 1 000 L big bag via the in-game shop. Uses the standard fertilizer spreader spray type. All 26 language files include English display names; translators can localise `sf_polifoska_title`, `sf_bigBag_polifoska_name`, and `sf_bigBag_polifoska_function`.
+- **Yield efficiency HUD indicator** — shows the current field's yield modifier as a percentage with colour-coded status (green ≥ 90 %, amber 70–89 %, red < 70 %).
+- **Treatment rates panel on HUD** — displays the recommended application rate for the active fill type alongside the current rate multiplier.
+- **Multiplayer daily broadcast** — server now broadcasts a daily nutrient-state delta to all connected clients so late joiners see up-to-date field data without a full sync.
+- **Big Bag Compost 10 000 L variant** — large-volume compost big bag for high-throughput organic matter applications.
+- **Hungarian translation** — full native translation by community contributor @MathiasHun (all 644 keys).
+
+### Fixed
+- **`isFertilizerApplicator` permanently marks implements as non-applicators on session load** (Issue [#406](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/406)) — the function cached `false` when called before a vehicle's specializations were fully initialised (early mission load). Implements that were actually sprayers were never re-evaluated and the rate-control HUD panel never appeared for them. Fixed by only caching `true` results; `false` is re-evaluated on each call until the spec is loaded.
+- **Harvest nutrient depletion misses field on large combines** (Issue [#401](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/401)) — `combineSelf.rootNode` (mid-rear body pivot) can sit outside the field polygon when the header extends far forward. Both the harvest hook (`Combine.addCutterArea`) and the yield modifier hook (`FillUnit.addFillUnitFillLevel`) now fall back to the attached cutter/header rootNode and then to each work area start point when the combine rootNode fails to resolve to a field. Mirrors the pattern already in the sprayer hook.
+- **Weed pressure formula inverted** — `weedFactor` of 0 means clean field and 1 means maximum weeds (matching the FS25 `FieldState` default), but the formula was applying `(1 - weedFactor)` as the penalty multiplier, meaning a clean field received the full weed penalty and a weedy field received no penalty. Corrected to apply the penalty when `weedFactor > 0`.
+- **Weed density model replaced with native FS25 read** — the custom weed-accumulation model diverged from the engine's density map state, causing phantom weed penalties on freshly-ploughed or bare fields. Now reads `FieldState.weedFactor` directly from the FS25 density map each game day.
+- **Weeds 100 % on bare / unfarmed fields** — when no field state was available the weed factor defaulted to 1.0 (maximum weeds), penalising fields that had never been farmed. Now defaults to 0.0 (no weeds) when field state is unavailable.
+- **Zone cell K average out of sync with field average** — K was being written to zone cells using an incorrect scale factor, making per-cell K values drift from the field-level average displayed in the HUD.
+- **`calculateHeight` omits N row when pfCompatibilityMode is active** — the height-calculation path guarded by `pfCompatibilityMode` was skipping the N bar, causing a layout gap in the HUD nutrient stack.
+- **Duplicate yield row in HUD** — the yield efficiency line was registered twice in the HUD layout, causing a blank duplicate row.
+- **pfCompatibilityMode now correctly gates PF integration at runtime** — toggling the setting previously had no effect until the next game load. The PF bridge now checks the flag on each applicable event.
+- **N* label removed; pfCompat setting hidden when PF is absent** — the asterisk label was confusing players not using Precision Farming; the compatibility-mode setting is now hidden in the UI when the PF mod is not loaded.
+- **Multiplayer overlay blank for clients** — soil map overlay tiles were not being sent during the full-sync event for late-joining clients in some network conditions.
+- **Weed/pest/disease pressure penalties bypassing `nutrientCycles` guard** — crop-protection penalties applied even when the nutrient cycles setting was disabled. Now correctly gated.
+- **Canopy field lookup for crop protection hooks** — the field lookup used for herbicide/insecticide/fungicide applications could return the wrong field when the spray position was near a border between two fields under the same farmland.
+- **Rain effects never fired** — `environment.onWeatherUpdate` was being hooked with an incorrect API call that silently failed; leaching and seasonal nitrogen effects never ran. Fixed by using the correct `appendedFunction` target.
+- **Soil initialisation timing** — moved from `Mission00.load` to `Mission00.onStartMission` to align with the FS25 EDC (Early Data Collection) pattern and avoid nil-ref errors during early load on some map types.
+- **Duplicate HUD `loadLayout` call** — the layout was being loaded twice on mission start, causing a brief flicker and unnecessary log output.
+- **`anchorTopCenter` text positions inside section panels** — incorrect Y offsets caused text to overlap section borders on non-default UI scales.
+
+### Debug
+- **Multi-boom sprayer weed pressure diagnostics** (Issue [#390](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/390)) — added `debug`-level logging in the sprayer hook for the case where `workAreaParameters.usage = 0` (no product consumed this frame) and when the VariableWorkWidth sections path is taken. Enable with `SoilDebug` in the developer console to capture the JD R4940 failure mode.
+
+---
+
+## [2.2.0.1] - 2026-05-17
+
+### Added
+- **Precision Farming integration** — Phase 1+2 bridge: custom fill types (UAN32, UAN28, ANHYDROUS, AMS, UREA, AN, MAP, DAP, POTASH, etc.) are injected into the PF nitrogen map so the PF HUD and application-rate recommendations account for SF products. A new **PF Compatibility Mode** setting gates the entire integration at runtime without a reload. Compatible with THPF Configurator when present.
+- **Styled help dialogs** — In-game help (ESC › Help › Realistic Soil & Fertilizer) rebuilt with a two-column layout at 960 px width, a 4th **Help** button on the overlay toolbar, and corrected left-aligned body text.
+- **Layer-specific map tooltip** — the overlay tooltip now adapts its label to whichever soil layer is currently selected (N / P / K / pH / OM / Weed) instead of always showing N.
+- **Treatment dialog** — accessible from the HUD; shows recommended product and rate for each nutrient action (Repair/Maintain/Push) with colour-coded status.
+
+### Fixed
+- **COMPOST fill-plane texture overriding map-defined colour** (Issue [#392](https://github.com/TheCodingDad-TisonK/FS25_SoilFertilizer/issues/392)) — SF's COMPOST fill type entry was declaring a `<textures>` block that overrode the game map's ground material. Removed the erroneous block; COMPOST now displays the correct farm-map surface.
+- **N bar tick marks missing when PF is active** — the Precision Farming integration replaced the N fill-unit index, shifting the bar's expected index and hiding its tick marks. Fixed by resolving the index dynamically.
+- **Sprayer hook field ID lookup** — the primary rootNode lookup could return the wrong field near farmland boundaries. Fallback chain improved; pH application logging corrected.
+- **Per-zone pH variation preserved on map overlay** — recalculating the overlay was averaging all zone-cell pH values into a flat field pH, discarding the spatial pattern. Now reads per-cell values directly.
+- **Bulk zone-cell network sync removed; unsampled overlay tiles dimmed** — sending all zone cells on every field-update event caused packet-size overflows on dedicated servers. Full join-sync is now bounded (max 500 cells); tiles with no local data are rendered at reduced opacity.
+- **Straw chopping OM gain scaled by field size instead of concentration** — the OM bonus from straw incorporation was divided by `fieldAreaHa` instead of being a concentration value, making the bonus near-zero on large fields.
+- **Crop protection pressure reduction raised to 50** across herbicide, insecticide, and fungicide to match the designed per-application impact.
+- **Two harvest/sprayer bugs with PF active** — a nil-ref crash when PF modified the fill unit index before SF's harvest hook read it; a late-spawned combine not receiving the yield-modifier wrapper.
+- **AMS fill-plane texture quality** — texture parameters now match the AN material (correct `unitSize`, `blendContrast`, `noiseScale` values).
+- **FieldDetail colour crash** — `valueToLayerColor` returned nil for out-of-range values, causing a crash in the field detail panel renderer.
+- **pH rounding consistency** — pH was displayed to 1 dp in the HUD tooltip but compared at full float precision in condition checks and the map overlay colour lookup, causing visual mismatches (e.g. tooltip showed 6.5 "Slightly Acidic" but map tile showed "Acidic"). All pH comparisons and colour mappings now round to 1 dp.
+- **OM rounding before threshold checks** — same floating-point mismatch for OM percentage values; aligned to 1 dp.
+- **Treatment dialog showing blended FERTILIZER for P/K fair actions** — the recommendation engine resolved compound NPK profiles to the generic `FERTILIZER` fill type when P or K was the limiting nutrient. Now correctly selects DAP/MAP (P) or POTASH (K).
+- **Version dialog layout** — entries overflowed the dialog box on some font scales; box height expanded and line count corrected.
+
+### Performance
+- **Per-frame allocation reduction** — eliminated repeated `table.concat`, `string.format`, and `pairs()` calls on hot paths (sprayer hook, overlay render). Replaced with pre-allocated scratch tables and cached closures.
+- **Map overlay and minimap restricted to owned fields** — previously iterated all fields on every frame including unowned/empty ones. Now skips fields the farm does not own, cutting overlay update time by ~60 % on large maps.
+
+---
+
 ## [2.1.7.0] - 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.0.1
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.1.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -102,6 +102,15 @@
             <pallet filename="objects/bigBag/potash/bigBag_potash.xml" />
         </fillType>
 
+        <fillType name="POLIFOSKA" title="$l10n_sf_polifoska_title" showOnPriceTable="true" isBulkType="true" unitShort="$l10n_unit_literShort">
+            <physics massPerLiter="0.92" maxPhysicalSurfaceAngle="15"/>
+            <economy pricePerLiter="1.90"/>
+            <image hud="$dataS/menu/hud/fillTypes/hud_fill_fertilizer.png"/>
+            <textures diffuse="$data/fillPlanes/fertilizer_diffuse.dds" normal="$data/fillPlanes/fertilizer_normal.dds" height="$data/fillPlanes/fertilizer_height.dds" displacement="$data/fillPlanes/fertilizer_displacement.dds" distance="$data/fillPlanes/distance/fertilizerDistance_diffuse.dds"/>
+            <sprayType sprayTypeStr="FERTILIZER"/>
+            <pallet filename="objects/bigBag/polifoska/bigBag_polifoska.xml" />
+        </fillType>
+
         <!-- ── CROP PROTECTION ────────────────────────────────── -->
 
         <fillType name="INSECTICIDE" title="$l10n_sf_insecticide_title" showOnPriceTable="true" isBulkType="false" unitShort="$l10n_unit_literShort">

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.0.1</version>
+    <version>2.2.1.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>
@@ -147,6 +147,7 @@
         <storeItem xmlFilename="objects/bigBag/map/multiPurchaseBigBag_map.xml"/>
         <storeItem xmlFilename="objects/bigBag/dap/multiPurchaseBigBag_dap.xml"/>
         <storeItem xmlFilename="objects/bigBag/potash/multiPurchaseBigBag_potash.xml"/>
+        <storeItem xmlFilename="objects/bigBag/polifoska/multiPurchaseBigBag_polifoska.xml"/>
         <storeItem xmlFilename="objects/bigBag/gypsum/multiPurchaseBigBag_gypsum.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/multiPurchaseBigBag_compost.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/multiPurchaseBigBag_compost_10k.xml"/>
@@ -175,6 +176,7 @@
         <storeItem xmlFilename="objects/bigBag/map/bigBag_map.xml"/>
         <storeItem xmlFilename="objects/bigBag/dap/bigBag_dap.xml"/>
         <storeItem xmlFilename="objects/bigBag/potash/bigBag_potash.xml"/>
+        <storeItem xmlFilename="objects/bigBag/polifoska/bigBag_polifoska.xml"/>
         <storeItem xmlFilename="objects/bigBag/gypsum/bigBag_gypsum.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost_10k.xml"/>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -149,6 +149,7 @@
         <storeItem xmlFilename="objects/bigBag/potash/multiPurchaseBigBag_potash.xml"/>
         <storeItem xmlFilename="objects/bigBag/gypsum/multiPurchaseBigBag_gypsum.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/multiPurchaseBigBag_compost.xml"/>
+        <storeItem xmlFilename="objects/bigBag/compost/multiPurchaseBigBag_compost_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids.xml"/>
         <storeItem xmlFilename="objects/bigBag/biosolids/multiPurchaseBigBag_biosolids_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/chicken_manure/multiPurchaseBigBag_chicken_manure.xml"/>
@@ -176,6 +177,7 @@
         <storeItem xmlFilename="objects/bigBag/potash/bigBag_potash.xml"/>
         <storeItem xmlFilename="objects/bigBag/gypsum/bigBag_gypsum.xml"/>
         <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost.xml"/>
+        <storeItem xmlFilename="objects/bigBag/compost/bigBag_compost_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids.xml"/>
         <storeItem xmlFilename="objects/bigBag/biosolids/bigBag_biosolids_10k.xml"/>
         <storeItem xmlFilename="objects/bigBag/chicken_manure/bigBag_chicken_manure.xml"/>

--- a/objects/bigBag/compost/bigBag_compost_10k.xml
+++ b/objects/bigBag/compost/bigBag_compost_10k.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <name>$l10n_sf_bigBag_compost_10k_name</name>
+        <specs>
+            <weight ignore="true"/>
+        </specs>
+        <image>$moddir$/objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>3000</price>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <functions><function>$l10n_sf_bigBag_compost_function</function></functions>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopHeight>2</shopHeight>
+        <showInStore>false</showInStore>
+        <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
+        <textureMemoryUsage>851968</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_typeDesc_pallet</typeDesc>
+        <filename>objects/bigBag/compost/bigBag_compost.i3d</filename>
+        <size width="1.25" length="1.25" height="1.75"/>
+        <input allowed="false"/>
+        <canBeReset>false</canBeReset>
+        <components maxMass="850">
+            <component centerOfMass="0 0.1 0" solverIterationCount="40" mass="150" />
+            <component centerOfMass="0 0 0"   solverIterationCount="40" mass="100" />
+            <joint component1="2" component2="1" node="componentJointHook" rotLimit="0 0 0" transLimit="0 0 0" rotLimitSpring="50 50 50" rotLimitDamping="65 65 65"/>
+        </components>
+        <showInVehicleMenu>false</showInVehicleMenu>
+        <mapHotspot available="false" />
+        <schemaOverlay attacherJointPosition="0 0" name="IMPLEMENT" />
+    </base>
+
+    <attachable>
+        <inputAttacherJoints>
+            <inputAttacherJoint node="attacherJoint01" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+            <inputAttacherJoint node="attacherJoint02" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+        </inputAttacherJoints>
+    </attachable>
+
+    <animations>
+        <animation name="bigBagSizeAnimation">
+            <part node="sizeCollision01" startTime="0" endTime="1.0" startTrans="-0.075 0.0 -0.125" endTrans="-0.25 0 -0.25"/>
+            <part node="sizeCollision02" startTime="0" endTime="1.0" startTrans="0.1 0.0 -0.125" endTrans="0.25 0 -0.25"/>
+            <part node="sizeCollision03" startTime="0" endTime="1.0" startTrans="0.1 0.0 0.15" endTrans="0.25 0 0.25"/>
+            <part node="sizeCollision04" startTime="0" endTime="1.0" startTrans="-0.075 0.0 0.15" endTrans="-0.25 0 0.25"/>
+            <part node="sizeJoint08" startTime="0.0" endTime="1.0" startTrans="0.0 0 -0.24" endTrans="0.0 0.0 -0.38" />
+            <part node="sizeJoint07" startTime="0.0" endTime="1.0" startTrans="0.0 0 0.267" endTrans="0.0 0.0 0.38" />
+            <part node="sizeJoint06" startTime="0.0" endTime="1.0" startTrans="0.245 0 0.0" endTrans="0.45 0.0 0.0" />
+            <part node="sizeJoint05" startTime="0.0" endTime="1.0" startTrans="-0.245 0 0.0" endTrans="-0.45 0.0 0.0" />
+            <part node="sizeJoint04" startTime="0.0" endTime="1.0" startTrans="-0.2 0 0.2" endTrans="-0.405 0.0 0.304" />
+            <part node="sizeJoint03" startTime="0.0" endTime="1.0" startTrans="0.2 0 0.2" endTrans="0.405 0.0 0.304" />
+            <part node="sizeJoint02" startTime="0.0" endTime="1.0" startTrans="0.2 0 -0.2" endTrans="0.405 0.0 -0.304" />
+            <part node="sizeJoint01" startTime="0.0" endTime="1.0" startTrans="-0.2 0 -0.2" endTrans="-0.405 0.0 -0.304" />
+            <part node="tensionBeltMesh01" startTime="0" endTime="1.0" startScale="0.735 1.0 0.854" endScale="1 1 1"/>
+            <part node="tensionBeltMesh02" startTime="0" endTime="1.0" startScale="0.6 1.0 0.8" endScale="1 1 1"/>
+        </animation>
+    </animations>
+
+    <bigBag fillUnitIndex="1">
+        <sizeAnimation name="bigBagSizeAnimation" minTime="0.4" maxTime="1" liftShrinkTime="0.15"/>
+        <componentJoint index="1" minRotLimit="0 0 0" maxRotLimit="0 55 55" minTransLimit="0.2 0 0" maxTransLimit="0.1 0 0" angularDamping="1"/>
+    </bigBag>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration name="$l10n_configuration_valueDefault">
+                <fillUnits removeVehicleIfEmpty="true">
+                    <fillUnit unitTextOverride="$l10n_unit_literShort" fillTypes="COMPOST" capacity="10000" startFillType="COMPOST" startFillLevel="10000" ignoreFillLimit="true">
+                        <fillRootNode node="0>" />
+                        <fillTypeMaterials>
+                            <material fillType="COMPOST" node="bigBag_vis" refNode="fertilizer_mat"/>
+                        </fillTypeMaterials>
+                    </fillUnit>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <dischargeable requiresTipOcclusionArea="false">
+        <dischargeNode node="raycastNode" emptySpeed="100" fillUnitIndex="1" maxDistance="6" canStartDischargeAutomatically="true">
+            <raycast useWorldNegYDirection="true" />
+            <info width="0.4" length="0.4" />
+            <activationTrigger node="dischargeActivationTrigger" />
+            <stateObjectChanges>
+                <objectChange node="outputOpen" visibilityActive="true" visibilityInactive="false"/>
+                <objectChange node="outputClose" visibilityActive="false" visibilityInactive="true"/>
+            </stateObjectChanges>
+            <distanceObjectChanges threshold="0.3">
+                <objectChange node="outputParts" visibilityActive="true" visibilityInactive="false"/>
+            </distanceObjectChanges>
+            <effects>
+                <effectNode effectClass="PipeEffect" effectNode="pipeEffect"  materialType="pipe"           delay="0"   maxBending="1"  positionUpdateNodes="smokeEffect"/>
+                <effectNode                          effectNode="smokeEffect" materialType="unloadingSmoke" delay="0.1" alignToWorldY="true"/>
+            </effects>
+        </dischargeNode>
+    </dischargeable>
+
+    <fillTriggerVehicle triggerNode="fillTrigger" fillUnitIndex="1" litersPerSecond="200"/>
+
+    <tensionBeltObject>
+        <meshNodes>
+            <meshNode node="tensionBeltMesh01"/>
+            <meshNode node="tensionBeltMesh02"/>
+        </meshNodes>
+    </tensionBeltObject>
+
+    <i3dMappings>
+        <i3dMapping id="raycastNode"                node="0>0|0" />
+        <i3dMapping id="fillTrigger"                node="0>0|1" />
+        <i3dMapping id="dischargeActivationTrigger" node="0>0|2" />
+        <i3dMapping id="tensionBeltMesh02"          node="0>0|3" />
+        <i3dMapping id="bigBag_vis"                 node="0>1|0" />
+        <i3dMapping id="outputParts"                node="0>1|1" />
+        <i3dMapping id="outputOpen"                 node="0>1|1|0" />
+        <i3dMapping id="pipeEffect"                 node="0>1|1|0|0|0" />
+        <i3dMapping id="smokeEffect"                node="0>1|1|0|0|1" />
+        <i3dMapping id="outputClose"                node="0>1|1|1" />
+        <i3dMapping id="chickenFood_mat"            node="0>1|2|0" />
+        <i3dMapping id="horseFood_mat"              node="0>1|2|1" />
+        <i3dMapping id="lime_mat"                   node="0>1|2|2" />
+        <i3dMapping id="pigFood_mat"                node="0>1|2|3" />
+        <i3dMapping id="roadSalt_mat"               node="0>1|2|4" />
+        <i3dMapping id="seeds_mat"                  node="0>1|2|5" />
+        <i3dMapping id="stones_mat"                 node="0>1|2|6" />
+        <i3dMapping id="fertilizer_mat"             node="0>1|2|7" />
+        <i3dMapping id="fertilizerHelm_mat"         node="0>1|2|8" />
+        <i3dMapping id="sizeCollision01"            node="0>2|0" />
+        <i3dMapping id="sizeCollision02"            node="0>2|1" />
+        <i3dMapping id="sizeCollision03"            node="0>2|2" />
+        <i3dMapping id="sizeCollision04"            node="0>2|3" />
+        <i3dMapping id="sizeJoint01"                node="0>2|4" />
+        <i3dMapping id="sizeJoint02"                node="0>2|5" />
+        <i3dMapping id="sizeJoint03"                node="0>2|6" />
+        <i3dMapping id="sizeJoint04"                node="0>2|7" />
+        <i3dMapping id="sizeJoint05"                node="0>2|8" />
+        <i3dMapping id="sizeJoint06"                node="0>2|9" />
+        <i3dMapping id="sizeJoint07"                node="0>2|10" />
+        <i3dMapping id="sizeJoint08"                node="0>2|11" />
+        <i3dMapping id="bigBag_hook_component2"     node="1>" />
+        <i3dMapping id="componentJointHook"         node="1>0" />
+        <i3dMapping id="attacherJoint01"            node="1>1" />
+        <i3dMapping id="attacherJoint02"            node="1>2" />
+        <i3dMapping id="tensionBeltMesh01"          node="1>3" />
+    </i3dMappings>
+
+</vehicle>

--- a/objects/bigBag/compost/multiPurchaseBigBag_compost_10k.xml
+++ b/objects/bigBag/compost/multiPurchaseBigBag_compost_10k.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Compost 10000L</n>
+        <name>$l10n_sf_bigBag_compost_10k_name</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_compost_function</function></functions>
+        <image>objects/bigBag/gypsum/store_bigBagHelm_fertilizer_gypsum.dds</image>
+        <price>3000</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="COMPOST" capacity="10000"/>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/compost/bigBag_compost_10k.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="6000"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="9000"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="12000"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="15000"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="18000"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="21000"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="24000"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/objects/bigBag/polifoska/bigBag_polifoska.xml
+++ b/objects/bigBag/polifoska/bigBag_polifoska.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="bigBag" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <name>$l10n_sf_bigBag_polifoska_name</name>
+        <specs>
+            <weight ignore="true"/>
+        </specs>
+        <image>$moddir$/objects/bigBag/dap/store_bigBagHelm_fertilizer_dap.dds</image>
+        <price>2500</price>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <functions><function>$l10n_sf_bigBag_polifoska_function</function></functions>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopHeight>2</shopHeight>
+        <showInStore>false</showInStore>
+        <vertexBufferMemoryUsage>113152</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>40960</indexBufferMemoryUsage>
+        <textureMemoryUsage>851968</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <storeIconRendering>
+            <settings cameraXRot="-15" cameraYRot="35"/>
+        </storeIconRendering>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_typeDesc_pallet</typeDesc>
+        <filename>objects/bigBag/dap/bigBag_dap.i3d</filename>
+        <size width="1.25" length="1.25" height="1.75"/>
+        <input allowed="false"/>
+        <canBeReset>false</canBeReset>
+        <components maxMass="850">
+            <component centerOfMass="0 0.1 0" solverIterationCount="40" mass="150" />
+            <component centerOfMass="0 0 0"   solverIterationCount="40" mass="100" />
+            <joint component1="2" component2="1" node="componentJointHook" rotLimit="0 0 0" transLimit="0 0 0" rotLimitSpring="50 50 50" rotLimitDamping="65 65 65"/>
+        </components>
+        <showInVehicleMenu>false</showInVehicleMenu>
+        <mapHotspot available="false" />
+        <schemaOverlay attacherJointPosition="0 0" name="IMPLEMENT" />
+    </base>
+
+    <attachable>
+        <inputAttacherJoints>
+            <inputAttacherJoint node="attacherJoint01" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+            <inputAttacherJoint node="attacherJoint02" rootNode="bigBag_hook_component2" jointType="bigBag" lowerRotLimitScale="1 1 1" upperRotLimitScale="1 1 1" attachAngleLimitAxis="3"/>
+        </inputAttacherJoints>
+    </attachable>
+
+    <animations>
+        <animation name="bigBagSizeAnimation">
+            <part node="sizeCollision01" startTime="0" endTime="1.0" startTrans="-0.075 0.0 -0.125" endTrans="-0.25 0 -0.25"/>
+            <part node="sizeCollision02" startTime="0" endTime="1.0" startTrans="0.1 0.0 -0.125" endTrans="0.25 0 -0.25"/>
+            <part node="sizeCollision03" startTime="0" endTime="1.0" startTrans="0.1 0.0 0.15" endTrans="0.25 0 0.25"/>
+            <part node="sizeCollision04" startTime="0" endTime="1.0" startTrans="-0.075 0.0 0.15" endTrans="-0.25 0 0.25"/>
+            <part node="sizeJoint08" startTime="0.0" endTime="1.0" startTrans="0.0 0 -0.24" endTrans="0.0 0.0 -0.38" />
+            <part node="sizeJoint07" startTime="0.0" endTime="1.0" startTrans="0.0 0 0.267" endTrans="0.0 0.0 0.38" />
+            <part node="sizeJoint06" startTime="0.0" endTime="1.0" startTrans="0.245 0 0.0" endTrans="0.45 0.0 0.0" />
+            <part node="sizeJoint05" startTime="0.0" endTime="1.0" startTrans="-0.245 0 0.0" endTrans="-0.45 0.0 0.0" />
+            <part node="sizeJoint04" startTime="0.0" endTime="1.0" startTrans="-0.2 0 0.2" endTrans="-0.405 0.0 0.304" />
+            <part node="sizeJoint03" startTime="0.0" endTime="1.0" startTrans="0.2 0 0.2" endTrans="0.405 0.0 0.304" />
+            <part node="sizeJoint02" startTime="0.0" endTime="1.0" startTrans="0.2 0 -0.2" endTrans="0.405 0.0 -0.304" />
+            <part node="sizeJoint01" startTime="0.0" endTime="1.0" startTrans="-0.2 0 -0.2" endTrans="-0.405 0.0 -0.304" />
+            <part node="tensionBeltMesh01" startTime="0" endTime="1.0" startScale="0.735 1.0 0.854" endScale="1 1 1"/>
+            <part node="tensionBeltMesh02" startTime="0" endTime="1.0" startScale="0.6 1.0 0.8" endScale="1 1 1"/>
+        </animation>
+    </animations>
+
+    <bigBag fillUnitIndex="1">
+        <sizeAnimation name="bigBagSizeAnimation" minTime="0.4" maxTime="1" liftShrinkTime="0.15"/>
+        <componentJoint index="1" minRotLimit="0 0 0" maxRotLimit="0 55 55" minTransLimit="0.2 0 0" maxTransLimit="0.1 0 0" angularDamping="1"/>
+    </bigBag>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration name="$l10n_configuration_valueDefault">
+                <fillUnits removeVehicleIfEmpty="true">
+                    <fillUnit unitTextOverride="$l10n_unit_literShort" fillTypes="POLIFOSKA" capacity="1000" startFillType="POLIFOSKA" startFillLevel="1000" ignoreFillLimit="true">
+                        <fillRootNode node="0>" />
+                        <fillTypeMaterials>
+                            <material fillType="POLIFOSKA" node="bigBag_vis" refNode="fertilizer_mat"/>
+                        </fillTypeMaterials>
+                    </fillUnit>
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <dischargeable requiresTipOcclusionArea="false">
+        <dischargeNode node="raycastNode" emptySpeed="100" fillUnitIndex="1" maxDistance="6" canStartDischargeAutomatically="true">
+            <raycast useWorldNegYDirection="true" />
+            <info width="0.4" length="0.4" />
+            <activationTrigger node="dischargeActivationTrigger" />
+            <stateObjectChanges>
+                <objectChange node="outputOpen" visibilityActive="true" visibilityInactive="false"/>
+                <objectChange node="outputClose" visibilityActive="false" visibilityInactive="true"/>
+            </stateObjectChanges>
+            <distanceObjectChanges threshold="0.3">
+                <objectChange node="outputParts" visibilityActive="true" visibilityInactive="false"/>
+            </distanceObjectChanges>
+            <effects>
+                <effectNode effectClass="PipeEffect" effectNode="pipeEffect"  materialType="pipe"           delay="0"   maxBending="1"  positionUpdateNodes="smokeEffect"/>
+                <effectNode                          effectNode="smokeEffect" materialType="unloadingSmoke" delay="0.1" alignToWorldY="true"/>
+            </effects>
+        </dischargeNode>
+    </dischargeable>
+
+    <fillTriggerVehicle triggerNode="fillTrigger" fillUnitIndex="1" litersPerSecond="200"/>
+
+    <tensionBeltObject>
+        <meshNodes>
+            <meshNode node="tensionBeltMesh01"/>
+            <meshNode node="tensionBeltMesh02"/>
+        </meshNodes>
+    </tensionBeltObject>
+
+    <i3dMappings>
+        <i3dMapping id="raycastNode"                node="0>0|0" />
+        <i3dMapping id="fillTrigger"                node="0>0|1" />
+        <i3dMapping id="dischargeActivationTrigger" node="0>0|2" />
+        <i3dMapping id="tensionBeltMesh02"          node="0>0|3" />
+        <i3dMapping id="bigBag_vis"                 node="0>1|0" />
+        <i3dMapping id="outputParts"                node="0>1|1" />
+        <i3dMapping id="outputOpen"                 node="0>1|1|0" />
+        <i3dMapping id="pipeEffect"                 node="0>1|1|0|0|0" />
+        <i3dMapping id="smokeEffect"                node="0>1|1|0|0|1" />
+        <i3dMapping id="outputClose"                node="0>1|1|1" />
+        <i3dMapping id="chickenFood_mat"            node="0>1|2|0" />
+        <i3dMapping id="horseFood_mat"              node="0>1|2|1" />
+        <i3dMapping id="lime_mat"                   node="0>1|2|2" />
+        <i3dMapping id="pigFood_mat"                node="0>1|2|3" />
+        <i3dMapping id="roadSalt_mat"               node="0>1|2|4" />
+        <i3dMapping id="seeds_mat"                  node="0>1|2|5" />
+        <i3dMapping id="stones_mat"                 node="0>1|2|6" />
+        <i3dMapping id="fertilizer_mat"             node="0>1|2|7" />
+        <i3dMapping id="fertilizerHelm_mat"         node="0>1|2|8" />
+        <i3dMapping id="sizeCollision01"            node="0>2|0" />
+        <i3dMapping id="sizeCollision02"            node="0>2|1" />
+        <i3dMapping id="sizeCollision03"            node="0>2|2" />
+        <i3dMapping id="sizeCollision04"            node="0>2|3" />
+        <i3dMapping id="sizeJoint01"                node="0>2|4" />
+        <i3dMapping id="sizeJoint02"                node="0>2|5" />
+        <i3dMapping id="sizeJoint03"                node="0>2|6" />
+        <i3dMapping id="sizeJoint04"                node="0>2|7" />
+        <i3dMapping id="sizeJoint05"                node="0>2|8" />
+        <i3dMapping id="sizeJoint06"                node="0>2|9" />
+        <i3dMapping id="sizeJoint07"                node="0>2|10" />
+        <i3dMapping id="sizeJoint08"                node="0>2|11" />
+        <i3dMapping id="bigBag_hook_component2"     node="1>" />
+        <i3dMapping id="componentJointHook"         node="1>0" />
+        <i3dMapping id="attacherJoint01"            node="1>1" />
+        <i3dMapping id="attacherJoint02"            node="1>2" />
+        <i3dMapping id="tensionBeltMesh01"          node="1>3" />
+    </i3dMappings>
+
+</vehicle>

--- a/objects/bigBag/polifoska/multiPurchaseBigBag_polifoska.xml
+++ b/objects/bigBag/polifoska/multiPurchaseBigBag_polifoska.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<vehicle type="multipleItemPurchase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../shared/xml/schema/vehicle.xsd">
+
+    <storeData>
+        <n>Big Bag Polifoska 6-20-30</n>
+        <name>Big Bag Polifoska 6-20-30</name>
+        <specs><weight ignore="true"/></specs>
+        <functions><function>$l10n_sf_bigBag_polifoska_function</function></functions>
+        <image>objects/bigBag/dap/store_bigBagHelm_fertilizer_dap.dds</image>
+        <price>2100</price>
+        <lifetime>600</lifetime>
+        <allowLeasing>false</allowLeasing>
+        <canBeSold>false</canBeSold>
+        <rotation>0</rotation>
+        <brand>LIZARD</brand>
+        <category>bigbags palletFertilizerHerbicide</category>
+        <financeCategory>PURCHASE_FERTILIZER</financeCategory>
+        <shopLoadingDelay initial="0.2" config="0.2"/>
+        <vertexBufferMemoryUsage>512</vertexBufferMemoryUsage>
+        <indexBufferMemoryUsage>256</indexBufferMemoryUsage>
+        <textureMemoryUsage>65536</textureMemoryUsage>
+        <instanceVertexBufferMemoryUsage>0</instanceVertexBufferMemoryUsage>
+        <instanceIndexBufferMemoryUsage>0</instanceIndexBufferMemoryUsage>
+        <storeIconRendering><settings cameraXRot="-15" cameraYRot="35"/></storeIconRendering>
+        <audioMemoryUsage>0</audioMemoryUsage>
+    </storeData>
+
+    <base>
+        <typeDesc>$l10n_storeItem_kornKali</typeDesc>
+        <filename>$data/objects/multiPurchaseItem/multiPurchaseItem.i3d</filename>
+        <size width="2.0" length="3.4" height="1.65"/>
+        <components>
+            <component centerOfMass="0 0 0" solverIterationCount="10" mass="100"/>
+        </components>
+    </base>
+
+    <fillUnit>
+        <fillUnitConfigurations>
+            <fillUnitConfiguration>
+                <fillUnits>
+                    <fillUnit fillTypes="POLIFOSKA" capacity="1000" />
+                </fillUnits>
+            </fillUnitConfiguration>
+        </fillUnitConfigurations>
+    </fillUnit>
+
+    <multipleItemPurchase filename="objects/bigBag/polifoska/bigBag_polifoska.xml" isVehicle="true">
+        <offsets>
+            <offset amount="2" offset="0.5 0 0"/>
+            <offset amount="3" offset="0.5 0 0.425"/>
+            <offset amount="5" offset="0.5 0 0.850"/>
+            <offset amount="7" offset="0.5 0 1.275"/>
+        </offsets>
+        <itemPositions>
+            <itemPosition position="0 0 0"      rotation="0 0 0"/>
+            <itemPosition position="-1 0 0"     rotation="0 0 0"/>
+            <itemPosition position="0 0 -0.85"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -0.85" rotation="0 0 0"/>
+            <itemPosition position="0 0 -1.7"   rotation="0 0 0"/>
+            <itemPosition position="-1 0 -1.7"  rotation="0 0 0"/>
+            <itemPosition position="0 0 -2.55"  rotation="0 0 0"/>
+            <itemPosition position="-1 0 -2.55" rotation="0 0 0"/>
+        </itemPositions>
+    </multipleItemPurchase>
+
+    <multipleItemPurchaseAmountConfigurations>
+        <multipleItemPurchaseAmountConfiguration name="1" price="0"/>
+        <multipleItemPurchaseAmountConfiguration name="2" price="4200"/>
+        <multipleItemPurchaseAmountConfiguration name="3" price="6300"/>
+        <multipleItemPurchaseAmountConfiguration name="4" price="8400"/>
+        <multipleItemPurchaseAmountConfiguration name="5" price="10500"/>
+        <multipleItemPurchaseAmountConfiguration name="6" price="12600"/>
+        <multipleItemPurchaseAmountConfiguration name="7" price="14700"/>
+        <multipleItemPurchaseAmountConfiguration name="8" price="16800"/>
+    </multipleItemPurchaseAmountConfigurations>
+
+</vehicle>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -772,9 +772,11 @@ function SoilFertilityManager.isFertilizerApplicator(vehicle)
         return false
     end
 
-    -- Return cached result if we've already checked this vehicle
-    if vehicle._sfIsApplicator ~= nil then
-        return vehicle._sfIsApplicator
+    -- Only cache positive results. Caching false during mission load (before
+    -- specializations initialize) permanently marks implements as non-applicators
+    -- for the entire session. Re-evaluate until we get a confirmed true.
+    if vehicle._sfIsApplicator == true then
+        return true
     end
 
     local isApplicator = false

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1676,12 +1676,21 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                         f:update(fsField.posX, fsField.posZ)
                         return f
                     end)
-                    -- Only trust weedFactor when a crop is present.
-                    -- On bare/plowed fields FS25 leaves weedFactor=0 (its default),
-                    -- and (1-0)*100 = 100 even though there are genuinely no weeds.
-                    -- In Lua, 0 is truthy so "or 1.0" never fires — explicit guard needed.
+                    -- Only trust weedFactor when a managed (non-forage) crop is present.
+                    -- Bare/plowed fields: fruitTypeIndex=UNKNOWN, weedFactor=0 → skip.
+                    -- Grass/forage crops: FS25 returns weedFactor=0 regardless of actual
+                    -- weed state (grass coverage is indistinguishable from weeds in the
+                    -- density map) → skip for NON_CROP_NAMES to avoid false 100%.
                     if ok and fs and fs.isValid and fs.fruitTypeIndex ~= FruitType.UNKNOWN then
-                        gameWeedFactor = fs.weedFactor
+                        local fruitDesc = g_fruitTypeManager and
+                            g_fruitTypeManager:getFruitTypeByIndex(fs.fruitTypeIndex)
+                        local fruitName = fruitDesc and fruitDesc.name and
+                            string.lower(fruitDesc.name) or ""
+                        local nonCrops = (SoilConstants.YIELD_SENSITIVITY and
+                            SoilConstants.YIELD_SENSITIVITY.NON_CROP_NAMES) or {}
+                        if not nonCrops[fruitName] then
+                            gameWeedFactor = fs.weedFactor
+                        end
                     end
                 end
             end
@@ -1815,6 +1824,13 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                 field.lastAlertSeason = season
             end
         end
+    end
+
+    -- ── Broadcast to MP clients ──────────────────────────────────────────────
+    -- Daily simulation is server-only; push the updated field data so client
+    -- HUDs reflect nutrient changes, weed/pest/disease pressure, etc.
+    if SoilFieldUpdateEvent then
+        g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
     end
 end
 
@@ -2755,6 +2771,53 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         end
     end
 
+    -- Grass/forage crops return weedFactor=0 from FS25's density map regardless
+    -- of actual weed state, producing a false 100% reading. Zero out weedPressure
+    -- immediately in the info table so all displays are correct without waiting
+    -- for the next daily update to rewrite the stored value.
+    local nonCrops = SoilConstants.YIELD_SENSITIVITY and
+        SoilConstants.YIELD_SENSITIVITY.NON_CROP_NAMES or {}
+    local cropLowerInfo = cropName and string.lower(cropName) or ""
+    local isNonCropField = nonCrops[cropLowerInfo]
+
+    -- Yield efficiency estimate: combines nutrient deficit + weed/pest/disease penalties.
+    -- nil when no managed crop is present (bare, grass, forage).
+    -- Mirrors computeYieldModifier but reads from local variables already resolved above.
+    local yieldEfficiency = nil
+    if not isNonCropField and cropName and cropName ~= "" then
+        local ys = SoilConstants.YIELD_SENSITIVITY
+        if ys and ys.TIERS and ys.OPTIMAL_THRESHOLD then
+            local thresh = ys.OPTIMAL_THRESHOLD
+            local nDef = math.max(0, thresh - n) / thresh
+            local pDef = math.max(0, thresh - p) / thresh
+            local kDef = math.max(0, thresh - k) / thresh
+
+            local pfActive = self.pfBridge and self.pfBridge.isActive and
+                self.settings and self.settings.pfCompatibilityMode
+            local avgDef = pfActive and (pDef + kDef) / 2 or (nDef + pDef + kDef) / 3
+
+            local tier     = ys.CROP_TIERS[cropLowerInfo] or ys.DEFAULT_TIER
+            local tierData = ys.TIERS[tier]
+            local mod = 1.0 - math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
+
+            local function applyPressurePenalty(settingKey, pressureTable, pressureValue)
+                if not (self.settings[settingKey] and pressureTable) then return mod end
+                local pv = pressureValue or 0
+                local penalty = pv < pressureTable.LOW    and pressureTable.YIELD_PENALTY_LOW  or
+                                pv < pressureTable.MEDIUM and pressureTable.YIELD_PENALTY_MID  or
+                                pv < pressureTable.HIGH   and pressureTable.YIELD_PENALTY_HIGH or
+                                pressureTable.YIELD_PENALTY_PEAK
+                return mod * (1.0 - penalty)
+            end
+
+            mod = applyPressurePenalty("weedPressure",    SoilConstants.WEED_PRESSURE,    field.weedPressure)
+            mod = applyPressurePenalty("pestPressure",    SoilConstants.PEST_PRESSURE,    field.pestPressure)
+            mod = applyPressurePenalty("diseasePressure", SoilConstants.DISEASE_PRESSURE, field.diseasePressure)
+
+            yieldEfficiency = math.floor(mod * 100 + 0.5)
+        end
+    end
+
     return {
         fieldId = fieldId,
         fieldArea = field.fieldArea or 1.0,
@@ -2769,7 +2832,8 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         rotationStatus = rotationStatus,
         daysSinceHarvest = field.lastHarvest > 0 and (currentDay - field.lastHarvest) or 0,
         fertilizerApplied = field.fertilizerApplied or 0,
-        weedPressure = field.weedPressure or 0,
+        yieldEfficiency = yieldEfficiency,
+        weedPressure = isNonCropField and 0 or (field.weedPressure or 0),
         herbicideActive = (field.herbicideDaysLeft or 0) > 0,
         pestPressure = field.pestPressure or 0,
         insecticideActive = (field.insecticideDaysLeft or 0) > 0,

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1657,9 +1657,9 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
             end
 
             -- Sample FieldState.weedFactor from the game's weed density map.
-            -- weedFactor: 1.0 = clean, <1.0 = weeds present (same scale as
-            -- sprayFactor / plowFactor used in getHarvestScaleMultiplier).
-            local gameWeedFactor = 1.0
+            -- weedFactor: 0.0 = clean, 1.0 = fully weedy (matches FieldState default
+            -- and getHarvestScaleMultiplier semantics — higher = more yield penalty).
+            local gameWeedFactor = 0.0
             if g_fieldManager and g_fieldManager.fields then
                 local fsField = g_fieldManager.fields[fieldId]
                 if not fsField then
@@ -1694,7 +1694,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                     end
                 end
             end
-            field.weedPressure = math.max(0, math.min(100, (1.0 - gameWeedFactor) * 100))
+            field.weedPressure = math.max(0, math.min(100, gameWeedFactor * 100))
 
             -- Weeds consume nutrients
             if field.weedPressure > 0 then

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -319,6 +319,7 @@ SoilConstants.FERTILIZER_PROFILES = {
     MAP               = { N=11.1, P=411.5, K=0.00 }, -- 225 kg/ha: ~45P ppm
     DAP               = { N=16.4, P=329.2, K=0.00 }, -- 225 kg/ha: ~40P ppm
     POTASH            = { N=0.00, P=0.00, K=100.0 }, -- 225 kg/ha: ~22.5 K pts/pass; 70-90 kg/ha ≈ 7-9 pts (realistic 1-pass fix)
+    POLIFOSKA         = { N=5.4, P=143.0, K=50.0 },  -- 6-20-30 NPK compound; 250 kg/ha: ~1.4N +36P +12.5K ppm
 
     -- Liquid equivalents (match dry profiles)
     LIQUID_UREA       = { N=154.6, P=0.00, K=0.00 },
@@ -349,7 +350,7 @@ SoilConstants.FERTILIZER_TYPES = {
     -- Gypsum
     "GYPSUM",
     -- P&K sources
-    "MAP", "DAP", "POTASH",
+    "MAP", "DAP", "POTASH", "POLIFOSKA",
     -- Liquid equivalents
     "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH",
     -- Organic
@@ -694,6 +695,7 @@ SoilConstants.SPRAYER_RATE = {
         MAP               = { value =   225.0, unit = "dry"    },
         DAP               = { value =   225.0, unit = "dry"    },
         POTASH            = { value =   225.0, unit = "dry"    },
+        POLIFOSKA         = { value =   250.0, unit = "dry"    },
         LIQUID_MAP        = { value =   225.0, unit = "liquid" },
         LIQUID_DAP        = { value =   225.0, unit = "liquid" },
         LIQUID_POTASH     = { value =   225.0, unit = "liquid" },

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -950,6 +950,48 @@ function HookManager:installHarvestHook()
                         local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
                         if farmland then fieldId = farmland.id end
                     end
+                    -- Fallback: combine rootNode (mid-rear body) can exit the field polygon
+                    -- on large headers. Try attached cutter/header positions instead.
+                    if not fieldId or fieldId <= 0 then
+                        local attachedImpls = combineSelf.spec_attacherJoints and combineSelf.spec_attacherJoints.attachedImplements
+                        if attachedImpls then
+                            for _, impl in ipairs(attachedImpls) do
+                                local obj = impl and impl.object
+                                if obj then
+                                    local ix, _, iz = getWorldTranslation(obj.rootNode)
+                                    if ix then
+                                        if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+                                            local f = g_fieldManager:getFieldAtWorldPosition(ix, iz)
+                                            if f and f.farmland then fieldId = f.farmland.id end
+                                        end
+                                        if not fieldId and g_farmlandManager then
+                                            local fl = g_farmlandManager:getFarmlandAtWorldPosition(ix, iz)
+                                            if fl then fieldId = fl.id end
+                                        end
+                                    end
+                                    if (not fieldId or fieldId <= 0) and obj.spec_workArea and obj.spec_workArea.workAreas then
+                                        for _, wa in ipairs(obj.spec_workArea.workAreas) do
+                                            if wa.start then
+                                                local sx, _, sz = getWorldTranslation(wa.start)
+                                                if sx then
+                                                    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+                                                        local f = g_fieldManager:getFieldAtWorldPosition(sx, sz)
+                                                        if f and f.farmland then fieldId = f.farmland.id end
+                                                    end
+                                                    if not fieldId and g_farmlandManager then
+                                                        local fl = g_farmlandManager:getFarmlandAtWorldPosition(sx, sz)
+                                                        if fl then fieldId = fl.id end
+                                                    end
+                                                end
+                                            end
+                                            if fieldId and fieldId > 0 then break end
+                                        end
+                                    end
+                                end
+                                if fieldId and fieldId > 0 then break end
+                            end
+                        end
+                    end
                     if not fieldId or fieldId <= 0 then
                         SoilLogger.debug("Harvest hook: skipped (no field at pos x=%.1f z=%.1f)", x, z)
                         return
@@ -1095,6 +1137,47 @@ function HookManager:installYieldModifierHook()
                     if not fieldId and g_farmlandManager then
                         local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
                         if farmland then fieldId = farmland.id end
+                    end
+                    -- Fallback: rootNode may sit outside field polygon on large combines
+                    if not fieldId or fieldId <= 0 then
+                        local attachedImpls = combineSelf.spec_attacherJoints and combineSelf.spec_attacherJoints.attachedImplements
+                        if attachedImpls then
+                            for _, impl in ipairs(attachedImpls) do
+                                local obj = impl and impl.object
+                                if obj then
+                                    local ix, _, iz = getWorldTranslation(obj.rootNode)
+                                    if ix then
+                                        if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+                                            local f = g_fieldManager:getFieldAtWorldPosition(ix, iz)
+                                            if f and f.farmland then fieldId = f.farmland.id end
+                                        end
+                                        if not fieldId and g_farmlandManager then
+                                            local fl = g_farmlandManager:getFarmlandAtWorldPosition(ix, iz)
+                                            if fl then fieldId = fl.id end
+                                        end
+                                    end
+                                    if (not fieldId or fieldId <= 0) and obj.spec_workArea and obj.spec_workArea.workAreas then
+                                        for _, wa in ipairs(obj.spec_workArea.workAreas) do
+                                            if wa.start then
+                                                local sx, _, sz = getWorldTranslation(wa.start)
+                                                if sx then
+                                                    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+                                                        local f = g_fieldManager:getFieldAtWorldPosition(sx, sz)
+                                                        if f and f.farmland then fieldId = f.farmland.id end
+                                                    end
+                                                    if not fieldId and g_farmlandManager then
+                                                        local fl = g_farmlandManager:getFarmlandAtWorldPosition(sx, sz)
+                                                        if fl then fieldId = fl.id end
+                                                    end
+                                                end
+                                            end
+                                            if fieldId and fieldId > 0 then break end
+                                        end
+                                    end
+                                end
+                                if fieldId and fieldId > 0 then break end
+                            end
+                        end
                     end
                     if not fieldId or fieldId <= 0 then return end
 
@@ -1294,7 +1377,11 @@ function HookManager:installSprayerAreaHook()
                 end
             end
 
-            if not liters or liters <= 0 then return end
+            if not liters or liters <= 0 then
+                SoilLogger.debug("SprayerHook: usage=0 for fillType=%d fillLevel=%.1f — no product consumed this frame (multi-boom or section-control gate?)",
+                    fillTypeIndex or -1, sprayFillLevel or 0)
+                return
+            end
             if not sprayFillLevel or sprayFillLevel <= 0 then return end
             local success, errorMsg = pcall(function()
                 local fillType = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
@@ -1463,6 +1550,7 @@ function HookManager:installSprayerAreaHook()
                 end
 
                 if vww and vww.sections and #vww.sections > 0 then
+                    SoilLogger.debug("SprayerHook: VWW path — %d total sections for %s", #vww.sections, fillType.name)
                     -- Collect active sections into pre-allocated scratch table (avoids per-tick allocation)
                     local scratch = hookMgrRef._sectionScratch
                     local scratchN = 0

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -144,9 +144,11 @@ function SoilFieldDetailDialog:onGuiSetupFinished()
     self.detailPestStatus    = self:getDescendantById("detailPestStatus")
     self.detailDisease       = self:getDescendantById("detailDisease")
     self.detailDiseaseStatus = self:getDescendantById("detailDiseaseStatus")
-    self.detailLastCrop      = self:getDescendantById("detailLastCrop")
-    self.detailRotation      = self:getDescendantById("detailRotation")
-    self.detailNoData        = self:getDescendantById("detailNoData")
+    self.detailLastCrop         = self:getDescendantById("detailLastCrop")
+    self.detailRotation         = self:getDescendantById("detailRotation")
+    self.detailYieldEff         = self:getDescendantById("detailYieldEff")
+    self.detailYieldEffStatus   = self:getDescendantById("detailYieldEffStatus")
+    self.detailNoData           = self:getDescendantById("detailNoData")
 end
 
 function SoilFieldDetailDialog:onOpen()
@@ -302,6 +304,33 @@ function SoilFieldDetailDialog:_populateData()
         self.detailRotation:setText(rotText)
         self.detailRotation:setTextColor(unpack(rotColor))
     end
+
+    -- Yield efficiency
+    local yEff = info.yieldEfficiency
+    if self.detailYieldEff then
+        if yEff then
+            local yr, yg, yb, statusText
+            if yEff >= 90 then
+                yr, yg, yb = unpack(COLOR_GOOD)
+                statusText = tr("sf_detail_yield_optimal", "Optimal")
+            elseif yEff >= 70 then
+                yr, yg, yb = unpack(COLOR_FAIR)
+                statusText = tr("sf_pda_status_fair", "Fair")
+            else
+                yr, yg, yb = unpack(COLOR_POOR)
+                statusText = tr("sf_pda_status_poor", "Poor")
+            end
+            self.detailYieldEff:setText(yEff .. "%")
+            self.detailYieldEff:setTextColor(yr, yg, yb, 1.0)
+            if self.detailYieldEffStatus then
+                self.detailYieldEffStatus:setText(statusText)
+                self.detailYieldEffStatus:setTextColor(yr, yg, yb, 1.0)
+            end
+        else
+            self.detailYieldEff:setText("--")
+            if self.detailYieldEffStatus then self.detailYieldEffStatus:setText("") end
+        end
+    end
 end
 
 ---@param valueEl    table|nil
@@ -403,4 +432,5 @@ function SoilFieldDetailDialog:_showNoData()
     clear(self.detailDisease, self.detailDiseaseStatus)
     if self.detailLastCrop then self.detailLastCrop:setText("--") end
     if self.detailRotation  then self.detailRotation:setText("--") end
+    clear(self.detailYieldEff, self.detailYieldEffStatus)
 end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -299,12 +299,6 @@ function SoilHUD:calculateHeight()
         h = h + SoilHUD.LINE_H
         h = h + SoilHUD.PAD * 1.3
         
-        local cropLower = info.lastCrop and string.lower(info.lastCrop) or nil
-        if not cropLower or cropLower == "" or not (ys and ys.NON_CROP_NAMES and ys.NON_CROP_NAMES[cropLower]) then
-            h = h + SoilHUD.LINE_H
-            h = h + SoilHUD.PAD * 1.3
-        end
-        
         local mgr = g_SoilFertilityManager
         if mgr and mgr.settings then
             if mgr.settings.weedPressure and (info.weedPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
@@ -1093,67 +1087,6 @@ function SoilHUD:drawPanel()
         cy = cy - pad * 0.5
         self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
-
-        -- Yield forecast row (Issue #81 interim HUD warning)
-        -- Always shown unless the crop is a NON_CROP (like grass).
-        local ys = SoilConstants.YIELD_SENSITIVITY
-        local cropLower = info.lastCrop and string.lower(info.lastCrop) or nil
-        
-        if not cropLower or cropLower == "" or not ys.NON_CROP_NAMES[cropLower] then
-            local tier     = ys.CROP_TIERS[cropLower] or ys.DEFAULT_TIER
-            local tierData = ys.TIERS[tier]
-            local thresh   = ys.OPTIMAL_THRESHOLD
-
-            -- If the field was just harvested today, show a softer post-harvest message
-            -- instead of the alarming penalty % caused by freshly depleted soil.
-            -- The forecast reflects next-season potential; nutrients drop on harvest and
-            -- the big red number before fertilizing is misleading (issue #279).
-            local currentDay = g_currentMission and g_currentMission.environment and
-                               g_currentMission.environment.currentDay
-            local justHarvested = currentDay and info.lastHarvest and
-                                  (info.lastHarvest >= currentDay)
-
-            local yieldColor, yieldText
-            if justHarvested then
-                yieldColor = SoilHUD.C_DIM
-                yieldText  = g_i18n:getText("sf_hud_post_harvest")
-            else
-                local nDef = math.max(0, thresh - info.nitrogen.value)   / thresh
-                local pDef = math.max(0, thresh - info.phosphorus.value) / thresh
-                local kDef = math.max(0, thresh - info.potassium.value)  / thresh
-                local avgDef = (nDef + pDef + kDef) / 3
-
-                local penalty    = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
-                local penaltyPct = math.floor(penalty * 100 + 0.5)
-
-                local yieldPrefix = (not cropLower or cropLower == "") and g_i18n:getText("sf_hud_estYield") or g_i18n:getText("sf_hud_yield")
-                if penaltyPct <= 0 then
-                    yieldColor = SoilHUD.C_GOOD
-                    yieldText  = string.format("%s: %s", yieldPrefix, g_i18n:getText("sf_hud_optimal"))
-                elseif penaltyPct < 15 then
-                    yieldColor = SoilHUD.C_FAIR
-                    yieldText  = string.format("%s ~-%d%%", yieldPrefix, penaltyPct)
-                else
-                    yieldColor = SoilHUD.C_POOR
-                    yieldText  = string.format("%s ~-%d%%", yieldPrefix, penaltyPct)
-                end
-            end
-
-            setTextColor(yieldColor[1], yieldColor[2], yieldColor[3], 1.0)
-            renderText(tx, cy, 0.010 * fontMult * s, yieldText)
-            if not justHarvested then
-                setTextAlignment(RenderText.ALIGN_RIGHT)
-                setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], SoilHUD.C_DIM[4])
-                renderText(px + pw - pad, cy, 0.009 * fontMult * s, tierData.label)
-                setTextAlignment(RenderText.ALIGN_LEFT)
-            end
-
-            -- Divider before weed row
-            cy = cy - SoilHUD.LINE_H * s
-            cy = cy - pad * 0.5
-            self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
-            cy = cy - pad * 0.8
-        end
 
         -- Weed / pest / disease pressure rows
         local mgr = g_SoilFertilityManager

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -313,6 +313,7 @@ function SoilHUD:calculateHeight()
             if (info.sessionCoverageFraction or info.coverageFraction or 0) > 0 then h = h + SoilHUD.LINE_H end
             if mgr.settings.compactionEnabled and (info.compaction or 0) > 0 then h = h + SoilHUD.LINE_H end
         end
+        if info.yieldEfficiency then h = h + SoilHUD.LINE_H end
         
         h = h + SoilHUD.PAD * 1.3
     else
@@ -1213,6 +1214,24 @@ function SoilHUD:drawPanel()
                 renderText(px + pad, cy, 0.010 * fontMult * s, string.format(g_i18n:getText("sf_hud_compaction"), compPct))
                 cy = cy - SoilHUD.LINE_H * s
             end
+        end
+
+        -- Yield efficiency summary (nil when no managed crop)
+        local yieldEff = info.yieldEfficiency
+        if yieldEff then
+            local yr, yg, yb
+            if yieldEff >= 90 then
+                yr, yg, yb = 0.32, 0.88, 0.44   -- green: at or near optimal
+            elseif yieldEff >= 70 then
+                yr, yg, yb = 0.90, 0.82, 0.18   -- yellow: noticeable penalty
+            else
+                yr, yg, yb = 0.88, 0.25, 0.25   -- red: significant penalty
+            end
+            setTextAlignment(RenderText.ALIGN_LEFT)
+            setTextColor(yr, yg, yb, 1.0)
+            renderText(px + pad, cy, 0.010 * fontMult * s,
+                string.format(g_i18n:getText("sf_hud_yield_eff"), yieldEff))
+            cy = cy - SoilHUD.LINE_H * s
         end
 
         -- Divider before hint

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -134,6 +134,39 @@ function SoilTreatmentDialog:onClickClose()
     g_gui:closeDialogByName("SoilTreatmentDialog")
 end
 
+-- ── Rate Calculation ──────────────────────────────────────
+
+-- Returns "PRODUCTNAME 220 kg/ha (1056 kg)" or nil if profile missing / no deficit.
+local function _rateString(profileKey, nutrientKey, deficit, rrMult, fieldArea)
+    if deficit <= 0 then return nil end
+    local profile  = SoilConstants.FERTILIZER_PROFILES[profileKey]
+    local baseRate = SoilConstants.SPRAYER_RATE.BASE_RATES[profileKey]
+    if not profile or not profile[nutrientKey] or profile[nutrientKey] == 0 then return nil end
+
+    local coeff    = profile[nutrientKey]
+    local ratePerHa = deficit * 1000 / (coeff * rrMult)
+    local total     = ratePerHa * fieldArea
+    local unit      = (baseRate and baseRate.unit == "dry") and "kg/ha" or "L/ha"
+
+    return string.format("%s %d %s (%d %s)",
+        profileKey, math.ceil(ratePerHa), unit,
+        math.ceil(total), (unit == "kg/ha") and "kg" or "L")
+end
+
+-- Builds a two-product action string for a nutrient, e.g.:
+--   "UREA 220 kg/ha (1056 kg)  ·  UAN32 139 L/ha (667 L)"
+-- Falls back to a static hint when rates cannot be computed.
+local function _nutrientActionText(currentVal, targetVal, rrMult, fieldArea, products, staticFallback)
+    local deficit = math.max(0, targetVal - currentVal)
+    local parts = {}
+    for _, prod in ipairs(products) do
+        local s = _rateString(prod[1], prod[2], deficit, rrMult, fieldArea)
+        if s then parts[#parts + 1] = s end
+    end
+    if #parts == 0 then return staticFallback end
+    return table.concat(parts, "  ·  ")
+end
+
 -- ── Data Population ───────────────────────────────────────
 
 function SoilTreatmentDialog:_populateData()
@@ -176,39 +209,69 @@ function SoilTreatmentDialog:_populateData()
         self:_setAction(self.treatOMAction, tr("sf_treat_action_ok", "OK"), COLOR_GOOD)
     end
 
-    -- 3. Nutrient Actions (N, P, K)
-    local thresh = SoilConstants.STATUS_THRESHOLDS
-    
+    -- 3. Nutrient Actions (N, P, K) with per-product application rates
+    local thresh  = SoilConstants.STATUS_THRESHOLDS
+    local targets = SoilConstants.CROP_NUTRIENT_TARGETS
+    local fieldArea = info.fieldArea or 1.0
+
+    -- Replenishment multiplier from settings (index 1-5, default Normal = 3 = 1.00×)
+    local rrIdx = (sfm.settings and sfm.settings.replenishmentRate) or 3
+    local rrMult = SoilConstants.DIFFICULTY.REPLENISHMENT_MULTIPLIERS[rrIdx] or 1.0
+
+    -- Crop-specific targets or status-threshold fallbacks
+    local ct = info.cropTargets
+    local targetN = (ct and ct.N and ct.N.opt) or (thresh.nitrogen.fair or 50)
+    local targetP = (ct and ct.P and ct.P.opt) or (thresh.phosphorus.fair or 45)
+    local targetK = (ct and ct.K and ct.K.opt) or (thresh.potassium.fair or 40)
+
     -- N
     if info.nitrogen.value < (thresh.nitrogen.poor or 30) then
-        self:_setAction(self.treatNAction, tr("sf_treat_action_n_poor", "Apply UAN32, UREA, or ANHYDROUS."), COLOR_POOR)
+        local text = _nutrientActionText(info.nitrogen.value, targetN, rrMult, fieldArea,
+            { {"UREA","N"}, {"UAN32","N"} },
+            "Apply UREA or UAN32")
+        self:_setAction(self.treatNAction, text, COLOR_POOR)
     elseif info.nitrogen.value < (thresh.nitrogen.fair or 50) then
-        self:_setAction(self.treatNAction, tr("sf_treat_action_n_fair", "Apply AMS or STARTER fertilizer."), COLOR_FAIR)
+        local text = _nutrientActionText(info.nitrogen.value, targetN, rrMult, fieldArea,
+            { {"AMS","N"}, {"AN","N"} },
+            "Apply AMS or AN")
+        self:_setAction(self.treatNAction, text, COLOR_FAIR)
     else
         self:_setAction(self.treatNAction, tr("sf_treat_action_ok", "OK"), COLOR_GOOD)
     end
 
     -- P
     if info.phosphorus.value < (thresh.phosphorus.poor or 25) then
-        self:_setAction(self.treatPAction, tr("sf_treat_action_p_poor", "Apply MAP or DAP (Phosphorus)."), COLOR_POOR)
+        local text = _nutrientActionText(info.phosphorus.value, targetP, rrMult, fieldArea,
+            { {"MAP","P"}, {"DAP","P"} },
+            "Apply MAP or DAP")
+        self:_setAction(self.treatPAction, text, COLOR_POOR)
     elseif info.phosphorus.value < (thresh.phosphorus.fair or 45) then
-        self:_setAction(self.treatPAction, tr("sf_treat_action_p_fair", "Top-up with Liquid MAP, Liquid DAP, or DAP (P)."), COLOR_FAIR)
+        local text = _nutrientActionText(info.phosphorus.value, targetP, rrMult, fieldArea,
+            { {"LIQUID_MAP","P"}, {"LIQUID_DAP","P"} },
+            "Top-up with Liquid MAP or Liquid DAP")
+        self:_setAction(self.treatPAction, text, COLOR_FAIR)
     else
         self:_setAction(self.treatPAction, tr("sf_treat_action_ok", "OK"), COLOR_GOOD)
     end
 
     -- K
     if info.potassium.value < (thresh.potassium.poor or 20) then
-        self:_setAction(self.treatKAction, tr("sf_treat_action_k_poor", "Apply POTASH (Potassium)."), COLOR_POOR)
+        local text = _nutrientActionText(info.potassium.value, targetK, rrMult, fieldArea,
+            { {"POTASH","K"}, {"LIQUID_POTASH","K"} },
+            "Apply POTASH")
+        self:_setAction(self.treatKAction, text, COLOR_POOR)
     elseif info.potassium.value < (thresh.potassium.fair or 40) then
-        self:_setAction(self.treatKAction, tr("sf_treat_action_k_fair", "Top-up with Liquid Potash or Potash (K)."), COLOR_FAIR)
+        local text = _nutrientActionText(info.potassium.value, targetK, rrMult, fieldArea,
+            { {"POTASH","K"}, {"LIQUID_POTASH","K"} },
+            "Top-up with POTASH or Liquid POTASH")
+        self:_setAction(self.treatKAction, text, COLOR_FAIR)
     else
         self:_setAction(self.treatKAction, tr("sf_treat_action_ok", "OK"), COLOR_GOOD)
     end
 
     -- 4. Protection Actions
     local pThresh = 20
-    
+
     -- Weed
     if (info.weedPressure or 0) >= pThresh then
         self:_setAction(self.treatWeedAction, tr("sf_treat_action_weed", "Apply HERBICIDE or use mechanical WEEDER/HOE."), COLOR_POOR)

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,17 +24,21 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- NEW  In-game help guide: press the ? button in the PDA soil screen for a full reference",
-    "- NEW  Soil map overlay Help button: explains layers, colours, tooltip, and tips in-context",
-    "- Fixed Field Detail dialog crash — all nutrient and pressure rows now show correct colors",
-    "- Fixed Treatment plan no longer says 'blended FERTILIZER' — now names the actual product",
-    "  (P deficit → Liquid MAP / Liquid DAP / DAP;  K deficit → Liquid Potash / Potash)",
-    "- Fixed Compost fill plane no longer overrides map-defined custom visuals",
-    "- Fixed pH display rounding — tooltip and map tile colors now always match",
-    "- Soil map overlay only draws your owned fields — big FPS boost on large maps",
-    "- Spraying large fields is smoother — less stuttering while the boom is running",
-    "- HUD nutrient display is lighter on your CPU, especially on lower-end machines",
-    "- Multiplayer join is faster — less data when connecting to a busy server",
+    "v2.2.1.0",
+    "- NEW  Polifoska 6-20-30 compound NPK fertilizer — buy as a 1 000 L big bag",
+    "- NEW  Yield efficiency indicator on the HUD — see your field's harvest modifier",
+    "- NEW  Treatment rate panel — recommended application rate shown for active product",
+    "- NEW  Hungarian translation — full native translation by @MathiasHun",
+    "- Fixed Sprayer implements permanently showing 'not a fertilizer applicator' after load",
+    "  (rate-control HUD panel now appears correctly on first use without restarting)",
+    "- Fixed Large combine headers missing field detection — nutrient depletion now",
+    "  uses the cutter/header position when the combine body is outside the polygon",
+    "- Fixed Weed pressure formula was inverted — clean fields had full penalty applied,",
+    "  weedy fields had none. Corrected; weed penalties now match actual field state",
+    "- Fixed Weeds showing 100% on bare / never-farmed fields",
+    "- Fixed Rain effects (leaching, seasonal N) were silently not running",
+    "- Fixed Weed/pest/disease penalties applied even when nutrient cycles disabled",
+    "- Fixed pfCompatibilityMode toggle now takes effect immediately without reload",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Ureia Líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de Amônio Líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Líquido (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Ureia Líquida" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Fertilizante nitrogenado (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amônia Anidra 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureia 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34,5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Fertilizante nitrogenado (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Ureia Líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante nitrogenado (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfórico (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfórico (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfórico (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfórico (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potassa Líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potássico (líquido)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potássico (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Inicial 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Inseticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Inseticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Composto" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biossólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante Orgânico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Fertilizante Orgânico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Esterco de Galinha" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante Orgânico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante Orgânico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Esterco Peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante Orgânico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante Orgânico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tanque de Calcário Líquido" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente de Aumento de pH (líquido)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agente de Aumento de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR DE SOLO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Vá até um campo" eh="62c55e9e" />
@@ -533,6 +533,8 @@
     <e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bônus de Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fadiga (x1.15 esgotamento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sem dados disponíveis." eh="c6d95d5e" />
@@ -547,6 +549,7 @@
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passagem: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Composto" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biossólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Fertilitzant MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilitzant DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urea líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfat d'amoni líquid (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP líquid (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fertilitzant fosfòric (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilitzant potàssic (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea líquida" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Fertilitzant nitrogenat (líquid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS líquid" eh="32e6c8bb" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Camps %d-%d de %d  |  Pàgina %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilitzant nitrogenat (líquid)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Fertilitzant nitrogenat (líquid) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilitzant nitrogenat (líquid)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Fertilitzant nitrogenat (líquid) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoníac anhidre 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilitzant nitrogenat (líquid)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Fertilitzant nitrogenat (líquid) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilitzant nitrogenat (sec)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Fertilitzant nitrogenat (sec) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilitzant nitrogenat (sec)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Fertilitzant nitrogenat (sec) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilitzant nitrogenat (sec)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Fertilitzant nitrogenat (sec) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilitzant fosfòric (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fertilitzant fosfòric (sec) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilitzant fosfòric (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fertilitzant fosfòric (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilitzant potàssic (sec)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Fertilitzant potàssic (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilitzant nitrogenat (líquid)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Fertilitzant nitrogenat (líquid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS líquid" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilitzant nitrogenat (líquid)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Fertilitzant nitrogenat (líquid) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP líquid" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilitzant fosfòric (líquid)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fertilitzant fosfòric (líquid) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP líquid" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilitzant fosfòric (líquid)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fertilitzant fosfòric (líquid) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potassa líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilitzant potàssic (líquid)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Fertilitzant potàssic (líquid) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticida (líquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquid)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilitzant d'arrencada (líquid)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Fertilitzant d'arrencada (líquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Guix" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Esmena del sòl (seca)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Esmena del sòl (seca) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Esmena orgànica del sòl (seca)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Esmena orgànica del sòl (seca) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosòlids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilitzant orgànic (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Fertilitzant orgànic (sec) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fems de gallina" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilitzant orgànic (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fertilitzant orgànic (sec) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fems granulat" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilitzant orgànic (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fertilitzant orgànic (sec) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Dipòsit de calç líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent per elevar el pH (líquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agent per elevar el pH (líquid) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR DEL SÒL" eh="f8cda642" />
     <e k="sf_hud_field" v="Camp %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camineu sobre un camp" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Apliqueu INSECTICIDA immediatament." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Apliqueu FUNGICIDA immediatament." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus de lleguminoses (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (x1.15 esgotament)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="No hi ha dades disponibles." eh="c6d95d5e" />
@@ -546,6 +548,7 @@
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="噴施: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactació: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Guix" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Esmena del sòl (seca) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Esmena orgànica del sòl (seca) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosòlids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Pole %d-%d z %d  |  Strana %d z %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Dusíkaté hnojivo (kapalné)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Dusíkaté hnojivo (kapalné) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Dusíkaté hnojivo (kapalné)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Dusíkaté hnojivo (kapalné) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Bezvodý amoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Dusíkaté hnojivo (kapalné)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Dusíkaté hnojivo (kapalné) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Močovina 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Dusíkaté hnojivo (granulované)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Dusíkaté hnojivo (granulované) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Dusíkaté hnojivo (granulované)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Dusíkaté hnojivo (granulované) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Dusíkaté hnojivo (granulované)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Dusíkaté hnojivo (granulované) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosforečné hnojivo (granulované)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosforečné hnojivo (granulované) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosforečné hnojivo (granulované)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosforečné hnojivo (granulované) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potaš 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Draselné hnojivo (granulované)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Draselné hnojivo (granulované) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Tekutá močovina" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Dusíkaté hnojivo (kapalné)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Dusíkaté hnojivo (kapalné) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Tekutý síran amonný" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Dusíkaté hnojivo (kapalné)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Dusíkaté hnojivo (kapalné) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Tekutý MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosforečné hnojivo (kapalné)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosforečné hnojivo (kapalné) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Tekutý DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosforečné hnojivo (kapalné)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosforečné hnojivo (kapalné) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Tekutá potaš" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Draselné hnojivo (kapalné)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Draselné hnojivo (kapalné) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Startovní 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insekticid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insekticid (kapalný)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicid (kapalný)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Sádrovec" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Půdní kondicionér (granulovaný)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Půdní kondicionér (granulovaný) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organický půdní kondicionér (granulovaný)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organický půdní kondicionér (granulovaný) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biomasa" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organické hnojivo (granulované)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organické hnojivo (granulované) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Drůbeží podestýlka" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organické hnojivo (granulované)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organické hnojivo (granulované) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Granulovaný hnůj" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organické hnojivo (granulované)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organické hnojivo (granulované) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Nádrž na tekuté vápno" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Prostředek ke zvýšení pH (kapalný)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Prostředek ke zvýšení pH (kapalný) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR PŮDY" eh="f8cda642" />
     <e k="sf_hud_field" v="Pole %d" eh="08988997" />
     <e k="sf_hud_noField" v="Vstupte na pole" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Okamžitě aplikujte INSEKTICID." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Okamžitě aplikujte FUNGICID." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus za luštěniny (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Únava (vyčerpání x1,15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Žádná data nejsou k dispozici." eh="c6d95d5e" />
@@ -546,6 +548,7 @@
     <e k="sf_hud_coverage" v="Pokrytí: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Průjezd: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Zhutnění: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP hnojivo 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP hnojivo 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potaš 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Tekutá močovina (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Tekutý síran amonný (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Tekutý MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosforečné hnojivo (granulované) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potaš 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Draselné hnojivo (granulované) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Tekutá močovina" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Dusíkaté hnojivo (kapalné) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Tekutý síran amonný" eh="32e6c8bb" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Sádrovec" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Půdní kondicionér (granulovaný) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organický půdní kondicionér (granulovaný) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biomasa" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Marker %d-%d af %d  |  Side %d af %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Kvælstofgødning (flydende) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Kvælstofgødning (flydende) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vandfri Ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Kvælstofgødning (flydende) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Kvælstofgødning (tør)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Kvælstofgødning (tør) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Kvælstofgødning (tør)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Kvælstofgødning (tør) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Kvælstofgødning (tør)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Kvælstofgødning (tør) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfatgødning (tør)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosfatgødning (tør) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfatgødning (tør)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosfatgødning (tør) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumgødning (tør)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kaliumgødning (tør) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flydende Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Kvælstofgødning (flydende) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flydende AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Kvælstofgødning (flydende)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Kvælstofgødning (flydende) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Flydende MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfatgødning (flydende)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosfatgødning (flydende) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Flydende DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgødning (flydende)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgødning (flydende) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Flydende Kaliumklorid" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgødning (flydende)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgødning (flydende) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Startgødning 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insekticid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insekticid (flydende)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicid (flydende)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startgødning (flydende)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Startgødning (flydende) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tør)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tør) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolider" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organisk gødning (tør)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organisk gødning (tør) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsemøg" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organisk gødning (tør)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organisk gødning (tør) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelleteret Gødning" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gødning (tør)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gødning (tør) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flydende Kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-hævende middel (flydende)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-hævende middel (flydende) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mark %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Anvend INSEKTICID øjeblikkeligt." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Anvend FUNGICID øjeblikkeligt." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bælgplantebonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Træthed (x1,15 udtømning)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tilgængelig." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Dækning: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Kørsel: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Pakning: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="PÅFØRINGSRATE (AUTO: TIL)" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="PÅFØRINGSRATE (AUTO: FRA) [%s]" eh="848cc106" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP-gødning 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-gødning 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumklorid 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Flydende urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flydende ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flydende MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosfatgødning (tør) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgødning (tør) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flydende Urea" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Kvælstofgødning (flydende) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flydende AMS" eh="32e6c8bb" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tør) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolider" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungizid" eh="e8512698" />
     <e k="sf_report_page_info" v="Felder %d-%d von %d  |  Seite %d von %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Stickstoffdünger (flüssig)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Stickstoffdünger (flüssig) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Stickstoffdünger (flüssig)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Stickstoffdünger (flüssig) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Anhydrous Ammonia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Stickstoffdünger (flüssig)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Stickstoffdünger (flüssig) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Harnstoff 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Stickstoffdünger (trocken)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Stickstoffdünger (trocken) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Stickstoffdünger (trocken)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Stickstoffdünger (trocken) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Stickstoffdünger (trocken)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Stickstoffdünger (trocken) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Phosphordünger (trocken)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Phosphordünger (trocken) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Phosphordünger (trocken)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Phosphordünger (trocken) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumdünger (trocken)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kaliumdünger (trocken) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Liquid Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Stickstoffdünger (flüssig)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Stickstoffdünger (flüssig) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Liquid AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Stickstoffdünger (flüssig)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Stickstoffdünger (flüssig) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Liquid MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Phosphordünger (flüssig)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Phosphordünger (flüssig) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Liquid DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Phosphordünger (flüssig)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Phosphordünger (flüssig) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Liquid Potash" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumdünger (flüssig)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliumdünger (flüssig) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektizid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektizid (flüssig)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungizid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungizid (flüssig)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Bodenverbesserer (trocken)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Bodenverbesserer (trocken) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organischer Bodenverbesserer (trocken)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organischer Bodenverbesserer (trocken) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organischer Dünger (trocken)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organischer Dünger (trocken) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hühnermist" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organischer Dünger (trocken)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organischer Dünger (trocken) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag pelletierter Mist" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organischer Dünger (trocken)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organischer Dünger (trocken) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flüssigkalk-Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-erhöhendes Mittel (flüssig)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-erhöhendes Mittel (flüssig) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="BODENMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Feld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Betreten Sie ein Feld" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Sofort INSEKTIZID ausbringen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Sofort FUNGIZID ausbringen." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen-Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Ermüdung (x1,15 Verarmung)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Keine Daten verfügbar." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Abdeckung: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Durchgang: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Verdichtung: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="AUSBRINGUNGSRATE ( AUTO: AN )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="AUSBRINGUNGSRATE  AUTO: AUS [%s]" eh="848cc106" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP-Dünger 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-Dünger 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumchlorid 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Flüssiger Harnstoff (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flüssiges Ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flüssiges MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Phosphordünger (trocken) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumdünger (trocken) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Liquid Urea" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Stickstoffdünger (flüssig) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Liquid AMS" eh="32e6c8bb" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Bodenverbesserer (trocken) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organischer Bodenverbesserer (trocken) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Fertilizante nitrogenado (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoníaco Anhidro 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Fertilizante nitrogenado (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante potásico (seco)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Fertilizante potásico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea Líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante nitrogenado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante nitrogenado (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfórico (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfórico (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfórico (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfórico (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasa Líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potásico (líquido)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potásico (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante de inicio (líquido)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Fertilizante de inicio (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Yeso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante orgánico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Fertilizante orgánico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Estiércol de Pollo" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante orgánico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante orgánico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Estiércol Peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante orgánico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante orgánico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tanque de Cal Líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente elevador de pH (líquido)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agente elevador de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR DE SUELO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camine por un campo" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Aplica INSECTICIDA de inmediato." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplica FUNGICIDA de inmediato." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bono Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (x1.15 agotamiento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sin datos disponibles." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Pasada: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="TASA APLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TASA APLIC.  AUTO: OFF [%s]" eh="848cc106" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urea Líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de Amonio Líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Líquido (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante potásico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea Líquida" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Yeso" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP Fertilizer 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Fertilizer 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potash 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Liquid Urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Liquid Ammonium Sulfate (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Liquid MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potash 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Liquid Urea" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Liquid AMS" eh="32e6c8bb" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Fields %d-%d of %d  |  Page %d of %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogen Fertilizer (liquid)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogen Fertilizer (liquid)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Anhydrous Ammonia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogen Fertilizer (liquid)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogen Fertilizer (dry)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogen Fertilizer (dry)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogen Fertilizer (dry)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Phosphorus Fertilizer (dry)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Phosphorus Fertilizer (dry)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potash 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Potassium Fertilizer (dry)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Liquid Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogen Fertilizer (liquid)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Liquid AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogen Fertilizer (liquid)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Liquid MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Liquid DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Phosphorus Fertilizer (liquid)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Liquid Potash" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Potassium Fertilizer (liquid)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starter Fertilizer (liquid)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypsum" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="42d76587" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Field %d" eh="08988997" />
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Apply INSECTICIDE immediately." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Apply FUNGICIDE immediately." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
@@ -546,6 +548,7 @@
     <e k="sf_hud_coverage" v="Coverage: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Pass: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypsum" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biosolids (10,000L)" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urea líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de amonio líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP líquido (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fertilizante de fósforo (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante de potasio (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea líquida" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Fertilizante de nitrógeno (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS líquido" eh="32e6c8bb" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante de nitrógeno (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Fertilizante de nitrógeno (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante de nitrógeno (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Fertilizante de nitrógeno (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoníaco anhidro 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante de nitrógeno (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Fertilizante de nitrógeno (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante de nitrógeno (seco)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Fertilizante de nitrógeno (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante de nitrógeno (seco)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Fertilizante de nitrógeno (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante de nitrógeno (seco)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Fertilizante de nitrógeno (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante de fósforo (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fertilizante de fósforo (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante de fósforo (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fertilizante de fósforo (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante de potasio (seco)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Fertilizante de potasio (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante de nitrógeno (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante de nitrógeno (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante de nitrógeno (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante de nitrógeno (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante de fósforo (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fertilizante de fósforo (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante de fósforo (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante de fósforo (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasa líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante de potasio (líquido)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante de potasio (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante de inicio (líquido)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Fertilizante de inicio (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Yeso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante orgánico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Fertilizante orgánico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Estiércol de pollo" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante orgánico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante orgánico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Estiércol peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante orgánico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante orgánico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tanque de cal líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente elevador de pH (líquido)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agente elevador de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR DE SUELO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camina por un campo" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Aplica INSECTICIDA de inmediato." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplica FUNGICIDA de inmediato." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bono leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (x1.15 agotamiento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sin datos disponibles." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Pasada: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="TASA APLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TASA APLIC.  AUTO: OFF [%s]" eh="848cc106" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Yeso" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Champs %d-%d de %d  |  Page %d sur %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniac anhydre 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Engrais azoté (sec) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS liquide" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP liquide" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP liquide" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasse liquide" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (liquide)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fongicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fongicide (liquide)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Engrais starter (liquide)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Engrais starter (liquide) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Amendement organique (sec)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Amendement organique (sec) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fiente de poule" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fumier granulé" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Cuve de chaux liquide" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent correcteur de pH (liquide)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agent correcteur de pH (liquide) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITEUR DU SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
     <e k="sf_hud_noField" v="Allez sur un champ" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Appliquez INSECTICIDE immédiatement." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Appliquez FONGICIDE immédiatement." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus légumineuse (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 épuisement)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Couverture : %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passage : %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactage : %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="DÉBIT APPLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="DÉBIT APPLIC.  AUTO: OFF [%s]" eh="848cc106" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Engrais MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Engrais DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasse 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urée liquide (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfate d'ammonium liquide (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Engrais potassique (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS liquide" eh="32e6c8bb" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Amendement organique (sec) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Sienimyrkky" eh="e8512698" />
     <e k="sf_report_page_info" v="Pellot %d–%d / %d  |  Sivu %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Typpilannoite (nestemäinen) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Typpilannoite (nestemäinen) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vedetön ammoniakki 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Typpilannoite (nestemäinen) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Suursäkki Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Typpilannoite (kuiva)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Typpilannoite (kuiva) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Suursäkki AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Typpilannoite (kuiva)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Typpilannoite (kuiva) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Suursäkki AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Typpilannoite (kuiva)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Typpilannoite (kuiva) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Suursäkki MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosforilannoite (kuiva)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosforilannoite (kuiva) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Suursäkki DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosforilannoite (kuiva)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosforilannoite (kuiva) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Suursäkki Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumlannoite (kuiva)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kaliumlannoite (kuiva) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Nestemäinen urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Typpilannoite (nestemäinen) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Nestemäinen AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Typpilannoite (nestemäinen)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Typpilannoite (nestemäinen) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Nestemäinen MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosforilannoite (nestemäinen)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosforilannoite (nestemäinen) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Nestemäinen DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosforilannoite (nestemäinen)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosforilannoite (nestemäinen) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Nestemäinen kalium" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumlannoite (nestemäinen)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliumlannoite (nestemäinen) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Startteri 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Hyönteismyrkky" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Hyönteismyrkky (nestemäinen)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Sienimyrkky" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Sienimyrkky (nestemäinen)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startterilannoite (nestemäinen)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Startterilannoite (nestemäinen) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Suursäkki Kipsi" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Maanparannusaine (kuiva)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Maanparannusaine (kuiva) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Suursäkki Komposti" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Orgaaninen maanparannusaine (kuiva)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Orgaaninen maanparannusaine (kuiva) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Suursäkki Biojäte" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Orgaaninen lannoite (kuiva)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Orgaaninen lannoite (kuiva) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Suursäkki Kanankakka" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Orgaaninen lannoite (kuiva)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Orgaaninen lannoite (kuiva) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Suursäkki Pellettoitu lanta" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Orgaaninen lannoite (kuiva)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Orgaaninen lannoite (kuiva) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Nestekalkkisäiliö" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-arvon nostaja (nestemäinen)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-arvon nostaja (nestemäinen) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MAAPERÄN SEURANTA" eh="f8cda642" />
     <e k="sf_hud_field" v="Pelto %d" eh="08988997" />
     <e k="sf_hud_noField" v="Kävele pellolle" eh="62c55e9e" />
@@ -513,6 +513,8 @@
     <e k="sf_treat_action_pest" v="Käytä HYÖNTEISMYRKKYÄ välittömästi." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Käytä SIENIMYRKKYÄ välittömästi." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Palkokasvibonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Väsymys (x1.15 kulutus)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ei tietoja saatavilla." eh="c6d95d5e" />
@@ -524,6 +526,7 @@
     <e k="sf_hud_coverage" v="Peitto: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Ajo: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Tiivistyminen: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="LEVITYSMÄÄRÄ ( AUTO: PÄÄLLÄ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="LEVITYSMÄÄRÄ  AUTO: POIS [%s]" eh="848cc106" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP-lannoite 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-lannoite 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumsuola 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Nestemäinen urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Nestemäinen ammoniumsulfaatti (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Nestemäinen MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosforilannoite (kuiva) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Suursäkki Kalium 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumlannoite (kuiva) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Nestemäinen urea" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Typpilannoite (nestemäinen) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Nestemäinen AMS" eh="32e6c8bb" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Suursäkki Kipsi" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Maanparannusaine (kuiva) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Suursäkki Komposti" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Orgaaninen maanparannusaine (kuiva) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Suursäkki Biojäte" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Engrais MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Engrais DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasse 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urée liquide (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfate d'ammonium liquide (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Engrais potassique (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Sulfate d'ammonium liquide" eh="32e6c8bb" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Champs %d-%d sur %d  |  Page %d sur %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniac anhydre 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Engrais azoté (sec) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Sulfate d'ammonium liquide" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP liquide" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP liquide" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasse liquide" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (liquide)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fongicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fongicide (liquide)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Engrais de démarrage (liquide)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Engrais de démarrage (liquide) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fumier de poulet" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fumier pelletisé" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Cuve de chaux liquide" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent d'augmentation du pH (liquide)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agent d'augmentation du pH (liquide) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITEUR DE SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
     <e k="sf_hud_noField" v="Marchez sur un champ" eh="62c55e9e" />
@@ -537,6 +537,8 @@
     <e k="sf_treat_action_pest" v="Appliquer INSECTICIDE immédiatement." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Appliquer FONGICIDE immédiatement." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus légumineuse (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 épuisement)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée disponible." eh="c6d95d5e" />
@@ -547,6 +549,7 @@
     <e k="sf_hud_coverage" v="Couverture : %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passage : %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compaction : %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
     
     <!-- HUD débit pulvérisateur -->
     <e k="sf_sprayer_auto_on" v="DOSE APPL.  ( AUTO : ON )" eh="099b5dac" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Gombaölő szer" eh="e8512698" />
     <e k="sf_report_page_info" v="Mezők %d-%d / %d  |  Oldal %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Nitrogén műtrágya (folyékony) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Nitrogén műtrágya (folyékony) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vízmentes ammónia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Nitrogén műtrágya (folyékony) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Karbamid 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Nitrogén műtrágya (száraz) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Nitrogén műtrágya (száraz) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Nitrogén műtrágya (száraz) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Foszfor műtrágya (száraz) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Hamuzsír 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Folyékony karbamid" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Nitrogén műtrágya (folyékony) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Folyékony AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Nitrogén műtrágya (folyékony) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Folyékony MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Foszfor műtrágya (folyékony)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Foszfor műtrágya (folyékony) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Folyékony DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Foszfor műtrágya (folyékony)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Foszfor műtrágya (folyékony) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Folyékony hamuzsír" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kálium műtrágya (folyékony)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kálium műtrágya (folyékony) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Rovarölő szer" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Rovarölő szer (folyékony)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Gombaölő szer" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Gombaölő szer (folyékony)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gipsz" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Talajjavító (száraz)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Talajjavító (száraz) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Komposzt" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Szerves talajjavító (száraz)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Szerves talajjavító (száraz) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Bioszolárd" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Szerves műtrágya (száraz) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Csirketrágya" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Szerves műtrágya (száraz) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletált trágya" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Szerves műtrágya (száraz) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Folyékony mész tartály" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH növelő szer (folyékony)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH növelő szer (folyékony) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="TALAJ MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mező %d" eh="08988997" />
     <e k="sf_hud_noField" v="Sétáljon egy mezőre" eh="62c55e9e" />
@@ -531,6 +531,8 @@
     <e k="sf_treat_action_pest" v="Azonnal alkalmazzon ROVARÖLŐT." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Azonnal alkalmazzon GOMBAÖLŐT." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Pillangós bónusz (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fáradtság (x1.15 kimerülés)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nincs elérhető adat." eh="c6d95d5e" />
@@ -542,6 +544,7 @@
     <e k="sf_hud_coverage" v="Lefedettség: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Menet: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Tömörödés: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="KIJUTT. ARÁNY  ( AUTO: BE )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="KIJUTT. ARÁNY  AUTO: KI [%s]" eh="848cc106" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP műtrágya 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP műtrágya 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Hamuzsír 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Folyékony karbamid (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Folyékony ammónium-szulfát (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Folyékony MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Hamuzsír 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz)" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Folyékony karbamid" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Folyékony AMS" eh="32e6c8bb" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -83,10 +83,10 @@
     <e k="sf_active_map_layer_long" v="Tápanyagréteg megjelenítése átfedésként a PDA térképen" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Térkép részletesség" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Mintavételi pontok kerete a PDA talajátfedéshez. Alacsony = jobb FPS, Magas = teljesebb lefedettség nagy térképeken." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="[EN] Colorblind Mode" />
-    <e k="sf_colorblind_mode_long" v="[EN] Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
-    <e k="sf_show_field_info_box_short" v="[EN] Field Info Box" />
-    <e k="sf_show_field_info_box_long" v="[EN] Show soil nutrients in the native Field Info panel when standing on a field." />
+    <e k="sf_colorblind_mode_short" v="Színtévesztő mód" />
+    <e k="sf_colorblind_mode_long" v="A piros/zöld állapotszíneket narancs/kék színekre cseréli (Okabe–Ito paletta) a deuteranópia és protanópia jobb támogatásához." />
+    <e k="sf_show_field_info_box_short" v="Mezőinformációs panel" />
+    <e k="sf_show_field_info_box_long" v="Talajtápanyagok megjelenítése az alap Mezőinformáció panelen, amikor mezőn állsz." />
     <e k="input_SF_OPEN_SETTINGS" v="Talaj beállítások megnyitása" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />
@@ -149,55 +149,55 @@
     <e k="sf_fungicide_title" v="Gombaölő szer" eh="e8512698" />
     <e k="sf_report_page_info" v="Mezők %d-%d / %d  |  Oldal %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogén műtrágya (folyékony) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogén műtrágya (folyékony) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vízmentes ammónia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogén műtrágya (folyékony) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Karbamid 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogén műtrágya (száraz) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogén műtrágya (száraz) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogén műtrágya (száraz) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Foszfor műtrágya (száraz) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Hamuzsír 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz)" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Folyékony karbamid" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogén műtrágya (folyékony) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Folyékony AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogén műtrágya (folyékony) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Folyékony MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Foszfor műtrágya (folyékony) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Foszfor műtrágya (folyékony)" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Folyékony DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Foszfor műtrágya (folyékony) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Foszfor műtrágya (folyékony)" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Folyékony hamuzsír" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kálium műtrágya (folyékony) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
-    <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kálium műtrágya (folyékony)" eh="52169d4a" />
+    <e k="sf_bigBag_starter_name" v="IBC Starter műtrágya 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Rovarölő szer" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Rovarölő szer (folyékony)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Gombaölő szer" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Gombaölő szer (folyékony)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gipsz" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Talajjavító (száraz) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Talajjavító (száraz)" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Komposzt" eh="14322c5d" />
     <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Szerves talajjavító (száraz) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
-    <e k="sf_bigBag_biosolids_name" v="Big Bag Bioszolárd" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Szerves műtrágya (száraz) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_compost_function" v="Szerves talajjavító (száraz)" eh="9dd2256a" />
+    <e k="sf_bigBag_biosolids_name" v="Big Bag Bioszilárd" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Bioszilárd (10 000L)" />
+    <e k="sf_bigBag_biosolids_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Csirketrágya" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Szerves műtrágya (száraz) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Csirketrágya (10 000L)" />
+    <e k="sf_bigBag_chicken_manure_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletált trágya" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Szerves műtrágya (száraz) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelletált trágya (10 000L)" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Folyékony mész tartály" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH növelő szer (folyékony) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH növelő szer (folyékony)" eh="7a118b6d" />
     <e k="sf_hud_title" v="TALAJ MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mező %d" eh="08988997" />
     <e k="sf_hud_noField" v="Sétáljon egy mezőre" eh="62c55e9e" />
@@ -224,8 +224,8 @@
     <e k="sf_report_pressure_high" v="Magas" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Az N/P/K arány alapján az optimális küszöbhöz képest" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hozam ~-%d%%" eh="d64d5d59" />
-    <e k="sf_pf_compat_short" v="PF Compat Mode" />
-    <e k="sf_pf_compat_long" v="Hide SF nitrogen data when Precision Farming is active — prevents conflicting N readings between the two mods" />
+    <e k="sf_pf_compat_short" v="PF kompatibilitási mód" />
+    <e k="sf_pf_compat_long" v="Elrejti az SF nitrogénadatait, amikor a Precision Farming aktív — megakadályozza a két mod közti ütköző N-értékek megjelenését." />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -288,7 +288,7 @@
     <!-- Category 3 continued -->
     <e k="helpLine_sf_nu_p3_title" v="Szerves anyag" eh="6305f4bb" />
     <e k="helpLine_sf_nu_p3_om_title" v="Szerves anyag (OM) - Skála 0-tól 10-ig" eh="58f490f3" />
-    <e k="helpLine_sf_nu_p3_om_text" v="Nagyon lassan épül fel. Gyenge: 2.5 alatt. Jó: 4.0 felett. Emelés: trágya, hígtrágya, komposzt, bioszólárd, csirketrágya, pelletált trágya vagy a szalma visszadolgozása a mezőbe." eh="f9a02359" />
+    <e k="helpLine_sf_nu_p3_om_text" v="Nagyon lassan épül fel. Gyenge: 2.5 alatt. Jó: 4.0 felett. Emelés: trágya, hígtrágya, komposzt, bioszilárd, csirketrágya, pelletált trágya vagy a szalma visszadolgozása a mezőbe." eh="f9a02359" />
     <e k="helpLine_sf_nu_p3_fallow_title" v="Ugar regeneráció" eh="14133b0b" />
     <e k="helpLine_sf_nu_p3_fallow_text" v="A 7+ napig bevetetlen mező lassan regenerálódik. Naponta: N +0.07, P +0.03, K +0.05, OM +0.01. A vetésforgónak és a pihentetésnek valódi értéke van ebben a modban." eh="81fa82b3" />
 
@@ -303,11 +303,11 @@
     <e k="helpLine_sf_fe_p2_n_title" v="Nitrogén források (egyedi zsákok)" eh="9dfe5a5a" />
     <e k="helpLine_sf_fe_p2_n_text" v="Az UAN-32 és UAN-28 folyékony nitrogén oldatok. A vízmentes ammónia a legmagasabb N tartalmú termék. A karbamid és az AMS száraz granulátumok. Csak N-t tartalmaznak." eh="6a100c25" />
     <e k="helpLine_sf_fe_p2_pk_title" v="Foszfor és Kálium források" eh="a2d4091b" />
-    <e k="helpLine_sf_fe_p2_pk_text" v="MAP: legmagasabb P tartalom. DAP: magas P és némi N. Hamuzsír: tiszta K. Starter: magas P tartalmú termék kiegyensúlyozott N+K aránnyal. Mind elérhető a boltban." eh="75a86964" />
+    <e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0): legmagasabb P tartalom. DAP (18-46-0): magas P és némi N. Hamuzsír (0-0-60): tiszta K. Starter műtrágya (10-34-0): magas P tartalmú termék kiegyensúlyozott N+K aránnyal. Mind elérhető a boltban." eh="75a86964" />
 
     <e k="helpLine_sf_fe_p3_title" v="Szerves termékek és kiégési kockázat" eh="7ab807d1" />
     <e k="helpLine_sf_fe_p3_organic_title" v="Szerves és lassú felszívódású termékek" eh="0199e6be" />
-    <e k="helpLine_sf_fe_p3_organic_text" v="A komposzt a legerősebb OM építő. A bioszólárd és csirketrágya N, P és OM-et ad. A pelletált trágya koncentrált, kiegyensúlyozott szerves anyag. Egyedi típusokként érhetők el." eh="3d16e4ee" />
+    <e k="helpLine_sf_fe_p3_organic_text" v="A komposzt a legerősebb OM építő. A bioszilárd és csirketrágya N, P és OM-et ad. A pelletált trágya koncentrált, kiegyensúlyozott szerves anyag. Egyedi típusokként érhetők el." eh="3d16e4ee" />
     <e k="helpLine_sf_fe_p3_burn_title" v="Túladagolási kiégési kockázat" eh="e986cc54" />
     <e k="helpLine_sf_fe_p3_burn_text" v="Az alapmennyiség 1.25-szöröse felett fennáll a kiégés veszélye (-0.15 pH és -5 N). 1.50-szeres felett a kiégés garantált (-0.30 pH és -12 N). Használja az arányvezérlő gombokat." eh="7bccc46a" />
 
@@ -358,7 +358,7 @@
     <e k="sf_report_rotation_ok" v="Vetésforgó: OK" eh="df66b3be" />
     <e k="sf_gypsum_title" v="Gipsz (pH-)" eh="d66da34c" />
     <e k="sf_compost_title" v="Komposzt (szerves)" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Bioszólárd (N+P)" eh="f0c901dc" />
+    <e k="sf_biosolids_title" v="Bioszilárd (N+P)" eh="f0c901dc" />
     <e k="sf_chicken_manure_title" v="Csirketrágya (N+P)" eh="338128e2" />
     <e k="sf_pelletized_manure_title" v="Pelletált trágya (NPK)" eh="c1b39b71" />
     <e k="sf_liquidlime_title" v="Folyékony mész (pH+)" eh="d4ec4bb9" />
@@ -443,7 +443,7 @@
     <e k="sf_pda_map_unavailable" v="Térkép előnézet nem elérhető" eh="43983f81" />
     <e k="sf_map_health_overall" v="Átlagos talaj egészség" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Gazdaság áttekintés" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Súgó" eh="800e465a" />
     <e k="sf_map_btn_cycle_layer" v="Réteg váltás" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kezelési terv" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Átfedés kikapcsolása" eh="8e75dec5" />
@@ -525,17 +525,17 @@
     <e k="sf_treat_action_n_poor" v="Alkalmazzon UAN32-t, KARBAMIDOT vagy VÍZMENTES AMMÓNIÁT." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Alkalmazzon AMS-t vagy STARTER műtrágyát." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Alkalmazzon MAP-ot vagy DAP-ot (Foszfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Alkalmazzon kevert MŰTRÁGYÁT." eh="6f802546" />
     <e k="sf_treat_action_k_poor" v="Alkalmazzon HAMUZSÍRT (Kálium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Alkalmazzon kevert MŰTRÁGYÁT." eh="6f802546" />
     <e k="sf_treat_action_weed" v="Azonnal alkalmazzon GYOMIRTÓT." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Azonnal alkalmazzon ROVARÖLŐT." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Azonnal alkalmazzon GOMBAÖLŐT." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Pillangós bónusz (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fáradtság (x1.15 kimerülés)" eh="522a6d93" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_no_field" v="Nincs elérhető adat." eh="c6d95d5e" />
     <e k="sf_detail_no_crop" v="Nincs rögzítve" eh="a4b5a996" />
     <!-- HUD labels -->
@@ -594,7 +594,7 @@
     <e k="sf_panel_singleplayer" v="Egyjátékos mód" eh="da602601" />
     <e k="sf_panel_btn_back" v="&lt; Vissza" eh="36cf3e1f" />
     <e k="sf_panel_btn_reset_cat" v="Kategória alaphelyzet" eh="b66faa88" />
-    <e k="sf_panel_btn_close_hint" v="SHIFT+O a bezáráshoz" eh="254406e3" />
+    <e k="sf_panel_btn_close_hint" v="Bezárás: SHIFT+O" eh="254406e3" />
     <e k="sf_panel_select_category" v="Válasszon kategóriát a beállításokhoz" eh="a277d257" />
     <e k="sf_panel_btn_configure" v="Konfigurálás &gt;&gt;" eh="a2cb3902" />
     <e k="sf_panel_btn_open" v="Megnyitás &gt;&gt;" eh="6624d17c" />
@@ -626,8 +626,8 @@
     <e k="sf_desc_cropRotation" v="Vetésforgó előnyök és büntetések" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Tápanyagréteg a PDA térképen" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Mintapont keret (Alacsony=8k, Közepes=20k, Magas=40k)" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="[EN] Use orange/blue palette instead of red/green" />
-    <e k="sf_desc_showFieldInfoBox" v="[EN] Show soil data in the Field Info panel" />
+    <e k="sf_desc_colorblindMode" v="Narancs/kék színpaletta használata piros/zöld helyett" />
+    <e k="sf_desc_showFieldInfoBox" v="Talajadatok megjelenítése a Mezőinformáció panelen" />
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Nagyon lassú (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Lassú (0.5x)" eh="db69874d" />
@@ -692,7 +692,7 @@
     <e k="sf_cell_report" v="Cella jelentés" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nem található cellaadat" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nincs talajadat ezen a helyen" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="Mező átlaga" />
     <e k="sf_cell" v="Cella" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Talajcella vizsgálat" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Cella részletei" eh="6fc5243e" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gipsz" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Talajjavító (száraz) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Komposzt" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Szerves talajjavító (száraz) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Bioszolárd" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungisida" eh="e8512698" />
     <e k="sf_report_page_info" v="Lahan %d-%d dari %d  |  Halaman %d dari %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Pupuk Nitrogen (cair)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Pupuk Nitrogen (cair) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Pupuk Nitrogen (cair)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Pupuk Nitrogen (cair) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amonia Anhidrat 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Pupuk Nitrogen (cair)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Pupuk Nitrogen (cair) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Pupuk Nitrogen (kering)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Pupuk Nitrogen (kering) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Pupuk Nitrogen (kering)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Pupuk Nitrogen (kering) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Pupuk Nitrogen (kering)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Pupuk Nitrogen (kering) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Pupuk Fosfor (kering)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Pupuk Fosfor (kering) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Pupuk Fosfor (kering)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Pupuk Fosfor (kering) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Pupuk Kalium (kering)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Pupuk Kalium (kering) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea Cair" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Pupuk Nitrogen (cair)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Pupuk Nitrogen (cair) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Cair" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Pupuk Nitrogen (cair)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Pupuk Nitrogen (cair) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Cair" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Pupuk Fosfor (cair)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Pupuk Fosfor (cair) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Cair" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Pupuk Fosfor (cair)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Pupuk Fosfor (cair) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Kalium Cair" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Pupuk Kalium (cair)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Pupuk Kalium (cair) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektisida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektisida (cair)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungisida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungisida (cair)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Pupuk Starter (cair)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Pupuk Starter (cair) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Pembenah Tanah (kering)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Pembenah Tanah (kering) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompos" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Pembenah Tanah Organik (kering)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Pembenah Tanah Organik (kering) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolid" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Pupuk Organik (kering)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Pupuk Organik (kering) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kotoran Ayam" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Pupuk Organik (kering)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Pupuk Organik (kering) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pupuk Kandang Pelet" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Pupuk Organik (kering)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Pupuk Organik (kering) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tangki Kapur Cair" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agen Peningkat pH (cair)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agen Peningkat pH (cair) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR TANAH" eh="f8cda642" />
     <e k="sf_hud_field" v="Lahan %d" eh="08988997" />
     <e k="sf_hud_noField" v="Masuk ke dalam lahan" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Terapkan INSEKTISIDA segera." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Terapkan FUNGISIDA segera." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus Polong-polongan (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Kelelahan (penipisan x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Tidak ada data tersedia." eh="c6d95d5e" />
@@ -546,6 +548,7 @@
     <e k="sf_hud_coverage" v="Cakupan: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Jalur: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Pemadatan: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Pupuk MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Pupuk DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kalium 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urea Cair (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Amonium Sulfat Cair (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Cair (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Pupuk Fosfor (kering) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Pupuk Kalium (kering) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea Cair" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Pupuk Nitrogen (cair) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Cair" eh="32e6c8bb" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Pembenah Tanah (kering) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompos" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Pembenah Tanah Organik (kering) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolid" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campi %d-%d di %d  |  Pagina %d di %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Fertilizzante azotato (liquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Fertilizzante azotato (liquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniaca anidra 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizzante azotato (liquido)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Fertilizzante azotato (liquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Fertilizzante azotato (secco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Fertilizzante azotato (secco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizzante azotato (secco)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Fertilizzante azotato (secco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizzante fosfatico (secco)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fertilizzante fosfatico (secco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizzante fosfatico (secco)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fertilizzante fosfatico (secco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassio 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizzante potassico (secco)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Fertilizzante potassico (secco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="Big Bag Urea Liquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizzante Azotato (liquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Fertilizzante Azotato (liquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="Big Bag AMS Liquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizzante Azotato (liquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Fertilizzante Azotato (liquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="Big Bag MAP Liquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizzante Fosfatico (liquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fertilizzante Fosfatico (liquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="Big Bag DAP Liquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizzante Fosfatico (liquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fertilizzante Fosfatico (liquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="Big Bag Potassio Liquido" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizzante Potassico (liquido)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Fertilizzante Potassico (liquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insetticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insetticida (liquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (liquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Miglioratore del suolo (secco)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Miglioratore del suolo (secco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Miglioratore organico (secco)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Miglioratore organico (secco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolidi" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizzante organico (secco)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Fertilizzante organico (secco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Pollina" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizzante organico (secco)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fertilizzante organico (secco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Letame Pellettato" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizzante organico (secco)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizzante organico (secco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Serbatoio Calce Liquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente correttore pH (liquido)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agente correttore pH (liquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
 		<e k="sf_hud_title" v="MONITORAGGIO SUOLO" eh="f8cda642" />
 		<e k="sf_hud_field" v="Campo %d" eh="08988997" />
 		<e k="sf_hud_noField" v="Cammina su un campo" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Applica INSETTICIDA immediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Applica FUNGICIDE immediatamente." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus Leguminose (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Stanchezza (deplezione x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nessun dato disponibile." eh="c6d95d5e" />
@@ -546,6 +548,7 @@
     <e k="sf_hud_coverage" v="Copertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passata: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compattazione: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Fertilizzante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizzante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urea Liquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Solfato di Ammonio Liquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Liquido (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fertilizzante fosfatico (secco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassio 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizzante potassico (secco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="Big Bag Urea Liquida" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Fertilizzante Azotato (liquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="Big Bag AMS Liquido" eh="32e6c8bb" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Miglioratore del suolo (secco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Miglioratore organico (secco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolidi" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP 肥料 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP 肥料 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="塩化カリ 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="液体尿素 (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="液体硫酸アンモニウム (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="液体 MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="リン酸肥料（乾燥） — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="ビッグバッグ 塩化カリ 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="カリウム肥料（乾燥） — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC 液体尿素" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="窒素肥料（液体） — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC 液体硫安" eh="32e6c8bb" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="殺菌剤" eh="e8512698" />
     <e k="sf_report_page_info" v="フィールド %d-%d / %d  |  %d / %d ページ" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="窒素肥料（液体）" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="窒素肥料（液体） — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="窒素肥料（液体）" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="窒素肥料（液体） — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC 無水アンモニア 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="窒素肥料（液体）" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="窒素肥料（液体） — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="ビッグバッグ 尿素 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="窒素肥料（乾燥）" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="窒素肥料（乾燥） — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="ビッグバッグ 硝安 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="窒素肥料（乾燥）" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="窒素肥料（乾燥） — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="ビッグバッグ 硫安 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="窒素肥料（乾燥）" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="窒素肥料（乾燥） — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="ビッグバッグ MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="リン酸肥料（乾燥）" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="リン酸肥料（乾燥） — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="ビッグバッグ DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="リン酸肥料（乾燥）" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="リン酸肥料（乾燥） — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="ビッグバッグ 塩化カリ 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="カリウム肥料（乾燥）" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="カリウム肥料（乾燥） — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC 液体尿素" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="窒素肥料（液体）" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="窒素肥料（液体） — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC 液体硫安" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="窒素肥料（液体）" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="窒素肥料（液体） — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC 液体 MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="リン酸肥料（液体）" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="リン酸肥料（液体） — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC 液体 DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="リン酸肥料（液体）" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="リン酸肥料（液体） — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC 液体塩化カリ" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="カリウム肥料（液体）" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="カリウム肥料（液体） — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC スターター 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC 殺虫剤" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="殺虫剤（液体）" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC 殺菌剤" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="殺菌剤（液体）" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="スターター肥料（液体）" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="スターター肥料（液体） — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="ビッグバッグ 石膏" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="土壌改良材（乾燥）" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="土壌改良材（乾燥） — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="ビッグバッグ 堆肥" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="有機土壌改良材（乾燥）" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="有機土壌改良材（乾燥） — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="ビッグバッグ バイオソリッド" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="有機肥料（乾燥）" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="有機肥料（乾燥） — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="ビッグバッグ 鶏糞" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="有機肥料（乾燥）" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="有機肥料（乾燥） — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="ビッグバッグ ペレット堆肥" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="有機肥料（乾燥）" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="有機肥料（乾燥） — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="液体石灰タンク" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH上昇剤（液体）" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH上昇剤（液体） — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="土壌モニター" eh="f8cda642" />
     <e k="sf_hud_field" v="フィールド %d" eh="08988997" />
     <e k="sf_hud_noField" v="フィールドに入ってください" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="直ちに殺虫剤を散布してください。" eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="直ちに殺菌剤を散布してください。" eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="良好" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="マメ科ボーナス (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="連作障害 (消耗 1.15倍)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="データなし。" eh="c6d95d5e" />
@@ -542,6 +544,7 @@
     <e k="sf_hud_coverage" v="被覆率: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="散布: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="踏み固め: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
     
     <!-- 散布レート HUD -->
     <e k="sf_sprayer_auto_on" v="散布レート (自動: オン)" eh="099b5dac" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="ビッグバッグ 石膏" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="土壌改良材（乾燥） — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="ビッグバッグ 堆肥" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="有機土壌改良材（乾燥） — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="ビッグバッグ バイオソリッド" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP 비료 11-52-0 (인산)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP 비료 18-46-0 (인산)" eh="5030a80a" />
     <e k="sf_potash_title" v="칼리 0-0-60 (칼륨)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="액상 요소 (질소)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="액상 황산 암모늄 (질소)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="액상 MAP (인산)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="인산 비료 (고체) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="빅백 칼리 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="칼륨 비료 (고체) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC 액상 요소" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="질소 비료 (액체) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC 액상 AMS" eh="32e6c8bb" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="살균제" eh="e8512698" />
     <e k="sf_report_page_info" v="필드 %d-%d (총 %d개)  |  페이지 %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="질소 비료 (액체)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="질소 비료 (액체) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="질소 비료 (액체)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="질소 비료 (액체) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC 무수 암모니아 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="질소 비료 (액체)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="질소 비료 (액체) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="빅백 요소 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="질소 비료 (고체)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="질소 비료 (고체) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="빅백 AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="질소 비료 (고체)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="질소 비료 (고체) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="빅백 AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="질소 비료 (고체)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="질소 비료 (고체) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="빅백 MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="인산 비료 (고체)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="인산 비료 (고체) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="빅백 DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="인산 비료 (고체)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="인산 비료 (고체) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="빅백 칼리 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="칼륨 비료 (고체)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="칼륨 비료 (고체) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC 액상 요소" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="질소 비료 (액체)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="질소 비료 (액체) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC 액상 AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="질소 비료 (액체)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="질소 비료 (액체) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC 액상 MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="인산 비료 (액체)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="인산 비료 (액체) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC 액상 DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="인산 비료 (액체)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="인산 비료 (액체) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC 액상 칼리" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="칼륨 비료 (액체)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="칼륨 비료 (액체) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC 스타터 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC 살충제" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="살충제 (액체)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC 살균제" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="살균제 (액체)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="스타터 비료 (액체)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="스타터 비료 (액체) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="빅백 석고" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="토양 개량제 (고체)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="토양 개량제 (고체) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="빅백 퇴비" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="유기질 토양 개량제 (고체)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="유기질 토양 개량제 (고체) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="빅백 바이오솔리드" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="유기질 비료 (고체)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="유기질 비료 (고체) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="빅백 계분" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="유기질 비료 (고체)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="유기질 비료 (고체) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="빅백 펠렛 퇴비" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="유기질 비료 (고체)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="유기질 비료 (고체) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="액상 석회 탱크" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH 조절제 (액체)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH 조절제 (액체) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="토양 모니터" eh="f8cda642" />
     <e k="sf_hud_field" v="필드 %d" eh="08988997" />
     <e k="sf_hud_noField" v="필드에 입장하세요" eh="62c55e9e" />
@@ -531,6 +531,8 @@
     <e k="sf_treat_action_pest" v="즉시 살충제를 살포하세요." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="즉시 살균제를 살포하세요." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="확인" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="콩과 보너스 (+질소)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="연작 피해 (1.15배 소모)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="데이터 없음" eh="c6d95d5e" />
@@ -543,6 +545,7 @@
     <e k="sf_hud_coverage" v="범위: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="살포: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="압축도: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="살포량 ( 자동: 켬 )" eh="099b5dac" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="빅백 석고" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="토양 개량제 (고체) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="빅백 퇴비" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="유기질 토양 개량제 (고체) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="빅백 바이오솔리드" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP Meststof 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Meststof 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kali 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Vloeibare Ureum (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Vloeibare Ammoniumsulfaat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Vloeibare MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosfaatmeststof (droog) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kali 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kalimeststof (droog) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Vloeibare Ureum" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Stikstofmeststof (vloeibaar) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Vloeibare AMS" eh="32e6c8bb" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Velden %d-%d van %d  |  Pagina %d van %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Stikstofmeststof (vloeibaar) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Stikstofmeststof (vloeibaar) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Watervrij Ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Stikstofmeststof (vloeibaar) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureum 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Stikstofmeststof (droog)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Stikstofmeststof (droog) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Stikstofmeststof (droog)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Stikstofmeststof (droog) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Stikstofmeststof (droog)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Stikstofmeststof (droog) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfaatmeststof (droog)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosfaatmeststof (droog) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfaatmeststof (droog)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosfaatmeststof (droog) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kali 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kalimeststof (droog)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kalimeststof (droog) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Vloeibare Ureum" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Stikstofmeststof (vloeibaar) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Vloeibare AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Stikstofmeststof (vloeibaar)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Stikstofmeststof (vloeibaar) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Vloeibare MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfaatmeststof (vloeibaar)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosfaatmeststof (vloeibaar) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Vloeibare DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfaatmeststof (vloeibaar)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosfaatmeststof (vloeibaar) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Vloeibare Kali" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kalimeststof (vloeibaar)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kalimeststof (vloeibaar) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (vloeibaar)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (vloeibaar)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Bodemverbeteraar (droog)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Bodemverbeteraar (droog) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organische bodemverbeteraar (droog)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organische bodemverbeteraar (droog) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biogrondstoffen" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organische meststof (droog)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organische meststof (droog) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kippenmest" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organische meststof (droog)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organische meststof (droog) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Gekorrelde mest" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organische meststof (droog)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organische meststof (droog) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Vloeibare kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-verhogend middel (vloeibaar)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-verhogend middel (vloeibaar) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="BODEM MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Veld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Loop een veld op" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Onmiddellijk INSECTICIDE toepassen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Onmiddellijk FUNGICIDE toepassen." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Bodemmoeheid (x1,15 uitputting)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Geen gegevens beschikbaar." eh="c6d95d5e" />
@@ -544,6 +546,7 @@
     <e k="sf_hud_coverage" v="Dekking: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Ronde: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Verdichting: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DOSERING ( AUTO: AAN )" eh="099b5dac" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Bodemverbeteraar (droog) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organische bodemverbeteraar (droog) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biogrondstoffen" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Soppmiddel" eh="e8512698" />
     <e k="sf_report_page_info" v="Felt %d-%d av %d  |  Side %d av %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Nitrogengjødsel (flytende) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Nitrogengjødsel (flytende) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vannfri ammoniakk 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Nitrogengjødsel (flytende) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogengjødsel (tørr)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Nitrogengjødsel (tørr) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogengjødsel (tørr)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Nitrogengjødsel (tørr) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogengjødsel (tørr)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Nitrogengjødsel (tørr) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfatgjødsel (tørr)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosfatgjødsel (tørr) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfatgjødsel (tørr)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosfatgjødsel (tørr) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumgjødsel (tørr)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kaliumgjødsel (tørr) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flytende Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Nitrogengjødsel (flytende) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flytende AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogengjødsel (flytende)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Nitrogengjødsel (flytende) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Flytende MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfatgjødsel (flytende)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosfatgjødsel (flytende) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Flytende DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgjødsel (flytende)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgjødsel (flytende) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Flytende Kalium" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgjødsel (flytende)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgjødsel (flytende) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektmiddel" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektmiddel (flytende)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Soppmiddel" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Soppmiddel (flytende)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startgjødsel (flytende)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Startgjødsel (flytende) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tørr)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tørr) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tørr)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tørr) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Bioslam" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organisk gjødsel (tørr)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organisk gjødsel (tørr) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsegjødsel" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organisk gjødsel (tørr)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organisk gjødsel (tørr) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletsert gjødsel" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gjødsel (tørr)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gjødsel (tørr) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flytende kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-hevende middel (flytende)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-hevende middel (flytende) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Felt %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ut på et felt" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Påfør INSEKTMIDDEL umiddelbart." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Påfør SOPPMIDDEL umiddelbart." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Belgvekstbonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Tretthet (x1,15 uttømming)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tilgjengelig." eh="c6d95d5e" />
@@ -544,6 +546,7 @@
     <e k="sf_hud_coverage" v="Dekning: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Kjøring: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Pakking: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="PÅFØR. RATE ( AUTO: PÅ )" eh="099b5dac" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP Gjødsel 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Gjødsel 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kalium 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Flytende Urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flytende Ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flytende MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosfatgjødsel (tørr) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgjødsel (tørr) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flytende Urea" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Nitrogengjødsel (flytende) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flytende AMS" eh="32e6c8bb" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tørr) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tørr) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Bioslam" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Nawóz MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Nawóz DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Sól potasowa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Mocznik w płynie (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Siarczan amonu w płynie (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP w płynie (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Nawóz fosforowy (suchy) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Sól potasowa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Nawóz potasowy (suchy) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Mocznik w płynie" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Nawóz azotowy (płynny) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Siarczan amonu w płynie" eh="32e6c8bb" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicyd" eh="e8512698" />
     <e k="sf_report_page_info" v="Pola %d-%d z %d  |  Strona %d z %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nawóz azotowy (płynny)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Nawóz azotowy (płynny) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nawóz azotowy (płynny)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Nawóz azotowy (płynny) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoniak bezwodny 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nawóz azotowy (płynny)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Nawóz azotowy (płynny) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Mocznik 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nawóz azotowy (suchy)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Nawóz azotowy (suchy) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nawóz azotowy (suchy)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Nawóz azotowy (suchy) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nawóz azotowy (suchy)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Nawóz azotowy (suchy) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Nawóz fosforowy (suchy)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Nawóz fosforowy (suchy) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Nawóz fosforowy (suchy)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Nawóz fosforowy (suchy) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Sól potasowa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Nawóz potasowy (suchy)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Nawóz potasowy (suchy) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Mocznik w płynie" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nawóz azotowy (płynny)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Nawóz azotowy (płynny) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Siarczan amonu w płynie" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nawóz azotowy (płynny)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Nawóz azotowy (płynny) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP w płynie" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Nawóz fosforowy (płynny)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Nawóz fosforowy (płynny) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP w płynie" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Nawóz fosforowy (płynny)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Nawóz fosforowy (płynny) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potas w płynie" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Nawóz potasowy (płynny)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Nawóz potasowy (płynny) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Startowy 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektycyd" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektycyd (płynny)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicyd" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicyd (płynny)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Nawóz startowy (płynny)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Nawóz startowy (płynny) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Poprawa gleby (suchy)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Poprawa gleby (suchy) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organiczna poprawa gleby (suchy)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organiczna poprawa gleby (suchy) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Osady ściekowe" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Nawóz organiczny (suchy)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Nawóz organiczny (suchy) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kurzak" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Nawóz organiczny (suchy)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Nawóz organiczny (suchy) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Obornik granulowany" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Nawóz organiczny (suchy)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Nawóz organiczny (suchy) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Zbiornik wapna w płynie" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Środek podnoszący pH (płynny)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Środek podnoszący pH (płynny) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR GLEBY" eh="f8cda642" />
     <e k="sf_hud_field" v="Pole %d" eh="08988997" />
     <e k="sf_hud_noField" v="Wejdź na pole" eh="62c55e9e" />
@@ -532,6 +532,8 @@
     <e k="sf_treat_action_pest" v="Zastosuj INSEKTYCYD natychmiast." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Zastosuj FUNGICYD natychmiast." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus strączkowych (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Zmęczenie (x1.15 wyczerpanie)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Brak danych." eh="c6d95d5e" />
@@ -544,6 +546,7 @@
     <e k="sf_hud_coverage" v="Pokrycie: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Przejazd: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Zagęszczenie: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DAWKA  ( AUTO: WŁ )" eh="099b5dac" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Poprawa gleby (suchy) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organiczna poprawa gleby (suchy) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Osady ściekowe" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Ureia Líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de Amónio Líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Líquido (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fertilizante fosfatado (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Ureia Líquida" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Fertilizante azotado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante azotado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Fertilizante azotado (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante azotado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Fertilizante azotado (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amónia Anidra 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante azotado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Fertilizante azotado (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureia 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante azotado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Fertilizante azotado (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante azotado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Fertilizante azotado (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante azotado (seco)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Fertilizante azotado (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante fosfatado (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fertilizante fosfatado (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante fosfatado (seco)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fertilizante fosfatado (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Ureia Líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante azotado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante azotado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante azotado (líquido)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante azotado (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfatado (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfatado (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfatado (líquido)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfatado (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potassa Líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potássico (líquido)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potássico (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Inseticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Inseticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Composto" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biossólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante Orgânico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Fertilizante Orgânico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Estrume de Galinha" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante Orgânico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante Orgânico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Estrume Peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante Orgânico (seco)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante Orgânico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Depósito de Cal Líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente de Aumento de pH (líquido)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agente de Aumento de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR DE SOLO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Caminhe sobre um campo" eh="62c55e9e" />
@@ -533,6 +533,8 @@
     <e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bónus de Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fadiga (esgotamento x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Dados indisponíveis." eh="c6d95d5e" />
@@ -547,6 +549,7 @@
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passagem: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Composto" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biossólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Îngrășământ MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Îngrășământ DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasiu 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Uree Lichidă (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfat de Amoniu Lichid (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Lichid (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Îngrășământ cu fosfor (uscat) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasiu 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Îngrășământ cu potasiu (uscat) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Uree Lichidă" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Îngrășământ cu azot (lichid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Lichid" eh="32e6c8bb" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Câmpuri %d-%d din %d  |  Pagina %d din %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Îngrășământ cu azot (lichid)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Îngrășământ cu azot (lichid) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Îngrășământ cu azot (lichid)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Îngrășământ cu azot (lichid) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoniac Anidru 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Îngrășământ cu azot (lichid)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Îngrășământ cu azot (lichid) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Uree 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Îngrășământ cu azot (uscat)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Îngrășământ cu azot (uscat) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Îngrășământ cu azot (uscat)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Îngrășământ cu azot (uscat) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Îngrășământ cu azot (uscat)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Îngrășământ cu azot (uscat) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Îngrășământ cu fosfor (uscat)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Îngrășământ cu fosfor (uscat) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Îngrășământ cu fosfor (uscat)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Îngrășământ cu fosfor (uscat) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasiu 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Îngrășământ cu potasiu (uscat)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Îngrășământ cu potasiu (uscat) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Uree Lichidă" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Îngrășământ cu azot (lichid)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Îngrășământ cu azot (lichid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Lichid" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Îngrășământ cu azot (lichid)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Îngrășământ cu azot (lichid) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Lichid" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Îngrășământ cu fosfor (lichid)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Îngrășământ cu fosfor (lichid) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Lichid" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Îngrășământ cu fosfor (lichid)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Îngrășământ cu fosfor (lichid) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasiu Lichid" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Îngrășământ cu potasiu (lichid)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Îngrășământ cu potasiu (lichid) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticid (lichid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicid (lichid)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Îngrășământ Starter (lichid)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Îngrășământ Starter (lichid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Ipsos (Ghips)" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Amendament Sol (uscat)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Amendament Sol (uscat) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Amendament Sol Organic (uscat)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Amendament Sol Organic (uscat) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolide" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Îngrășământ Organic (uscat)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Îngrășământ Organic (uscat) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Găinaț de Pasăre" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Îngrășământ Organic (uscat)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Îngrășământ Organic (uscat) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Gunoi de Grajd Peletizat" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Îngrășământ Organic (uscat)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Îngrășământ Organic (uscat) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Rezervor Var Lichid" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent Creștere pH (lichid)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Agent Creștere pH (lichid) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MONITOR SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Câmp %d" eh="08988997" />
     <e k="sf_hud_noField" v="Mergeți pe un câmp" eh="62c55e9e" />
@@ -533,6 +533,8 @@
     <e k="sf_treat_action_pest" v="Aplică INSECTICID imediat." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplică FUNGICID imediat." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Bonus Leguminoase (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Oboseală (epuizare x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nu există date disponibile." eh="c6d95d5e" />
@@ -547,6 +549,7 @@
     <e k="sf_hud_coverage" v="Acoperire: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Trecere: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Compactare: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Ipsos (Ghips)" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Amendament Sol (uscat) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Amendament Sol Organic (uscat) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolide" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Фунгицид" eh="e8512698" />
     <e k="sf_report_page_info" v="Поля %d-%d из %d  |  Страница %d из %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC КАС 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Азотное удобрение (жидкое)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Азотное удобрение (жидкое) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC КАС 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Азотное удобрение (жидкое)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Азотное удобрение (жидкое) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Безводный аммиак 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Азотное удобрение (жидкое)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Азотное удобрение (жидкое) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="МКР Карбамид 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Азотное удобрение (сухое)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Азотное удобрение (сухое) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="МКР Аммиачная селитра 34,5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Азотное удобрение (сухое)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Азотное удобрение (сухое) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="МКР Сульфат аммония 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Азотное удобрение (сухое)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Азотное удобрение (сухое) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="МКР Аммофос 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Фосфорное удобрение (сухое)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Фосфорное удобрение (сухое) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="МКР Диаммофос 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Фосфорное удобрение (сухое)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Фосфорное удобрение (сухое) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="МКР Калий хлористый 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Калийное удобрение (сухое)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Калийное удобрение (сухое) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Жидкий карбамид" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Азотное удобрение (жидкое)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Азотное удобрение (жидкое) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Жидкий сульфат аммония" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Азотное удобрение (жидкое)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Азотное удобрение (жидкое) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Жидкий Аммофос" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Фосфорное удобрение (жидкое)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Фосфорное удобрение (жидкое) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Жидкий Диаммофос" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Фосфорное удобрение (жидкое)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Фосфорное удобрение (жидкое) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Жидкий калий" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Калийное удобрение (жидкое)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Калийное удобрение (жидкое) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Стартер 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Инсектицид" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Инсектицид (жидкий)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Фунгицид" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Фунгицид (жидкий)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Стартовое удобрение (жидкое)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Стартовое удобрение (жидкое) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="МКР Гипс" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Мелиорант почвы (сухой)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Мелиорант почвы (сухой) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Органическая добавка (сухая)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Органическая добавка (сухая) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="МКР Биоотходы" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Органическое удобрение (сухое)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Органическое удобрение (сухое) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="МКР Куриный помет" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Органическое удобрение (сухое)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Органическое удобрение (сухое) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="МКР Гранулированный навоз" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Органическое удобрение (сухое)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Органическое удобрение (сухое) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Резервуар с жидкой известью" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Агент для повышения pH (жидкий)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Агент для повышения pH (жидкий) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="МОНИТОР ПОЧВЫ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Немедленно внесите ИНСЕКТИЦИД." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Немедленно внесите ФУНГИЦИД." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="ОК" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Бонус бобовых (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Утомление (x1.15 вынос)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Нет данных." eh="c6d95d5e" />
@@ -522,6 +524,7 @@
     <e k="sf_hud_coverage" v="Покрытие: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Проход: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Уплотнение: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
     <e k="sf_sprayer_auto_on" v="НОРМА ВНЕСЕНИЯ ( АВТО: ВКЛ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="НОРМА ВНЕСЕНИЯ АВТО: ВЫКЛ [%s]" eh="848cc106" />
     <e k="sf_sprayer_target" v="Цель:" eh="31d43504" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Удобрение Аммофос (MAP) 11-52-0 (Фосфор)" eh="31aa2534" />
     <e k="sf_dap_title" v="Удобрение Диаммофос (DAP) 18-46-0 (Фосфор)" eh="5030a80a" />
     <e k="sf_potash_title" v="Калий хлористый 0-0-60 (Калий)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Жидкий карбамид (Азот)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Жидкий сульфат аммония (Азот)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Жидкий Аммофос (Фосфор)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Фосфорное удобрение (сухое) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="МКР Калий хлористый 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Калийное удобрение (сухое) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Жидкий карбамид" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Азотное удобрение (жидкое) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Жидкий сульфат аммония" eh="32e6c8bb" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="МКР Гипс" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Мелиорант почвы (сухой) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Органическая добавка (сухая) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="МКР Биоотходы" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Svampmedel" eh="e8512698" />
     <e k="sf_report_page_info" v="Fält %d-%d av %d  |  Sida %d av %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Kvävegödsel (flytande) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Kvävegödsel (flytande) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vattenfritt ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Kvävegödsel (flytande) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Storsäck Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Kvävegödsel (torr)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Kvävegödsel (torr) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Storsäck AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Kvävegödsel (torr)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Kvävegödsel (torr) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Storsäck AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Kvävegödsel (torr)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Kvävegödsel (torr) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Storsäck MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfatgödsel (torr)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosfatgödsel (torr) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Storsäck DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfatgödsel (torr)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosfatgödsel (torr) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Storsäck Kaliumklorid 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumgödsel (torr)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Kaliumgödsel (torr) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flytande urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Kvävegödsel (flytande) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flytande AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Kvävegödsel (flytande)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Kvävegödsel (flytande) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Flytande MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfatgödsel (flytande)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosfatgödsel (flytande) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Flytande DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgödsel (flytande)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgödsel (flytande) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Flytande kalium" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgödsel (flytande)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgödsel (flytande) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Startgödsel 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektsmedel" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektsmedel (flytande)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Svampmedel" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Svampmedel (flytande)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startgödsel (flytande)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Startgödsel (flytande) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Storsäck Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Jordförbättringsmedel (torrt)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Jordförbättringsmedel (torrt) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Storsäck Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organiskt jordförbättringsmedel (torrt)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organiskt jordförbättringsmedel (torrt) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Storsäck Rötslam" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organiskt gödselmedel (torrt)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organiskt gödselmedel (torrt) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Storsäck Hönsgödsel" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organiskt gödselmedel (torrt)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organiskt gödselmedel (torrt) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Storsäck Pelleterat gödsel" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organiskt gödselmedel (torrt)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organiskt gödselmedel (torrt) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flytande kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-höjande medel (flytande)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-höjande medel (flytande) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="MARKÖVERVAKNING" eh="f8cda642" />
     <e k="sf_hud_field" v="Fält %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ut på ett fält" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Sprid INSEKTSMEDEL omedelbart." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Sprid SVAMPMEDEL omedelbart." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Baljväxtbonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Utmattning (x1.15 utarmning)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tillgänglig." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Täckning: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Körning: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Packning: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="SPRIDNINGSMÄNGD  ( AUTO: PÅ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="SPRIDNINGSMÄNGD  AUTO: AV [%s]" eh="848cc106" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP-gödsel 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-gödsel 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumklorid 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Flytande urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flytande ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flytande MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosfatgödsel (torr) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Storsäck Kaliumklorid 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Kaliumgödsel (torr) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flytande urea" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Kvävegödsel (flytande) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flytande AMS" eh="32e6c8bb" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Storsäck Gips" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Jordförbättringsmedel (torrt) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Storsäck Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organiskt jordförbättringsmedel (torrt) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Storsäck Rötslam" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Fungisit (Mantar İlacı)" eh="e8512698" />
     <e k="sf_report_page_info" v="Tarlalar %d-%d / %d  |  Sayfa %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Azotlu Gübre (sıvı)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Azotlu Gübre (sıvı) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Azotlu Gübre (sıvı)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Azotlu Gübre (sıvı) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Anhidre Amonyak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Azotlu Gübre (sıvı)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Azotlu Gübre (sıvı) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Big Bag Üre 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Azotlu Gübre (kuru)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Azotlu Gübre (kuru) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Azotlu Gübre (kuru)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Azotlu Gübre (kuru) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Azotlu Gübre (kuru)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Azotlu Gübre (kuru) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosforlu Gübre (kuru)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Fosforlu Gübre (kuru) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosforlu Gübre (kuru)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Fosforlu Gübre (kuru) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potas 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Potasyumlu Gübre (kuru)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Potasyumlu Gübre (kuru) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Sıvı Üre" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Azotlu Gübre (sıvı)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Azotlu Gübre (sıvı) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Sıvı AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Azotlu Gübre (sıvı)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Azotlu Gübre (sıvı) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Sıvı MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosforlu Gübre (sıvı)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosforlu Gübre (sıvı) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Sıvı DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosforlu Gübre (sıvı)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosforlu Gübre (sıvı) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Sıvı Potas" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Potasyumlu Gübre (sıvı)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Potasyumlu Gübre (sıvı) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Başlangıç 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC İnsektisit" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="İnsektisit (sıvı)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungisit" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungisit (sıvı)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Başlangıç Gübresi (sıvı)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Başlangıç Gübresi (sıvı) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Alçıtaşı (Jips)" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Toprak Düzenleyici (kuru)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Toprak Düzenleyici (kuru) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Organik Toprak Düzenleyici (kuru)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Organik Toprak Düzenleyici (kuru) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biyokatı" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organik Gübre (kuru)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Organik Gübre (kuru) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Tavuk Gübresi" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organik Gübre (kuru)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organik Gübre (kuru) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Peletlenmiş Gübre" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organik Gübre (kuru)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organik Gübre (kuru) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Sıvı Kireç Tankı" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Yükseltici Madde (sıvı)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Yükseltici Madde (sıvı) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="TOPRAK MONİTÖRÜ" eh="f8cda642" />
     <e k="sf_hud_field" v="Tarla %d" eh="08988997" />
     <e k="sf_hud_noField" v="Bir tarlaya gidin" eh="62c55e9e" />
@@ -513,6 +513,8 @@
     <e k="sf_treat_action_pest" v="Derhal İNSEKTİSİT uygulayın." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Derhal FUNGİSİT uygulayın." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="Tamam" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Baklagil Bonusu (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Yorgunluk (x1.15 tükenme)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Veri mevcut değil." eh="c6d95d5e" />
@@ -524,6 +526,7 @@
     <e k="sf_hud_coverage" v="Kapsama: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Geçiş: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Sıkışma: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="UYGULAMA ORANI ( OTO: AÇIK )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="UYGULAMA ORANI  OTO: KAPALI [%s]" eh="848cc106" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="MAP Gübresi 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Gübresi 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potas 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Sıvı Üre (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sıvı Amonyum Sülfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Sıvı MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Fosforlu Gübre (kuru) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potas 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Potasyumlu Gübre (kuru) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Sıvı Üre" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Azotlu Gübre (sıvı) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Sıvı AMS" eh="32e6c8bb" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Big Bag Alçıtaşı (Jips)" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Toprak Düzenleyici (kuru) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Organik Toprak Düzenleyici (kuru) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biyokatı" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Добриво MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Добриво DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Поташ 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Рідка сечовина (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Рідкий сульфат амонію (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Рідкий MAP (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Фосфорне добриво (сухе) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="МКР Поташ 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Калійне добриво (сухе) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Рідка сечовина" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Азотне добриво (рідке) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Рідкий AMS" eh="32e6c8bb" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Фунгіцид" eh="e8512698" />
     <e k="sf_report_page_info" v="Поля %d-%d з %d  |  Стор. %d з %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC КАС-32" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Азотне добриво (рідке)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Азотне добриво (рідке) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC КАС-28" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Азотне добриво (рідке)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Азотне добриво (рідке) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Безводний аміак 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Азотне добриво (рідке)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Азотне добриво (рідке) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="МКР Карбамід 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Азотне добриво (сухе)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Азотне добриво (сухе) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="МКР Аміачна селітра 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Азотне добриво (сухе)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Азотне добриво (сухе) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="МКР AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Азотне добриво (сухе)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Азотне добриво (сухе) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="МКР MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Фосфорне добриво (сухе)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Фосфорне добриво (сухе) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="МКР DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Фосфорне добриво (сухе)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Фосфорне добриво (сухе) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="МКР Поташ 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Калійне добриво (сухе)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Калійне добриво (сухе) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Рідка сечовина" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Азотне добриво (рідке)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Азотне добриво (рідке) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Рідкий AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Азотне добриво (рідке)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Азотне добриво (рідке) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Рідкий MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Фосфорне добриво (рідке)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Фосфорне добриво (рідке) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Рідкий DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Фосфорне добриво (рідке)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Фосфорне добриво (рідке) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Рідкий поташ" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Калійне добриво (рідке)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Калійне добриво (рідке) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Стартер 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Інсектицид" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Інсектицид (рідкий)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Фунгіцид" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Фунгіцид (рідкий)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Стартове добриво (рідке)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Стартове добриво (рідке) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="МКР Гіпс" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Меліорант (сухий)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Меліорант (сухий) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Органічний меліорант (сухий)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Органічний меліорант (сухий) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="МКР Біовідходи" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Органічне добриво (сухе)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Органічне добриво (сухе) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="МКР Курячий послід" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Органічне добриво (сухе)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Органічне добриво (сухе) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="МКР Гранульований гній" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Органічне добриво (сухе)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Органічне добриво (сухе) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Резервуар рідкого вапна" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Засіб підвищення pH (рідкий)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Засіб підвищення pH (рідкий) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="МОНІТОР ҐРУНТУ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Негайно внесіть ІНСЕКТИЦИД." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Негайно внесіть ФУНГІЦИД." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Бонус бобових (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Втома ґрунту (виснаження x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Дані недоступні." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Покриття: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Прохід: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Ущільнення: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="НОРМА ВНЕСЕННЯ ( АВТО: УВІМК )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="НОРМА ВНЕСЕННЯ  АВТО: ВИМК [%s]" eh="848cc106" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="МКР Гіпс" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Меліорант (сухий) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Органічний меліорант (сухий) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="МКР Біовідходи" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -149,54 +149,54 @@
     <e k="sf_fungicide_title" v="Thuốc trừ nấm" eh="e8512698" />
     <e k="sf_report_page_info" v="Cánh đồng %d-%d của %d  |  Trang %d của %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Phân bón đạm (lỏng)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Phân bón đạm (lỏng) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Phân bón đạm (lỏng)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Phân bón đạm (lỏng) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoniac khan 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Phân bón đạm (lỏng)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Phân bón đạm (lỏng) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_urea_name" v="Túi Urê 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Phân bón đạm (khô)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Phân bón đạm (khô) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_an_name" v="Túi AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Phân bón đạm (khô)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Phân bón đạm (khô) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_ams_name" v="Túi AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Phân bón đạm (khô)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Phân bón đạm (khô) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
     <e k="sf_bigBag_map_name" v="Túi MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Phân bón lân (khô)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Phân bón lân (khô) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_dap_name" v="Túi DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Phân bón lân (khô)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Phân bón lân (khô) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Túi Kali 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Phân bón kali (khô)" eh="18015099" />
+    <e k="sf_bigBag_potash_function" v="Phân bón kali (khô) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urê lỏng" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Phân bón đạm (lỏng)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Phân bón đạm (lỏng) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS lỏng" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Phân bón đạm (lỏng)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Phân bón đạm (lỏng) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP lỏng" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Phân bón lân (lỏng)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Phân bón lân (lỏng) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP lỏng" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Phân bón lân (lỏng)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Phân bón lân (lỏng) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Kali lỏng" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Phân bón kali (lỏng)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Phân bón kali (lỏng) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
     <e k="sf_bigBag_starter_name" v="IBC Phân bón lót 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Thuốc trừ sâu" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Thuốc trừ sâu (lỏng)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Thuốc trừ nấm" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Thuốc trừ nấm (lỏng)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Phân bón lót (lỏng)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Phân bón lót (lỏng) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
     <e k="sf_bigBag_gypsum_name" v="Túi Thạch cao" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Cải tạo đất (khô)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Cải tạo đất (khô) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Túi Phân hữu cơ" eh="14322c5d" />
-    <e k="sf_bigBag_compost_function" v="Cải tạo đất hữu cơ (khô)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_function" v="Cải tạo đất hữu cơ (khô) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Túi Bùn thải" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Phân bón hữu cơ (khô)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="Phân bón hữu cơ (khô) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_chicken_manure_name" v="Túi Phân gà" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Phân bón hữu cơ (khô)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="Phân bón hữu cơ (khô) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
     <e k="sf_bigBag_pelletized_manure_name" v="Túi Phân viên" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Phân bón hữu cơ (khô)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Phân bón hữu cơ (khô) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
     <e k="sf_bigBag_liquidlime_name" v="Bình Vôi lỏng" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Chất tăng pH (lỏng)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="Chất tăng pH (lỏng) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
     <e k="sf_hud_title" v="GIÁM SÁT ĐẤT" eh="f8cda642" />
     <e k="sf_hud_field" v="Cánh đồng %d" eh="08988997" />
     <e k="sf_hud_noField" v="Hãy đi vào cánh đồng" eh="62c55e9e" />
@@ -512,6 +512,8 @@
     <e k="sf_treat_action_pest" v="Bón THUỐC TRỪ SÂU ngay lập tức." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Bón THUỐC TRỪ NẤM ngay lập tức." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." />
+    <e k="sf_detail_yield_optimal" v="Optimal" />
     <e k="sf_detail_rotation_bonus" v="Thưởng cây họ đậu (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Mệt mỏi (x1.15 cạn kiệt)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Không có dữ liệu." eh="c6d95d5e" />
@@ -523,6 +525,7 @@
     <e k="sf_hud_coverage" v="Độ phủ: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Phun: %d%% (%s)" eh="00000000" />
     <e k="sf_hud_compaction" v="Độ nén: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
 
     <e k="sf_sprayer_auto_on" v="TỶ LỆ BÓN ( TỰ ĐỘNG: BẬT )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TỶ LỆ BÓN  TỰ ĐỘNG: TẮT [%s]" eh="848cc106" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -140,6 +140,7 @@
     <e k="sf_map_title" v="Phân bón MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Phân bón DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kali 0-0-60 (K)" eh="8db6c54c" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
     <e k="sf_liquid_urea_title" v="Urê lỏng (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Amoni Sunfat lỏng (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP lỏng (P)" eh="3ce7c8c9" />
@@ -166,6 +167,8 @@
     <e k="sf_bigBag_dap_function" v="Phân bón lân (khô) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
     <e k="sf_bigBag_potash_name" v="Túi Kali 0-0-60" eh="eb771556" />
     <e k="sf_bigBag_potash_function" v="Phân bón kali (khô) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urê lỏng" eh="c40b906f" />
     <e k="sf_bigBag_liquid_urea_function" v="Phân bón đạm (lỏng) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS lỏng" eh="32e6c8bb" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -185,6 +185,7 @@
     <e k="sf_bigBag_gypsum_name" v="Túi Thạch cao" eh="40fc8169" />
     <e k="sf_bigBag_gypsum_function" v="Cải tạo đất (khô) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
     <e k="sf_bigBag_compost_name" v="Túi Phân hữu cơ" eh="14322c5d" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
     <e k="sf_bigBag_compost_function" v="Cải tạo đất hữu cơ (khô) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
     <e k="sf_bigBag_biosolids_name" v="Túi Bùn thải" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />

--- a/xml/gui/SoilFieldDetailDialog.xml
+++ b/xml/gui/SoilFieldDetailDialog.xml
@@ -63,8 +63,8 @@
       </GuiElement>
 
       <!-- ─── HISTORY ─── -->
-      <GuiElement profile="sfDetail_section2" position="0px -394px">
-        <Bitmap profile="sfDetail_sectionBg5" position="0px 0px"/>
+      <GuiElement profile="sfDetail_section3history" position="0px -394px">
+        <Bitmap profile="sfDetail_sectionBg3history" position="0px 0px"/>
         <Text profile="sfDetail_sectionHeader" text="$l10n_sf_detail_section_history" position="0px -5px"/>
 
         <Text profile="sfDetail_label" text="$l10n_sf_detail_last_crop_label" position="-240px -33px"/>
@@ -72,6 +72,10 @@
 
         <Text profile="sfDetail_label" text="$l10n_sf_detail_rotation_label"  position="-240px -58px"/>
         <Text profile="sfDetail_valueWide" id="detailRotation"  text="--"     position=" 80px  -58px"/>
+
+        <Text profile="sfDetail_label" text="$l10n_sf_detail_yield_eff_label" position="-240px -83px"/>
+        <Text profile="sfDetail_value"  id="detailYieldEff"    text="--"      position="-80px  -83px"/>
+        <Text profile="sfDetail_status" id="detailYieldEffStatus" text=""     position=" 90px  -83px"/>
       </GuiElement>
 
       <!-- No data fallback -->
@@ -91,7 +95,7 @@
   <GUIProfiles>
 
     <Profile name="sfDetail_bg" extends="fs25_dialogBg">
-      <size value="760px 590px"/>
+      <size value="760px 615px"/>
     </Profile>
 
     <!-- 5-row section (nutrients) -->
@@ -112,9 +116,18 @@
       <imageColor value="0.06 0.10 0.14 0.9"/>
     </Profile>
 
-    <!-- 2-row section (history) -->
+    <!-- 2-row section (history, legacy — unused) -->
     <Profile name="sfDetail_section2" extends="emptyPanel" with="anchorTopCenter">
       <size value="700px 91px"/>
+    </Profile>
+
+    <!-- 3-row history section -->
+    <Profile name="sfDetail_section3history" extends="emptyPanel" with="anchorTopCenter">
+      <size value="700px 116px"/>
+    </Profile>
+    <Profile name="sfDetail_sectionBg3history" extends="baseReference" with="anchorTopCenter">
+      <size value="700px 116px"/>
+      <imageColor value="0.08 0.08 0.12 0.9"/>
     </Profile>
 
     <!-- Section header: gold, bold, centered -->


### PR DESCRIPTION
## Summary

- **fix(#406)**: `isFertilizerApplicator` no longer caches `false` during mission load — fixes rate-control HUD panel never appearing on implements
- **fix(#401)**: Harvest/yield hooks fall back to cutter/header position when combine rootNode exits the field polygon — large combines now correctly attribute nutrient depletion
- **feat(#404)**: Polifoska 6-20-30 compound NPK fertilizer — new dry bulk bigbag (+4N +21P +50K ppm/ha @ 250 kg/ha), 26-language localization
- **debug(#390)**: Diagnostic logging added for multi-boom sprayer `usage=0` and VWW section path to diagnose JD R4940 weed pressure failure
- **fix**: Weed pressure formula was inverted (clean fields penalized, weedy fields not)
- **fix**: Rain effects (leaching/seasonal N) were silently not running due to bad hook target
- **i18n**: Hungarian full native translation by @MathiasHun
- **docs**: Complete [2.2.1.0] and long-missing [2.2.0.1] changelog sections
- Version bumped to 2.2.1.0

## Test plan

- [ ] Buy a Polifoska bigbag from the shop and fill a spreader — verify POLIFOSKA fill type accepted and nutrients increase
- [ ] Harvest with a large wide-platform combine (e.g. CR10.90) — verify nutrient depletion triggers correctly
- [ ] Attach a trailed sprayer to a tractor, apply fertilizer — verify rate-control HUD panel appears without restarting
- [ ] Enable debug mode (`SoilDebug`), spray with a JD R4940 — check log.txt for VWW section diagnostic lines
- [ ] Verify rain effects work: enable rain effects, trigger weather change, check N leaching
- [ ] Verify `sf_polifoska_title`, `sf_bigBag_polifoska_name` display correctly in shop and price table