### PR TITLE
feat: Disease Climate Moisture setting (Arid / Temperate / Humid / Wet)

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1011,11 +1011,14 @@ function SoilFertilitySystem:onFungicideApplied(fieldId, effectiveness)
     self.fungicideAppliedDay[fieldId] = today
 
     local dp = SoilConstants.DISEASE_PRESSURE
+    local cm = SoilConstants.DISEASE_CLIMATE_MOISTURE[self.settings.diseaseMoisture or 2]
+        or SoilConstants.DISEASE_CLIMATE_MOISTURE[2]
+
     local reduction = dp.FUNGICIDE_PRESSURE_REDUCTION * (effectiveness or 1.0)
     local before = field.diseasePressure or 0
     field.diseasePressure = math.max(0, before - reduction)
     local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
-    field.fungicideDaysLeft = dp.FUNGICIDE_DURATION_DAYS * daysPerMonth
+    field.fungicideDaysLeft = math.floor(dp.FUNGICIDE_DURATION_DAYS * cm.fungicideMult * daysPerMonth)
 
     self:log("[Fungicide] Field %d: disease pressure %.0f -> %.0f, protected for %d days",
         fieldId, before, field.diseasePressure, field.fungicideDaysLeft)
@@ -1761,6 +1764,9 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     -- ── Disease pressure daily growth ────────────────────────────────────────
     if self.settings.diseasePressure and SoilConstants.DISEASE_PRESSURE then
         local dp = SoilConstants.DISEASE_PRESSURE
+        local cm = SoilConstants.DISEASE_CLIMATE_MOISTURE[self.settings.diseaseMoisture or 2]
+            or SoilConstants.DISEASE_CLIMATE_MOISTURE[2]
+
         local isRaining = false
         if g_currentMission and g_currentMission.environment and g_currentMission.environment.weather then
             local rs = g_currentMission.environment.weather:getRainFallScale()
@@ -1778,10 +1784,10 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         end
 
         local pressure = field.diseasePressure or 0
+        local dryThreshold = cm.dryThreshold * daysPerMonth
 
-        -- Dry days threshold also scales
-        if (field.dryDayCount or 0) >= dp.DRY_DAYS_THRESHOLD * daysPerMonth then
-            field.diseasePressure = math.max(0, pressure - dp.DRY_DECAY_RATE * timeFactor)
+        if (field.dryDayCount or 0) >= dryThreshold then
+            field.diseasePressure = math.max(0, pressure - dp.DRY_DECAY_RATE * cm.dryDecayMult * timeFactor)
         elseif (field.fungicideDaysLeft or 0) <= 0 then
             local baseRate
             if     pressure < dp.LOW    then baseRate = dp.GROWTH_RATE_LOW
@@ -1804,8 +1810,8 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                 cropMult = dp.CROP_SUSCEPTIBILITY[string.lower(field.lastCrop)] or 1.0
             end
 
-            local rainBonus = isRaining and dp.RAIN_BONUS or 0
-            field.diseasePressure = math.min(100, pressure + ((baseRate * seasonMult * cropMult) + rainBonus) * timeFactor)
+            local rainBonus = isRaining and (dp.RAIN_BONUS * cm.rainBonusMult) or 0
+            field.diseasePressure = math.min(100, pressure + ((baseRate * cm.growthMult * seasonMult * cropMult) + rainBonus) * timeFactor)
         end
     end
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -901,6 +901,22 @@ SoilConstants.DISEASE_PRESSURE = {
 }
 
 -- ========================================
+-- DISEASE CLIMATE MOISTURE (1=Arid … 4=Wet)
+-- ========================================
+-- Each entry multiplies the disease-pressure constants at runtime.
+-- growthMult     : scales all four GROWTH_RATE_* tiers
+-- rainBonusMult  : scales RAIN_BONUS added per rainy day
+-- dryThreshold   : overrides DRY_DAYS_THRESHOLD (consecutive dry days before decay)
+-- dryDecayMult   : scales DRY_DECAY_RATE (pts/day removed during dry stretch)
+-- fungicideMult  : scales FUNGICIDE_DURATION_DAYS (shorter in wet climates)
+SoilConstants.DISEASE_CLIMATE_MOISTURE = {
+    [1] = { growthMult = 0.5,  rainBonusMult = 0.5,  dryThreshold = 2,  dryDecayMult = 1.5,  fungicideMult = 1.3  }, -- Arid
+    [2] = { growthMult = 1.0,  rainBonusMult = 1.0,  dryThreshold = 3,  dryDecayMult = 1.0,  fungicideMult = 1.0  }, -- Temperate (baseline)
+    [3] = { growthMult = 1.5,  rainBonusMult = 1.6,  dryThreshold = 6,  dryDecayMult = 0.5,  fungicideMult = 0.75 }, -- Humid
+    [4] = { growthMult = 2.0,  rainBonusMult = 2.5,  dryThreshold = 14, dryDecayMult = 0.2,  fungicideMult = 0.6  }, -- Wet
+}
+
+-- ========================================
 -- SOIL MAP OVERLAY (SoilMapOverlay.lua)
 -- ========================================
 -- Legend panel geometry expressed as fractions of the map render area.

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -166,6 +166,14 @@ SettingsSchema.definitions = {
         uiId = "sf_disease_pressure",
     },
     {
+        id = "diseaseMoisture",
+        type = "number",
+        default = 2,  -- 1=Arid, 2=Temperate, 3=Humid, 4=Wet
+        min = 1,
+        max = 4,
+        uiId = "sf_disease_moisture",
+    },
+    {
         id = "compactionEnabled",
         type = "boolean",
         default = true,

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -118,7 +118,7 @@ local CATEGORIES = {
             },
             {
                 headerKey = "sf_panel_hdr_crop_stress",
-                items     = { "weedPressure", "pestPressure", "diseasePressure", "compactionEnabled" }
+                items     = { "weedPressure", "pestPressure", "diseasePressure", "diseaseMoisture", "compactionEnabled" }
             },
         }
     },
@@ -164,6 +164,7 @@ local CATEGORIES = {
 local MULTI_OPTS = {
     difficulty        = {"sf_diff_1", "sf_diff_2", "sf_diff_3"},
     replenishmentRate = {"sf_rr_1", "sf_rr_2", "sf_rr_3", "sf_rr_4", "sf_rr_5"},
+    diseaseMoisture   = {"sf_dm_1", "sf_dm_2", "sf_dm_3", "sf_dm_4"},
     hudPosition       = {"sf_hud_pos_1", "sf_hud_pos_2", "sf_hud_pos_3",
                          "sf_hud_pos_4", "sf_hud_pos_5", "sf_hud_pos_6"},
     hudColorTheme     = {"sf_hud_color_1", "sf_hud_color_2", "sf_hud_color_3", "sf_hud_color_4"},
@@ -192,6 +193,7 @@ local SETTING_DESCS = {
     weedPressure      = "sf_desc_weedPressure",
     pestPressure      = "sf_desc_pestPressure",
     diseasePressure   = "sf_desc_diseasePressure",
+    diseaseMoisture   = "sf_desc_diseaseMoisture",
     compactionEnabled = "sf_desc_compactionEnabled",
     showHUD           = "sf_desc_showHUD",
     showMiniReport    = "sf_desc_showMiniReport",
@@ -242,6 +244,7 @@ local ADMIN_SECTIONS = {
             { stype = "setting", id = "seasonalEffects" },
             { stype = "setting", id = "rainEffects" },
             { stype = "setting", id = "plowingBonus" },
+            { stype = "setting", id = "diseaseMoisture" },
             { stype = "setting", id = "compactionEnabled" },
         },
     },

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Nível de dificuldade de gestão do solo" eh="d6f4560c" />
     <e k="sf_rr_short" v="Taxa de Reposição" eh="b363b336" />
     <e k="sf_rr_long" v="Quão rapidamente o fertilizante restaura os nutrientes do campo (0,25x Muito Lento a 2,0x Muito Rápido)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Controle automático de taxa" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automaticamente a taxa de aplicação com base nas necessidades do campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -641,6 +647,7 @@
     <e k="sf_desc_weedPressure" v="Rastrear e penalizar a propagação de ervas daninhas" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Rastrear infestação de pragas de insetos" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Rastrear doenças fúngicas de culturas" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactação do solo por veículos pesados" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nível de intensidade de drenagem de nutrientes" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Velocidade de restauração de nutrientes do fertilizante" eh="858d2b23" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Nivell de dificultat de la gestió del sòl" eh="d6f4560c" />
     <e k="sf_rr_short" v="Taxa de reposició" eh="b363b336" />
     <e k="sf_rr_long" v="Amb quina rapidesa el fertilitzant restaura els nutrients del camp (0,25x Molt lent a 2,0x Molt ràpid)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Control automàtic de la taxa" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automàticament la taxa d'aplicació del fertilitzant segons les necessitats del camp" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verd" eh="d382816a" />
@@ -640,6 +646,7 @@
     <e k="sf_desc_weedPressure" v="Seguiment i penalització de la propagació de males herbes" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Seguiment de la infestació de plagues d'insectes" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Seguiment de les malalties fúngiques dels cultius" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactació del sòl per vehicles pesants" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nivell d'intensitat de drenatge de nutrients" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Velocitat de restauració de nutrients del fertilitzant" eh="858d2b23" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Úroveň obtížnosti správy půdy" eh="d6f4560c" />
     <e k="sf_rr_short" v="Rychlost doplňování" eh="b363b336" />
     <e k="sf_rr_long" v="Jak rychle hnojivo obnovuje živiny v poli (0,25x Velmi pomalu až 2,0x Velmi rychle)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automatické řízení dávky" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automaticky upravuje dávku hnojiva podle potřeb pole" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Zelený" eh="d382816a" />
@@ -640,6 +646,7 @@
     <e k="sf_desc_weedPressure" v="Sledovat a penalizovat šíření plevele" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Sledovat napadení hmyzími škůdci" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Sledovat plísňové choroby plodin" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Zhutňování půdy těžkými vozidly" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Úroveň intenzity odčerpávání živin" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Rychlost obnovy živin hnojivem" eh="858d2b23" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Sværhedsgrad for jordstyring" eh="d6f4560c" />
     <e k="sf_rr_short" v="Genopfyldningshastighed" eh="b363b336" />
     <e k="sf_rr_long" v="Hvor hurtigt gødning genopretter næringsstoffer i marken (0,25x meget langsomt til 2,0x meget hurtigt)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automatisk hastighedskontrol" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerer automatisk gødningsraten baseret på markens behov" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grøn" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Spor og straf ukrudtsspredning" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Spor insektangreb" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Spor svampesygdomme" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Jordpakning fra tunge køretøjer" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensitet af næringsstofdræn" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Hastighed for gødningsgenopbygning" eh="858d2b23" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Schwierigkeitsgrad der Bodenverwaltung" eh="d6f4560c" />
     <e k="sf_rr_short" v="Wiederauffüllrate" eh="b363b336" />
     <e k="sf_rr_long" v="Wie schnell Dünger Feldnährstoffe wiederherstellt (0,25x sehr langsam bis 2,0x sehr schnell)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automatische Ratensteuerung" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Passt die Düngerrate automatisch an den Bedarf des Feldes an" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grün" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Unkrautausbreitung verfolgen und bestrafen" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Insektenbefall verfolgen" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Pilzkrankheiten verfolgen" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Bodenverdichtung durch schwere Fahrzeuge" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensität des Nährstoffentzugs" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Geschwindigkeit der Nährstoffwiederherstellung" eh="858d2b23" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Nivel de dificultad de gestión del suelo" eh="d6f4560c" />
     <e k="sf_rr_short" v="Tasa de Reposición" eh="b363b336" />
     <e k="sf_rr_long" v="Rapidez con la que el fertilizante restaura los nutrientes (0.25x Muy Lento a 2.0x Muy Rápido)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Control de Tasa Automático" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automáticamente la tasa de aplicación según las necesidades del campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Seguimiento y penalización por maleza" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Seguimiento de infestación por insectos" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Seguimiento de enfermedades fúngicas" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactación por vehículos pesados" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nivel de intensidad de drenaje" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Velocidad de restauración de nutrientes" eh="858d2b23" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Soil management difficulty level" eh="d6f4560c" />
     <e k="sf_rr_short" v="Replenishment Rate" eh="b363b336" />
     <e k="sf_rr_long" v="How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="Disease Climate" />
+    <e k="sf_dm_long" v="Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="Arid" />
+    <e k="sf_dm_2" v="Temperate" />
+    <e k="sf_dm_3" v="Humid" />
+    <e k="sf_dm_4" v="Wet" />
     <e k="sf_auto_rate_short" v="Auto Rate Control" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatically adjusts fertilizer application rate based on field needs" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Green" eh="d382816a" />
@@ -640,6 +646,7 @@
     <e k="sf_desc_weedPressure" v="Track and penalize weed spread" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Track insect pest infestation" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Track fungal crop diseases" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Heavy vehicle soil compaction" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nutrient drain intensity level" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Fertilizer nutrient restoration speed" eh="858d2b23" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Nivel de dificultad de gestión del suelo" eh="d6f4560c" />
     <e k="sf_rr_short" v="Tasa de reposición" eh="b363b336" />
     <e k="sf_rr_long" v="Rapidez con la que el fertilizante restaura los nutrientes (0.25x muy lento a 2.0x muy rápido)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Control tasa automático" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automáticamente la tasa de aplicación según las necesidades del campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Seguimiento y penalización por maleza" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Seguimiento de infestación por insectos" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Seguimiento de enfermedades fúngicas" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactación por vehículos pesados" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nivel de intensidad de drenaje" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Velocidad de restauración de nutrientes" eh="858d2b23" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Niveau de difficulté de gestion du sol" eh="d6f4560c" />
     <e k="sf_rr_short" v="Taux de réapprovisionnement" eh="b363b336" />
     <e k="sf_rr_long" v="Vitesse à laquelle l'engrais restaure les nutriments du champ (0.25x très lent à 2.0x très rapide)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Contrôle de débit automatique" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajuste automatiquement le débit d'application d'engrais selon les besoins du champ" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Vert" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Suivre et pénaliser les herbes" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Suivre les infestations d'insectes" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Suivre les maladies fongiques" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactage par les véhicules lourds" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Niveau d'intensité d'épuisement" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Vitesse de restauration des nutriments" eh="858d2b23" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Maaperänhallinnan vaikeustaso" eh="d6f4560c" />
     <e k="sf_rr_short" v="Täyttymisnopeus" eh="b363b336" />
     <e k="sf_rr_long" v="Kuinka nopeasti lannoite palauttaa pellon ravinteet (0,25x erittäin hidas – 2,0x erittäin nopea)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automaattinen annostelun hallinta" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Säätää lannoitteen levitysmäärän automaattisesti pellon tarpeiden mukaan" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Vihreä" eh="d382816a" />
@@ -603,6 +609,7 @@
     <e k="sf_desc_weedPressure" v="Seuraa rikkakasvien leviämistä" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Seuraa tuholaisten esiintymistä" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Seuraa kasvitautien esiintymistä" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Raskaiden koneiden aiheuttama tiivistyminen" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Ravinteiden kulumisnopeuden taso" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Lannoituksen palautumisnopeus" eh="858d2b23" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Niveau de difficulté de la gestion du sol" eh="d6f4560c" />
     <e k="sf_rr_short" v="Taux de reconstitution" eh="b363b336" />
     <e k="sf_rr_long" v="Vitesse à laquelle l'engrais restaure les nutriments du champ (0.25x très lent à 2.0x très rapide)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Contrôle automatique du taux" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajuste automatiquement la dose d'engrais selon les besoins du champ" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Vert" eh="d382816a" />
@@ -631,6 +637,7 @@
     <e k="sf_desc_weedPressure" v="Suivi et pénalisation de la propagation des mauvaises herbes" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Suivi des infestations d'insectes ravageurs" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Suivi des maladies fongiques des cultures" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compaction du sol par les véhicules lourds" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Niveau d'intensité de l'épuisement des nutriments" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Vitesse de restauration des nutriments par les engrais" eh="858d2b23" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Talajkezelés nehézségi szintje" eh="d6f4560c" />
     <e k="sf_rr_short" v="Feltöltési sebesség" eh="b363b336" />
     <e k="sf_rr_long" v="Milyen gyorsan állítja vissza a műtrágya a terület tápanyagait (0.25x Nagyon lassú - 2.0x Nagyon gyors)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automatikus adagolás vezérlés" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatikusan állítja be a műtrágya kijuttatási arányát a terület igényei alapján" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Zöld" eh="d382816a" />
@@ -621,6 +627,7 @@
     <e k="sf_desc_weedPressure" v="Gyomterjedés követése és büntetése" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Rovarkártevő fertőzések követése" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Gombás növénybetegségek követése" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Nehézgépjárművek okozta talajtömörödés" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Tápanyag-fogyasztás intenzitása" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Műtrágya tápanyag-visszapótlási sebessége" eh="858d2b23" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -59,6 +59,12 @@
 		<e k="sf_diff_long" v="Tingkat kesulitan pengelolaan tanah" eh="d6f4560c" />
     <e k="sf_rr_short" v="Laju Pemulihan" eh="b363b336" />
     <e k="sf_rr_long" v="Seberapa cepat pupuk memulihkan nutrisi lahan (0.25x Sangat Lambat hingga 2.0x Sangat Cepat)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Kontrol Laju Otomatis" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Secara otomatis menyesuaikan laju aplikasi pupuk berdasarkan kebutuhan lahan" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Hijau" eh="d382816a" />
@@ -640,6 +646,7 @@
     <e k="sf_desc_weedPressure" v="Lacak dan beri penalti penyebaran gulma" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Lacak serangan hama serangga" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Lacak penyakit jamur tanaman" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Pemadatan tanah kendaraan berat" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Tingkat intensitas penipisan nutrisi" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Kecepatan pemulihan nutrisi pupuk" eh="858d2b23" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Livello difficoltà gestione suolo" eh="d6f4560c" />
     <e k="sf_rr_short" v="Tasso di ripristino" eh="b363b336" />
     <e k="sf_rr_long" v="Velocità con cui il fertilizzante ripristina i nutrienti (da 0.25x Molto lento a 2.0x Molto veloce)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Controllo dose auto" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Regola automaticamente il tasso di applicazione in base alle esigenze del campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -640,6 +646,7 @@
     <e k="sf_desc_weedPressure" v="Monitora e penalizza la diffusione delle erbacce" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Monitora l'infestazione di insetti nocivi" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Monitora le malattie fungine delle colture" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compattazione del suolo da veicoli pesanti" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Livello di intensità del consumo di nutrienti" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Velocità di ripristino nutrienti del fertilizzante" eh="858d2b23" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -59,6 +59,12 @@
 		<e k="sf_diff_long" v="土壌管理の難易度レベル" eh="d6f4560c" />
     <e k="sf_rr_short" v="補充率" eh="b363b336" />
     <e k="sf_rr_long" v="肥料がフィールドの養分を回復する速さ（0.25x 極めて遅い 〜 2.0x 極めて速い）" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="自動レート制御" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="圃場の状態に基づいて肥料散布量を自動調整します" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="グリーン" eh="d382816a" />
@@ -626,6 +632,7 @@
     <e k="sf_desc_weedPressure" v="雑草の広がりを追跡し、収量に反映させます" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="害虫の発生を追跡します" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="菌類による作物の病害を追跡します" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="重量車両による土壌の踏み固め" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="養分消耗の激しさのレベル" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="肥料による養分回復の速さ" eh="858d2b23" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="토양 관리 난이도 수준" eh="d6f4560c" />
     <e k="sf_rr_short" v="보충 속도" eh="b363b336" />
     <e k="sf_rr_long" v="비료가 필드 영양분을 복구하는 속도 (0.25x 매우 느림 ~ 2.0x 매우 빠름)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="자동 살포량 제어" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="필드 필요량에 따라 비료 살포량을 자동으로 조절합니다" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="초록" eh="d382816a" />
@@ -627,6 +633,7 @@
     <e k="sf_desc_weedPressure" v="잡초 확산 추적 및 불이익 부여" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="곤충 해충 발생 추적" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="균류 작물 병해 추적" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="대형 차량에 의한 토양 압축" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="영양분 소모 강도 수준" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="비료 영양분 복구 속도" eh="858d2b23" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Moeilijkheidsgraad bodembeheer" eh="d6f4560c" />
     <e k="sf_rr_short" v="Aanvullingssnelheid" eh="b363b336" />
     <e k="sf_rr_long" v="Hoe snel meststof de veldvoedingsstoffen herstelt (0,25x Zeer langzaam tot 2,0x Zeer snel)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automatische snelheidscontrole" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Past automatisch de bemestingssnelheid aan op basis van veldbehoeften" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Groen" eh="d382816a" />
@@ -628,6 +634,7 @@
     <e k="sf_desc_weedPressure" v="Onkruidverspreiding bijhouden en bestraffen" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Insectenplagen bijhouden" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Schimmelziekten bijhouden" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Bodemverdichting door zware voertuigen" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensiteitsniveau van nutriëntenafvoer" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Snelheid van nutriëntenherstel door meststof" eh="858d2b23" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Vanskelighetsgrad for jordforvaltning" eh="d6f4560c" />
     <e k="sf_rr_short" v="Påfyllingsrate" eh="b363b336" />
     <e k="sf_rr_long" v="Hvor raskt gjødsel gjenoppretter jordens næringsstoffer (0,25x veldig sakte til 2,0x veldig raskt)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Automatisk ratekontroll" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerer automatisk gjødslingsraten basert på jordbehov" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grønn" eh="d382816a" />
@@ -628,6 +634,7 @@
     <e k="sf_desc_weedPressure" v="Spor og straff ugressspredning" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Spor angrep av skadedyr" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Spor soppsykdommer på avlinger" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Jordpakking fra tunge kjøretøy" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensitetsnivå for næringstap" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Gjenopprettingshastighet for næringsstoffer fra gjødsel" eh="858d2b23" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Poziom trudności zarządzania glebą" eh="d6f4560c" />
     <e k="sf_rr_short" v="Tempo uzupełniania" eh="b363b336" />
     <e k="sf_rr_long" v="Jak szybko nawóz przywraca składniki odżywcze pola (0.25x Bardzo wolno do 2.0x Bardzo szybko)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Auto kontrola dawki" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatycznie dostosowuje dawkę nawożenia na podstawie potrzeb pola" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Zielony" eh="d382816a" />
@@ -628,6 +634,7 @@
     <e k="sf_desc_weedPressure" v="Śledź i karz rozprzestrzenianie chwastów" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Śledź infestację szkodnikami" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Śledź choroby grzybowe upraw" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Zagęszczanie gleby przez ciężkie pojazdy" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Poziom intensywności drenażu składników" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Prędkość przywracania składników przez nawóz" eh="858d2b23" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Nível de dificuldade de gestão do solo" eh="d6f4560c" />
     <e k="sf_rr_short" v="Taxa de Reposição" eh="b363b336" />
     <e k="sf_rr_long" v="Quão rapidamente o fertilizante restaura os nutrientes do campo (0.25x Muito Lento a 2.0x Muito Rápido)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Controlo automático de taxa" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajusta automaticamente a taxa de aplicação com base nas necessidades do campo" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -641,6 +647,7 @@
     <e k="sf_desc_weedPressure" v="Monitorizar e penalizar propagação de ervas daninhas" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Monitorizar infestação de pragas de insetos" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Monitorizar doenças fúngicas das culturas" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactação do solo por veículos pesados" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nível de intensidade de drenagem de nutrientes" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Velocidade de restauração de nutrientes do fertilizante" eh="858d2b23" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Nivelul de dificultate al managementului solului" eh="d6f4560c" />
     <e k="sf_rr_short" v="Rată de Refacere" eh="b363b336" />
     <e k="sf_rr_long" v="Cât de repede îngrășământul restabilește nutrienții câmpului (0.25x Foarte Lent la 2.0x Foarte Rapid)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Control Automat Rată" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajustează automat rata de aplicare a îngrășământului în funcție de nevoile câmpului" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Verde" eh="d382816a" />
@@ -641,6 +647,7 @@
     <e k="sf_desc_weedPressure" v="Urmărește și penalizează răspândirea buruienilor" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Urmărește infestarea cu insecte dăunători" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Urmărește bolile fungice ale culturilor" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Compactarea solului de către vehiculele grele" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nivelul de intensitate al drenajului de nutrienți" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Viteza de restabilire a nutrienților prin îngrășământ" eh="858d2b23" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Уровень сложности управления почвой" eh="d6f4560c" />
     <e k="sf_rr_short" v="Скорость восполнения" eh="b363b336" />
     <e k="sf_rr_long" v="Насколько быстро удобрения восстанавливают питательные вещества в поле (от 0,25x - очень медленно до 2,0x - очень быстро)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Автоматическое управление нормой" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Автоматически регулирует норму внесения удобрений в зависимости от потребностей поля" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Зеленый" eh="d382816a" />
@@ -596,6 +602,7 @@
     <e k="sf_desc_weedPressure" v="Распространение сорняков" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Заражение вредителями" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Грибковые заболевания" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Уплотнение тяжелой техникой" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Интенсивность истощения" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Скорость восполнения элементов" eh="858d2b23" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Svårighetsgrad för markförvaltning" eh="d6f4560c" />
     <e k="sf_rr_short" v="Påfyllningshastighet" eh="b363b336" />
     <e k="sf_rr_long" v="Hur snabbt gödsel återställer fältnäring (0.25x Mycket långsamt till 2.0x Mycket snabbt)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Auto-dosering" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerar automatiskt gödselspridning baserat på fältets behov" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grön" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Spåra och bestraffa ogrässpridning" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Spåra insekts- och skadedjursangrepp" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Spåra svamp- och grödosjukdomar" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Markpackning från tunga fordon" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensitetsnivå för näringsdränering" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Återställningshastighet för gödselnäring" eh="858d2b23" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Toprak yönetimi zorluk seviyesi" eh="d6f4560c" />
     <e k="sf_rr_short" v="İkmal Oranı" eh="b363b336" />
     <e k="sf_rr_long" v="Gübre tarladaki besinleri ne kadar hızlı geri kazandırır (0.25x Çok Yavaş - 2.0x Çok Hızlı)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Otomatik Oran Kontrolü" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Tarla ihtiyaçlarına göre gübre uygulama oranını otomatik olarak ayarlar" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Yeşil" eh="d382816a" />
@@ -603,6 +609,7 @@
     <e k="sf_desc_weedPressure" v="Yabancı ot yayılımını takip edin ve cezalandırın" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Böcek zararlı istilasını takip edin" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Mantar kökenli ürün hastalıklarını takip edin" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Ağır vasıta toprak sıkışması" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Besin tükenme yoğunluğu seviyesi" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Gübre besin maddesi geri kazanım hızı" eh="858d2b23" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Рівень складності управління ґрунтом" eh="d6f4560c" />
     <e k="sf_rr_short" v="Швидкість відновлення" eh="b363b336" />
     <e k="sf_rr_long" v="Як швидко добрива відновлюють поживні речовини (0.25x дуже повільно, 2.0x дуже швидко)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Автоматична норма" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Автоматично регулює норму внесення добрив відповідно до потреб поля" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Зелений" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Відстеження та штраф за бур'яни" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Відстеження зараження шкідниками" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Відстеження грибкових хвороб" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Ущільнення ґрунту важкою технікою" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Інтенсивність виснаження речовин" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Швидкість відновлення добривами" eh="858d2b23" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -59,6 +59,12 @@
     <e k="sf_diff_long" v="Mức độ khó quản lý đất" eh="d6f4560c" />
     <e k="sf_rr_short" v="Tỷ lệ bổ sung" eh="b363b336" />
     <e k="sf_rr_long" v="Tốc độ phân bón phục hồi dinh dưỡng (0.25x Rất chậm đến 2.0x Rất nhanh)" eh="afe78a6d" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
+    <e k="sf_dm_1" v="[EN] Arid" />
+    <e k="sf_dm_2" v="[EN] Temperate" />
+    <e k="sf_dm_3" v="[EN] Humid" />
+    <e k="sf_dm_4" v="[EN] Wet" />
     <e k="sf_auto_rate_short" v="Kiểm soát tỷ lệ tự động" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Tự động điều chỉnh tỷ lệ bón phân dựa trên nhu cầu của cánh đồng" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Xanh lá" eh="d382816a" />
@@ -602,6 +608,7 @@
     <e k="sf_desc_weedPressure" v="Theo dõi và phạt khi cỏ dại lan rộng" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Theo dõi sự xâm nhiễm của sâu bệnh" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Theo dõi các bệnh hại cây trồng do nấm" eh="0858395f" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
     <e k="sf_desc_compactionEnabled" v="Nén đất do xe hạng nặng" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Mức độ cường độ rút dinh dưỡng" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Tốc độ phục hồi dinh dưỡng của phân bón" eh="858d2b23" />


### PR DESCRIPTION
## Summary

- Adds a new admin-controlled **Disease Climate Moisture** setting (4 levels) that scales all disease pressure mechanics to match the map's real-world climate
- Closes #408 — request for more realistic fungicide behaviour on UK/humid maps

## What changed

**`src/config/Constants.lua`** — New `DISEASE_CLIMATE_MOISTURE` lookup table with per-level multipliers:
| Level | Growth | Rain bonus | Dry threshold | Dry decay | Fungicide duration |
|-------|--------|------------|---------------|-----------|-------------------|
| Arid | ×0.5 | ×0.5 | 2 days | ×1.5 | ×1.3 |
| Temperate | ×1.0 | ×1.0 | 3 days | ×1.0 | ×1.0 |
| Humid | ×1.5 | ×1.6 | 6 days | ×0.5 | ×0.75 |
| Wet | ×2.0 | ×2.5 | 14 days | ×0.2 | ×0.60 |

**`src/config/SettingsSchema.lua`** — `diseaseMoisture` (number, default 2 = Temperate, min 1, max 4)

**`src/SoilFertilitySystem.lua`** — Climate multipliers applied in:
- Daily disease growth block (growth rate, rain bonus, dry threshold, dry decay)
- `onFungicideApplied` (fungicide duration scaled by `fungicideMult`)

**`src/ui/SoilSettingsPanel.lua`** — Setting surfaced in Crop Stress section and admin panel; `MULTI_OPTS` and `SETTING_DESCS` entries added

**`translations/`** — EN keys added; all 25 other languages get `[EN]` prefixed strings awaiting community translation

## Behaviour in Wet mode (UK-style maps)

- Disease grows 2× faster at every pressure tier
- Rain adds 2.5× more pressure than baseline
- Disease only starts to decay after **14+ consecutive dry days** — almost never happens
- Fungicide lasts ~21 days instead of 35, making T1–T2–T3 timing genuinely necessary

## Backwards compatibility

Default is **Temperate** — identical to previous behaviour. No save migration needed.

## Test plan

- [ ] Settings panel shows "Disease Climate" row under Crop Stress with 4 options
- [ ] Switching to Wet: disease pressure climbs noticeably faster; fungicide applied mid-season expires before harvest
- [ ] Switching to Arid: disease barely grows; dry weather decays it quickly
- [ ] Default (Temperate): behaviour matches previous release
- [ ] Multiplayer: setting change syncs to all clients via existing `SoilSettingsEvent` path