### PR TITLE
fix: section control overlap + AN fill type remap; bump to v2.2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,29 +29,13 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 
 ---
 
-## 🆕 What's New in v2.2.0
+## 🆕 What's New in v2.2.2.0
 
-### Precision Farming DLC Support
-If you run the Precision Farming DLC, the soil HUD bars now read **live sensor data** as you drive. Nitrogen, Phosphorus and Potassium update in real time across different parts of the field — you'll see the variation with your own eyes as you cross from a worked strip into an untouched one.
+### Section Control Overlap Fix (Precision Farming)
+Section control with the Precision Farming DLC now correctly **closes individual boom sections over already-fertilized areas while the sprayer is moving** — not just at headland/field boundaries. Previously, all sections opened the moment you drove back onto the field, even over soil that was 100% at target nutrient levels. This fix resolves the issue reported by community member Tomi89.
 
-### The Map Finally Shows What's Happening in Each Spot
-The soil overlay has been rebuilt to show **real per-zone data**, not just a single colour for the whole field. Lime the east half of a field and come back — the east shows green (optimal), the west still shows yellow (acidic). Two halves of the same field, two different stories.
-
-Over-limed areas (pH above 7.0) now correctly show **red**. Too much lime locks out nutrients just like too little does. The map now makes that visible.
-
-### Click a Tile — See Only What Matters
-The info box that pops up when you click a map tile is now **layer-specific**. On the pH layer you see: your pH reading, what that means (*Optimal*, *Acidic*, *Over-limed*), and exactly what to do about it. On the Nitrogen layer you see: your current N level, the target for the crop you're growing, and how many ppm you're over or under. No more scrolling through eight rows of numbers to find the one thing you're looking for.
-
-### "How Much More Does My Crop Actually Need?"
-The N, P and K tooltips now pull in the **nutrient target for your specific crop**. Wheat has different N needs than potatoes. The tooltip shows the target for what's in the ground right now and tells you whether you're above it, hitting it, or short — and by exactly how much.
-
-### Treatment Status at a Glance
-The Weed, Pest and Disease map layers now show whether a protection product is still active on that tile. Green means you're covered. Amber means the pressure is building and nothing's been applied. No guessing whether your herbicide from last week is still doing its job.
-
-### Fixes
-- N bar tick marks and crop targets now work correctly when Precision Farming mod is active
-- Straw chopping now builds Organic Matter correctly based on your field's actual size (was previously using concentration instead of area)
-- Map tiles now refresh immediately when clicked — no more stale colors after applying lime or fertilizer
+### Startup Loader Fix
+`SoilMapCellDialog` (the Shift+S map tile popup) was silently never registering because its class file was missing from the mod's load chain. It now loads correctly on every startup.
 
 ---
 
@@ -408,7 +392,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.1.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.2.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.1.0</version>
+    <version>2.2.2.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -377,7 +377,7 @@ function HookManager:registerCustomSprayTypes()
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH",
                           "LIQUIDMANURE", "MANURE", "DIGESTATE" }
     -- Granular/solid types → inherit visual from FERTILIZER
-    local solidNames  = { "UREA", "AMS", "MAP", "DAP", "POTASH",
+    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
 
     local registered = 0
@@ -457,7 +457,7 @@ function HookManager:installEffectTypeHook()
     -- Build remap: customFillTypeIndex → vanillaFillTypeIndex
     local remap = {}
     if fertIdx then
-        for _, name in ipairs({ "UREA", "AMS", "MAP", "DAP", "POTASH",
+        for _, name in ipairs({ "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
                                  "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }) do
             local idx = fm:getFillTypeIndexByName(name)
             if idx then remap[idx] = fertIdx end
@@ -616,7 +616,7 @@ end
 ---@return boolean success
 function HookManager:installSprayTypeEffectsHook()
     -- Solid custom types visually match FERTILIZER spreading
-    local solidNames  = { "UREA", "AMS", "MAP", "DAP", "POTASH",
+    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
     -- Liquid custom types visually match LIQUIDFERTILIZER spraying
     local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
@@ -798,7 +798,7 @@ function HookManager:installDensityMapSprayHook()
     local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
                           "INSECTICIDE", "FUNGICIDE",
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
-    local solidNames  = { "UREA", "AMS", "MAP", "DAP", "POTASH",
+    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
 
     local remap = {}
@@ -823,26 +823,31 @@ function HookManager:installDensityMapSprayHook()
     local count = 0
     for _ in pairs(remap) do count = count + 1 end
 
-    -- Append to onStartWorkAreaProcessing (event listener — dynamic lookup, reaches all vehicles).
-    -- After the original resolves wap.sprayType = getSprayTypeIndexByFillTypeIndex(fillType),
-    -- remap any custom index to the vanilla equivalent so processSprayerArea passes a valid
-    -- C++ index to FSDensityMapUtil.updateSprayArea.
+    -- MUST use appendedFunction (not prependedFunction) — fix for issue #415 (section control).
+    --
+    -- WHY APPEND:
+    --   onStartWorkAreaProcessing (original) sets wap.sprayType = getSprayTypeIndexByFillTypeIndex(fillType).
+    --   A prepended hook runs BEFORE the original, so the original's assignment overwrites the remap every
+    --   frame. processSprayerArea then calls FSDensityMapUtil.updateSprayArea with our custom index, which
+    --   C++ doesn't recognise → silently writes nothing → returns changedArea=0 always → PF's inside-field
+    --   section control (which reads changedArea to detect already-treated areas) gets no signal → sections
+    --   stay open over fertilised soil while moving.
+    --
+    --   With APPEND the remap runs AFTER the original sets wap.sprayType. processSprayerArea receives the
+    --   vanilla index → updateSprayArea writes the density map correctly → changedArea reflects actual soil
+    --   state → overlap-prevention section control works while moving (fix for Tomi89's Discord report).
+    --
+    -- WHY THIS IS SAFE FOR TANK DRAIN:
+    --   getSprayerUsage(fillType, dt) uses the fill type (not wap.sprayType) to look up LPS from
+    --   g_sprayTypeManager. Our custom fill types are registered there with their correct application
+    --   rates, so tank drain is unaffected by what wap.sprayType contains.
     local original = Sprayer.onStartWorkAreaProcessing
-    Sprayer.onStartWorkAreaProcessing = Utils.prependedFunction(
+    Sprayer.onStartWorkAreaProcessing = Utils.appendedFunction(
         original,
         function(sprayerSelf, dt)
             local spec = sprayerSelf.spec_sprayer
             local wap  = spec and spec.workAreaParameters
             if not wap then return end
-
-            -- If sprayType is nil (vehicle loaded before our custom types were registered),
-            -- try to resolve it now from sprayFillType so the remap below can fire.
-            -- MUST run as prependedFunction (before vanilla + processSprayerArea) so that
-            -- wap.sprayType is valid when processSprayerArea calls getSprayerUsage.
-            -- A nil sprayType causes lps=nil → usage=0 → tank never depletes for solid types.
-            if not wap.sprayType and wap.sprayFillType and wap.sprayFillType > 0 then
-                wap.sprayType = g_sprayTypeManager:getSprayTypeIndexByFillTypeIndex(wap.sprayFillType)
-            end
 
             if wap.sprayType then
                 local vanillaIdx = remap[wap.sprayType]
@@ -855,7 +860,7 @@ function HookManager:installDensityMapSprayHook()
     self:register(Sprayer, "onStartWorkAreaProcessing", original,
         "Sprayer.onStartWorkAreaProcessing (density map sprayType remap)")
 
-    SoilLogger.info("[OK] DensityMap spray hook installed on onStartWorkAreaProcessing — %d custom spray types remapped to vanilla for C++ density map call", count)
+    SoilLogger.info("[OK] DensityMap spray hook installed on onStartWorkAreaProcessing (APPEND) — %d custom spray types remapped to vanilla for C++ density map call; section control overlap fix active", count)
     return true
 end
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,21 +24,12 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.2.1.0",
-    "- NEW  Polifoska 6-20-30 compound NPK fertilizer — buy as a 1 000 L big bag",
-    "- NEW  Yield efficiency indicator on the HUD — see your field's harvest modifier",
-    "- NEW  Treatment rate panel — recommended application rate shown for active product",
-    "- NEW  Hungarian translation — full native translation by @MathiasHun",
-    "- Fixed Sprayer implements permanently showing 'not a fertilizer applicator' after load",
-    "  (rate-control HUD panel now appears correctly on first use without restarting)",
-    "- Fixed Large combine headers missing field detection — nutrient depletion now",
-    "  uses the cutter/header position when the combine body is outside the polygon",
-    "- Fixed Weed pressure formula was inverted — clean fields had full penalty applied,",
-    "  weedy fields had none. Corrected; weed penalties now match actual field state",
-    "- Fixed Weeds showing 100% on bare / never-farmed fields",
-    "- Fixed Rain effects (leaching, seasonal N) were silently not running",
-    "- Fixed Weed/pest/disease penalties applied even when nutrient cycles disabled",
-    "- Fixed pfCompatibilityMode toggle now takes effect immediately without reload",
+    "v2.2.2.0",
+    "- Fixed Section control overlap prevention not working while moving with Precision",
+    "  Farming active — sections now correctly close over already-fertilized areas",
+    "  inside the field, not just at headland/field boundaries (#415)",
+    "- Fixed SoilMapCellDialog class not loaded on mod startup — no-op guard meant",
+    "  the Shift+S map cell popup silently never registered (#tools)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Fix #415** (Tomi89 Discord report — section control inside-field overlap):
  `installDensityMapSprayHook` switched from `Utils.prependedFunction` to `Utils.appendedFunction` on `Sprayer.onStartWorkAreaProcessing`. Root cause: the vanilla original sets `wap.sprayType` every frame, overwriting any prepended remap. C++ `FSDensityMapUtil.updateSprayArea` then received an unrecognised custom index, silently returned `changedArea=0`, and PF's overlap detection had no signal — sections stayed open over 100%-fertilised soil while moving. Appended hook runs after the original, so `updateSprayArea` receives a valid vanilla spray type index and `changedArea` reflects actual ground state.

- **Fix Discord AN error** (`FertilizerMotionPathEffect`): Added `"AN"` (Ammonium Nitrate) to `solidNames` in all four hook functions: `registerCustomSprayTypes`, `installEffectTypeHook`, `installSprayTypeEffectsHook`, `installDensityMapSprayHook`.

- **SoilMapCellDialog** (prior commit `f7296b5`): Added missing `source()` call in `main.lua` — Shift+S map cell popup silently never registered.

- **Version bump**: `2.2.1.0` → `2.2.2.0` (`modDesc.xml`, `README.md`, `SoilVersionDialog` changelog).

## Test plan

- [ ] Load savegame with a custom fertilizer (UREA, AN, UAN32, etc.) in a sprayer
- [ ] Enable Precision Farming section control
- [ ] Drive over a field already at 100% — sections should close while moving (not just at 0 km/h)
- [ ] Verify no `FertilizerMotionPathEffect` error for `fillType 'AN'` in log.txt
- [ ] Verify Shift+S map cell popup opens correctly
- [ ] Check tank drain rate is unchanged for all custom fill types