### PR TITLE
v2.2.2.1 — Hotfix: nil crash in HUD on first draw frame

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.2.0</version>
+    <version>2.2.2.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1022,7 +1022,7 @@ function SoilHUD:drawPanel()
 
     cy = cy - SoilHUD.LINE_H * s
     setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-    renderText(tx, cy, 0.010 * fontMult * s, fieldText)
+    renderText(tx, cy, 0.010 * fontMult * s, fieldText or "")
     if cropText then
         setTextAlignment(RenderText.ALIGN_RIGHT)
         setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], SoilHUD.C_DIM[4])


### PR DESCRIPTION
## Summary

- Fix `renderText` crash when `fieldText` is nil before the first 2Hz refresh cycle runs

## Details

On the very first draw frame after loading, `SoilHUD.drawPanel` could call `renderText` with a nil string argument because `_fmt_fieldText` is only populated by the throttled `refreshFieldData` function. Added an `or ""` guard to prevent the script error.

Reported in the wild by an external user — reproducible on any install.

## Migration

No save migration needed. Drop-in replacement.