### PR TITLE
hotfix: unbound keybindings + cell map improvements v2.2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.2.2
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.2.3
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.2.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.2.2
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.2.2</version>
+    <version>2.2.2.3</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>
@@ -82,33 +82,15 @@
     <l10n filenamePrefix="translations/translation" />
 
     <inputBinding>
-        <actionBinding action="SF_TOGGLE_HUD">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_J" />
-        </actionBinding>
-        <actionBinding action="SF_SOIL_REPORT">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_K" />
-        </actionBinding>
-        <actionBinding action="SF_RATE_UP">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_RIGHTBRACKET" />
-        </actionBinding>
-        <actionBinding action="SF_RATE_DOWN">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_LEFTBRACKET" />
-        </actionBinding>
-        <actionBinding action="SF_TOGGLE_AUTO">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_l" />
-        </actionBinding>
-        <actionBinding action="SF_CYCLE_MAP_LAYER">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_m" />
-        </actionBinding>
-        <actionBinding action="SF_OPEN_SETTINGS">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_o" />
-        </actionBinding>
-        <actionBinding action="SF_HUD_DRAG">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h" />
-        </actionBinding>
-        <actionBinding action="SF_TOGGLE_CELL_MAP">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_F7" />
-        </actionBinding>
+        <actionBinding action="SF_TOGGLE_HUD" />
+        <actionBinding action="SF_SOIL_REPORT" />
+        <actionBinding action="SF_RATE_UP" />
+        <actionBinding action="SF_RATE_DOWN" />
+        <actionBinding action="SF_TOGGLE_AUTO" />
+        <actionBinding action="SF_CYCLE_MAP_LAYER" />
+        <actionBinding action="SF_OPEN_SETTINGS" />
+        <actionBinding action="SF_HUD_DRAG" />
+        <actionBinding action="SF_TOGGLE_CELL_MAP" />
     </inputBinding>
 
     <!-- Custom fill types declared in external file (FS25 requires filename= attribute) -->

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.2.2.1</version>
+    <version>2.2.2.2</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>
@@ -107,7 +107,7 @@
             <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h" />
         </actionBinding>
         <actionBinding action="SF_TOGGLE_CELL_MAP">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_s" />
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_F7" />
         </actionBinding>
     </inputBinding>
 

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -139,11 +139,11 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             SoilLogger.info("Settings panel created")
         end
 
-        -- Soil Map Cell dialog (Shift+S)
+        -- Soil Map Cell dialog (F7)
         if SoilMapCellDialog and g_gui then
             local dialog = SoilMapCellDialog.new()
             g_gui:loadGui(modDirectory .. "xml/gui/SoilMapCellDialog.xml", "SoilMapCellDialog", dialog)
-            self.soilMapCellDialog = dialog  -- must be stored so the Shift+S input guard passes
+            self.soilMapCellDialog = dialog  -- must be stored so the F7 input guard passes
             SoilLogger.info("Soil Map Cell dialog registered")
         end
 
@@ -191,7 +191,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     end
                 end
 
-                -- Cell Map Inspection (Shift+S)
+                -- Cell Map Inspection (F7)
                 if g_SoilFertilityManager.soilMapCellDialog then
                     local cellOk, cellId = g_inputBinding:registerActionEvent(
                         InputAction.SF_TOGGLE_CELL_MAP, g_SoilFertilityManager,
@@ -202,7 +202,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                         g_SoilFertilityManager.toggleCellMapEventId = cellId
                         g_inputBinding:setActionEventTextVisibility(cellId, true)
                         g_inputBinding:setActionEventText(cellId, g_i18n:getText("input_SF_TOGGLE_CELL_MAP"))
-                        SoilLogger.info("Soil Cell Map (Shift+S) registered in PLAYER context")
+                        SoilLogger.info("Soil Cell Map (F7) registered in PLAYER context")
                     end
                 end
 
@@ -347,7 +347,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     end
                 end
 
-                -- Cell Map (Shift+S) in vehicle
+                -- Cell Map (F7) in vehicle
                 if g_SoilFertilityManager.soilMapCellDialog then
                     local vCellOk, vCellId = binding:registerActionEvent(
                         InputAction.SF_TOGGLE_CELL_MAP, g_SoilFertilityManager,
@@ -358,7 +358,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                         g_SoilFertilityManager.vehicleCellMapEventId = vCellId
                         binding:setActionEventTextVisibility(vCellId, true)
                         binding:setActionEventText(vCellId, g_i18n:getText("input_SF_TOGGLE_CELL_MAP"))
-                        SoilLogger.debug("Soil Cell Map (Shift+S) registered in VEHICLE context")
+                        SoilLogger.debug("Soil Cell Map (F7) registered in VEHICLE context")
                     end
                 end
 
@@ -492,7 +492,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     end
                 end
 
-                -- Cell Map (Shift+S) re-registration in PLAYER context
+                -- Cell Map (F7) re-registration in PLAYER context
                 if g_SoilFertilityManager.soilMapCellDialog then
                     local pCellOk, pCellId = binding:registerActionEvent(
                         InputAction.SF_TOGGLE_CELL_MAP, g_SoilFertilityManager,
@@ -503,7 +503,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                         g_SoilFertilityManager.toggleCellMapEventId = pCellId
                         binding:setActionEventTextVisibility(pCellId, true)
                         binding:setActionEventText(pCellId, g_i18n:getText("input_SF_TOGGLE_CELL_MAP"))
-                        SoilLogger.debug("Cell Map (Shift+S) re-registered in PLAYER context after vehicle exit")
+                        SoilLogger.debug("Cell Map (F7) re-registered in PLAYER context after vehicle exit")
                     end
                 end
 
@@ -738,17 +738,17 @@ function SoilFertilityManager:onCycleMapLayerInput()
     end
 end
 
--- Input callback for Soil Cell Map dialog (Shift+S)
+-- Input callback for Soil Cell Map dialog (F7)
 function SoilFertilityManager:onToggleCellMapInput()
-    if self.soilMapCellDialog and g_gui then
-        if g_gui.currentGui ~= nil then
-            if g_gui.currentGui.name == "SoilMapCellDialog" then
-                g_gui:closeDialogByName("SoilMapCellDialog")
-            end
-        else
-            g_gui:showDialog("SoilMapCellDialog")
-        end
+    if not self.soilMapCellDialog or not g_gui then return end
+    local currentName = g_gui.currentGui and g_gui.currentGui.name
+    if currentName == "SoilMapCellDialog" then
+        g_gui:closeDialogByName("SoilMapCellDialog")
+    elseif currentName == nil then
+        -- Only open when nothing else is already showing
+        g_gui:showDialog("SoilMapCellDialog")
     end
+    -- If a different dialog/GUI is open, do nothing — prevents cross-mod GUI corruption
 end
 
 --- Helper function to determine if a vehicle is a fertilizer applicator (sprayer, spreader, planter)

--- a/src/ui/SoilMapCellDialog.lua
+++ b/src/ui/SoilMapCellDialog.lua
@@ -32,25 +32,64 @@ end
 
 function SoilMapCellDialog:onOpen()
     SoilMapCellDialog:superClass().onOpen(self)
-    
+
     if self.mapElement then
         self.mapElement:setMapCenter(0.5, 0.5)
         self.mapElement:setMapZoom(1.0)
     end
-    
+
     if self.detailsGroup then
         self.detailsGroup:setVisible(false)
     end
-    
+
     if self.hintText then
         self.hintText:setVisible(true)
         self.hintText:setText(tr("sf_cell_click_hint", "Click map to inspect cell"))
     end
-    
-    -- Sync map overlay state
+
     if self.overlay then
         self.overlay.isMapOpen = true
     end
+
+    -- Auto-show data for the current player/vehicle position so the dialog
+    -- is never blank on open — onClickMap handles the "no farmland here" case
+    -- gracefully by keeping the hint visible.
+    local x, z = SoilMapCellDialog._getPlayerWorldXZ()
+    if x ~= nil then
+        self:onClickMap(x, z)
+    end
+end
+
+-- Returns the current player/vehicle world X, Z position (or nil, nil on failure).
+function SoilMapCellDialog._getPlayerWorldXZ()
+    if g_localPlayer then
+        if type(g_localPlayer.getPosition) == "function" then
+            local ok, x, y, z = pcall(g_localPlayer.getPosition, g_localPlayer)
+            if ok and x then return x, z end
+        end
+        if g_localPlayer.rootNode then
+            local ok, x, y, z = pcall(getWorldTranslation, g_localPlayer.rootNode)
+            if ok and x then return x, z end
+        end
+        if type(g_localPlayer.getIsInVehicle) == "function" and g_localPlayer:getIsInVehicle() then
+            local v = type(g_localPlayer.getCurrentVehicle) == "function" and g_localPlayer:getCurrentVehicle()
+            if v and v.rootNode then
+                local ok, x, y, z = pcall(getWorldTranslation, v.rootNode)
+                if ok and x then return x, z end
+            end
+        end
+    end
+    if g_currentMission then
+        if g_currentMission.player and g_currentMission.player.rootNode then
+            local ok, x, y, z = pcall(getWorldTranslation, g_currentMission.player.rootNode)
+            if ok and x then return x, z end
+        end
+        if g_currentMission.controlledVehicle and g_currentMission.controlledVehicle.rootNode then
+            local ok, x, y, z = pcall(getWorldTranslation, g_currentMission.controlledVehicle.rootNode)
+            if ok and x then return x, z end
+        end
+    end
+    return nil, nil
 end
 
 function SoilMapCellDialog:onClose()

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,13 +24,13 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.2.2.2",
-    "- Changed Soil Cell Map keybinding from Shift+S to F7",
-    "  Shift+S conflicts with sprint-backwards; using the same key as another",
-    "  soil mod caused a hard-lock (GUI corruption). F7 has no vanilla conflicts.",
-    "  Existing saves: rebind F7 in Controls > Other if you prefer a different key.",
-    "- Cell map dialog now auto-shows soil data for your current position on open",
-    "  instead of starting blank — click anywhere on the map to inspect other cells",
+    "v2.2.2.3",
+    "- All keybindings now ship UNBOUND by default",
+    "  Go to Controls > Mods and assign your preferred keys.",
+    "  This eliminates hard-locks caused when multiple mods share the same",
+    "  default key (e.g. Shift+S, Shift+O, Shift+H were all conflicting).",
+    "- Soil Cell Map dialog now auto-shows data for your current position on open",
+    "  instead of always starting blank — click the map to inspect any other cell",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,12 +24,13 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.2.2.0",
-    "- Fixed Section control overlap prevention not working while moving with Precision",
-    "  Farming active — sections now correctly close over already-fertilized areas",
-    "  inside the field, not just at headland/field boundaries (#415)",
-    "- Fixed SoilMapCellDialog class not loaded on mod startup — no-op guard meant",
-    "  the Shift+S map cell popup silently never registered (#tools)",
+    "v2.2.2.2",
+    "- Changed Soil Cell Map keybinding from Shift+S to F7",
+    "  Shift+S conflicts with sprint-backwards; using the same key as another",
+    "  soil mod caused a hard-lock (GUI corruption). F7 has no vanilla conflicts.",
+    "  Existing saves: rebind F7 in Controls > Other if you prefer a different key.",
+    "- Cell map dialog now auto-shows soil data for your current position on open",
+    "  instead of starting blank — click anywhere on the map to inspect other cells",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- All 9 keybindings now ship unbound by default — no more cross-mod key conflicts
- Soil Cell Map dialog auto-shows data for player's current position on open
- Fixes hard-lock caused by Shift+S conflicting with SeasonalCropStress and vanilla sprint-backwards

## ⚠️ ACTION REQUIRED FOR EXISTING PLAYERS
All keybindings are now **unbound by default**.

**To set up your keys:**
1. Launch the game
2. Go to **Settings → Controls → Mods**
3. Find **FS25_SoilFertilizer** in the list
4. Assign a key to each action you want to use

This is a one-time setup — your bindings are saved automatically.

## Why this change?
Cross-mod audit revealed 4 direct conflicts between this mod's defaults and other mods in this suite:
- Shift+S → SeasonalCropStress (caused hard-lock reported by users)
- Shift+O → RandomWorldEvents
- Shift+H → SeasonalCropStress
- Shift+M → SeasonalCropStress

## Save compatibility
✅ No save migration needed.