### PR TITLE
fix: wire POLIFOSKA into all spray-type hooks and thPFConfig

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -606,6 +606,16 @@
                 <fertilizerUsage amount="0.18"/> <!-- 18-46-0 granular — 18% N -->
             </sprayType>
 
+            <sprayType name="POLIFOSKA" litersPerSecond="0.0600" type="FERTILIZER" sprayGroundType="FERTILIZER">
+                <applicationRate autoAdjustToFruit="true" regularRate="250">
+                    <soil soilTypeIndex="1" rate="120"/>
+                    <soil soilTypeIndex="2" rate="165"/>
+                    <soil soilTypeIndex="3" rate="210"/>
+                    <soil soilTypeIndex="4" rate="165"/>
+                </applicationRate>
+                <fertilizerUsage amount="0.06"/> <!-- 6-20-30 compound — 6% N by weight -->
+            </sprayType>
+
             <!-- Lime types (pH amendment — no N content) -->
             <sprayType name="LIQUIDLIME" litersPerSecond="0.0815" type="LIME" sprayGroundType="LIME"/>
             <sprayType name="GYPSUM"     litersPerSecond="0.0600" type="LIME" sprayGroundType="LIME"/>
@@ -626,9 +636,10 @@
             <sprayType name="UREA"   group="FERTILIZER" isLiquid="false"/>
             <sprayType name="AN"     group="FERTILIZER" isLiquid="false"/>
             <sprayType name="AMS"    group="FERTILIZER" isLiquid="false"/>
-            <sprayType name="MAP"    group="FERTILIZER" isLiquid="false"/>
-            <sprayType name="DAP"    group="FERTILIZER" isLiquid="false"/>
-            <sprayType name="POTASH" group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="MAP"      group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="DAP"      group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="POTASH"   group="FERTILIZER" isLiquid="false"/>
+            <sprayType name="POLIFOSKA" group="FERTILIZER" isLiquid="false"/>
             <!-- Organic amendments -->
             <sprayType name="COMPOST"           group="MANURE" isLiquid="false"/>
             <sprayType name="BIOSOLIDS"         group="MANURE" isLiquid="false"/>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -388,7 +388,7 @@ function HookManager:registerCustomSprayTypes()
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH",
                           "LIQUIDMANURE", "MANURE", "DIGESTATE" }
     -- Granular/solid types → inherit visual from FERTILIZER
-    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
+    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
 
     local registered = 0
@@ -468,7 +468,7 @@ function HookManager:installEffectTypeHook()
     -- Build remap: customFillTypeIndex → vanillaFillTypeIndex
     local remap = {}
     if fertIdx then
-        for _, name in ipairs({ "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
+        for _, name in ipairs({ "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                                  "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }) do
             local idx = fm:getFillTypeIndexByName(name)
             if idx then remap[idx] = fertIdx end
@@ -627,7 +627,7 @@ end
 ---@return boolean success
 function HookManager:installSprayTypeEffectsHook()
     -- Solid custom types visually match FERTILIZER spreading
-    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
+    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
     -- Liquid custom types visually match LIQUIDFERTILIZER spraying
     local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
@@ -809,7 +809,7 @@ function HookManager:installDensityMapSprayHook()
     local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
                           "INSECTICIDE", "FUNGICIDE",
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
-    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH",
+    local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
 
     local remap = {}


### PR DESCRIPTION
## Summary

- Add POLIFOSKA to `solidNames` in all four spray-type hook functions in `HookManager.lua` — fixes instant tank drain (was using default 36,000 L/ha instead of calibrated 250 kg/ha) and no spray/ground-overlay effects
- Add POLIFOSKA `<sprayType>` and `<sprayTypeMapping>` entries to `<thPFConfig>` in `modDesc.xml` — fixes PF/THPF not recognizing the product

## Root cause

POLIFOSKA was added to `FERTILIZER_PROFILES` and `BASE_RATES` in Constants.lua and to the big-bag objects, but was never added to the four `solidNames` arrays in HookManager that register custom spray types, remap effect types, inject spray visuals, and remap the density-map spray index. It was also missing from the thPFConfig block that THPF Configurator reads for PF integration.

## Test plan

- [ ] Load a save with a spreader filled with POLIFOSKA — confirm tank drains at ~250 kg/ha (not instantly)
- [ ] Confirm spreader particle/ground-overlay effects are visible while spreading
- [ ] With PF/THPF active, confirm POLIFOSKA appears in the PF sprayer panel