### PR TITLE
feat: pH HUD bar (#438) + lime/OM crop burn penalty (#437)

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -283,6 +283,15 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         end
     end
 
+    -- Amendment burn penalty: lime or OM applied to growing crop (issue #437)
+    if field.amendBurnPenalty and field.amendBurnPenalty > 0 then
+        local burnPct = field.amendBurnPenalty
+        modifier = modifier * (1.0 - burnPct)
+        self:log("Amendment burn penalty field %d: -%.0f%%", fieldId, burnPct * 100)
+        field.amendBurnPenalty   = nil
+        field._amendBurnNotified = nil
+    end
+
     return modifier
 end
 
@@ -2088,6 +2097,33 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         return
     end
 
+    -- Issue #437: pH/OM amendment burn on growing crops.
+    -- LIME/LIQUIDLIME on growing crop → -80% yield. OM amendments → -20%.
+    -- Throttled to one warning per field per crop cycle via _amendBurnNotified flag.
+    local isLimeAmendment = entry.pH and entry.pH > 0  -- raises pH (LIME, LIQUIDLIME)
+    local isOMAmendment   = entry.OM and not (entry.pH and entry.pH > 0)
+    if (isLimeAmendment or isOMAmendment) and not field._amendBurnNotified then
+        local spx, spz = self._lastSprayX, self._lastSprayZ
+        if spx and spz and g_fieldManager then
+            local ok, fsField = pcall(g_fieldManager.getFieldAtWorldPosition, g_fieldManager, spx, spz)
+            if ok and fsField and (fsField.fruitType or 0) > 0 then
+                if isLimeAmendment then
+                    field.amendBurnPenalty = 0.80
+                    field._amendBurnNotified = true
+                    self:showNotification(
+                        g_i18n:getText("sf_notify_lime_crop_title"),
+                        string.format(g_i18n:getText("sf_notify_lime_crop_body"), fieldId))
+                else
+                    field.amendBurnPenalty = math.max(field.amendBurnPenalty or 0, 0.20)
+                    field._amendBurnNotified = true
+                    self:showNotification(
+                        g_i18n:getText("sf_notify_om_crop_title"),
+                        string.format(g_i18n:getText("sf_notify_om_crop_body"), fieldId))
+                end
+            end
+        end
+    end
+
     local limits = SoilConstants.NUTRIENT_LIMITS
 
     -- AREA NORMALIZATION: Calculate hectares for this field.
@@ -3010,6 +3046,7 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             setXMLInt(xmlFile, fieldKey .. "#lastAlertSeason", field.lastAlertSeason or 0)
             setXMLFloat(xmlFile, fieldKey .. "#coverageFraction", field.coverageFraction or 0)
             setXMLFloat(xmlFile, fieldKey .. "#compaction", field.compaction or 0)
+            setXMLFloat(xmlFile, fieldKey .. "#amendBurnPenalty", field.amendBurnPenalty or 0)
 
             -- Save daily application throttles
             setXMLInt(xmlFile, fieldKey .. "#herbicideAppliedDay", self.herbicideAppliedDay[fieldId] or 0)
@@ -3090,6 +3127,7 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             fungicideDaysLeft = getXMLInt(xmlFile, fieldKey .. "#fungicideDaysLeft") or 0,
             dryDayCount = getXMLInt(xmlFile, fieldKey .. "#dryDayCount") or 0,
             burnDaysLeft = getXMLInt(xmlFile, fieldKey .. "#burnDaysLeft") or 0,
+            amendBurnPenalty = getXMLFloat(xmlFile, fieldKey .. "#amendBurnPenalty") or nil,
             coverageFraction = getXMLFloat(xmlFile, fieldKey .. "#coverageFraction") or 0,
             lastAlertSeason = getXMLInt(xmlFile, fieldKey .. "#lastAlertSeason") or nil,
             compaction = 0,

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1159,20 +1159,17 @@ function SoilHUD:drawPanel()
         self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
 
-        -- pH + OM row
-        local pHCol = self:pHColor(info.pH)
+        -- pH bar row (issue #438: center-anchored bar with ghost bar)
+        cy = self:drawPHRow(info, px, cy + SoilHUD.ROW_H * s, pw, s, fontMult, fillType)
+
+        -- OM text row (compact, alongside divider)
         local omCol = self:omColor(info.organicMatter)
-
+        local omLabelX = tx
+        local omValX   = tx + 0.018*s
         setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-        renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_label_ph"))
-        setTextColor(pHCol[1], pHCol[2], pHCol[3], 1.0)
-        renderText(tx + 0.020*s, cy, 0.010 * fontMult * s, self._fmt_pHStr or "")
-
-        local omX = tx + pw * 0.50
-        setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-        renderText(omX, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_label_om"))
+        renderText(omLabelX, cy, 0.010 * fontMult * s, g_i18n:getText("sf_hud_label_om"))
         setTextColor(omCol[1], omCol[2], omCol[3], 1.0)
-        renderText(omX + 0.020*s, cy, 0.010 * fontMult * s, self._fmt_omStr or "")
+        renderText(omValX + 0.015*s, cy, 0.010 * fontMult * s, self._fmt_omStr or "")
 
         -- Divider below pH/OM row
         cy = cy - SoilHUD.LINE_H * s
@@ -1406,6 +1403,103 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     setTextAlignment(RenderText.ALIGN_RIGHT)
     setTextColor(displayCol[1], displayCol[2], displayCol[3], 0.80)
     renderText(px + pw - pad, cy + (rowH - 0.009*s) * 0.5, 0.009 * fontMult * s, nutrient.status)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+
+    return cy
+end
+
+-- ── pH bar row ───────────────────────────────────────────
+-- Center-anchored bar: left = acidic, right = alkaline, center = optimal (6.75).
+-- Ghost bar shows the direction lime/gypsum will push pH.
+-- Returns updated cy.
+function SoilHUD:drawPHRow(info, px, cy, pw, s, fontMult, fillType)
+    local pad  = SoilHUD.PAD * s
+    local rowH = SoilHUD.ROW_H * s
+    local barH = SoilHUD.BAR_H * s
+    local barW = SoilHUD.BAR_W * s
+    local tx   = px + pad
+
+    cy = cy - rowH
+
+    -- Label
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
+    renderText(tx, cy + (rowH - 0.010*s) * 0.5, 0.010 * fontMult * s, g_i18n:getText("sf_hud_label_ph"))
+
+    local barX  = tx + 0.015*s
+    local barY  = cy + (rowH - barH) * 0.5
+    local PH_MIN, PH_MAX, PH_OPT = 5.0, 8.5, 6.75
+    local phRange = PH_MAX - PH_MIN
+
+    local pH = info.pH or PH_OPT
+    local phNorm  = (math.max(PH_MIN, math.min(PH_MAX, pH)) - PH_MIN) / phRange
+    local optNorm = (PH_OPT - PH_MIN) / phRange  -- 0.5
+
+    -- Background
+    self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
+
+    -- Colored fill from optimal toward current pH
+    local pHCol = self:pHColor(pH)
+    if phNorm < optNorm then
+        local fillW = (optNorm - phNorm) * barW
+        self:drawRect(barX + phNorm * barW, barY, fillW, barH, pHCol)
+    elseif phNorm > optNorm then
+        local fillW = (phNorm - optNorm) * barW
+        self:drawRect(barX + optNorm * barW, barY, fillW, barH, pHCol)
+    end
+
+    -- Ghost bar: directional preview if a pH-modifying product is loaded
+    if fillType then
+        local profile = SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[fillType.name]
+        if profile and profile.pH then
+            -- Typical full-pass delta is ~0.4 for LIME; scale visually to ~15% of bar width
+            local ghostW = barW * 0.15 * (math.abs(profile.pH) / 0.16)
+            ghostW = math.max(barW * 0.04, math.min(barW * 0.25, ghostW))
+            if profile.pH > 0 then
+                -- Raises pH: ghost extends right from current position
+                local gx = barX + phNorm * barW
+                self:drawRect(gx, barY, ghostW, barH, pHCol, 0.30)
+            else
+                -- Lowers pH: ghost extends left from current position
+                local gx = barX + phNorm * barW - ghostW
+                self:drawRect(gx, barY, ghostW, barH, pHCol, 0.30)
+            end
+        end
+    end
+
+    -- Center optimal line
+    local divW = 0.0005 * s
+    local optX = barX + optNorm * barW
+    self:drawRect(optX - divW*0.5, barY - 0.001*s, divW, barH + 0.002*s, {0.85, 0.85, 0.85, 0.6})
+
+    -- Threshold tick marks: 5.5=poor, 6.0=fair, 7.0=fair, 7.5=poor
+    local ticks = {
+        {pH=5.5, col={0.90, 0.35, 0.20, 0.75}},
+        {pH=6.0, col={0.90, 0.80, 0.20, 0.75}},
+        {pH=7.0, col={0.90, 0.80, 0.20, 0.75}},
+        {pH=7.5, col={0.90, 0.35, 0.20, 0.75}},
+    }
+    local tickW = 0.0005 * s
+    local tickH = barH + 0.002 * s
+    for _, tk in ipairs(ticks) do
+        local tNorm = (tk.pH - PH_MIN) / phRange
+        self:drawRect(barX + tNorm*barW - tickW*0.5, barY - 0.001*s, tickW, tickH, tk.col)
+    end
+
+    -- Numeric value
+    local valX = barX + barW + 0.006*s
+    setTextColor(pHCol[1], pHCol[2], pHCol[3], 1.0)
+    renderText(valX, cy + (rowH - 0.010*s) * 0.5, 0.010 * fontMult * s,
+               string.format("%.1f", pH))
+
+    -- Status text (right-aligned)
+    local phStatus
+    if pH >= 6.5 and pH <= 7.0 then phStatus = "Good"
+    elseif pH >= 5.5 and pH <= 7.5 then phStatus = "Fair"
+    else phStatus = "Poor" end
+    setTextAlignment(RenderText.ALIGN_RIGHT)
+    setTextColor(pHCol[1], pHCol[2], pHCol[3], 0.80)
+    renderText(px + pw - pad, cy + (rowH - 0.009*s) * 0.5, 0.009 * fontMult * s, phStatus)
     setTextAlignment(RenderText.ALIGN_LEFT)
 
     return cy

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -33,7 +33,13 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed field pass % counter resetting incorrectly when switching products mid-field",
     "- Fixed auto spray rate using generic N/P/K targets instead of per-crop optimal targets",
     "- Fixed herbicide/insecticide/fungicide granting field protection before 80% coverage reached",
+    "- Fixed Smart Sensor status showing blank when pest/disease pressure is zero",
+    "- Fixed minimap tile size mismatch on large maps (dots now align to 10m soil cells)",
     "- Added Field Boundary Control setting: automatically shuts off boom sections that extend outside field boundaries",
+    "- Added minimap soil layer gradient: each tile now shows the actual per-cell soil color (not just field average)",
+    "- Added minimap zoom: bind a key to SF_MINIMAP_ZOOM to cycle 1x / 2x / 4x zoom",
+    "- Added pH bar in soil HUD: center-anchored bar shows acidic/alkaline deviation with threshold ticks and ghost bar",
+    "- Added lime/OM crop burn: applying lime to growing crops triggers -80% yield penalty at harvest (OM: -20%)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Ureia Líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de Amônio Líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Líquido (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante nitrogenado (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amônia Anidra 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureia 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34,5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante nitrogenado (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Ureia Líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante nitrogenado (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfórico (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfórico (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potassa Líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potássico (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Inicial 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Inseticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Inseticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Composto" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biossólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante Orgânico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Esterco de Galinha" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante Orgânico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Esterco Peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante Orgânico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tanque de Calcário Líquido" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente de Aumento de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR DE SOLO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Vá até um campo" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limiar ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Produção ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibilidade Detectada" />
-    <e k="sf_incompatibility_pf_text" v="O mod Soil & Fertilizer foi desativado porque o Precision Farming foi detectado.\n\nEstes dois mods não são compatíveis e não podem ser usados juntos." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -452,7 +452,7 @@
     <e k="sf_pda_map_unavailable" v="Visualização do mapa indisponível" eh="43983f81" />
     <e k="sf_map_health_overall" v="Saúde Média do Solo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir Visão Geral da Fazenda" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Mudar camada" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plano de tratamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desativar camada" eh="8e75dec5" />
@@ -536,15 +536,15 @@
     <e k="sf_treat_action_n_poor" v="Aplique UAN32, UREIA ou AMÔNIA ANIDRA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplique AMS ou fertilizante STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplique MAP ou DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Aplique POTASSA (Potássio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Aplique HERBICIDA imediatamente." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bônus de Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fadiga (x1.15 esgotamento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sem dados disponíveis." eh="c6d95d5e" />
@@ -557,9 +557,9 @@
     <e k="sf_hud_label_om" v="MO" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Passagem: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -588,6 +588,10 @@
     <e k="sf_notify_burn_title" v="Queima de Fertilizante" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Campo %d: dano por excesso de aplicação (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mod Solo: Detectado problema de sincronização de dados. Por favor, relate se isso persistir." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -610,6 +614,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Controle do Mod &amp; Dificuldade" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemas" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Ações &amp; Ferramentas de Campo" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -730,7 +737,7 @@
     <e k="sf_cell_report" v="Relatório de Célula" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nenhum dado de célula encontrado" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Sem dados de solo neste local" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Méd. campo" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Célula" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeção de Célula de Solo" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalhes da Célula" eh="6fc5243e" />
@@ -742,7 +749,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -750,7 +757,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -774,33 +780,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Fertilitzant MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilitzant DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urea líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfat d'amoni líquid (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP líquid (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Camps %d-%d de %d  |  Pàgina %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilitzant nitrogenat (líquid) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilitzant nitrogenat (líquid) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoníac anhidre 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilitzant nitrogenat (líquid) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilitzant nitrogenat (sec) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilitzant nitrogenat (sec) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilitzant nitrogenat (sec) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilitzant fosfòric (sec) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilitzant fosfòric (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilitzant potàssic (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilitzant nitrogenat (líquid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS líquid" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilitzant nitrogenat (líquid) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP líquid" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilitzant fosfòric (líquid) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP líquid" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilitzant fosfòric (líquid) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potassa líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilitzant potàssic (líquid) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticida (líquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquid)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilitzant d'arrencada (líquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Guix" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Esmena del sòl (seca) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Esmena orgànica del sòl (seca) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosòlids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilitzant orgànic (sec) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fems de gallina" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilitzant orgànic (sec) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fems granulat" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilitzant orgànic (sec) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Dipòsit de calç líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent per elevar el pH (líquid) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR DEL SÒL" eh="f8cda642" />
     <e k="sf_hud_field" v="Camp %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camineu sobre un camp" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basat en N/P/K vs llindar òptim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Pèrdua de rendiment ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Vista prèvia del mapa no disponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salut mitjana del sòl" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Obrir resum de la granja" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Canviar capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Pla de tractament" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar capa" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Apliqueu UAN32, UREA o AMONÍAC ANHIDRE." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Apliqueu AMS o fertilitzant STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Apliqueu MAP o DAP (Fòsfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Apliqueu POTASSA (Potassi)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Apliqueu HERBICIDA immediatament." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Apliqueu INSECTICIDA immediatament." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Apliqueu FUNGICIDA immediatament." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus de lleguminoses (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (x1.15 esgotament)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="No hi ha dades disponibles." eh="c6d95d5e" />
@@ -556,9 +556,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="噴施: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactació: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -587,6 +587,10 @@
     <e k="sf_notify_burn_title" v="Cremada per fertilitzant" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Camp %d: danys per sobreaplicació (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mod de sòl: S'ha detectat un problema de sincronització de dades. Informeu-ne si persisteix." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -609,6 +613,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Control del mod i dificultat" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemes" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Accions i eines de camp" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -729,7 +736,7 @@
     <e k="sf_cell_report" v="Informe de cel·la" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="No s'han trobat dades de la cel·la" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No hi ha dades del sòl en aquesta ubicació" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cel·la" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspecció de cel·la de sòl" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalls de la cel·la" eh="6fc5243e" />
@@ -741,7 +748,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -749,7 +756,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -773,33 +779,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP hnojivo 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP hnojivo 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potaš 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Tekutá močovina (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Tekutý síran amonný (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Tekutý MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Pole %d-%d z %d  |  Strana %d z %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Dusíkaté hnojivo (kapalné) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Dusíkaté hnojivo (kapalné) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Bezvodý amoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Dusíkaté hnojivo (kapalné) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Močovina 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Dusíkaté hnojivo (granulované) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Dusíkaté hnojivo (granulované) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Dusíkaté hnojivo (granulované) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosforečné hnojivo (granulované) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosforečné hnojivo (granulované) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potaš 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Draselné hnojivo (granulované) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Tekutá močovina" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Dusíkaté hnojivo (kapalné) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Tekutý síran amonný" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Dusíkaté hnojivo (kapalné) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Tekutý MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosforečné hnojivo (kapalné) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Tekutý DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosforečné hnojivo (kapalné) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Tekutá potaš" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Draselné hnojivo (kapalné) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Startovní 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insekticid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insekticid (kapalný)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicid (kapalný)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startovní hnojivo (kapalné) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Sádrovec" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Půdní kondicionér (granulovaný) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organický půdní kondicionér (granulovaný) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biomasa" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organické hnojivo (granulované) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Drůbeží podestýlka" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organické hnojivo (granulované) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Granulovaný hnůj" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organické hnojivo (granulované) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Nádrž na tekuté vápno" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Prostředek ke zvýšení pH (kapalný) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR PŮDY" eh="f8cda642" />
     <e k="sf_hud_field" v="Pole %d" eh="08988997" />
     <e k="sf_hud_noField" v="Vstupte na pole" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Vysoký" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Založeno na N/P/K vs optimální práh" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Výnos ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Náhled mapy nedostupný" eh="43983f81" />
     <e k="sf_map_health_overall" v="Průměrné zdraví půdy" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Otevřít přehled farmy" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Přepnout vrstvu" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plán ošetření" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Vypnout překryv" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Aplikujte UAN32, MOČOVINU nebo BEZVODÝ AMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplikujte AMS nebo hnojivo STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplikujte MAP nebo DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Aplikujte POTAŠ (Draslík)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Okamžitě aplikujte HERBICID." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Okamžitě aplikujte INSEKTICID." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Okamžitě aplikujte FUNGICID." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus za luštěniny (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Únava (vyčerpání x1,15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Žádná data nejsou k dispozici." eh="c6d95d5e" />
@@ -556,9 +556,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Pokrytí: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Průjezd: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Zhutnění: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -587,6 +587,10 @@
     <e k="sf_notify_burn_title" v="Popálení hnojivem" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Pole %d: poškození nadměrnou aplikací (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Zjištěn problém se synchronizací dat. Pokud to přetrvává, nahlaste to prosím." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -609,6 +613,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Ovládání modu &amp; Obtížnost" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systémy" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Akce &amp; Nástroje pole" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -729,7 +736,7 @@
     <e k="sf_cell_report" v="Zpráva o buňce" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Žádná data buňky nenalezena" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Na tomto místě nejsou žádná data o půdě" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Buňka" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspekce půdní buňky" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detaily buňky" eh="6fc5243e" />
@@ -741,7 +748,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -749,7 +756,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -773,33 +779,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -59,12 +59,12 @@
     <e k="sf_diff_long" v="Sværhedsgrad for jordstyring" eh="d6f4560c" />
     <e k="sf_rr_short" v="Genopfyldningshastighed" eh="b363b336" />
     <e k="sf_rr_long" v="Hvor hurtigt gødning genopretter næringsstoffer i marken (0,25x meget langsomt til 2,0x meget hurtigt)" eh="afe78a6d" />
-    <e k="sf_dm_short" v="Sygdomsklima" />
-    <e k="sf_dm_long" v="Klimaets fugtighedsniveau — styrer hvor hurtigt svampesygdomme udvikler sig, og hvor længe svampebeskyttelse varer" />
-    <e k="sf_dm_1" v="Tørt" />
-    <e k="sf_dm_2" v="Tempereret" />
-    <e k="sf_dm_3" v="“Fugtigt" />
-    <e k="sf_dm_4" v="Vådt" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" eh="86eac820" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" eh="9948c967" />
+    <e k="sf_dm_1" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_dm_2" v="[EN] Temperate" eh="e8328062" />
+    <e k="sf_dm_3" v="[EN] Humid" eh="ccb2fc34" />
+    <e k="sf_dm_4" v="[EN] Wet" eh="ae789b86" />
     <e k="sf_auto_rate_short" v="Automatisk hastighedskontrol" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Justerer automatisk gødningsraten baseret på markens behov" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Grøn" eh="d382816a" />
@@ -89,10 +89,10 @@
     <e k="sf_active_map_layer_long" v="Næringsstoflag vist som overlejring på PDA-kortet" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kortdetalje" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Prøvepunktsbudget for PDA-jordoverlejringen. Lav = bedre FPS, Høj = bedre dækning på store kort." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="Farveblindtilstand" />
-    <e k="sf_colorblind_mode_long" v="“Erstatter røde/grønne statusfarver med orange/blå (Okabe-Ito-paletten) for bedre tilgængelighed ved deuteranopi og protanopi" />
-    <e k="sf_show_field_info_box_short" v="Markinfo-boks" />
-    <e k="sf_show_field_info_box_long" v="Vis jordens næringsstoffer i det indbyggede markinfo-panel, når du står på en mark." />
+    <e k="sf_colorblind_mode_short" v="[EN] Colorblind Mode" eh="d5a644f4" />
+    <e k="sf_colorblind_mode_long" v="[EN] Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." eh="4de2f9fb" />
+    <e k="sf_show_field_info_box_short" v="[EN] Field Info Box" eh="bf8bc5c7" />
+    <e k="sf_show_field_info_box_long" v="[EN] Show soil nutrients in the native Field Info panel when standing on a field." eh="f7cd7156" />
     <e k="input_SF_OPEN_SETTINGS" v="Åbn jordindstillinger" eh="2e31c0dd" />
     <e k="sf_reset" v="Nulstil jordindstillinger" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Slå jord-HUD til/fra" eh="f0224a10" />
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP-gødning 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-gødning 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumklorid 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Flydende urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flydende ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flydende MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Marker %d-%d af %d  |  Side %d af %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Kvælstofgødning (flydende) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Kvælstofgødning (flydende) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vandfri Ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Kvælstofgødning (flydende) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Kvælstofgødning (tør) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Kvælstofgødning (tør) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Kvælstofgødning (tør) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfatgødning (tør) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfatgødning (tør) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kaliumklorid 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumgødning (tør) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (tør) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flydende Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Kvælstofgødning (flydende) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flydende AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Kvælstofgødning (flydende) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Flydende MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfatgødning (flydende) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Flydende DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgødning (flydende) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Flydende Kaliumklorid" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgødning (flydende) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Startgødning 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insekticid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insekticid (flydende)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicid (flydende)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startgødning (flydende) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tør) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tør) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolider" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Bioslam (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organisk gødning (tør) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" eh="53b60563" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsemøg" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Hønse Møg (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organisk gødning (tør) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" eh="dd621023" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelleteret Gødning" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelleteret gødning (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gødning (tør) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" eh="261ca096" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flydende Kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-hævende middel (flydende) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mark %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Høj" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baseret på N/P/K vs. optimal grænse" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Udbytte ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Oversigt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Kom godt i gang" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Kortvisning ikke tilgængelig" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gennemsnitlig jordsundhed" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Åbn gårdsoversigt" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Skift lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver lag" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Anvend UAN32, UREA eller VANDFRI AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Anvend AMS eller STARTGØDNING." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Anvend MAP eller DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Anvend KALIUMKLORID (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Anvend HERBICID øjeblikkeligt." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Anvend INSEKTICID øjeblikkeligt." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Anvend FUNGICID øjeblikkeligt." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bælgplantebonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Træthed (x1,15 udtømning)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tilgængelig." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dækning: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Kørsel: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Pakning: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="PÅFØRINGSRATE (AUTO: TIL)" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="PÅFØRINGSRATE (AUTO: FRA) [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Gødningssvidning" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Mark %d: Skade fra overdosering (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Jordmod: Datasynkroniseringsfejl. Rapportér venligst hvis dette fortsætter." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulering" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Landbrugsmekanik, sværhedsgrad og næringsstofkredsløb" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod-kontrol &amp; Sværhedsgrad" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systemer" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Handlinger &amp; Markværktøjer" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: JA" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: NEJ" eh="a9394f7b" />
@@ -608,7 +615,7 @@
     <e k="sf_desc_weedPressure" v="Spor og straf ukrudtsspredning" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Spor insektangreb" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Spor svampesygdomme" eh="0858395f" />
-    <e k="sf_desc_diseaseMoisture" v="Klimaets fugtighedsniveau, som påvirker sygdomsspredning og fungicidets varighed”" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" eh="97cb48de" />
     <e k="sf_desc_compactionEnabled" v="Jordpakning fra tunge køretøjer" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensitet af næringsstofdræn" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Hastighed for gødningsgenopbygning" eh="858d2b23" />
@@ -617,8 +624,8 @@
     <e k="sf_desc_cropRotation" v="Sædskiftefordele og -ulemper" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Næringslag vist på PDA-kortet" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Antal datapunkter (Lav=8k, Mid=20k, Høj=40k)" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="Brug orange/blå farvepalette i stedet for rød/grøn" />
-    <e k="sf_desc_showFieldInfoBox" v="Vis jorddata i markinfo-panelet" />
+    <e k="sf_desc_colorblindMode" v="[EN] Use orange/blue palette instead of red/green" eh="2862b921" />
+    <e k="sf_desc_showFieldInfoBox" v="[EN] Show soil data in the Field Info panel" eh="815e419e" />
 
     <e k="sf_rr_1" v="Meget langsom (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Langsom (0.5x)" eh="db69874d" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Cellerapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Ingen celledata fundet" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ingen jorddata på denne placering" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Mark gns." />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Celle" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Jordcelle-inspektion" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celledetaljer" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Aktivér eller deaktiver Smart Spray Sensor-systemet" />
     <e k="sf_desc_smartSensorEnabled"    v="Tillad spillere at bruge Smart Sensor-bomsektionsstyring baseret på jorddata" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Skadedyrssensor" />
     <e k="sf_sensor_disease"     v="Sygdomssensor" />
     <e k="sf_sensor_nutrient"    v="Næringsstofsensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="SLUKKET" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Aktivér eller deaktiver skadedyrssensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Aktiver eller deaktiver sygdomssensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Aktiver eller deaktiver Næringstofsensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -724,33 +730,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Skadedyrssensor" />
     <e k="sf_sensor_disease"     v="Sygdomssensor" />
     <e k="sf_sensor_nutrient"    v="Næringsstofsensor" />
     <e k="sf_sensor_state_on"    v="TÆNDT" />
     <e k="sf_sensor_state_off"   v="SLUKKET" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="PRÆCISIONSPRØJTNING" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Skadedyr" />
     <e k="sf_see_spray_disease"     v="Sygdom" />
     <e k="sf_see_spray_weed"        v="Ukrudt" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABEL DOSERING" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. dose" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Aktivér eller deaktiver skadedyrssensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Aktiver eller deaktiver sygdomssensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Aktiver eller deaktiver Næringstofsensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Aktiver eller deaktiver Spøjtning for skadedyr" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Aktiver eller deaktiver spøjtning for sygdom" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Aktiver eller deaktiver spøjtning for ukrudt" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Aktiver eller deaktiver Variabel dosering" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Panel Layout" />
-    <e k="sf_independent_panels_long" v="Tillad, at smart system-paneler kan placeres uafhængigt i redigeringstilstand" />
-    <e k="sf_desc_independentPanels" v="Træk hvert panel frit i Shift+H-redigeringstilstand. Minimer paneler med knappen (-) i deres titellinje." />    <e k="sf_hud_enter_drag_label"   v="Flyt &amp; tilpas størrelse på paneler" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Flyt &amp; tilpas størrelse på paneler" />
     <e k="sf_hud_enter_drag_desc"    v="Træk HUD’en for at flytte den — træk i hjørnet for at ændre størrelse — højreklik eller Esc for at afslutte" />
     </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP-Dünger 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-Dünger 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumchlorid 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Flüssiger Harnstoff (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flüssiges Ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flüssiges MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungizid" eh="e8512698" />
     <e k="sf_report_page_info" v="Felder %d-%d von %d  |  Seite %d von %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Stickstoffdünger (flüssig) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Stickstoffdünger (flüssig) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Anhydrous Ammonia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Stickstoffdünger (flüssig) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Harnstoff 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Stickstoffdünger (trocken) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Stickstoffdünger (trocken) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Stickstoffdünger (trocken) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Phosphordünger (trocken) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Phosphordünger (trocken) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumdünger (trocken) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Liquid Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Stickstoffdünger (flüssig) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Liquid AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Stickstoffdünger (flüssig) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Liquid MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Phosphordünger (flüssig) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Liquid DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Phosphordünger (flüssig) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Liquid Potash" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumdünger (flüssig) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektizid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektizid (flüssig)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungizid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungizid (flüssig)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starterdünger (flüssig) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Bodenverbesserer (trocken) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organischer Bodenverbesserer (trocken) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organischer Dünger (trocken) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hühnermist" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organischer Dünger (trocken) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag pelletierter Mist" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organischer Dünger (trocken) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flüssigkalk-Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-erhöhendes Mittel (flüssig) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="BODENMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Feld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Betreten Sie ein Feld" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Hoch" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basierend auf N/P/K vs. optimalem Schwellenwert" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Ertrag ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Inkompatibilität erkannt" />
-    <e k="sf_incompatibility_pf_text" v="Die Soil & Fertilizer Mod wurde deaktiviert, da Precision Farming erkannt wurde.\n\nDiese beiden Mods sind nicht kompatibel und können nicht zusammen verwendet werden." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Übersicht" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Erste Schritte" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Karten-Vorschau nicht verfügbar" eh="43983f81" />
     <e k="sf_map_health_overall" v="Durchschn. Bodengesundheit" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Hofübersicht öffnen" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Ebene wechseln" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlungsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay deaktivieren" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="UAN32, HARNSTOFF oder FLÜSSIGAMMONIAK ausbringen." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS oder STARTER-Dünger ausbringen." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP oder DAP (Phosphor) ausbringen." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="KALI (Kalium) ausbringen." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Sofort HERBIZID ausbringen." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Sofort INSEKTIZID ausbringen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Sofort FUNGIZID ausbringen." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen-Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Ermüdung (x1,15 Verarmung)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Keine Daten verfügbar." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="OS" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Abdeckung: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Durchgang: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Verdichtung: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="AUSBRINGUNGSRATE ( AUTO: AN )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="AUSBRINGUNGSRATE  AUTO: AUS [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Düngerschäden" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Feld %d: Schäden durch Überdosierung (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Boden-Mod: Datensynchronisationsproblem erkannt. Bitte melden, falls dies anhält." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulation" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Hofmechanik, Schwierigkeit und Nährstoffkreisläufe" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod-Steuerung &amp; Schwierigkeit" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systeme" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Aktionen &amp; Feldwerkzeuge" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: JA" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: NEIN" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Zellenbericht" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Keine Zellendaten gefunden" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Keine Bodendaten an dieser Position" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Feld Ø" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Zelle" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Bodenellen-Inspektion" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Zellendetails" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urea Líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de Amonio Líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Líquido (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante nitrogenado (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante nitrogenado (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoníaco Anhidro 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante nitrogenado (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante nitrogenado (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante nitrogenado (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante nitrogenado (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante fosfórico (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante fosfórico (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante potásico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea Líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante nitrogenado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante nitrogenado (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfórico (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfórico (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasa Líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potásico (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante de inicio (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Yeso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante orgánico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Estiércol de Pollo" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante orgánico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Estiércol Peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante orgánico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tanque de Cal Líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente elevador de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR DE SUELO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camine por un campo" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Alto" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibilidad detectada" />
-    <e k="sf_incompatibility_pf_text" v="El mod Soil & Fertilizer ha sido desactivado porque se detectó Precision Farming.\n\nEstos dos mods no son compatibles y no se pueden usar juntos." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros Pasos" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Previsualización no disponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salud Media del Suelo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir Resumen de Granja" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Ciclar Capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de Tratamiento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar Capa" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Aplica UAN32, UREA o ANHIDRO." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplica AMS o fertilizante INICIADOR." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplica MAP o DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Aplica POTASA (Potasio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Aplica HERBICIDA de inmediato." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplica INSECTICIDA de inmediato." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplica FUNGICIDA de inmediato." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bono Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (x1.15 agotamiento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sin datos disponibles." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Pasada: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="TASA APLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TASA APLIC.  AUTO: OFF [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Quemadura por Abono" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Campo %d: daño por sobre-aplicación (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Error de sincronización. Infórmalo si persiste." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulación" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Mecánicas de granja, dificultad y ciclos" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Control y Dificultad" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemas" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Acciones y Herramientas" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: SÍ" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: NO" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Informe Celda" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Sin datos de celda" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No hay datos de suelo aquí" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Prom. campo" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Celda" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspección de Celda" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalles Celda" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -59,12 +59,12 @@
     <e k="sf_diff_long" v="Soil management difficulty level" eh="d6f4560c" />
     <e k="sf_rr_short" v="Replenishment Rate" eh="b363b336" />
     <e k="sf_rr_long" v="How quickly fertilizer restores field nutrients (0.25x Very Slow to 2.0x Very Fast)" eh="afe78a6d" />
-    <e k="sf_dm_short" v="Disease Climate" />
-    <e k="sf_dm_long" v="Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
-    <e k="sf_dm_1" v="Arid" />
-    <e k="sf_dm_2" v="Temperate" />
-    <e k="sf_dm_3" v="Humid" />
-    <e k="sf_dm_4" v="Wet" />
+    <e k="sf_dm_short" v="Disease Climate" eh="86eac820" />
+    <e k="sf_dm_long" v="Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" eh="9948c967" />
+    <e k="sf_dm_1" v="Arid" eh="cf9aa4a8" />
+    <e k="sf_dm_2" v="Temperate" eh="e8328062" />
+    <e k="sf_dm_3" v="Humid" eh="ccb2fc34" />
+    <e k="sf_dm_4" v="Wet" eh="ae789b86" />
     <e k="sf_auto_rate_short" v="Auto Rate Control" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Automatically adjusts fertilizer application rate based on field needs" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Green" eh="d382816a" />
@@ -89,10 +89,10 @@
     <e k="sf_active_map_layer_long" v="Nutrient layer shown as overlay in the PDA map" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Map Detail" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Sample point budget for the PDA soil overlay. Low = better FPS, High = fuller coverage on large maps." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="Colorblind Mode" />
-    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
-    <e k="sf_show_field_info_box_short" v="Field Info Box" />
-    <e k="sf_show_field_info_box_long" v="Show soil nutrients in the native Field Info panel when standing on a field." />
+    <e k="sf_colorblind_mode_short" v="Colorblind Mode" eh="d5a644f4" />
+    <e k="sf_colorblind_mode_long" v="Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." eh="4de2f9fb" />
+    <e k="sf_show_field_info_box_short" v="Field Info Box" eh="bf8bc5c7" />
+    <e k="sf_show_field_info_box_long" v="Show soil nutrients in the native Field Info panel when standing on a field." eh="f7cd7156" />
     <e k="input_SF_OPEN_SETTINGS" v="Open Soil Settings" eh="2e31c0dd" />
     <e k="sf_reset" v="Reset Soil Settings" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Toggle Soil HUD" eh="f0224a10" />
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP Fertilizer 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Fertilizer 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potash 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Liquid Urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Liquid Ammonium Sulfate (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Liquid MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Fields %d-%d of %d  |  Page %d of %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Anhydrous Ammonia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potash 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Liquid Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Liquid AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Liquid MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Liquid DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Liquid Potash" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (liquid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (liquid)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypsum" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolids" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biosolids (10,000L)" eh="53b60563" />
+    <e k="sf_bigBag_biosolids_function" v="Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Chicken Manure" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
-    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="42d76587" />
-    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Chicken Manure (10,000L)" eh="dd621023" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
+    <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletized Manure" eh="064be7fa" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelletized Manure (10,000L)" eh="261ca096" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Liquid Lime Tank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Field %d" eh="08988997" />
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="High" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Map preview unavailable" eh="43983f81" />
     <e k="sf_map_health_overall" v="Average Soil Health" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Open Farm Overview" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Cycle Layer" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Treatment Plan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disable Overlay" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Apply UAN32, UREA, or ANHYDROUS." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Apply AMS or STARTER fertilizer." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Apply MAP or DAP (Phosphorus)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Apply POTASH (Potassium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Apply HERBICIDE immediately." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Apply INSECTICIDE immediately." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Apply FUNGICIDE immediately." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Legume Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 depletion)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="No data available." eh="c6d95d5e" />
@@ -556,9 +556,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Coverage: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Pass: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -587,6 +587,10 @@
     <e k="sf_notify_burn_title" v="Fertilizer Burn" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Field %d: over-application damage (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Data sync issue detected. Please report if this persists." eh="1a307946" />
+    <e k="sf_notify_lime_crop_title" v="Amendment Warning" eh="33228c86" />
+    <e k="sf_notify_lime_crop_body" v="Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+    <e k="sf_notify_om_crop_title" v="Amendment Warning" eh="33228c86" />
+    <e k="sf_notify_om_crop_body" v="Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -609,12 +613,12 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod Control &amp; Difficulty" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systems" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Actions &amp; Field Tools" eh="f64ba1c9" />
-    <e k="sf_panel_hdr_hud_layout" v="HUD Layout" />
-    <e k="sf_hud_enter_drag_label" v="Move &amp; Resize Panels" />
-    <e k="sf_hud_enter_drag_desc" v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." />
+    <e k="sf_panel_hdr_hud_layout" v="HUD Layout" eh="54e1930b" />
+    <e k="sf_hud_enter_drag_label" v="Move &amp; Resize Panels" eh="be34d24d" />
+    <e k="sf_hud_enter_drag_desc" v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
+    <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -652,7 +656,7 @@
     <e k="sf_desc_weedPressure" v="Track and penalize weed spread" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Track insect pest infestation" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Track fungal crop diseases" eh="0858395f" />
-    <e k="sf_desc_diseaseMoisture" v="Climate moisture level affecting disease spread and fungicide duration" />
+    <e k="sf_desc_diseaseMoisture" v="Climate moisture level affecting disease spread and fungicide duration" eh="97cb48de" />
     <e k="sf_desc_compactionEnabled" v="Heavy vehicle soil compaction" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Nutrient drain intensity level" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Fertilizer nutrient restoration speed" eh="858d2b23" />
@@ -661,8 +665,8 @@
     <e k="sf_desc_cropRotation" v="Rotation benefits and penalties" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Nutrient layer shown in PDA map" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Sample point budget (Low=8k, Med=20k, High=40k)" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" />
-    <e k="sf_desc_showFieldInfoBox" v="Show soil data in the Field Info panel" />
+    <e k="sf_desc_colorblindMode" v="Use orange/blue palette instead of red/green" eh="2862b921" />
+    <e k="sf_desc_showFieldInfoBox" v="Show soil data in the Field Info panel" eh="815e419e" />
 
     <!-- ======================================================
          SETTINGS PANEL — MULTI-OPTION VALUES
@@ -735,7 +739,7 @@
     <e k="sf_cell_report" v="Cell Report" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="No cell data found" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No soil data at this location" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cell" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Soil Cell Inspection" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Cell Details" eh="6fc5243e" />
@@ -770,7 +774,7 @@
     <!-- ======================================================
          SMART SENSOR PANEL
          ====================================================== -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -780,7 +784,7 @@
     <!-- ======================================================
          SEE & SPRAY PANEL
          ====================================================== -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
@@ -788,7 +792,7 @@
     <!-- ======================================================
          VARIABLE RATE PANEL
          ====================================================== -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
 
     <!-- input action display names -->
@@ -796,7 +800,7 @@
     <e k="action_SF_SENSOR_DISEASE"   v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"  v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"   v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"   v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"    v="SF: Toggle Variable Rate" />
     </elements>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urea líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de amonio líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP líquido (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante de nitrógeno (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante de nitrógeno (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoníaco anhidro 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante de nitrógeno (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante de nitrógeno (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante de nitrógeno (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante de nitrógeno (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante de fósforo (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante de fósforo (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante de potasio (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante de nitrógeno (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante de nitrógeno (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante de fósforo (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante de fósforo (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasa líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante de potasio (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante de inicio (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Yeso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Enmienda del suelo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Enmienda orgánica (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante orgánico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Estiércol de pollo" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante orgánico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Estiércol peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante orgánico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tanque de cal líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente elevador de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR DE SUELO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camina por un campo" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basado en N/P/K vs umbral óptimo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimiento ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibilidad detectada" />
-    <e k="sf_incompatibility_pf_text" v="El mod Soil & Fertilizer ha sido desactivado porque se detectó Precision Farming.\n\nEstos dos mods no son compatibles y no se pueden usar juntos." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Resumen" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Primeros pasos" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Previsualización no disponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salud promedio del suelo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir resumen de granja" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Ciclar capa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de tratamiento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desactivar capa" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Aplica UAN32, UREA o ANHIDRO." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplica AMS o fertilizante INICIADOR." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplica MAP o DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Aplica POTASA (Potasio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Aplica HERBICIDA de inmediato." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplica INSECTICIDA de inmediato." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplica FUNGICIDA de inmediato." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bono leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatiga (x1.15 agotamiento)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Sin datos disponibles." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Pasada: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="TASA APLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TASA APLIC.  AUTO: OFF [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Quemadura por abono" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Campo %d: daño por sobre-aplicación (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Error de sincronización. Infórmalo si persiste." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulación" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Mecánicas de granja, dificultad y ciclos" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Control y dificultad" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemas" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Acciones y herramientas" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: SÍ" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: NO" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Informe celda" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Sin datos de celda" eh="dc41c753" />
     <e k="sf_cell_no_data" v="No hay datos de suelo aquí" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Prom. campo" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Celda" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspección de celda" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalles celda" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Engrais MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Engrais DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasse 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urée liquide (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfate d'ammonium liquide (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Champs %d-%d de %d  |  Page %d sur %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniac anhydre 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Engrais azoté (sec) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS liquide" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP liquide" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP liquide" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasse liquide" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (liquide)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fongicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fongicide (liquide)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Engrais starter (liquide) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Amendement organique (sec) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fiente de poule" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fumier granulé" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Cuve de chaux liquide" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent correcteur de pH (liquide) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITEUR DU SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
     <e k="sf_hud_noField" v="Allez sur un champ" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Haute" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Aperçu" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Mise en route" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Aperçu indisponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Santé moyenne du sol" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Ouvrir aperçu ferme" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Changer couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan traitement" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Désactiver couche" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Appliquez UAN32, URÉE ou AMMONIAC." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Appliquez AMS ou engrais STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Appliquez MAP ou DAP (Phosphore)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Appliquez POTASSE (Potassium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Appliquez HERBICIDE immédiatement." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Appliquez INSECTICIDE immédiatement." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Appliquez FONGICIDE immédiatement." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus légumineuse (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 épuisement)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="MO" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Couverture : %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Passage : %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactage : %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="DÉBIT APPLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="DÉBIT APPLIC.  AUTO: OFF [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Brûlure d'engrais" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Champ %d : dégâts de surdosage (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod : Erreur de synchro détectée. Signalez-le si cela persiste." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulation" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Mécaniques, difficulté et cycles nutritifs" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Contrôle mod et difficulté" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systèmes" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Actions et outils de champ" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin : OUI" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin : NON" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Rapport cellule" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Données absentes" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Pas de données sol ici" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cellule" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspection de cellule" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Détails cellule" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP-lannoite 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-lannoite 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumsuola 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Nestemäinen urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Nestemäinen ammoniumsulfaatti (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Nestemäinen MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Sienimyrkky" eh="e8512698" />
     <e k="sf_report_page_info" v="Pellot %d–%d / %d  |  Sivu %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Typpilannoite (nestemäinen) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Typpilannoite (nestemäinen) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vedetön ammoniakki 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Typpilannoite (nestemäinen) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Suursäkki Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Typpilannoite (kuiva) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Suursäkki AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Typpilannoite (kuiva) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Suursäkki AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Typpilannoite (kuiva) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Suursäkki MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosforilannoite (kuiva) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Suursäkki DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosforilannoite (kuiva) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Suursäkki Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumlannoite (kuiva) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Nestemäinen urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Typpilannoite (nestemäinen) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Nestemäinen AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Typpilannoite (nestemäinen) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Nestemäinen MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosforilannoite (nestemäinen) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Nestemäinen DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosforilannoite (nestemäinen) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Nestemäinen kalium" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumlannoite (nestemäinen) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Startteri 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Hyönteismyrkky" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Hyönteismyrkky (nestemäinen)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Sienimyrkky" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Sienimyrkky (nestemäinen)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startterilannoite (nestemäinen) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Suursäkki Kipsi" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Maanparannusaine (kuiva) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Suursäkki Komposti" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Orgaaninen maanparannusaine (kuiva) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Suursäkki Biojäte" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Orgaaninen lannoite (kuiva) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Suursäkki Kanankakka" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Orgaaninen lannoite (kuiva) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Suursäkki Pellettoitu lanta" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Orgaaninen lannoite (kuiva) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Nestekalkkisäiliö" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-arvon nostaja (nestemäinen) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MAAPERÄN SEURANTA" eh="f8cda642" />
     <e k="sf_hud_field" v="Pelto %d" eh="08988997" />
     <e k="sf_hud_noField" v="Kävele pellolle" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Korkea" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Perustuu N/P/K-tasoihin vs. kynnysarvo" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Satohäviö ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Yleiskatsaus" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Aloittaminen" eh="bf647454" />
@@ -436,7 +436,7 @@
     <e k="sf_pda_map_unavailable" v="Kartan esikatselu ei ole käytettävissä" eh="43983f81" />
     <e k="sf_map_health_overall" v="Maaperän keskim. terveys" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Avaa tilan yleiskatsaus" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Vaihda tasoa" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Hoitosuunnitelma" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Poista peite käytöstä" eh="8e75dec5" />
@@ -516,15 +516,15 @@
     <e k="sf_treat_action_n_poor" v="Käytä UAN32:ta, UREAA tai AMMONIAKKIA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Käytä AMS- tai STARTTERIlannoitetta." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Käytä MAPia tai DAPia (Fosfori)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Käytä KALIUMSUOLAA (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Käytä RIKKAKASVIMYRKKYÄ välittömästi." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Käytä HYÖNTEISMYRKKYÄ välittömästi." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Käytä SIENIMYRKKYÄ välittömästi." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Palkokasvibonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Väsymys (x1.15 kulutus)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ei tietoja saatavilla." eh="c6d95d5e" />
@@ -534,9 +534,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Peitto: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Ajo: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Tiivistyminen: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="LEVITYSMÄÄRÄ ( AUTO: PÄÄLLÄ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="LEVITYSMÄÄRÄ  AUTO: POIS [%s]" eh="848cc106" />
@@ -559,6 +559,10 @@
     <e k="sf_notify_burn_title" v="Lannoitepolte" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Pelto %d: yliannostusvaurioita (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Synkronointivirhe havaittu. Raportoi, jos tämä toistuu." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulaatio" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Mekaniikat, vaikeusaste ja ravinnekierrot" eh="3c584cdb" />
@@ -578,6 +582,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Modin hallinta ja vaikeus" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Järjestelmät" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Toiminnot ja työkalut" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: KYLLÄ" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: EI" eh="a9394f7b" />
@@ -683,7 +690,7 @@
     <e k="sf_cell_report" v="Soluraportti" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Solutietoja ei löytynyt" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ei maaperätietoja tässä kohdassa" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Pelto kesk." />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Solu" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Maaperäsolun tarkastelu" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Solun tiedot" eh="6fc5243e" />
@@ -695,7 +702,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -703,7 +710,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -727,33 +733,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -59,12 +59,12 @@
     <e k="sf_diff_long" v="Niveau de difficulté de la gestion du sol" eh="d6f4560c" />
     <e k="sf_rr_short" v="Taux de reconstitution" eh="b363b336" />
     <e k="sf_rr_long" v="Vitesse à laquelle l'engrais restaure les nutriments du champ (0.25x très lent à 2.0x très rapide)" eh="afe78a6d" />
-    <e k="sf_dm_short" v="Climat des maladies" />
-    <e k="sf_dm_long" v="Niveau d’humidité du climat — contrôle la vitesse d’apparition des maladies fongiques et la durée de protection des fongicides" />
-    <e k="sf_dm_1" v="Aride" />
-    <e k="sf_dm_2" v="Tempéré" />
-    <e k="sf_dm_3" v="Humide" />
-    <e k="sf_dm_4" v="Très humide" />
+    <e k="sf_dm_short" v="[EN] Disease Climate" eh="86eac820" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" eh="9948c967" />
+    <e k="sf_dm_1" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_dm_2" v="[EN] Temperate" eh="e8328062" />
+    <e k="sf_dm_3" v="[EN] Humid" eh="ccb2fc34" />
+    <e k="sf_dm_4" v="[EN] Wet" eh="ae789b86" />
     <e k="sf_auto_rate_short" v="Contrôle automatique du taux" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Ajuste automatiquement la dose d'engrais selon les besoins du champ" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Vert" eh="d382816a" />
@@ -89,10 +89,10 @@
     <e k="sf_active_map_layer_long" v="Couche de nutriments affichée en superposition sur la carte PDA" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Détail de la carte" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Budget de points d'échantillonnage pour la superposition du sol sur la PDA. Faible = meilleures performances, Élevé = couverture plus complète sur les grandes cartes." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="Mode daltonien" />
-    <e k="sf_colorblind_mode_long" v="Remplace les couleurs d'état rouge/vert par orange/bleu (palette Okabe-Ito) pour améliorer l'accessibilité des personnes atteintes de deutéranopie et de protanopie." />
-    <e k="sf_show_field_info_box_short" v="Boîte d'informations du champ" />
-    <e k="sf_show_field_info_box_long" v="Afficher les nutriments du sol dans le panneau natif d'informations du champ lorsque vous vous trouvez sur un champ." />
+    <e k="sf_colorblind_mode_short" v="[EN] Colorblind Mode" eh="d5a644f4" />
+    <e k="sf_colorblind_mode_long" v="[EN] Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." eh="4de2f9fb" />
+    <e k="sf_show_field_info_box_short" v="[EN] Field Info Box" eh="bf8bc5c7" />
+    <e k="sf_show_field_info_box_long" v="[EN] Show soil nutrients in the native Field Info panel when standing on a field." eh="f7cd7156" />
     <e k="input_SF_OPEN_SETTINGS" v="Ouvrir les paramètres du sol" eh="2e31c0dd" />
     <e k="sf_reset" v="Réinitialiser les paramètres du sol" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Activer/désactiver le HUD du sol" eh="f0224a10" />
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Engrais MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Engrais DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasse 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urée liquide (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfate d'ammonium liquide (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP liquide (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fongicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Champs %d-%d sur %d  |  Page %d sur %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Engrais azoté (liquide) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Engrais azoté (liquide) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniac anhydre 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Engrais azoté (liquide) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urée 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Engrais azoté (sec) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Engrais azoté (sec) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Engrais azoté (sec) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Engrais phosphaté (sec) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Engrais phosphaté (sec) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasse 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Engrais potassique (sec) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="Engrais NPK (sec) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urée liquide" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Engrais azoté (liquide) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Sulfate d'ammonium liquide" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Engrais azoté (liquide) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP liquide" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Engrais phosphaté (liquide) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP liquide" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Engrais phosphaté (liquide) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasse liquide" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Engrais potassique (liquide) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (liquide)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fongicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fongicide (liquide)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Engrais de démarrage (liquide) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gypse" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Amendement du sol (sec) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Amendement organique du sol (sec) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolides" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biosolides (10 000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Engrais organique (sec) — +28N +3P +22K ppm, +2.0% MO @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" eh="53b60563" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Fumier de poulet" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Fumier de poulet (10 000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Engrais organique (sec) — +22N +3P +22K ppm, +1.1% MO @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" eh="dd621023" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Fumier pelletisé" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Fumier pelletisé (10 000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Engrais organique (sec) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" eh="261ca096" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Cuve de chaux liquide" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent d'augmentation du pH (liquide) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITEUR DE SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
     <e k="sf_hud_noField" v="Marchez sur un champ" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Élevé" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basé sur N/P/K par rapport au seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibilité détectée" />
-    <e k="sf_incompatibility_pf_text" v="Le mod Soil & Fertilizer a été désactivé car Precision Farming a été détecté.\n\nCes deux mods ne sont pas compatibles et ne peuvent pas être utilisés ensemble." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          LIGNES D’AIDE (ESC > Aide > Sol & Fertilisation réalistes)
@@ -440,7 +440,7 @@
     <e k="sf_pda_map_unavailable" v="Aperçu de la carte indisponible" eh="43983f81" />
     <e k="sf_map_health_overall" v="Santé moyenne du sol" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Ouvrir l'aperçu de la ferme" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Changer de couche" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan de traitement" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Désactiver la superposition" eh="8e75dec5" />
@@ -527,15 +527,15 @@
     <e k="sf_treat_action_n_poor" v="Appliquer UAN32, URÉE ou ANHYDRE." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Appliquer AMS ou engrais STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Appliquer MAP ou DAP (Phosphore)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Compléter avec du MAP liquide, du DAP liquide ou du DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Appliquer POTASSE (Potassium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Compléter avec de la potasse liquide ou de la potasse (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Appliquer HERBICIDE immédiatement." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Appliquer INSECTICIDE immédiatement." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Appliquer FONGICIDE immédiatement." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Effic. rendement" />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus légumineuse (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fatigue (x1.15 épuisement)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Aucune donnée disponible." eh="c6d95d5e" />
@@ -544,9 +544,9 @@
     <e k="sf_hud_label_om" v="MO" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="ppm" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Couverture : %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Passage : %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compaction : %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Rendement : %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     
     <!-- HUD débit pulvérisateur -->
     <e k="sf_sprayer_auto_on" v="DOSE APPL.  ( AUTO : ON )" eh="099b5dac" />
@@ -571,6 +571,10 @@
     <e k="sf_notify_burn_title" v="Brûlure d'engrais" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Champ %d : dégâts dus à une sur-application (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mod Sol : problème de synchronisation des données détecté. Veuillez signaler si cela persiste." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
     
     <!-- Catégories du panneau -->
     <e k="sf_panel_cat_sim" v="Simulation" eh="4f502b57" />
@@ -624,7 +628,7 @@
     <e k="sf_desc_weedPressure" v="Suivi et pénalisation de la propagation des mauvaises herbes" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Suivi des infestations d'insectes ravageurs" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Suivi des maladies fongiques des cultures" eh="0858395f" />
-    <e k="sf_desc_diseaseMoisture" v="Niveau d’humidité du climat influençant la propagation des maladies et la durée des fongicides" />
+    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" eh="97cb48de" />
     <e k="sf_desc_compactionEnabled" v="Compaction du sol par les véhicules lourds" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Niveau d'intensité de l'épuisement des nutriments" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Vitesse de restauration des nutriments par les engrais" eh="858d2b23" />
@@ -633,8 +637,8 @@
     <e k="sf_desc_cropRotation" v="Avantages et pénalités de la rotation des cultures" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Couche de nutriments affichée sur la carte PDA" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Budget des points d'échantillonnage (Bas=8k, Moyen=20k, Élevé=40k)" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="Utiliser une palette orange/bleu au lieu du rouge/vert" />
-    <e k="sf_desc_showFieldInfoBox" v="Afficher les données du sol dans le panneau d'informations du champ" />
+    <e k="sf_desc_colorblindMode" v="[EN] Use orange/blue palette instead of red/green" eh="2862b921" />
+    <e k="sf_desc_showFieldInfoBox" v="[EN] Show soil data in the Field Info panel" eh="815e419e" />
 
     <!-- Valeurs multi-options -->
     <e k="sf_rr_1" v="Très lent (0.25x)" eh="b681a1b4" />
@@ -702,7 +706,7 @@
     <e k="sf_cell_report" v="Rapport de cellule" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Aucune donnée de cellule trouvée" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Aucune donnée de sol à cet endroit" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Moy. champ" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cellule" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspection de cellule de sol" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Détails de la cellule" eh="6fc5243e" />
@@ -714,62 +718,32 @@
     <!-- PANNEAU CAPTEURS INTELLIGENTS -->
 	
     <!-- SYSTÈMES INTELLIGENTS -->
-    <e k="sf_panel_hdr_smart_systems" v="Systèmes intelligents" />
-    <e k="sf_nav_smart_systems_label" v="Systèmes intelligents" />
-    <e k="sf_nav_smart_systems_desc" v="Configurer les systèmes Smart Sensor, See &amp; Spray et application à dose variable" />
     <e k="sf_nav_tuning_label"            v="Constants Tuning Editor" />
     <e k="sf_nav_tuning_desc"             v="Fine-tune simulation constants: depletion rates, stress growth, starting soil values" />
-    <e k="sf_panel_hdr_smart_sensor_sys" v="Système Smart Sensor" />
-    <e k="sf_panel_hdr_see_spray_sys" v="Système See &amp; Spray" />
-    <e k="sf_panel_hdr_var_rate_sys" v="Système d’application à dose variable" />
-    <e k="sf_smart_sensor_short" v="Smart Sensor" />
-    <e k="sf_smart_sensor_long" v="Activer ou désactiver le système de capteurs de pulvérisation Smart Sensor" />
-    <e k="sf_see_and_spray_short" v="See &amp; Spray" />
-    <e k="sf_see_and_spray_long" v="Activer ou désactiver le système de pulvérisation de précision See &amp; Spray" />
-    <e k="sf_variable_rate_short" v="Dose variable" />
-    <e k="sf_variable_rate_long" v="Activer ou désactiver l’application à dose variable selon les déficits du sol" />
-    <e k="sf_desc_smartSensorEnabled" v="Permet aux joueurs d’utiliser le contrôle des sections de rampe Smart Sensor basé sur les données du sol en temps réel" />
-    <e k="sf_desc_seeAndSprayEnabled" v="Désactive les sections de rampe sur les zones ne nécessitant pas de traitement" />
-    <e k="sf_desc_variableRateEnabled" v="Ajuste le taux d’application par section selon les déficits de nutriments du sol" />
     <e k="sf_panel_hdr_field_boundary"     v="Field Boundary Control" />
     <e k="sf_field_boundary_short"         v="Boundary Control" />
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
 	
     <!-- PANNEAU CAPTEURS INTELLIGENTS -->
-    <e k="sf_sensor_panel_title" v="CAPTEURS INTELLIGENTS" />
-    <e k="sf_sensor_pest" v="Capteur de ravageurs" />
-    <e k="sf_sensor_disease" v="Capteur de maladies" />
-    <e k="sf_sensor_nutrient" v="Capteur de nutriments" />
-    <e k="sf_sensor_state_on" v="ON" />
-    <e k="sf_sensor_state_off" v="OFF" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
 	
     <!-- PANNEAU SEE & SPRAY -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
-    <e k="sf_see_spray_pest" v="Ravageurs" />
-    <e k="sf_see_spray_disease" v="Maladies" />
-    <e k="sf_see_spray_weed" v="Mauvaises herbes" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
 	
     <!-- PANNEAU DOSE VARIABLE -->
-    <e k="sf_var_rate_panel_title" v="DOSE VARIABLE" />
-    <e k="sf_var_rate_label" v="Dose var." />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
 	
     <!-- ACTIONS D'ENTRÉE -->
-    <e k="action_SF_SENSOR_PEST" v="SF : Activer/Désactiver capteur ravageurs" />
-    <e k="action_SF_SENSOR_DISEASE" v="SF : Activer/Désactiver capteur maladies" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF : Activer/Désactiver capteur nutriments" />
-    <e k="action_SF_SEE_SPRAY_PEST" v="SF : Activer/Désactiver See &amp; Spray ravageurs" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF : Activer/Désactiver See &amp; Spray maladies" />
-    <e k="action_SF_SEE_SPRAY_WEED" v="SF : Activer/Désactiver See &amp; Spray mauvaises herbes" />
-    <e k="action_SF_VARIABLE_RATE" v="SF : Activer/Désactiver dose variable" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
 	
     <!-- MISE EN PAGE HUD (glisser-déposer) -->
-    <e k="sf_panel_hdr_hud_layout" v="Disposition HUD" />
-    <e k="sf_independent_panels_short" v="Disposition libre des panneaux" />
-    <e k="sf_independent_panels_long" v="Permet de positionner indépendamment les panneaux des systèmes intelligents en mode édition" />
-    <e k="sf_desc_independentPanels" v="Déplacez chaque panneau librement via le mode édition Shift+H. Réduisez les panneaux avec le bouton - dans leur barre de titre." />
-    <e k="sf_hud_enter_drag_label" v="Déplacer &amp; redimensionner les panneaux" />
-    <e k="sf_hud_enter_drag_desc" v="Faites glisser pour repositionner — tirez un coin pour redimensionner — clic droit ou Échap pour terminer" />
+    <e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />
+    <e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+    <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
     </elements>
 
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -89,10 +89,10 @@
     <e k="sf_active_map_layer_long" v="Tápanyagréteg megjelenítése átfedésként a PDA térképen" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Térkép részletesség" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Mintavételi pontok kerete a PDA talajátfedéshez. Alacsony = jobb FPS, Magas = teljesebb lefedettség nagy térképeken." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="Színtévesztő mód" />
-    <e k="sf_colorblind_mode_long" v="A piros/zöld állapotszíneket narancs/kék színekre cseréli (Okabe–Ito paletta) a deuteranópia és protanópia jobb támogatásához." />
-    <e k="sf_show_field_info_box_short" v="Mezőinformációs panel" />
-    <e k="sf_show_field_info_box_long" v="Talajtápanyagok megjelenítése az alap Mezőinformáció panelen, amikor mezőn állsz." />
+    <e k="sf_colorblind_mode_short" v="[EN] Colorblind Mode" eh="d5a644f4" />
+    <e k="sf_colorblind_mode_long" v="[EN] Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." eh="4de2f9fb" />
+    <e k="sf_show_field_info_box_short" v="[EN] Field Info Box" eh="bf8bc5c7" />
+    <e k="sf_show_field_info_box_long" v="[EN] Show soil nutrients in the native Field Info panel when standing on a field." eh="f7cd7156" />
     <e k="input_SF_OPEN_SETTINGS" v="Talaj beállítások megnyitása" eh="2e31c0dd" />
     <e k="sf_reset" v="Talajbeállítások alaphelyzetbe állítása" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Talaj HUD váltása" eh="f0224a10" />
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP műtrágya 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP műtrágya 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Hamuzsír 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Folyékony karbamid (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Folyékony ammónium-szulfát (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Folyékony MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Gombaölő szer" eh="e8512698" />
     <e k="sf_report_page_info" v="Mezők %d-%d / %d  |  Oldal %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vízmentes ammónia 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Karbamid 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogén műtrágya (száraz)" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Foszfor műtrágya (száraz)" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Hamuzsír 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kálium műtrágya (száraz)" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Folyékony karbamid" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Folyékony AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogén műtrágya (folyékony)" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Folyékony MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Foszfor műtrágya (folyékony)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Folyékony DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Foszfor műtrágya (folyékony)" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Folyékony hamuzsír" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kálium műtrágya (folyékony)" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter műtrágya 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Rovarölő szer" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Rovarölő szer (folyékony)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Gombaölő szer" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Gombaölő szer (folyékony)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Starter műtrágya (folyékony)" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gipsz" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Talajjavító (száraz)" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Komposzt" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Szerves talajjavító (száraz)" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Bioszilárd" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Bioszilárd (10 000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" eh="53b60563" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Csirketrágya" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Csirketrágya (10 000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" eh="dd621023" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletált trágya" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Pelletált trágya (10 000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Szerves műtrágya (száraz)" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" eh="261ca096" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Folyékony mész tartály" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH növelő szer (folyékony)" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="TALAJ MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mező %d" eh="08988997" />
     <e k="sf_hud_noField" v="Sétáljon egy mezőre" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Magas" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Az N/P/K arány alapján az optimális küszöbhöz képest" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hozam ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -452,7 +452,7 @@
     <e k="sf_pda_map_unavailable" v="Térkép előnézet nem elérhető" eh="43983f81" />
     <e k="sf_map_health_overall" v="Átlagos talaj egészség" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Gazdaság áttekintés" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Súgó" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Réteg váltás" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kezelési terv" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Átfedés kikapcsolása" eh="8e75dec5" />
@@ -534,17 +534,17 @@
     <e k="sf_treat_action_n_poor" v="Alkalmazzon UAN32-t, KARBAMIDOT vagy VÍZMENTES AMMÓNIÁT." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Alkalmazzon AMS-t vagy STARTER műtrágyát." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Alkalmazzon MAP-ot vagy DAP-ot (Foszfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Alkalmazzon kevert MŰTRÁGYÁT." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Alkalmazzon HAMUZSÍRT (Kálium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Alkalmazzon kevert MŰTRÁGYÁT." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Azonnal alkalmazzon GYOMIRTÓT." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Azonnal alkalmazzon ROVARÖLŐT." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Azonnal alkalmazzon GOMBAÖLŐT." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
     <e k="sf_detail_rotation_bonus" v="Pillangós bónusz (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fáradtság (x1.15 kimerülés)" eh="522a6d93" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_no_field" v="Nincs elérhető adat." eh="c6d95d5e" />
     <e k="sf_detail_no_crop" v="Nincs rögzítve" eh="a4b5a996" />
     <!-- HUD labels -->
@@ -552,9 +552,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Lefedettség: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Menet: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Tömörödés: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="KIJUTT. ARÁNY  ( AUTO: BE )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="KIJUTT. ARÁNY  AUTO: KI [%s]" eh="848cc106" />
@@ -577,6 +577,10 @@
     <e k="sf_notify_burn_title" v="Műtrágya kiégés" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="%d mező: túladagolási kár (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Talaj Mod: Adatszinkronizálási hiba észlelve. Jelentsd, ha továbbra is fennáll." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
     <!-- Panel categories -->
     <e k="sf_panel_cat_sim" v="Szimuláció" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Gazdasági mechanika, nehézség és tápanyagciklusok" eh="3c584cdb" />
@@ -596,6 +600,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod vezérlés &amp; Nehézség" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Rendszerek" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Műveletek &amp; Mező eszközök" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
     <!-- Panel chrome -->
     <e k="sf_panel_admin_yes" v="Admin: IGEN" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: NEM" eh="a9394f7b" />
@@ -636,8 +643,8 @@
     <e k="sf_desc_cropRotation" v="Vetésforgó előnyök és büntetések" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Tápanyagréteg a PDA térképen" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Mintapont keret (Alacsony=8k, Közepes=20k, Magas=40k)" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="Narancs/kék színpaletta használata piros/zöld helyett" />
-    <e k="sf_desc_showFieldInfoBox" v="Talajadatok megjelenítése a Mezőinformáció panelen" />
+    <e k="sf_desc_colorblindMode" v="[EN] Use orange/blue palette instead of red/green" eh="2862b921" />
+    <e k="sf_desc_showFieldInfoBox" v="[EN] Show soil data in the Field Info panel" eh="815e419e" />
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Nagyon lassú (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Lassú (0.5x)" eh="db69874d" />
@@ -702,7 +709,7 @@
     <e k="sf_cell_report" v="Cella jelentés" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nem található cellaadat" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nincs talajadat ezen a helyen" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Mező átlaga" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cella" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Talajcella vizsgálat" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Cella részletei" eh="6fc5243e" />
@@ -714,7 +721,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -722,7 +729,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -746,33 +752,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Pupuk MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Pupuk DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kalium 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urea Cair (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Amonium Sulfat Cair (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Cair (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungisida" eh="e8512698" />
     <e k="sf_report_page_info" v="Lahan %d-%d dari %d  |  Halaman %d dari %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Pupuk Nitrogen (cair) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Pupuk Nitrogen (cair) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amonia Anhidrat 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Pupuk Nitrogen (cair) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Pupuk Nitrogen (kering) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Pupuk Nitrogen (kering) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Pupuk Nitrogen (kering) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Pupuk Fosfor (kering) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Pupuk Fosfor (kering) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Pupuk Kalium (kering) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urea Cair" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Pupuk Nitrogen (cair) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Cair" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Pupuk Nitrogen (cair) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Cair" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Pupuk Fosfor (cair) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Cair" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Pupuk Fosfor (cair) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Kalium Cair" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Pupuk Kalium (cair) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektisida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektisida (cair)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungisida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungisida (cair)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Pupuk Starter (cair) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Pembenah Tanah (kering) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompos" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Pembenah Tanah Organik (kering) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolid" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Pupuk Organik (kering) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kotoran Ayam" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Pupuk Organik (kering) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pupuk Kandang Pelet" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Pupuk Organik (kering) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Tangki Kapur Cair" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agen Peningkat pH (cair) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR TANAH" eh="f8cda642" />
     <e k="sf_hud_field" v="Lahan %d" eh="08988997" />
     <e k="sf_hud_noField" v="Masuk ke dalam lahan" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Tinggi" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Berdasarkan N/P/K vs ambang batas optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Hasil ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Pratinjau peta tidak tersedia" eh="43983f81" />
     <e k="sf_map_health_overall" v="Rata-rata Kesehatan Tanah" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Buka Ikhtisar Pertanian" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Siklus Lapisan" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Rencana Perawatan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Nonaktifkan Overlay" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Terapkan UAN32, UREA, atau ANHIDRAT." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Terapkan AMS atau pupuk STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Terapkan MAP atau DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Terapkan KALIUM (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Terapkan HERBISIDA segera." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Terapkan INSEKTISIDA segera." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Terapkan FUNGISIDA segera." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus Polong-polongan (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Kelelahan (penipisan x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Tidak ada data tersedia." eh="c6d95d5e" />
@@ -556,9 +556,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cakupan: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Jalur: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Pemadatan: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -587,6 +587,10 @@
     <e k="sf_notify_burn_title" v="Terbakar Pupuk" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Lahan %d: kerusakan aplikasi berlebih (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mod Tanah: Masalah sinkronisasi data terdeteksi. Silakan lapor jika berlanjut." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -609,6 +613,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Kontrol Mod &amp; Kesulitan" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistem" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Aksi &amp; Alat Lahan" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -729,7 +736,7 @@
     <e k="sf_cell_report" v="Laporan Sel" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Data sel tidak ditemukan" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Tidak ada data tanah di lokasi ini" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Sel" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeksi Sel Tanah" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detail Sel" eh="6fc5243e" />
@@ -741,7 +748,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -749,7 +756,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -773,33 +779,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Fertilizzante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizzante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urea Liquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Solfato di Ammonio Liquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Liquido (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicida" eh="e8512698" />
     <e k="sf_report_page_info" v="Campi %d-%d di %d  |  Pagina %d di %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizzante azotato (liquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizzante azotato (liquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Ammoniaca anidra 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizzante azotato (liquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizzante azotato (secco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizzante azotato (secco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizzante azotato (secco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizzante fosfatico (secco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizzante fosfatico (secco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassio 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizzante potassico (secco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="Big Bag Urea Liquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizzante Azotato (liquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="Big Bag AMS Liquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizzante Azotato (liquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="Big Bag MAP Liquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizzante Fosfatico (liquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="Big Bag DAP Liquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizzante Fosfatico (liquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="Big Bag Potassio Liquido" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizzante Potassico (liquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insetticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insetticida (liquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (liquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizzante starter (liquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Miglioratore del suolo (secco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Miglioratore organico (secco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolidi" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizzante organico (secco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Pollina" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizzante organico (secco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Letame Pellettato" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizzante organico (secco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Serbatoio Calce Liquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente correttore pH (liquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
 		<e k="sf_hud_title" v="MONITORAGGIO SUOLO" eh="f8cda642" />
 		<e k="sf_hud_field" v="Campo %d" eh="08988997" />
 		<e k="sf_hud_noField" v="Cammina su un campo" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basato su N/P/K rispetto alla soglia ottimale" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Resa ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Anteprima mappa non disponibile" eh="43983f81" />
     <e k="sf_map_health_overall" v="Salute Media del Suolo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Apri Panoramica Fattoria" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Cambia livello" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Piano di trattamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disabilita overlay" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Applica UAN32, UREA o ANIDRA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Applica AMS o fertilizzante STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Applica MAP o DAP (Fosforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Applica POTASSIO (Potash)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Applica ERBICIDA immediatamente." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Applica INSETTICIDA immediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Applica FUNGICIDE immediatamente." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus Leguminose (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Stanchezza (deplezione x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nessun dato disponibile." eh="c6d95d5e" />
@@ -556,9 +556,9 @@
     <e k="sf_hud_label_om" v="Sostanza Organica" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Copertura: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Passata: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compattazione: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -587,6 +587,10 @@
     <e k="sf_notify_burn_title" v="Bruciatura da Fertilizzante" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Campo %d: danno da sovrapplicazione (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Rilevato errore di sincronizzazione dati. Segnala se il problema persiste." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -609,6 +613,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Controllo Mod &amp; Difficoltà" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemi" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Azioni &amp; Strumenti Campo" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -729,7 +736,7 @@
     <e k="sf_cell_report" v="Rapporto Cella" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Dati cella non trovati" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nessun dato del suolo in questa posizione" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Media campo" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cella" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Ispezione Cella Suolo" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Dettagli Cella" eh="6fc5243e" />
@@ -741,7 +748,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -749,7 +756,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -773,33 +779,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP 肥料 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP 肥料 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="塩化カリ 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="液体尿素 (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="液体硫酸アンモニウム (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="液体 MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="殺菌剤" eh="e8512698" />
     <e k="sf_report_page_info" v="フィールド %d-%d / %d  |  %d / %d ページ" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="窒素肥料（液体） — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="窒素肥料（液体） — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC 無水アンモニア 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="窒素肥料（液体） — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="ビッグバッグ 尿素 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="窒素肥料（乾燥） — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="ビッグバッグ 硝安 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="窒素肥料（乾燥） — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="ビッグバッグ 硫安 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="窒素肥料（乾燥） — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="ビッグバッグ MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="リン酸肥料（乾燥） — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="ビッグバッグ DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="リン酸肥料（乾燥） — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="ビッグバッグ 塩化カリ 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="カリウム肥料（乾燥） — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC 液体尿素" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="窒素肥料（液体） — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC 液体硫安" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="窒素肥料（液体） — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC 液体 MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="リン酸肥料（液体） — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC 液体 DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="リン酸肥料（液体） — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC 液体塩化カリ" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="カリウム肥料（液体） — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC スターター 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC 殺虫剤" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="殺虫剤（液体）" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC 殺菌剤" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="殺菌剤（液体）" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="スターター肥料（液体） — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="ビッグバッグ 石膏" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="土壌改良材（乾燥） — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="ビッグバッグ 堆肥" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="有機土壌改良材（乾燥） — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="ビッグバッグ バイオソリッド" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="有機肥料（乾燥） — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="ビッグバッグ 鶏糞" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="有機肥料（乾燥） — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="ビッグバッグ ペレット堆肥" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="有機肥料（乾燥） — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="液体石灰タンク" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH上昇剤（液体） — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="土壌モニター" eh="f8cda642" />
     <e k="sf_hud_field" v="フィールド %d" eh="08988997" />
     <e k="sf_hud_noField" v="フィールドに入ってください" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="高" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="窒素/リン/カリの最適閾値に基づきます" eh="022663e0" />
     <e k="sf_report_yield_loss" v="収量予測 ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="マッププレビュー利用不可" eh="43983f81" />
     <e k="sf_map_health_overall" v="平均土壌健全度" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="農場概要を開く" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="レイヤー切替" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="施肥計画" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="オーバーレイ無効" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="UAN32、尿素、または無水アンモニアを散布してください。" eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS またはスターター肥料を散布してください。" eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP または DAP (リン酸) を散布してください。" eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="塩化カリ (カリウム) を散布してください。" eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="直ちに除草剤を散布してください。" eh="625551c5" />
     <e k="sf_treat_action_pest" v="直ちに殺虫剤を散布してください。" eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="直ちに殺菌剤を散布してください。" eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="良好" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="マメ科ボーナス (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="連作障害 (消耗 1.15倍)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="データなし。" eh="c6d95d5e" />
@@ -552,9 +552,9 @@
     <e k="sf_hud_label_om" v="有機物" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="被覆率: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="散布: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="踏み固め: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     
     <!-- 散布レート HUD -->
     <e k="sf_sprayer_auto_on" v="散布レート (自動: オン)" eh="099b5dac" />
@@ -579,6 +579,10 @@
     <e k="sf_notify_burn_title" v="肥料焼け" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="フィールド %d: 過剰散布によるダメージ (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="土壌Mod: データ同期の問題を検出しました。続くようであれば報告してください。" eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
     
     <!-- 設定パネルカテゴリ -->
     <e k="sf_panel_cat_sim" v="シミュレーション" eh="4f502b57" />
@@ -599,6 +603,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod制御と難易度" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="システム" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="アクションとツール" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
     
     <!-- パネル Chrome -->
     <e k="sf_panel_admin_yes" v="管理者: はい" eh="4628842a" />
@@ -709,7 +716,7 @@
     <e k="sf_cell_report" v="セルレポート" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="セルデータなし" eh="dc41c753" />
     <e k="sf_cell_no_data" v="この場所には土壌データがありません" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="セル" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="土壌セル検査" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="セル詳細" eh="6fc5243e" />
@@ -721,7 +728,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -729,7 +736,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -753,33 +759,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP 비료 11-52-0 (인산)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP 비료 18-46-0 (인산)" eh="5030a80a" />
     <e k="sf_potash_title" v="칼리 0-0-60 (칼륨)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="액상 요소 (질소)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="액상 황산 암모늄 (질소)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="액상 MAP (인산)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="살균제" eh="e8512698" />
     <e k="sf_report_page_info" v="필드 %d-%d (총 %d개)  |  페이지 %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="질소 비료 (액체) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="질소 비료 (액체) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC 무수 암모니아 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="질소 비료 (액체) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="빅백 요소 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="질소 비료 (고체) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="빅백 AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="질소 비료 (고체) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="빅백 AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="질소 비료 (고체) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="빅백 MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="인산 비료 (고체) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="빅백 DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="인산 비료 (고체) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="빅백 칼리 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="칼륨 비료 (고체) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC 액상 요소" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="질소 비료 (액체) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC 액상 AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="질소 비료 (액체) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC 액상 MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="인산 비료 (액체) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC 액상 DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="인산 비료 (액체) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC 액상 칼리" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="칼륨 비료 (액체) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC 스타터 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC 살충제" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="살충제 (액체)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC 살균제" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="살균제 (액체)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="스타터 비료 (액체) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="빅백 석고" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="토양 개량제 (고체) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="빅백 퇴비" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="유기질 토양 개량제 (고체) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="빅백 바이오솔리드" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="유기질 비료 (고체) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="빅백 계분" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="유기질 비료 (고체) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="빅백 펠렛 퇴비" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="유기질 비료 (고체) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="액상 석회 탱크" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH 조절제 (액체) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="토양 모니터" eh="f8cda642" />
     <e k="sf_hud_field" v="필드 %d" eh="08988997" />
     <e k="sf_hud_noField" v="필드에 입장하세요" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="높음" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="최적 임계값 대비 N/P/K 기준" eh="022663e0" />
     <e k="sf_report_yield_loss" v="수확량 ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -450,7 +450,7 @@
     <e k="sf_pda_map_unavailable" v="지도 미리보기를 사용할 수 없음" eh="43983f81" />
     <e k="sf_map_health_overall" v="평균 토양 건강도" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="농장 개요 열기" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="레이어 전환" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="처리 계획" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="오버레이 비활성화" eh="8e75dec5" />
@@ -534,15 +534,15 @@
     <e k="sf_treat_action_n_poor" v="UAN32, 요소 또는 무수 암모니아를 살포하세요." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS 또는 스타터 비료를 살포하세요." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP 또는 DAP(인산)를 살포하세요." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="칼리(칼륨)를 살포하세요." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="즉시 제초제를 살포하세요." eh="625551c5" />
     <e k="sf_treat_action_pest" v="즉시 살충제를 살포하세요." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="즉시 살균제를 살포하세요." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="확인" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="콩과 보너스 (+질소)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="연작 피해 (1.15배 소모)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="데이터 없음" eh="c6d95d5e" />
@@ -553,9 +553,9 @@
     <e k="sf_hud_label_om" v="유기물" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="범위: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="살포: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="압축도: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="살포량 ( 자동: 켬 )" eh="099b5dac" />
@@ -580,6 +580,10 @@
     <e k="sf_notify_burn_title" v="비료 피해" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="%d번 필드: 과다 살포 피해 발생 (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="토양 모드: 데이터 동기화 문제가 감지되었습니다. 지속될 경우 보고해 주세요." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- Settings Panel -->
     <e k="sf_panel_cat_sim" v="시뮬레이션" eh="4f502b57" />
@@ -600,6 +604,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="모드 제어 및 난이도" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="시스템" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="작업 및 필드 도구" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- Settings Panel Chrome -->
     <e k="sf_panel_admin_yes" v="관리자: 예" eh="4628842a" />
@@ -710,7 +717,7 @@
     <e k="sf_cell_report" v="셀 보고서" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="셀 데이터를 찾을 수 없음" eh="dc41c753" />
     <e k="sf_cell_no_data" v="이 위치에 토양 데이터가 없습니다" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="셀" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="토양 셀 조사" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="셀 상세 정보" eh="6fc5243e" />
@@ -722,7 +729,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -730,7 +737,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -754,33 +760,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP Meststof 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Meststof 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kali 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Vloeibare Ureum (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Vloeibare Ammoniumsulfaat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Vloeibare MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Velden %d-%d van %d  |  Pagina %d van %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Stikstofmeststof (vloeibaar) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Stikstofmeststof (vloeibaar) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Watervrij Ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Stikstofmeststof (vloeibaar) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureum 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Stikstofmeststof (droog) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Stikstofmeststof (droog) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Stikstofmeststof (droog) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfaatmeststof (droog) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfaatmeststof (droog) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kali 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kalimeststof (droog) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Vloeibare Ureum" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Stikstofmeststof (vloeibaar) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Vloeibare AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Stikstofmeststof (vloeibaar) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Vloeibare MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfaatmeststof (vloeibaar) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Vloeibare DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfaatmeststof (vloeibaar) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Vloeibare Kali" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kalimeststof (vloeibaar) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (vloeibaar)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (vloeibaar)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Bodemverbeteraar (droog) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organische bodemverbeteraar (droog) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biogrondstoffen" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organische meststof (droog) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kippenmest" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organische meststof (droog) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Gekorrelde mest" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organische meststof (droog) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Vloeibare kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-verhogend middel (vloeibaar) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="BODEM MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Veld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Loop een veld op" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Hoog" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Gebaseerd op N/P/K versus optimale drempel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Opbrengstverlies ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Kaartvoorbeeld niet beschikbaar" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gemiddelde bodemgezondheid" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Open boerderijoverzicht" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Laag wisselen" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandelplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay uitschakelen" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Gebruik UAN32, UREUM of WATERVRIJ AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Gebruik AMS of STARTER meststof." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Gebruik MAP of DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Gebruik POTASH (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Onmiddellijk HERBICIDE toepassen." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Onmiddellijk INSECTICIDE toepassen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Onmiddellijk FUNGICIDE toepassen." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Bodemmoeheid (x1,15 uitputting)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Geen gegevens beschikbaar." eh="c6d95d5e" />
@@ -554,9 +554,9 @@
     <e k="sf_hud_label_om" v="OS" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dekking: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Ronde: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Verdichting: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DOSERING ( AUTO: AAN )" eh="099b5dac" />
@@ -581,6 +581,10 @@
     <e k="sf_notify_burn_title" v="Meststofverbranding" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Veld %d: schade door overdosering (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Bodem Mod: Datasynchronisatieprobleem gedetecteerd. Meld dit als het aanhoudt." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- Settings Panel -->
     <e k="sf_panel_cat_sim" v="Simulatie" eh="4f502b57" />
@@ -601,6 +605,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod-beheer &amp; Moeilijkheid" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systemen" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Acties &amp; Veldtools" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- Settings Panel Chrome -->
     <e k="sf_panel_admin_yes" v="Admin: JA" eh="4628842a" />
@@ -711,7 +718,7 @@
     <e k="sf_cell_report" v="Celrapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Geen celgegevens gevonden" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Geen bodemgegevens op deze locatie" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Veld gem." />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cel" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Bodemcel-inspectie" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celdetails" eh="6fc5243e" />
@@ -723,7 +730,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -731,7 +738,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -755,33 +761,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP Gjødsel 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Gjødsel 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kalium 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Flytende Urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flytende Ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flytende MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Soppmiddel" eh="e8512698" />
     <e k="sf_report_page_info" v="Felt %d-%d av %d  |  Side %d av %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nitrogengjødsel (flytende) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nitrogengjødsel (flytende) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vannfri ammoniakk 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nitrogengjødsel (flytende) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nitrogengjødsel (tørr) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nitrogengjødsel (tørr) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nitrogengjødsel (tørr) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfatgjødsel (tørr) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfatgjødsel (tørr) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kalium 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumgjødsel (tørr) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flytende Urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nitrogengjødsel (flytende) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flytende AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nitrogengjødsel (flytende) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Flytende MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfatgjødsel (flytende) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Flytende DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgjødsel (flytende) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Flytende Kalium" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgjødsel (flytende) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektmiddel" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektmiddel (flytende)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Soppmiddel" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Soppmiddel (flytende)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startgjødsel (flytende) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Jordforbedring (tørr) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organisk jordforbedring (tørr) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Bioslam" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organisk gjødsel (tørr) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Hønsegjødsel" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organisk gjødsel (tørr) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Pelletsert gjødsel" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organisk gjødsel (tørr) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flytende kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-hevende middel (flytende) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Felt %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ut på et felt" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Høy" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Basert på N/P/K mot optimal terskel" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Avlingstap ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Kartforhåndsvisning utilgjengelig" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gjennomsnittlig jordhelse" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Åpne gårdsoversikt" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Bytt lag" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Deaktiver overlegg" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Påfør UAN32, UREA eller VANNFRI AMMONIAKK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Påfør AMS eller START-gjødsel." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Påfør MAP eller DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Påfør KALIUM (K-gjødsel)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Påfør UGRESSMIDDEL umiddelbart." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Påfør INSEKTMIDDEL umiddelbart." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Påfør SOPPMIDDEL umiddelbart." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Belgvekstbonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Tretthet (x1,15 uttømming)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tilgjengelig." eh="c6d95d5e" />
@@ -554,9 +554,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dekning: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Kjøring: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Pakking: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="PÅFØR. RATE ( AUTO: PÅ )" eh="099b5dac" />
@@ -581,6 +581,10 @@
     <e k="sf_notify_burn_title" v="Sviskade fra gjødsel" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Felt %d: skade ved overdosering (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Jordmod: Problem med datasynkronisering oppdaget. Vennligst rapporter hvis dette vedvarer." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- Settings Panel -->
     <e k="sf_panel_cat_sim" v="Simulering" eh="4f502b57" />
@@ -601,6 +605,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod-kontroll og vanskelighetsgrad" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systemer" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Handlinger og feltverktøy" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- Settings Panel Chrome -->
     <e k="sf_panel_admin_yes" v="Admin: JA" eh="4628842a" />
@@ -711,7 +718,7 @@
     <e k="sf_cell_report" v="Cellerapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Ingen celledata funnet" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ingen jorddata på denne lokasjonen" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Felt gj.snitt" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Celle" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeksjon av jordcelle" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celledetaljer" eh="6fc5243e" />
@@ -723,7 +730,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -731,7 +738,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -755,33 +761,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Nawóz MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Nawóz DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Sól potasowa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Mocznik w płynie (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Siarczan amonu w płynie (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP w płynie (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicyd" eh="e8512698" />
     <e k="sf_report_page_info" v="Pola %d-%d z %d  |  Strona %d z %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Nawóz azotowy (płynny) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Nawóz azotowy (płynny) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoniak bezwodny 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Nawóz azotowy (płynny) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Mocznik 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Nawóz azotowy (suchy) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Nawóz azotowy (suchy) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Nawóz azotowy (suchy) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Nawóz fosforowy (suchy) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Nawóz fosforowy (suchy) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Sól potasowa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Nawóz potasowy (suchy) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Mocznik w płynie" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Nawóz azotowy (płynny) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Siarczan amonu w płynie" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Nawóz azotowy (płynny) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP w płynie" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Nawóz fosforowy (płynny) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP w płynie" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Nawóz fosforowy (płynny) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potas w płynie" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Nawóz potasowy (płynny) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Startowy 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektycyd" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektycyd (płynny)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicyd" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicyd (płynny)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Nawóz startowy (płynny) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Poprawa gleby (suchy) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organiczna poprawa gleby (suchy) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Osady ściekowe" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Nawóz organiczny (suchy) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kurzak" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Nawóz organiczny (suchy) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Obornik granulowany" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Nawóz organiczny (suchy) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Zbiornik wapna w płynie" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Środek podnoszący pH (płynny) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR GLEBY" eh="f8cda642" />
     <e k="sf_hud_field" v="Pole %d" eh="08988997" />
     <e k="sf_hud_noField" v="Wejdź na pole" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Wysoka" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Na podstawie N/P/K vs próg optymalny" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Strata plonu ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Wykryto niekompatybilność" />
-    <e k="sf_incompatibility_pf_text" v="Mod Soil & Fertilizer został wyłączony, ponieważ wykryto Precision Farming.\n\nTe dwa mody nie są kompatybilne i nie mogą być używane razem." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -451,7 +451,7 @@
     <e k="sf_pda_map_unavailable" v="Podgląd mapy niedostępny" eh="43983f81" />
     <e k="sf_map_health_overall" v="Średnie zdrowie gleby" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Otwórz przegląd gospodarstwa" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Przełącz warstwę" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan zabiegów" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Wyłącz nakładkę" eh="8e75dec5" />
@@ -535,15 +535,15 @@
     <e k="sf_treat_action_n_poor" v="Zastosuj UAN32, MOCZNIK lub BEZWODNY AMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Zastosuj AMS lub nawóz STARTOWY." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Zastosuj MAP lub DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Zastosuj POTAS (Sól potasową)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Zastosuj HERBICYD natychmiast." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Zastosuj INSEKTYCYD natychmiast." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Zastosuj FUNGICYD natychmiast." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus strączkowych (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Zmęczenie (x1.15 wyczerpanie)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Brak danych." eh="c6d95d5e" />
@@ -554,9 +554,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Pokrycie: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Przejazd: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Zagęszczenie: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DAWKA  ( AUTO: WŁ )" eh="099b5dac" />
@@ -581,6 +581,10 @@
     <e k="sf_notify_burn_title" v="Przypalenie nawozem" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Pole %d: uszkodzenie przez przedawkowanie (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Wykryto problem z synchronizacją danych. Zgłoś to, jeśli błąd będzie trwał." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- Settings Panel -->
     <e k="sf_panel_cat_sim" v="Symulacja" eh="4f502b57" />
@@ -601,6 +605,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Kontrola modu i trudność" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systemy" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Działania i narzędzia pola" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- Settings Panel Chrome -->
     <e k="sf_panel_admin_yes" v="Admin: TAK" eh="4628842a" />
@@ -711,7 +718,7 @@
     <e k="sf_cell_report" v="Raport komórki" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Brak danych komórki" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Brak danych glebowych w tej lokalizacji" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Śr. pola" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Komórka" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspekcja komórki gleby" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Szczegóły komórki" eh="6fc5243e" />
@@ -723,7 +730,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -731,7 +738,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -755,33 +761,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Fertilizante MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Fertilizante DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potassa 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Ureia Líquida (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfato de Amónio Líquido (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Líquido (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_report_page_info" v="Campos %d-%d de %d  |  Página %d de %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fertilizante azotado (líquido) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fertilizante azotado (líquido) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amónia Anidra 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fertilizante azotado (líquido) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureia 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fertilizante azotado (seco) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fertilizante azotado (seco) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fertilizante azotado (seco) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fertilizante fosfatado (seco) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fertilizante fosfatado (seco) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potassa 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fertilizante potássico (seco) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Ureia Líquida" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fertilizante azotado (líquido) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Líquido" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fertilizante azotado (líquido) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Líquido" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fertilizante fosfatado (líquido) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Líquido" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fertilizante fosfatado (líquido) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potassa Líquida" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fertilizante potássico (líquido) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Inseticida" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Inseticida (líquido)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicida" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicida (líquido)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Fertilizante inicial (líquido) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gesso" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Corretivo de Solo (seco) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Composto" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Corretivo de Solo Orgânico (seco) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biossólidos" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Fertilizante Orgânico (seco) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Estrume de Galinha" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fertilizante Orgânico (seco) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Estrume Peletizado" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fertilizante Orgânico (seco) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Depósito de Cal Líquida" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agente de Aumento de pH (líquido) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR DE SOLO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Caminhe sobre um campo" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Alta" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baseado em N/P/K vs limite ideal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendimento ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibilidade Detectada" />
-    <e k="sf_incompatibility_pf_text" v="O mod Soil & Fertilizer foi desativado porque o Precision Farming foi detectado.\n\nEstes dois mods não são compatíveis e não podem ser usados juntos." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          LINHAS DE AJUDA (ESC > Ajuda > Solo e Fertilizante Realista)
@@ -452,7 +452,7 @@
     <e k="sf_pda_map_unavailable" v="Pré-visualização do mapa indisponível" eh="43983f81" />
     <e k="sf_map_health_overall" v="Saúde Média do Solo" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Abrir Visão Geral da Quinta" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Ciclar Camada" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plano de Tratamento" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Desativar Sobreposição" eh="8e75dec5" />
@@ -536,15 +536,15 @@
     <e k="sf_treat_action_n_poor" v="Aplique UAN32, UREIA ou ANIDRA." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplique AMS ou fertilizante STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplique MAP ou DAP (Fósforo)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Aplique POTASSA (Potássio)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Aplique HERBICIDA imediatamente." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplique INSETICIDA imediatamente." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplique FUNGICIDA imediatamente." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bónus de Leguminosa (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Fadiga (esgotamento x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Dados indisponíveis." eh="c6d95d5e" />
@@ -557,9 +557,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Passagem: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -588,6 +588,10 @@
     <e k="sf_notify_burn_title" v="Queimadura por Fertilizante" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Campo %d: danos por sobreaplicação (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mod Solo: detetado problema de sincronização de dados. Por favor reporte se persistir." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          PAINEL DE DEFINIÇÕES — CATEGORIAS E CABEÇALHOS
@@ -610,6 +614,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Controlo do Mod e Dificuldade" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemas" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Ações e Ferramentas de Campo" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          PAINEL DE DEFINIÇÕES — CHROME
@@ -730,7 +737,7 @@
     <e k="sf_cell_report" v="Relatório de Célula" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Sem dados de célula" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Sem dados de solo nesta localização" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Méd. campo" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Célula" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspeção de Célula de Solo" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalhes da Célula" eh="6fc5243e" />
@@ -742,7 +749,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -750,7 +757,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -774,33 +780,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Îngrășământ MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Îngrășământ DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potasiu 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Uree Lichidă (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sulfat de Amoniu Lichid (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP Lichid (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungicid" eh="e8512698" />
     <e k="sf_report_page_info" v="Câmpuri %d-%d din %d  |  Pagina %d din %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Îngrășământ cu azot (lichid) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Îngrășământ cu azot (lichid) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoniac Anidru 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Îngrășământ cu azot (lichid) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Uree 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Îngrășământ cu azot (uscat) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Îngrășământ cu azot (uscat) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Îngrășământ cu azot (uscat) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Îngrășământ cu fosfor (uscat) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Îngrășământ cu fosfor (uscat) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potasiu 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Îngrășământ cu potasiu (uscat) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Uree Lichidă" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Îngrășământ cu azot (lichid) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS Lichid" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Îngrășământ cu azot (lichid) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP Lichid" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Îngrășământ cu fosfor (lichid) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP Lichid" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Îngrășământ cu fosfor (lichid) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Potasiu Lichid" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Îngrășământ cu potasiu (lichid) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticid" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticid (lichid)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicid (lichid)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Îngrășământ Starter (lichid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Ipsos (Ghips)" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Amendament Sol (uscat) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Amendament Sol Organic (uscat) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biosolide" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Îngrășământ Organic (uscat) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Găinaț de Pasăre" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Îngrășământ Organic (uscat) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Gunoi de Grajd Peletizat" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Îngrășământ Organic (uscat) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Rezervor Var Lichid" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Agent Creștere pH (lichid) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MONITOR SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Câmp %d" eh="08988997" />
     <e k="sf_hud_noField" v="Mergeți pe un câmp" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Ridicată" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Bazat pe N/P/K vs prag optim" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Recoltă ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- ======================================================
          LINII DE AJUTOR (ESC > Ajutor > Sol și Îngrășământ Realist)
@@ -452,7 +452,7 @@
     <e k="sf_pda_map_unavailable" v="Previzualizare hartă indisponibilă" eh="43983f81" />
     <e k="sf_map_health_overall" v="Sănătatea Medie a Solului" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Deschide Prezentare Fermă" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Schimbă Stratul" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Plan Tratament" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Dezactivează Suprapunerea" eh="8e75dec5" />
@@ -536,15 +536,15 @@
     <e k="sf_treat_action_n_poor" v="Aplică UAN32, UREE sau AMONIAC ANIDRU." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Aplică AMS sau îngrășământ STARTER." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Aplică MAP sau DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Aplică POTASIU (Potasiu)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Aplică ERBICID imediat." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Aplică INSECTICID imediat." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Aplică FUNGICID imediat." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Bonus Leguminoase (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Oboseală (epuizare x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Nu există date disponibile." eh="c6d95d5e" />
@@ -557,9 +557,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Acoperire: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Trecere: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Compactare: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <!-- ======================================================
          SPRAYER RATE HUD
@@ -588,6 +588,10 @@
     <e k="sf_notify_burn_title" v="Arsură de Îngrășământ" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Câmpul %d: daune de supra-aplicare (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mod Sol: s-a detectat o problemă de sincronizare a datelor. Te rugăm să raportezi dacă persistă." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <!-- ======================================================
          SETTINGS PANEL — CATEGORIES & SECTION HEADERS
@@ -610,6 +614,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Control Mod și Dificultate" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sisteme" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Acțiuni și Unelte Câmp" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -730,7 +737,7 @@
     <e k="sf_cell_report" v="Raport Celulă" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Nu s-au găsit date despre celulă" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Nu există date despre sol la această locație" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Celulă" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Inspecție Celulă Sol" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Detalii Celulă" eh="6fc5243e" />
@@ -742,7 +749,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -750,7 +757,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -774,33 +780,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Удобрение Аммофос (MAP) 11-52-0 (Фосфор)" eh="31aa2534" />
     <e k="sf_dap_title" v="Удобрение Диаммофос (DAP) 18-46-0 (Фосфор)" eh="5030a80a" />
     <e k="sf_potash_title" v="Калий хлористый 0-0-60 (Калий)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Жидкий карбамид (Азот)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Жидкий сульфат аммония (Азот)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Жидкий Аммофос (Фосфор)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Фунгицид" eh="e8512698" />
     <e k="sf_report_page_info" v="Поля %d-%d из %d  |  Страница %d из %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC КАС 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Азотное удобрение (жидкое) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC КАС 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Азотное удобрение (жидкое) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Безводный аммиак 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Азотное удобрение (жидкое) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="МКР Карбамид 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Азотное удобрение (сухое) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="МКР Аммиачная селитра 34,5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Азотное удобрение (сухое) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="МКР Сульфат аммония 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Азотное удобрение (сухое) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="МКР Аммофос 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Фосфорное удобрение (сухое) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="МКР Диаммофос 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Фосфорное удобрение (сухое) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="МКР Калий хлористый 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Калийное удобрение (сухое) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Жидкий карбамид" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Азотное удобрение (жидкое) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Жидкий сульфат аммония" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Азотное удобрение (жидкое) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Жидкий Аммофос" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Фосфорное удобрение (жидкое) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Жидкий Диаммофос" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Фосфорное удобрение (жидкое) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Жидкий калий" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Калийное удобрение (жидкое) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Стартер 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Инсектицид" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Инсектицид (жидкий)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Фунгицид" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Фунгицид (жидкий)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Стартовое удобрение (жидкое) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="МКР Гипс" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Мелиорант почвы (сухой) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Органическая добавка (сухая) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="МКР Биоотходы" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Органическое удобрение (сухое) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="МКР Куриный помет" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Органическое удобрение (сухое) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="МКР Гранулированный навоз" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Органическое удобрение (сухое) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Резервуар с жидкой известью" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Агент для повышения pH (жидкий) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="МОНИТОР ПОЧВЫ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Высокая" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="На основе N/P/K относительно оптимума" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Потеря урожая ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <!-- Help Lines -->
     <e k="helpLine_sf_cat_overview" v="Обзор" eh="3b878279" />
@@ -436,7 +436,7 @@
     <e k="sf_pda_map_unavailable" v="Предпросмотр недоступен" eh="43983f81" />
     <e k="sf_map_health_overall" v="Среднее здоровье почвы" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Открыть обзор фермы" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Сменить слой" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="План обработки" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Убрать наложение" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Внесите КАС-32, КАРБАМИД или АММИАК." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Внесите СУЛЬФАТ АММОНИЯ или СТАРТЕР." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Внесите АММОФОС или ДИАММОФОС (P)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Внесите КАЛИЙ (0-0-60)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Немедленно внесите ГЕРБИЦИД." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Немедленно внесите ИНСЕКТИЦИД." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Немедленно внесите ФУНГИЦИД." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="ОК" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Бонус бобовых (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Утомление (x1.15 вынос)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Нет данных." eh="c6d95d5e" />
@@ -532,9 +532,9 @@
     <e k="sf_hud_label_om" v="ОВ" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(млн⁻¹)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Покрытие: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Проход: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Уплотнение: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_sprayer_auto_on" v="НОРМА ВНЕСЕНИЯ ( АВТО: ВКЛ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="НОРМА ВНЕСЕНИЯ АВТО: ВЫКЛ [%s]" eh="848cc106" />
     <e k="sf_sprayer_target" v="Цель:" eh="31d43504" />
@@ -555,6 +555,10 @@
     <e k="sf_notify_burn_title" v="Ожог удобрениями" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Поле %d: урон от передозировки (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Мод: Ошибка синхронизации данных. Сообщите, если повторится." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
     <e k="sf_panel_cat_sim" v="Симуляция" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Механика, сложность и циклы" eh="3c584cdb" />
     <e k="sf_panel_cat_display" v="Экран и HUD" eh="37b17394" />
@@ -573,6 +577,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Управление модом" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Системы" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Действия и инструменты" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
     <e k="sf_panel_admin_yes" v="Админ: ДА" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Админ: НЕТ" eh="a9394f7b" />
     <e k="sf_panel_multiplayer" v="Мультиплеер" eh="901a7320" />
@@ -671,7 +678,7 @@
     <e k="sf_cell_report" v="Отчет по ячейке" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Данные не найдены" eh="dc41c753" />
     <e k="sf_cell_no_data" v="В этой точке нет данных почвы" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Ср. поля" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Ячейка" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Осмотр ячейки" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Детали ячейки" eh="6fc5243e" />
@@ -683,7 +690,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -691,7 +698,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -715,33 +721,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP-gödsel 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP-gödsel 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumklorid 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Flytande urea (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Flytande ammoniumsulfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Flytande MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Svampmedel" eh="e8512698" />
     <e k="sf_report_page_info" v="Fält %d-%d av %d  |  Sida %d av %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Kvävegödsel (flytande) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Kvävegödsel (flytande) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Vattenfritt ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Kvävegödsel (flytande) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Storsäck Urea 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Kvävegödsel (torr) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Storsäck AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Kvävegödsel (torr) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Storsäck AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Kvävegödsel (torr) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Storsäck MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosfatgödsel (torr) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Storsäck DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosfatgödsel (torr) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Storsäck Kaliumklorid 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Kaliumgödsel (torr) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Flytande urea" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Kvävegödsel (flytande) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Flytande AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Kvävegödsel (flytande) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Flytande MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosfatgödsel (flytande) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Flytande DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosfatgödsel (flytande) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Flytande kalium" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Kaliumgödsel (flytande) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Startgödsel 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insektsmedel" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insektsmedel (flytande)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Svampmedel" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Svampmedel (flytande)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Startgödsel (flytande) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Storsäck Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Jordförbättringsmedel (torrt) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Storsäck Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organiskt jordförbättringsmedel (torrt) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Storsäck Rötslam" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organiskt gödselmedel (torrt) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Storsäck Hönsgödsel" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organiskt gödselmedel (torrt) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Storsäck Pelleterat gödsel" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organiskt gödselmedel (torrt) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Flytande kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH-höjande medel (flytande) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="MARKÖVERVAKNING" eh="f8cda642" />
     <e k="sf_hud_field" v="Fält %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ut på ett fält" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Hög" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Baserat på N/P/K mot optimalt tröskelvärde" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Skörd ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Översikt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Komma igång" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Kartförhandsvisning ej tillgänglig" eh="43983f81" />
     <e k="sf_map_health_overall" v="Genomsnittlig markhälsa" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Öppna gårdsöversikt" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Byt lager" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlingsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Inaktivera överlagring" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Sprid UAN32, UREA eller VATTENFRITT AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Sprid AMS eller STARTGÖDSEL." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Sprid MAP eller DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Sprid KALIUMKLORID (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Sprid OGRÄSMEDEL omedelbart." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Sprid INSEKTSMEDEL omedelbart." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Sprid SVAMPMEDEL omedelbart." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Baljväxtbonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Utmattning (x1.15 utarmning)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Ingen data tillgänglig." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Täckning: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Körning: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Packning: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="SPRIDNINGSMÄNGD  ( AUTO: PÅ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="SPRIDNINGSMÄNGD  AUTO: AV [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Gödselbränna" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Fält %d: skada vid överdosering (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Mark-mod: Datasynkroniseringsproblem upptäckt. Rapportera om detta kvarstår." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simulering" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Gårdsmekanik, svårighetsgrad och näringscykler" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Modkontroll &amp; Svårighetsgrad" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="System" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Åtgärder &amp; Fältverktyg" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: JA" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: NEJ" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Cellrapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Ingen celldata hittades" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Ingen markdata på denna plats" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Fält snitt" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Cell" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Markcellsinspektion" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celldetaljer" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="MAP Gübresi 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Gübresi 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Potas 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Sıvı Üre (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Sıvı Amonyum Sülfat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Sıvı MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Fungisit (Mantar İlacı)" eh="e8512698" />
     <e k="sf_report_page_info" v="Tarlalar %d-%d / %d  |  Sayfa %d / %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Azotlu Gübre (sıvı) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Azotlu Gübre (sıvı) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Anhidre Amonyak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Azotlu Gübre (sıvı) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Üre 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Azotlu Gübre (kuru) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Azotlu Gübre (kuru) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Azotlu Gübre (kuru) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fosforlu Gübre (kuru) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fosforlu Gübre (kuru) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Potas 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Potasyumlu Gübre (kuru) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Sıvı Üre" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Azotlu Gübre (sıvı) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Sıvı AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Azotlu Gübre (sıvı) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Sıvı MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fosforlu Gübre (sıvı) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Sıvı DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fosforlu Gübre (sıvı) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Sıvı Potas" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Potasyumlu Gübre (sıvı) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Başlangıç 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC İnsektisit" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="İnsektisit (sıvı)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungisit" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungisit (sıvı)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Başlangıç Gübresi (sıvı) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Alçıtaşı (Jips)" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Toprak Düzenleyici (kuru) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Kompost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Organik Toprak Düzenleyici (kuru) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biyokatı" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Organik Gübre (kuru) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Tavuk Gübresi" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Organik Gübre (kuru) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Peletlenmiş Gübre" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Organik Gübre (kuru) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Sıvı Kireç Tankı" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="pH Yükseltici Madde (sıvı) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="TOPRAK MONİTÖRÜ" eh="f8cda642" />
     <e k="sf_hud_field" v="Tarla %d" eh="08988997" />
     <e k="sf_hud_noField" v="Bir tarlaya gidin" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Yüksek" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Optimal eşiğe göre N/P/K baz alınmıştır" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Verim ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Genel Bakış" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Başlangıç" eh="bf647454" />
@@ -436,7 +436,7 @@
     <e k="sf_pda_map_unavailable" v="Harita önizlemesi mevcut değil" eh="43983f81" />
     <e k="sf_map_health_overall" v="Ortalama Toprak Sağlığı" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Çiftlik Özetini Aç" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Katmanı Değiştir" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Tedavi Planı" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Katmanı Kapat" eh="8e75dec5" />
@@ -516,15 +516,15 @@
     <e k="sf_treat_action_n_poor" v="UAN32, ÜRE veya ANHİDRE uygulayın." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="AMS veya BAŞLANGIÇ gübresi uygulayın." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP veya DAP (Fosfor) uygulayın." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="POTAS (Potasyum) uygulayın." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Derhal HERBİSİT uygulayın." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Derhal İNSEKTİSİT uygulayın." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Derhal FUNGİSİT uygulayın." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="Tamam" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Baklagil Bonusu (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Yorgunluk (x1.15 tükenme)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Veri mevcut değil." eh="c6d95d5e" />
@@ -534,9 +534,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Kapsama: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Geçiş: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Sıkışma: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="UYGULAMA ORANI ( OTO: AÇIK )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="UYGULAMA ORANI  OTO: KAPALI [%s]" eh="848cc106" />
@@ -559,6 +559,10 @@
     <e k="sf_notify_burn_title" v="Gübre Yanması" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Tarla %d: aşırı uygulama hasarı (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Toprak Modu: Veri senkronizasyon sorunu algılandı. Bu devam ederse lütfen bildirin." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Simülasyon" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Çiftlik mekanikleri, zorluk ve besin döngüleri" eh="3c584cdb" />
@@ -578,6 +582,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod Kontrolü &amp; Zorluk" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Sistemler" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Eylemler &amp; Tarla Araçları" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Yönetici: EVET" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Yönetici: HAYIR" eh="a9394f7b" />
@@ -683,7 +690,7 @@
     <e k="sf_cell_report" v="Hücre Raporu" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Hücre verisi bulunamadı" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Bu konumda toprak verisi yok" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Alan ort." />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Hücre" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Toprak Hücresi İncelemesi" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Hücre Ayrıntıları" eh="6fc5243e" />
@@ -695,7 +702,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -703,7 +710,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -727,33 +733,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Добриво MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Добриво DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Поташ 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Рідка сечовина (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Рідкий сульфат амонію (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Рідкий MAP (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Фунгіцид" eh="e8512698" />
     <e k="sf_report_page_info" v="Поля %d-%d з %d  |  Стор. %d з %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC КАС-32" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Азотне добриво (рідке) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC КАС-28" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Азотне добриво (рідке) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Безводний аміак 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Азотне добриво (рідке) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="МКР Карбамід 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Азотне добриво (сухе) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="МКР Аміачна селітра 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Азотне добриво (сухе) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="МКР AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Азотне добриво (сухе) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="МКР MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Фосфорне добриво (сухе) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="МКР DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Фосфорне добриво (сухе) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="МКР Поташ 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Калійне добриво (сухе) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Рідка сечовина" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Азотне добриво (рідке) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Рідкий AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Азотне добриво (рідке) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Рідкий MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Фосфорне добриво (рідке) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Рідкий DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Фосфорне добриво (рідке) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Рідкий поташ" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Калійне добриво (рідке) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Стартер 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Інсектицид" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Інсектицид (рідкий)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Фунгіцид" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Фунгіцид (рідкий)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Стартове добриво (рідке) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="МКР Гіпс" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Меліорант (сухий) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="МКР Компост" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Органічний меліорант (сухий) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="МКР Біовідходи" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Органічне добриво (сухе) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="МКР Курячий послід" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Органічне добриво (сухе) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="МКР Гранульований гній" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Органічне добриво (сухе) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Резервуар рідкого вапна" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Засіб підвищення pH (рідкий) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="МОНІТОР ҐРУНТУ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Висока" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Базується на N/P/K відносно порогу" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Врожайність ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Огляд" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Початок роботи" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Прев'ю карти недоступне" eh="43983f81" />
     <e k="sf_map_health_overall" v="Середній стан ґрунту" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Відкрити огляд ферми" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Змінити шар" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="План обробки" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Вимкнути оверлей" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Внесіть КАС-32, КАРБАМІД або БЕЗВОДНИЙ АМІАК." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Внесіть AMS або СТАРТОВЕ добриво." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Внесіть MAP або DAP (Фосфор)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Внесіть ПОТАШ (Калій)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Негайно внесіть ГЕРБІЦИД." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Негайно внесіть ІНСЕКТИЦИД." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Негайно внесіть ФУНГІЦИД." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Бонус бобових (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Втома ґрунту (виснаження x1.15)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Дані недоступні." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="ОР" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Покриття: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Прохід: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Ущільнення: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="НОРМА ВНЕСЕННЯ ( АВТО: УВІМК )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="НОРМА ВНЕСЕННЯ  АВТО: ВИМК [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Опік добривами" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Поле %d: пошкодження від надмірної норми (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Помилка синхронізації даних. Повідомте, якщо це повториться." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Симуляція" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Механіки ферми, складність та цикли речовин" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Керування модом" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Системи" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Дії та інструменти" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Адмін: ТАК" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Адмін: НІ" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Звіт комірки" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Дані комірки відсутні" eh="dc41c753" />
     <e k="sf_cell_no_data" v="В цій точці немає даних ґрунту" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Сер. поля" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Комірка" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Інспекція комірки ґрунту" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Деталі комірки" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -146,7 +146,7 @@
     <e k="sf_map_title" v="Phân bón MAP 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="Phân bón DAP 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kali 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" />
+    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Urê lỏng (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Amoni Sunfat lỏng (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP lỏng (P)" eh="3ce7c8c9" />
@@ -156,57 +156,57 @@
     <e k="sf_fungicide_title" v="Thuốc trừ nấm" eh="e8512698" />
     <e k="sf_report_page_info" v="Cánh đồng %d-%d của %d  |  Trang %d của %d" eh="8db851d1" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Phân bón đạm (lỏng) — +44N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Phân bón đạm (lỏng) — +38N ppm/ha @ 60.8 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Amoniac khan 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Phân bón đạm (lỏng) — +67N ppm/ha @ 28 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Túi Urê 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Phân bón đạm (khô) — +78N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Túi AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Phân bón đạm (khô) — +68N ppm/ha @ 200 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Túi AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Phân bón đạm (khô) — +33N ppm/ha @ 168 kg/ha" eh="63efea20" />
+    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Túi MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Phân bón lân (khô) — +8N +56P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Túi DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Phân bón lân (khô) — +11N +44P ppm/ha @ 225 kg/ha" eh="0cc85c60" />
+    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Túi Kali 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Phân bón kali (khô) — +90K ppm/ha @ 225 kg/ha" eh="18015099" />
-    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" />
-    <e k="sf_bigBag_polifoska_function" v="NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" />
+    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Urê lỏng" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Phân bón đạm (lỏng) — +78N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC AMS lỏng" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Phân bón đạm (lỏng) — +33N ppm/ha @ 168 L/ha" eh="27de5f41" />
+    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC MAP lỏng" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Phân bón lân (lỏng) — +8N +56P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC DAP lỏng" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Phân bón lân (lỏng) — +11N +44P ppm/ha @ 225 L/ha" eh="eeb5ef5d" />
+    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Kali lỏng" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Phân bón kali (lỏng) — +90K ppm/ha @ 225 L/ha" eh="52169d4a" />
+    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Phân bón lót 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Thuốc trừ sâu" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Thuốc trừ sâu (lỏng)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Thuốc trừ nấm" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Thuốc trừ nấm (lỏng)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="Phân bón lót (lỏng) — +9N +17P ppm/ha @ 46.8 L/ha" eh="2c36ea57" />
+    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Túi Thạch cao" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Cải tạo đất (khô) — pH -0.15/pass @ 1500 kg/ha" eh="51503c54" />
+    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Túi Phân hữu cơ" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" />
-    <e k="sf_bigBag_compost_function" v="Cải tạo đất hữu cơ (khô) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="9dd2256a" />
+    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Túi Bùn thải" eh="61a60ff3" />
     <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="Phân bón hữu cơ (khô) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Túi Phân gà" eh="cb60fddc" />
     <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="Phân bón hữu cơ (khô) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Túi Phân viên" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Phân bón hữu cơ (khô) — +22N +2P +33K ppm @ 450 kg/ha" eh="374c7b1e" />
+    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Bình Vôi lỏng" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Chất tăng pH (lỏng) — pH +0.40/pass @ 374 L/ha" eh="7a118b6d" />
+    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="GIÁM SÁT ĐẤT" eh="f8cda642" />
     <e k="sf_hud_field" v="Cánh đồng %d" eh="08988997" />
     <e k="sf_hud_noField" v="Hãy đi vào cánh đồng" eh="62c55e9e" />
@@ -233,8 +233,8 @@
     <e k="sf_report_pressure_high" v="Cao" eh="655d20c1" />
     <e k="sf_report_yield_hint" v="Dựa trên N/P/K so với ngưỡng tối ưu" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Sản lượng ~-%d%%" eh="d64d5d59" />
-    <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" />
-    <e k="sf_incompatibility_pf_text" v="Soil & Fertilizer Mod has been disabled because Precision Farming was detected.\n\nThese two mods are not compatible and cannot be used together." />
+    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
 
     <e k="helpLine_sf_cat_overview" v="Tổng quan" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Bắt đầu" eh="bf647454" />
@@ -435,7 +435,7 @@
     <e k="sf_pda_map_unavailable" v="Không có xem trước bản đồ" eh="43983f81" />
     <e k="sf_map_health_overall" v="Sức khỏe đất trung bình" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Mở tổng quan trang trại" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="Help" eh="800e465a" />
+    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Đổi lớp" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Kế hoạch xử lý" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Tắt lớp phủ" eh="8e75dec5" />
@@ -515,15 +515,15 @@
     <e k="sf_treat_action_n_poor" v="Bón UAN32, URÊ hoặc AMONIAC KHAN." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Bón AMS hoặc PHÂN BÓN LÓT." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Bón MAP hoặc DAP (Lân)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="6f802546" />
+    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Bón KALI (Potash)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="Top-up with Liquid Potash or Potash (K)." eh="6f802546" />
+    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Bón THUỐC DIỆT CỎ ngay lập tức." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Bón THUỐC TRỪ SÂU ngay lập tức." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Bón THUỐC TRỪ NẤM ngay lập tức." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="Yield eff." />
-    <e k="sf_detail_yield_optimal" v="Optimal" />
+    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Thưởng cây họ đậu (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Mệt mỏi (x1.15 cạn kiệt)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Không có dữ liệu." eh="c6d95d5e" />
@@ -533,9 +533,9 @@
     <e k="sf_hud_label_om" v="OM" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Độ phủ: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="Phun: %d%% (%s)" eh="00000000" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Độ nén: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="Yield: %d%%" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
 
     <e k="sf_sprayer_auto_on" v="TỶ LỆ BÓN ( TỰ ĐỘNG: BẬT )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TỶ LỆ BÓN  TỰ ĐỘNG: TẮT [%s]" eh="848cc106" />
@@ -558,6 +558,10 @@
     <e k="sf_notify_burn_title" v="Cháy lá do phân bón" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Cánh đồng %d: thiệt hại do bón quá liều (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Phát hiện lỗi đồng bộ dữ liệu. Hãy báo cáo nếu lỗi này lặp lại." eh="1a307946" />
+		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
+		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
+		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
 
     <e k="sf_panel_cat_sim" v="Mô phỏng" eh="4f502b57" />
     <e k="sf_panel_cat_sim_desc" v="Cơ chế trang trại, độ khó và chu kỳ dinh dưỡng" eh="3c584cdb" />
@@ -577,6 +581,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Điều khiển Mod &amp; Độ khó" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Hệ thống" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Hành động &amp; Công cụ" eh="f64ba1c9" />
+		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
+		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
+		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
 
     <e k="sf_panel_admin_yes" v="Admin: CÓ" eh="4628842a" />
     <e k="sf_panel_admin_no" v="Admin: KHÔNG" eh="a9394f7b" />
@@ -682,7 +689,7 @@
     <e k="sf_cell_report" v="Báo cáo ô" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Không thấy dữ liệu ô" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Không có dữ liệu đất tại vị trí này" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="Field avg" />
+    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
     <e k="sf_cell" v="Ô" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Kiểm tra ô đất" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Chi tiết ô" eh="6fc5243e" />
@@ -694,7 +701,7 @@
     <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
     <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
+    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
@@ -702,7 +709,6 @@
     <e k="sf_sensor_state_off"   v="OFF" />
     <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF: Toggle Nutrient Sensor" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -726,33 +732,32 @@
     <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
     <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="SMART SENSORS" />
     <e k="sf_sensor_pest"        v="Pest Sensor" />
     <e k="sf_sensor_disease"     v="Disease Sensor" />
     <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
     <e k="sf_sensor_state_on"    v="ON" />
     <e k="sf_sensor_state_off"   v="OFF" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="SEE &amp; SPRAY" />
+    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
     <e k="sf_see_spray_pest"        v="Pest" />
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="VARIABLE RATE" />
+    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- INPUT ACTIONS -->
     <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
     <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
     <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
     <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="Free Panel Layout" />
-    <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
+    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
     </elements>
 


### PR DESCRIPTION
## Summary

- **#438 pH bar in HUD** — Replaces the pH text-only row with a center-anchored visual bar (pH 5.0–8.5, optimal center at 6.75). Fills left when acidic, right when alkaline. Threshold tick marks at 5.5/6.0/7.0/7.5. Ghost bar shows the direction and magnitude of the loaded product's pH effect. OM remains as a compact text row.
- **#437 Lime/OM burn on growing crops** — Applying lime to a growing crop flags a -80% yield penalty at harvest. OM amendments (manure, compost, digestate, etc.) flag -20%. One blinking warning notification fires per crop cycle. Penalty persists in save data.
- l10n strings added to all 26 language files via lang_sync.py

## Test plan

- [ ] Open the soil HUD on a planted field — confirm pH shows as a bar with left/right fill and tick marks
- [ ] Load lime in a sprayer — confirm ghost bar appears in the right direction
- [ ] Apply lime to a field with a growing crop — confirm blinking warning notification fires once
- [ ] Harvest that field — confirm yield is reduced ~80%; check log for `Amendment burn penalty` entry
- [ ] Apply manure to growing crop → harvest — confirm ~20% yield reduction
- [ ] Apply lime to a bare (unharvested/fallow) field — confirm no warning, no penalty
- [ ] Save and reload — confirm amendBurnPenalty persists if lime was applied before save