### PR TITLE
fix(#489,#475,#476,#479,#469,#488,#474): v2.2.4.1 — nutrient defaults, pass%, VR, DA translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.4.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.5.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.5.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.4.1
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.3.9
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.4.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -232,24 +232,22 @@
 
     <fillTypeCategories>
         <!--
-            Use the NATIVE FS25 category names FERTILIZER and LIQUIDFERTILIZER instead of
-            custom names like SPREADER/SPRAYER.
-
-            Vanilla FS25 equipment (e.g. Case IH spreaders, Amazone sprayers) has fill units
-            that accept the FERTILIZER or LIQUIDFERTILIZER category. If we define a category
-            called "SPREADER", vanilla equipment never matches it because their XML only
-            references "FERTILIZER" — not our new name. By extending the native category
-            names, any spreader that already accepts FERTILIZER will automatically also
-            accept UREA, AMS, MAP, DAP, POTASH without any equipment mod changes.
+            Extend the NATIVE FS25 FERTILIZER category with our custom dry types.
+            Vanilla spreaders, bigBag specialization fill checks, and any other category-based
+            lookup all use "FERTILIZER" — extending it here means our custom types pass
+            every check automatically, including the BigBag fill trigger.
+            The Lua installFillUnitHook also patches supportedFillTypes directly as a
+            belt-and-suspenders fallback for vehicles that use name-based (not category-based)
+            fill unit definitions.
         -->
-        <fillTypeCategory name="SPREADER">FERTILIZER UREA AN AMS MAP DAP POTASH GYPSUM COMPOST BIOSOLIDS CHICKEN_MANURE PELLETIZED_MANURE</fillTypeCategory>
+        <fillTypeCategory name="FERTILIZER">FERTILIZER UREA AN AMS MAP DAP POTASH GYPSUM COMPOST BIOSOLIDS CHICKEN_MANURE PELLETIZED_MANURE POLIFOSKA</fillTypeCategory>
 
         <!--
             Same principle for liquid sprayers — extend LIQUIDFERTILIZER so vanilla sprayers
             that already accept LIQUIDFERTILIZER will also accept our liquid nitrogen products
             and starter fertilizer.
         -->
-        <fillTypeCategory name="SPRAYER">LIQUIDFERTILIZER UAN32 UAN28 ANHYDROUS STARTER INSECTICIDE FUNGICIDE LIQUID_UREA LIQUID_AMS LIQUID_MAP LIQUID_DAP LIQUID_POTASH LIQUIDLIME</fillTypeCategory>
+        <fillTypeCategory name="LIQUIDFERTILIZER">LIQUIDFERTILIZER UAN32 UAN28 ANHYDROUS STARTER INSECTICIDE FUNGICIDE LIQUID_UREA LIQUID_AMS LIQUID_MAP LIQUID_DAP LIQUID_POTASH LIQUIDLIME</fillTypeCategory>
     </fillTypeCategories>
 
 </map>

--- a/fillTypes.xml
+++ b/fillTypes.xml
@@ -224,7 +224,7 @@
             <physics massPerLiter="1.40" maxPhysicalSurfaceAngle="0"/>
             <economy pricePerLiter="0.28"/>
             <image hud="$dataS/menu/hud/fillTypes/hud_fill_liquidFertilizer.png"/>
-            <sprayType sprayTypeStr="LIME"/>
+            <sprayType sprayTypeStr="LIQUIDFERTILIZER"/>
             <pallet filename="objects/liquidTank/liquidlime/liquidTank_liquidlime.xml" />
         </fillType>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.4.1</version>
+    <version>2.2.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.3.9</version>
+    <version>2.2.4.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.4.0</version>
+    <version>2.2.4.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.5.0</version>
+    <version>2.2.4.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -995,7 +995,20 @@ function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
     local weedSystem = g_currentMission and g_currentMission.weedSystem
     if not weedSystem or not weedSystem:getMapHasWeed() then return end
 
-    local fsField = g_fieldManager and g_fieldManager:getFieldById(fieldId)
+    -- fieldId is the farmland ID — getFieldById uses field's own internal ID (different).
+    -- Search by farmland.id instead, matching the pattern used in the daily update.
+    local fsField = nil
+    if g_fieldManager and g_fieldManager.fields then
+        fsField = g_fieldManager.fields[fieldId]
+        if not fsField or not fsField.farmland then
+            for _, f in pairs(g_fieldManager.fields) do
+                if f and f.farmland and f.farmland.id == fieldId then
+                    fsField = f
+                    break
+                end
+            end
+        end
+    end
     if not fsField then return end
 
     local weedState = targetState
@@ -1015,9 +1028,9 @@ function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
                 weedState = replacement
                 self:log("[Herbicide] Field %d: weed state %d → withered %d (from replacements)",
                     fieldId, currentState, weedState)
-            elseif currentState == 0 then
-                return  -- no weeds present — nothing to wither
             end
+            -- If currentState==0 at the indicator position, the rest of the field may still
+            -- have weeds — fall through and apply state 7 (withered) field-wide.
         end
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1809,12 +1809,19 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         if not isGrassland then
             local wp = SoilConstants.WEED_PRESSURE
 
-            -- Tick herbicideDaysLeft counter; clear the density map when protection expires
+            -- Tick herbicideDaysLeft counter.
+            -- When protection expires: reset session coverage so the next application
+            -- requires a full field pass again rather than triggering on the first tick.
+            -- Do NOT force WEED_STATE_CLEAR — state 7 (withered) transitions to 0
+            -- naturally via the vanilla WeedSystem; forcing it here causes an abrupt
+            -- "weeds vanish instantly" when time is fast-forwarded.
             if (field.herbicideDaysLeft or 0) > 0 then
                 field.herbicideDaysLeft = field.herbicideDaysLeft - 1
                 if field.herbicideDaysLeft == 0 then
-                    -- Withered weeds have been brown for one day — now erase them entirely
-                    self:applyWeedMapState(fieldId, SoilConstants.WEED_PRESSURE.WEED_STATE_CLEAR)
+                    field.sessionCoverageHa       = 0
+                    field.sessionCoverageFraction = 0
+                    field.sessionCoverageCells    = {}
+                    field.sessionLastProduct      = nil
                 end
             end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -945,18 +945,26 @@ end
 ---@param fieldId number
 ---@param effectiveness number 0.0-1.0 herbicide effectiveness multiplier
 function SoilFertilitySystem:onHerbicideApplied(fieldId, effectiveness)
+    self:log("[Herbicide] onHerbicideApplied called: fieldId=%s effectiveness=%s weedPressureSetting=%s",
+        tostring(fieldId), tostring(effectiveness), tostring(self.settings.weedPressure))
     if not self.settings.weedPressure then return end
     if not SoilConstants.WEED_PRESSURE then return end
 
     local field = self:getOrCreateField(fieldId, false)
-    if not field then return end
+    if not field then
+        self:log("[Herbicide] SKIP: no field data for fieldId=%s", tostring(fieldId))
+        return
+    end
 
     -- Throttle: apply pressure reduction at most once per field per in-game day.
     -- The sprayer hook fires every frame (~60x/sec). Without this guard, a single
     -- pass applies the full reduction hundreds of times, instantly zeroing pressure.
     local today = (g_currentMission and g_currentMission.environment and
                    g_currentMission.environment.currentDay) or 0
-    if self.herbicideAppliedDay[fieldId] == today then return end
+    if self.herbicideAppliedDay[fieldId] == today then
+        self:log("[Herbicide] SKIP: already applied today (day=%s) for fieldId=%s", tostring(today), tostring(fieldId))
+        return
+    end
     self.herbicideAppliedDay[fieldId] = today
 
     local wp = SoilConstants.WEED_PRESSURE
@@ -991,9 +999,27 @@ end
 ---@param fieldId number
 ---@param targetState number  WEED_STATE_WITHERED or WEED_STATE_CLEAR
 function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
-    if not g_server then return end
+    self:log("[WeedMap] applyWeedMapState called: fieldId=%s targetState=%s isServer=%s",
+        tostring(fieldId), tostring(targetState), tostring(g_server ~= nil))
+
+    if not g_server then
+        self:log("[WeedMap] SKIP: not server")
+        return
+    end
+
     local weedSystem = g_currentMission and g_currentMission.weedSystem
-    if not weedSystem or not weedSystem:getMapHasWeed() then return end
+    if not weedSystem then
+        self:log("[WeedMap] SKIP: no weedSystem")
+        return
+    end
+    local mapHasWeed = false
+    local hwOk, hwResult = pcall(function() return weedSystem:getMapHasWeed() end)
+    if hwOk then mapHasWeed = hwResult end
+    self:log("[WeedMap] weedSystem:getMapHasWeed() = %s (pcallOk=%s)", tostring(mapHasWeed), tostring(hwOk))
+    if not mapHasWeed then
+        self:log("[WeedMap] SKIP: map has no weed system")
+        return
+    end
 
     -- fieldId is the farmland ID — getFieldById uses field's own internal ID (different).
     -- Search by farmland.id instead, matching the pattern used in the daily update.
@@ -1009,7 +1035,13 @@ function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
             end
         end
     end
-    if not fsField then return end
+    if not fsField then
+        self:log("[WeedMap] SKIP: could not find field object for farmlandId=%s (fields count=%s)",
+            tostring(fieldId), tostring(g_fieldManager and g_fieldManager.fields and #g_fieldManager.fields or "nil"))
+        return
+    end
+    self:log("[WeedMap] Found field: farmlandId=%s fieldId=%s name=%s",
+        tostring(fieldId), tostring(fsField.fieldId or fsField.id or "?"), tostring(fsField.fieldName or "?"))
 
     local weedState = targetState
 
@@ -1017,23 +1049,29 @@ function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
     -- own herbicide replacement table instead of hardcoding state 7.
     if targetState == SoilConstants.WEED_PRESSURE.WEED_STATE_WITHERED then
         local repOk, repData = pcall(function() return weedSystem:getHerbicideReplacements() end)
+        self:log("[WeedMap] getHerbicideReplacements: ok=%s hasWeed=%s hasReplacements=%s",
+            tostring(repOk),
+            tostring(repOk and repData and repData.weed ~= nil),
+            tostring(repOk and repData and repData.weed and repData.weed.replacements ~= nil))
+
         if repOk and repData and repData.weed and repData.weed.replacements then
-            -- Read the field's current weed state to pick the right replacement
             local fieldState = fsField:getFieldState()
             local posX, posZ = fsField:getIndicatorPosition()
             fieldState:update(posX, posZ)
             local currentState = fieldState.weedState or 0
             local replacement = repData.weed.replacements[currentState]
+            self:log("[WeedMap] Field %d: indicatorPos=(%.1f,%.1f) currentWeedState=%s replacement=%s",
+                fieldId, posX or 0, posZ or 0, tostring(currentState), tostring(replacement))
             if replacement and replacement ~= 0 then
                 weedState = replacement
-                self:log("[Herbicide] Field %d: weed state %d → withered %d (from replacements)",
-                    fieldId, currentState, weedState)
+                self:log("[WeedMap] Using replacement state %d", weedState)
+            else
+                self:log("[WeedMap] No replacement for state %d — using fallback state %d", currentState, weedState)
             end
-            -- If currentState==0 at the indicator position, the rest of the field may still
-            -- have weeds — fall through and apply state 7 (withered) field-wide.
         end
     end
 
+    self:log("[WeedMap] Enqueuing FieldUpdateTask: fieldId=%s weedState=%s", tostring(fieldId), tostring(weedState))
     local ok, err = pcall(function()
         local task = FieldUpdateTask.new()
         task:setField(fsField)
@@ -1041,9 +1079,7 @@ function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
         task:setWeedState(weedState)
         task:enqueue(true)
     end)
-    if not ok then
-        self:log("[Herbicide] applyWeedMapState field %d state %d failed: %s", fieldId, weedState, tostring(err))
-    end
+    self:log("[WeedMap] FieldUpdateTask result: ok=%s err=%s", tostring(ok), tostring(err))
 end
 
 --- Called when insecticide is applied to a field.

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -238,18 +238,21 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         end
     end
 
-    -- Weed pressure modifier (skip for grassland)
+    -- Weed pressure modifier (skip for grassland; skip when herbicide is active)
     if self.settings.weedPressure and SoilConstants.WEED_PRESSURE and not isGrass then
-        local wp       = SoilConstants.WEED_PRESSURE
-        local pressure = field.weedPressure or 0
-        local penalty
-        if pressure < wp.LOW then         penalty = wp.YIELD_PENALTY_LOW
-        elseif pressure < wp.MEDIUM then  penalty = wp.YIELD_PENALTY_MID
-        elseif pressure < wp.HIGH then    penalty = wp.YIELD_PENALTY_HIGH
-        else                              penalty = wp.YIELD_PENALTY_PEAK end
-        if penalty > 0 then
-            modifier = modifier * (1.0 - penalty)
-            self:log("Weed penalty field %d: pressure=%.0f → -%.0f%%", fieldId, pressure, penalty * 100)
+        local isProtected = (field.herbicideDaysLeft or 0) > 0
+        if not isProtected then
+            local wp       = SoilConstants.WEED_PRESSURE
+            local pressure = field.weedPressure or 0
+            local penalty
+            if pressure < wp.LOW then         penalty = wp.YIELD_PENALTY_LOW
+            elseif pressure < wp.MEDIUM then  penalty = wp.YIELD_PENALTY_MID
+            elseif pressure < wp.HIGH then    penalty = wp.YIELD_PENALTY_HIGH
+            else                              penalty = wp.YIELD_PENALTY_PEAK end
+            if penalty > 0 then
+                modifier = modifier * (1.0 - penalty)
+                self:log("Weed penalty field %d: pressure=%.0f → -%.0f%%", fieldId, pressure, penalty * 100)
+            end
         end
     end
 
@@ -966,11 +969,67 @@ function SoilFertilitySystem:onHerbicideApplied(fieldId, effectiveness)
     self:log("[Herbicide] Field %d: weed pressure %.0f -> %.0f, protected for %d days",
         fieldId, before, field.weedPressure, field.herbicideDaysLeft)
 
+    -- Transition weeds to withered (brown) visual state in the game's density map.
+    -- The game's FieldState.weedFactor stays high until the density map is updated, so
+    -- we drive it ourselves: withered now so weeds turn brown, cleared on next daily tick.
+    self:applyWeedMapState(fieldId, SoilConstants.WEED_PRESSURE.WEED_STATE_WITHERED)
+
     -- Broadcast in multiplayer
     if g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
         if SoilFieldUpdateEvent then
             g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
         end
+    end
+end
+
+--- Writes a weed state to the game's density map for the given field.
+--- When targetState is WEED_STATE_WITHERED, reads the field's current weed state and
+--- looks up its herbicide replacement via weedSystem:getHerbicideReplacements() so we
+--- transition to the correct withered equivalent rather than hardcoding state 7.
+--- When targetState is WEED_STATE_CLEAR (0), unconditionally clears all weeds.
+--- Uses FieldUpdateTask — same API as EasyDevControls, server-side only.
+---@param fieldId number
+---@param targetState number  WEED_STATE_WITHERED or WEED_STATE_CLEAR
+function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
+    if not g_server then return end
+    local weedSystem = g_currentMission and g_currentMission.weedSystem
+    if not weedSystem or not weedSystem:getMapHasWeed() then return end
+
+    local fsField = g_fieldManager and g_fieldManager:getFieldById(fieldId)
+    if not fsField then return end
+
+    local weedState = targetState
+
+    -- For withered transitions: look up the correct target state from the game's
+    -- own herbicide replacement table instead of hardcoding state 7.
+    if targetState == SoilConstants.WEED_PRESSURE.WEED_STATE_WITHERED then
+        local repOk, repData = pcall(function() return weedSystem:getHerbicideReplacements() end)
+        if repOk and repData and repData.weed and repData.weed.replacements then
+            -- Read the field's current weed state to pick the right replacement
+            local fieldState = fsField:getFieldState()
+            local posX, posZ = fsField:getIndicatorPosition()
+            fieldState:update(posX, posZ)
+            local currentState = fieldState.weedState or 0
+            local replacement = repData.weed.replacements[currentState]
+            if replacement and replacement ~= 0 then
+                weedState = replacement
+                self:log("[Herbicide] Field %d: weed state %d → withered %d (from replacements)",
+                    fieldId, currentState, weedState)
+            elseif currentState == 0 then
+                return  -- no weeds present — nothing to wither
+            end
+        end
+    end
+
+    local ok, err = pcall(function()
+        local task = FieldUpdateTask.new()
+        task:setField(fsField)
+        task:setArea(fsField:getDensityMapPolygon())
+        task:setWeedState(weedState)
+        task:enqueue(true)
+    end)
+    if not ok then
+        self:log("[Herbicide] applyWeedMapState field %d state %d failed: %s", fieldId, weedState, tostring(err))
     end
 end
 
@@ -1701,9 +1760,13 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         if not isGrassland then
             local wp = SoilConstants.WEED_PRESSURE
 
-            -- Tick herbicideDaysLeft for HUD display only (game handles suppression)
+            -- Tick herbicideDaysLeft counter; clear the density map when protection expires
             if (field.herbicideDaysLeft or 0) > 0 then
                 field.herbicideDaysLeft = field.herbicideDaysLeft - 1
+                if field.herbicideDaysLeft == 0 then
+                    -- Withered weeds have been brown for one day — now erase them entirely
+                    self:applyWeedMapState(fieldId, SoilConstants.WEED_PRESSURE.WEED_STATE_CLEAR)
+                end
             end
 
             -- Sample FieldState.weedFactor from the game's weed density map.
@@ -1744,7 +1807,14 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                     end
                 end
             end
-            field.weedPressure = math.max(0, math.min(100, gameWeedFactor * 100))
+            -- When herbicide is active the game's density map still shows dying weeds for
+            -- 1-2 days — reading it would overwrite the pressure reduction from onHerbicideApplied.
+            -- Under protection, only allow pressure to decrease (weeds dying), never increase.
+            if (field.herbicideDaysLeft or 0) > 0 then
+                field.weedPressure = math.min(field.weedPressure or 0, math.max(0, gameWeedFactor * 100))
+            else
+                field.weedPressure = math.max(0, math.min(100, gameWeedFactor * 100))
+            end
 
             -- Sync zone cells so overlay map matches field-level weed pressure.
             -- Zone WP is only written during event-driven paths (spray/plow/cultivate),

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1325,13 +1325,20 @@ function SoilFertilitySystem:scanFields()
             local actualFieldId = field.farmland and field.farmland.id
 
             if actualFieldId and actualFieldId > 0 then
-                -- Farmland.areaInHa is loaded from XML and always populated (default 2.5 ha).
-                -- Field.areaHa is computed from polygon geometry but defaults to 1.0 in Field.new()
-                -- before the polygon loads — 1.0 is truthy in Lua, so using field.areaHa first
-                -- means the farmland fallback would NEVER fire for un-loaded polygons, causing
-                -- every field to be recorded as exactly 1 ha regardless of actual size.
-                -- Use farmland.areaInHa as the primary source; field.areaHa only as fallback.
-                local area = (field.farmland and field.farmland.areaInHa) or field.areaHa or 1.0
+                -- Prefer the actual crop polygon area (field.areaHa) over farmland.areaInHa.
+                -- Farmlands include roads, hedges, and uncultivable land — typically ~2× the
+                -- actual sprayed area — which causes Pass% to cap at ~50% after a full field pass.
+                -- field.areaHa defaults to 1.0 before the polygon loads; skip it when it is
+                -- suspiciously close to that sentinel value so we don't record tiny false areas.
+                -- initialize() runs after loadMission00Finished so polygons are loaded by now.
+                local farmlandArea = (field.farmland and field.farmland.areaInHa) or 1.0
+                local cropArea     = field.areaHa
+                local area
+                if cropArea and math.abs(cropArea - 1.0) > 0.05 and cropArea <= farmlandArea + 0.1 then
+                    area = cropArea
+                else
+                    area = farmlandArea
+                end
 
                 SoilLogger.debug("Found field %d (%.2f ha)", actualFieldId, area)
 
@@ -2253,14 +2260,20 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     local limits = SoilConstants.NUTRIENT_LIMITS
 
     -- AREA NORMALIZATION: Calculate hectares for this field.
-    -- Confirm area from farmland on first spray — fixes dedicated-server first-frame spike
-    -- where fields are lazy-created with default 1.0 ha before the farmland manager is
-    -- queried.  Without this, factor = liters/1.0 instead of liters/realArea, causing
-    -- nutrients to jump by (realArea)× too much on the opening spray frame (issue #290).
+    -- Confirm area on first spray — prefer the actual crop polygon area (field.areaHa)
+    -- because farmland.areaInHa includes roads/hedges (~2× crop area), which causes
+    -- Pass% to cap at ~50% after a full field pass (issue #475/#476).
     if not field._farmlandAreaConfirmed and g_farmlandManager then
         local farmlandObj = g_farmlandManager:getFarmlandById(fieldId)
         if farmlandObj and farmlandObj.areaInHa and farmlandObj.areaInHa > 0 then
-            field.fieldArea = farmlandObj.areaInHa
+            -- Try crop polygon area first via world-position lookup
+            local cropField = g_fieldManager and g_fieldManager:getFieldAtWorldPosition(rootX, rootZ)
+            local cropArea  = cropField and cropField.areaHa
+            if cropArea and math.abs(cropArea - 1.0) > 0.05 then
+                field.fieldArea = cropArea
+            else
+                field.fieldArea = farmlandObj.areaInHa
+            end
         end
         field._farmlandAreaConfirmed = true
     end
@@ -3283,14 +3296,26 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
         self.insecticideAppliedDay[fieldId] = getXMLInt(xmlFile, fieldKey .. "#insecticideAppliedDay") or 0
         self.fungicideAppliedDay[fieldId] = getXMLInt(xmlFile, fieldKey .. "#fungicideAppliedDay") or 0
 
-        -- Refresh fieldArea from the live farmland object — corrects stale values from saves
-        -- written before the scan priority bug was fixed (where field.areaHa == 1.0 default
-        -- was recorded as the real area because it's truthy and blocked the farmland fallback).
-        -- g_farmlandManager.farmlands[id].areaInHa comes from map XML and is always reliable.
+        -- Refresh fieldArea — prefer the actual crop polygon area (field.areaHa) so that
+        -- Pass% uses the correct denominator. Farmland.areaInHa includes roads/hedges
+        -- (~2× crop area), causing Pass% to cap at ~50% on a full-field spray (#475/#476).
+        -- Use farmland area as fallback when crop polygon area is the unloaded default (1.0).
         if g_farmlandManager then
             local farmlandObj = g_farmlandManager:getFarmlandById(fieldId)
             if farmlandObj and farmlandObj.areaInHa and farmlandObj.areaInHa > 0 then
-                self.fieldData[fieldId].fieldArea = farmlandObj.areaInHa
+                local bestArea = farmlandObj.areaInHa
+                if g_fieldManager and g_fieldManager.fields then
+                    for _, fld in ipairs(g_fieldManager.fields) do
+                        if fld and fld.farmland and fld.farmland.id == fieldId then
+                            local ca = fld.areaHa
+                            if ca and math.abs(ca - 1.0) > 0.05 and ca <= farmlandObj.areaInHa + 0.1 then
+                                bestArea = ca
+                                break
+                            end
+                        end
+                    end
+                end
+                self.fieldData[fieldId].fieldArea = bestArea
             end
         end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2736,8 +2736,14 @@ function SoilFertilitySystem:onHerbicideAppliedDirect(fieldId, effectiveness, li
         local daysPerMonth = (g_currentMission and g_currentMission.environment and g_currentMission.environment.daysPerPeriod) or 1
         -- Only grant protected status once 80% of the field has been covered (issue #441)
         local protThreshold = SoilConstants.COVERAGE and SoilConstants.COVERAGE.PROTECTION_THRESHOLD or 0.80
+        local wasProtected = (field.herbicideDaysLeft or 0) > 0
         if (field.sessionCoverageFraction or 0) >= protThreshold then
             field.herbicideDaysLeft = SoilConstants.WEED_PRESSURE.HERBICIDE_DURATION_DAYS * daysPerMonth
+            -- Apply weed map state (visual browning) exactly once when protection is first granted.
+            -- applyWeedMapState is server-only; guards inside it handle the nil-field case.
+            if not wasProtected and g_server then
+                self:applyWeedMapState(fieldId, SoilConstants.WEED_PRESSURE.WEED_STATE_WITHERED)
+            end
         end
 
         -- Update per-cell weed pressure so the PDA cell-report shows changes immediately.

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -787,6 +787,11 @@ SoilConstants.WEED_PRESSURE = {
     LOW    = 20,
     MEDIUM = 50,
     HIGH   = 75,
+
+    -- FS25 density-map weed state integers (matches EasyDevControls / LUADOC)
+    -- 0 = no weeds, 1-6 = living stages, 7-9 = withered (dying/brown visual)
+    WEED_STATE_CLEAR     = 0,
+    WEED_STATE_WITHERED  = 7,   -- small withered — visible brown weeds
 }
 
 -- ========================================

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -991,9 +991,9 @@ SoilConstants.VARIABLE_RATE = {
 -- Index 3 = default (×1.0 or base value).  Admin-only panel maps
 -- settings integer 1-5 → actual simulation value via these tables.
 SoilConstants.TUNING = {
-    DEFAULT_N  = {50, 75, 100, 125, 150},       -- Starting nitrogen  (points)
+    DEFAULT_N  = {15, 30,  50,  75, 100},       -- Starting nitrogen  (points); idx 3 = fair (~FIELD_DEFAULTS)
     DEFAULT_P  = {15, 25,  35,  50,  70},        -- Starting phosphorus (points)
-    DEFAULT_K  = {50, 75, 100, 125, 150},        -- Starting potassium  (points)
+    DEFAULT_K  = {10, 20,  40,  65, 100},        -- Starting potassium  (points); idx 3 = fair (~FIELD_DEFAULTS)
     DEFAULT_PH = {5.5, 6.0, 6.5, 7.0, 7.5},     -- Starting pH
     DEFAULT_OM = {2.0, 4.0, 6.0, 8.0, 10.0},    -- Starting organic matter (%)
     RATE_MULT  = {0.25, 0.50, 1.0, 1.50, 2.0},  -- Depletion / efficiency multiplier

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1392,6 +1392,10 @@ function HookManager:installVariableRateHook()
                         end
                     end
 
+                    -- Smooth rate to prevent tick-to-tick flickering as the boom crosses
+                    -- zone boundaries (#479). 40% blend toward target per tick gives ~0.5s lag.
+                    local prevRate = sensorMgr:getSectionRate(vehicleId, section) or rate
+                    rate = prevRate * 0.6 + rate * 0.4
                     -- Never exceed the player's manual rate ceiling
                     rate = math.min(rate, manualMult)
                     sensorMgr:setSectionRate(vehicleId, section, rate)
@@ -4428,7 +4432,10 @@ function HookManager:getBoomCellPositions(vehicle, rootX, rootZ)
         local vww = obj.spec_variableWorkWidth
         if vww and vww.sections then
             for _, section in ipairs(vww.sections) do
-                if section.maxWidthNode then
+                -- Skip inactive sections (Partial Width mode): their maxWidthNodes are still
+                -- physically at the boom tip position, which would incorrectly inflate the
+                -- detected boom span and credit cells that were never sprayed (#475/#476).
+                if section.isActive ~= false and section.maxWidthNode then
                     local ok, x, _, z = pcall(getWorldTranslation, section.maxWidthNode)
                     if ok and x then table.insert(xs, x); table.insert(zs, z) end
                 end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1988,6 +1988,12 @@ function HookManager:installSprayerAreaHook()
                 return
             end
             if not sprayFillLevel or sprayFillLevel <= 0 then return end
+
+            -- Require minimum forward speed (matches WeedSpotSpray.onEndWorkAreaProcessing).
+            -- A stationary sprayer drains the tank and consumes liters but covers no ground —
+            -- without this guard coverage climbs to 100% without moving.
+            if (self.getLastSpeed and self:getLastSpeed() or 0) < 0.5 then return end
+
             local success, errorMsg = pcall(function()
                 local fillType = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
                 if not fillType then return end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -430,6 +430,21 @@ function HookManager:registerCustomSprayTypes()
         end
     end
 
+    -- LIQUIDLIME: fillTypes.xml uses sprayTypeStr="LIQUIDFERTILIZER" as a safe XML-load-time fallback,
+    -- but that sets fillType.sprayTypeIndex to LIQUIDFERTILIZER's index (291.6 L/ha).
+    -- Override it now so the vanilla sprayer uses our calibrated LIQUIDLIME spray type (374 L/ha,
+    -- LIME ground state). addSprayType already wrote fillTypeIndexToSprayType[LIQUIDLIME] = ours,
+    -- but the drain uses fillType.sprayTypeIndex, so we must patch that field too.
+    local llFT = g_fillTypeManager:getFillTypeByName("LIQUIDLIME")
+    local llST = g_sprayTypeManager:getSprayTypeByName("LIQUIDLIME")
+    if llFT and llST then
+        llFT.sprayTypeIndex = llST.index
+        SoilLogger.debug("LIQUIDLIME: overrode sprayTypeIndex → %d (LPS=%.5f, ~%.0f L/ha)",
+            llST.index, llST.litersPerSecond or 0, (llST.litersPerSecond or 0) * 36000)
+    else
+        SoilLogger.warning("LIQUIDLIME spray type override failed: ft=%s st=%s", tostring(llFT), tostring(llST))
+    end
+
     SoilLogger.info(
         "[OK] Custom spray types registered: %d types (direct LPS: vanilla ref liq=%.5f dry=%.5f, %d skipped)",
         registered, liquidLPS, solidLPS, skipped

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -651,6 +651,8 @@ function HookManager:installSprayTypeEffectsHook()
     local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
     -- Liquid custom types visually match LIQUIDFERTILIZER spraying
+    -- HERBICIDE is included so it gets added to LIQUIDFERTILIZER slots (full-boom spray),
+    -- but it is a vanilla fill type and must NOT be stripped from HERBICIDE-only slots in Pass 2.
     local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
                           "HERBICIDE", "INSECTICIDE", "FUNGICIDE",
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
@@ -660,6 +662,11 @@ function HookManager:installSprayTypeEffectsHook()
     local solidNameSet  = {}
     for _, n in ipairs(liquidNames) do liquidNameSet[string.upper(n)] = true end
     for _, n in ipairs(solidNames)  do solidNameSet[string.upper(n)]  = true end
+
+    -- Pass 2 must NOT strip vanilla fill type names from their native slots.
+    -- HERBICIDE is a vanilla type that lives in HERBICIDE-only slots — removing it would
+    -- break herbicide application. Only strip our own custom types.
+    local vanillaNames = { HERBICIDE = true }  -- extend if more vanilla types added to liquidNames
 
     -- Shared helper: walk a vehicle's sprayType entries and inject our names.
     --
@@ -731,7 +738,8 @@ function HookManager:installSprayTypeEffectsHook()
                 if not hasFert and not hasLiqFert then
                     for i = #st.fillTypes, 1, -1 do
                         local upper = string.upper(st.fillTypes[i])
-                        if liquidNameSet[upper] or solidNameSet[upper] then
+                        -- Don't strip vanilla fill type names — only strip our custom injected names
+                        if not vanillaNames[upper] and (liquidNameSet[upper] or solidNameSet[upper]) then
                             table.remove(st.fillTypes, i)
                         end
                     end
@@ -856,23 +864,30 @@ function HookManager:installDensityMapSprayHook()
         return false
     end
 
-    local liqST = g_sprayTypeManager:getSprayTypeByName("LIQUIDFERTILIZER")
-    local dryST = g_sprayTypeManager:getSprayTypeByName("FERTILIZER")
+    local liqST  = g_sprayTypeManager:getSprayTypeByName("LIQUIDFERTILIZER")
+    local dryST  = g_sprayTypeManager:getSprayTypeByName("FERTILIZER")
+    local limeST = g_sprayTypeManager:getSprayTypeByName("LIME")
 
     if not liqST and not dryST then
         SoilLogger.warning("DensityMap spray hook: vanilla spray types not found - skipping")
         return false
     end
 
-    local liqIdx = liqST and liqST.index
-    local dryIdx = dryST and dryST.index
+    local liqIdx  = liqST  and liqST.index
+    local dryIdx  = dryST  and dryST.index
+    local limeIdx = limeST and limeST.index
 
     -- Build remap: customSprayTypeIndex → vanillaSprayTypeIndex
-    local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
-                          "HERBICIDE", "INSECTICIDE", "FUNGICIDE",
+    -- LIQUIDLIME is excluded from liquidNames here — it must remap to LIME (not LIQUIDFERTILIZER)
+    -- so FSDensityMapUtil.updateSprayArea writes the lime ground state, not the fertilizer state.
+    -- HERBICIDE is excluded — it must keep its native HERBICIDE spray type for weed density map.
+    local liquidNames = { "UAN32", "UAN28", "ANHYDROUS", "STARTER",
+                          "INSECTICIDE", "FUNGICIDE",
                           "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }
     local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
+    -- LIQUIDLIME must remap to LIME so FSDensityMapUtil writes the lime ground state
+    local limeNames   = { "LIQUIDLIME" }
 
     local remap = {}
     if liqIdx then
@@ -885,6 +900,12 @@ function HookManager:installDensityMapSprayHook()
         for _, name in ipairs(solidNames) do
             local st = g_sprayTypeManager:getSprayTypeByName(name)
             if st then remap[st.index] = dryIdx end
+        end
+    end
+    if limeIdx then
+        for _, name in ipairs(limeNames) do
+            local st = g_sprayTypeManager:getSprayTypeByName(name)
+            if st then remap[st.index] = limeIdx end
         end
     end
 
@@ -2768,7 +2789,7 @@ function HookManager:installFillUnitHookEarly()
     local liquidNames        = {"UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "INSECTICIDE", "FUNGICIDE",
                                 "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH"}
     -- Organic dry types also work in manure spreaders (MANURE fill-unit base)
-    local manureCompatNames  = {"BIOSOLIDS", "CHICKEN_MANURE"}
+    local manureCompatNames  = {"COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE"}
 
     local original = FillUnit.onPostLoad
     FillUnit.onPostLoad = Utils.prependedFunction(original, function(vehicleSelf)
@@ -2883,8 +2904,8 @@ function HookManager:installFillUnitHook()
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM"}
     local liquidNames = {"UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "INSECTICIDE", "FUNGICIDE",
                          "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH"}
-    -- These organic dry types also work in manure spreaders (MANURE fill-unit base).
-    local manureCompatNames = {"BIOSOLIDS", "CHICKEN_MANURE"}
+    -- Organic dry types also work in manure spreaders (MANURE fill-unit base).
+    local manureCompatNames = {"COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE"}
     -- Store for deferred re-patch (dedi server timing fix)
     self._fuSolidNames  = solidNames
     self._fuLiquidNames = liquidNames

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2831,7 +2831,7 @@ function HookManager:installFillUnitHookEarly()
                     end)
                     if ok and catTypes then
                         for _, ft in pairs(catTypes) do
-                            if ft and ft.index then fu.supportedFillTypes[ft.index] = true end
+                            if ft then fu.supportedFillTypes[ft] = true end
                         end
                     end
                 end
@@ -2841,7 +2841,7 @@ function HookManager:installFillUnitHookEarly()
                     end)
                     if ok and catTypes then
                         for _, ft in pairs(catTypes) do
-                            if ft and ft.index then fu.supportedFillTypes[ft.index] = true end
+                            if ft then fu.supportedFillTypes[ft] = true end
                         end
                     end
                 end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -4262,7 +4262,9 @@ function HookManager:installSprayerVisualEffectHook()
 
             if not vanillaFillType then return end  -- not our custom type, nothing to manage
 
-            local effectsVisible = sprayerSelf:getAreEffectsVisible()
+            -- Gate on speed: no visual spray when standing still (matches our nutrient hook guard)
+            local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
+            local effectsVisible = sprayerSelf:getAreEffectsVisible() and speed >= 0.5
 
             -- Suppress effects while the fold animation is actively running mid-travel.
             -- Courseplay folds the implement before filling completes, leaving effects stuck on.

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -4261,16 +4261,13 @@ function HookManager:installSprayerVisualEffectHook()
             end
 
             if not vanillaFillType then
-                -- Vanilla fill type (e.g. HERBICIDE): apply speed gate so effects stop when stationary.
-                -- The vanilla game starts effects each tick before our appended hook runs; we stop them
-                -- once on each stationary→moving transition (state-tracked to avoid per-tick calls).
+                -- Vanilla fill type (e.g. HERBICIDE): stop effects every tick when stationary.
+                -- We run AFTER the vanilla onUpdateTick (appendedFunction), so vanilla may restart
+                -- effects each tick. State-change guards don't work here — must suppress every tick.
+                -- g_effectManager:stopEffects is a no-op when effects are already stopped.
                 local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
-                local wantStopped = speed < 0.5
-                if wantStopped ~= spec._soilVanillaStopActive then
-                    spec._soilVanillaStopActive = wantStopped
-                    if wantStopped then
-                        stopSprayerEffects(sprayerSelf)
-                    end
+                if speed < 0.5 then
+                    stopSprayerEffects(sprayerSelf)
                 end
                 return
             end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -4260,7 +4260,20 @@ function HookManager:installSprayerVisualEffectHook()
                 spec._soilEffectsActive   = nil
             end
 
-            if not vanillaFillType then return end  -- not our custom type, nothing to manage
+            if not vanillaFillType then
+                -- Vanilla fill type (e.g. HERBICIDE): apply speed gate so effects stop when stationary.
+                -- The vanilla game starts effects each tick before our appended hook runs; we stop them
+                -- once on each stationary→moving transition (state-tracked to avoid per-tick calls).
+                local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
+                local wantStopped = speed < 0.5
+                if wantStopped ~= spec._soilVanillaStopActive then
+                    spec._soilVanillaStopActive = wantStopped
+                    if wantStopped then
+                        stopSprayerEffects(sprayerSelf)
+                    end
+                end
+                return
+            end
 
             -- Gate on speed: no visual spray when standing still (matches our nutrient hook guard)
             local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
@@ -4382,16 +4395,31 @@ function HookManager:getBoomCellPositions(vehicle, rootX, rootZ)
     local xs, zs = {}, {}
 
     local function collectFromObj(obj)
-        if not obj or not obj.spec_workArea or not obj.spec_workArea.workAreas then return end
-        for _, wa in ipairs(obj.spec_workArea.workAreas) do
-            if wa.start then
-                local ok, x, _, z = pcall(getWorldTranslation, wa.start)
-                if ok and x then table.insert(xs, x); table.insert(zs, z) end
+        if not obj then return end
+        -- WorkArea start/end nodes
+        if obj.spec_workArea and obj.spec_workArea.workAreas then
+            for _, wa in ipairs(obj.spec_workArea.workAreas) do
+                if wa.start then
+                    local ok, x, _, z = pcall(getWorldTranslation, wa.start)
+                    if ok and x then table.insert(xs, x); table.insert(zs, z) end
+                end
+                local waEnd = wa["end"]  -- "end" is a Lua keyword; must use bracket access
+                if waEnd then
+                    local ok, x, _, z = pcall(getWorldTranslation, waEnd)
+                    if ok and x then table.insert(xs, x); table.insert(zs, z) end
+                end
             end
-            local waEnd = wa["end"]  -- "end" is a Lua keyword; must use bracket access
-            if waEnd then
-                local ok, x, _, z = pcall(getWorldTranslation, waEnd)
-                if ok and x then table.insert(xs, x); table.insert(zs, z) end
+        end
+        -- VWW section maxWidthNodes capture the outer boom edge of each section —
+        -- workArea start/end nodes are often co-located at the centre, giving a
+        -- near-zero span and causing the function to return nil for boom sprayers.
+        local vww = obj.spec_variableWorkWidth
+        if vww and vww.sections then
+            for _, section in ipairs(vww.sections) do
+                if section.maxWidthNode then
+                    local ok, x, _, z = pcall(getWorldTranslation, section.maxWidthNode)
+                    if ok and x then table.insert(xs, x); table.insert(zs, z) end
+                end
             end
         end
     end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1530,40 +1530,46 @@ end
 -- pressure is 0-100.  isProtected shows "(protected)" suffix when true.
 -- Returns updated cy after the row.
 function SoilHUD:drawPressureRow(labelKey, pressure, isProtected, px, cy, pw, s, fontMult)
-    local pad  = SoilHUD.PAD * s
-    local barH = SoilHUD.BAR_H * s
-    local barW = SoilHUD.BAR_W * s
-    local tx   = px + pad
+    local pad      = SoilHUD.PAD * s
+    local rowH     = SoilHUD.LINE_H * s
+    local barH     = SoilHUD.BAR_H * s
+    local barW     = SoilHUD.BAR_W * s
+    local textSize = 0.010 * fontMult * s
+    local tx       = px + pad
+
+    -- Pre-decrement so the row occupies [cy, cy+rowH] — same pattern as drawNutrientRow,
+    -- which ensures bars are centred within their own row and not in the row above (#HUD).
+    cy = cy - rowH
 
     -- 3-level color (matches getPressureColor in SoilReportDialog — aligned with Constants thresholds)
     local wp = SoilConstants.WEED_PRESSURE  -- LOW=20, MEDIUM=50 (shared by weed/pest/disease)
     local col
-    if pressure < wp.LOW    then col = SoilHUD.C_GOOD
+    if pressure < wp.LOW        then col = SoilHUD.C_GOOD
     elseif pressure < wp.MEDIUM then col = SoilHUD.C_FAIR
-    else                         col = SoilHUD.C_POOR end
+    else                             col = SoilHUD.C_POOR end
 
-    -- Label
+    -- Label — vertically centred in row
     setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
-    renderText(tx, cy, 0.010 * fontMult * s, g_i18n:getText(labelKey))
+    renderText(tx, cy + (rowH - textSize) * 0.5, textSize, g_i18n:getText(labelKey))
 
-    -- Bar
+    -- Bar — centred in row, horizontally aligned with nutrient bars
     local barX = tx + 0.038*s
-    local barY = cy + (SoilHUD.LINE_H * s - barH) * 0.5
+    local barY = cy + (rowH - barH) * 0.5
     self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
     local fill = math.max(0, math.min(1, pressure / 100))
     if fill > 0 then
         self:drawRect(barX, barY, barW * fill, barH, col)
     end
 
-    -- Value + protection tag
+    -- Value + protection tag — vertically centred in row
     local label = string.format("%.0f%%", pressure)
     if isProtected then label = label .. " " .. g_i18n:getText("sf_hud_protected") end
     setTextAlignment(RenderText.ALIGN_RIGHT)
     setTextColor(col[1], col[2], col[3], 1.0)
-    renderText(px + pw - pad, cy, 0.010 * fontMult * s, label)
+    renderText(px + pw - pad, cy + (rowH - textSize) * 0.5, textSize, label)
     setTextAlignment(RenderText.ALIGN_LEFT)
 
-    return cy - SoilHUD.LINE_H * s
+    return cy
 end
 
 -- ── Sprayer fill-type helpers ─────────────────────────────

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -359,6 +359,7 @@ function SoilHUD:calculateHeight()
 
         h = h + SoilHUD.ROW_H   -- pH bar row
         h = h + SoilHUD.LINE_H  -- OM text row
+        h = h + SoilHUD.LINE_H  -- gap between OM row and divider (matches drawPanel extra subtract)
         h = h + SoilHUD.PAD * 1.3
         
         local mgr = g_SoilFertilityManager
@@ -366,7 +367,7 @@ function SoilHUD:calculateHeight()
             if mgr.settings.weedPressure and (info.weedPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
             if mgr.settings.pestPressure and (info.pestPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
             if mgr.settings.diseasePressure and (info.diseasePressure or 0) > 0 then h = h + SoilHUD.LINE_H end
-            if (info.sessionCoverageFraction or info.coverageFraction or 0) > 0 then h = h + SoilHUD.LINE_H end
+            if self._cachedSprayer and (info.sessionCoverageFraction or info.coverageFraction or 0) > 0 then h = h + SoilHUD.LINE_H end
             if mgr.settings.compactionEnabled and (info.compaction or 0) > 0 then h = h + SoilHUD.LINE_H end
         end
         if info.yieldEfficiency then h = h + SoilHUD.LINE_H end
@@ -639,7 +640,9 @@ function SoilHUD:update(dt)
                 pcall(setRotation, cam, self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ)
             end
         end
-        -- Vehicle camera freeze: restore spec_cameraSystem rotX/rotY each frame
+        -- Vehicle camera freeze: restore rotX/rotY and push to the scene node each frame.
+        -- Setting ac.rotX/Y alone isn't enough — VehicleCamera calls setRotation(rotateNode)
+        -- BEFORE our update runs (APPEND hook), so we must re-apply to the actual scene node.
         if self.savedVehicleCamRotX ~= nil then
             local cv = g_currentMission and g_currentMission.controlledVehicle
             if cv and cv.spec_cameraSystem then
@@ -647,6 +650,10 @@ function SoilHUD:update(dt)
                 if ac then
                     ac.rotX = self.savedVehicleCamRotX
                     ac.rotY = self.savedVehicleCamRotY
+                    local node = ac.rotateNode or ac.cameraNode
+                    if node and setRotation then
+                        pcall(setRotation, node, self.savedVehicleCamRotX, self.savedVehicleCamRotY, 0)
+                    end
                 end
             end
         end
@@ -1224,9 +1231,9 @@ function SoilHUD:drawPanel()
                     info.fungicideActive, px, cy, pw, s, fontMult)
             end
 
-            -- Coverage row: session fraction (survives daily resets) with product label
+            -- Coverage row: only show when player is actively in a fertilizer applicator
             local cov = info.sessionCoverageFraction or info.coverageFraction or 0
-            if cov > 0 then
+            if self._cachedSprayer and cov > 0 then
                 local minCov = SoilConstants.COVERAGE and SoilConstants.COVERAGE.MIN_FULL_CREDIT or 0.70
                 local covPct = math.floor(cov * 100 + 0.5)
                 local covText
@@ -2006,11 +2013,17 @@ function SoilHUD:drawSprayerRatePanel()
                     pH = defaults.pH,
                     OM = defaults.OM,
                 } or defaults
-                local ppm = SoilConstants.PPM_DISPLAY or { N=1, P=1, K=1 }
-                if profile.N and profile.N > 0 then targetText = targetText .. math.floor(targets.N * (ppm.N or 1) + 0.5) .. "N " end
-                if profile.P and profile.P > 0 then targetText = targetText .. math.floor(targets.P * (ppm.P or 1) + 0.5) .. "P " end
-                if profile.K and profile.K > 0 then targetText = targetText .. math.floor(targets.K * (ppm.K or 1) + 0.5) .. "K " end
-                if profile.pH and profile.pH > 0 then targetText = targetText .. targets.pH .. "pH " end
+                local isOMPrimary = SoilConstants.OM_PRIMARY_PRODUCTS and SoilConstants.OM_PRIMARY_PRODUCTS[fillType.name]
+                if isOMPrimary then
+                    -- OM-primary products target organic matter, not N/P/K
+                    targetText = targetText .. string.format("%.1f", targets.OM) .. "% OM"
+                else
+                    local ppm = SoilConstants.PPM_DISPLAY or { N=1, P=1, K=1 }
+                    if profile.N and profile.N > 0 then targetText = targetText .. math.floor(targets.N * (ppm.N or 1) + 0.5) .. "N " end
+                    if profile.P and profile.P > 0 then targetText = targetText .. math.floor(targets.P * (ppm.P or 1) + 0.5) .. "P " end
+                    if profile.K and profile.K > 0 then targetText = targetText .. math.floor(targets.K * (ppm.K or 1) + 0.5) .. "K " end
+                    if profile.pH and profile.pH > 0 then targetText = targetText .. targets.pH .. "pH " end
+                end
                 setTextColor(0.7, 0.9, 0.7, 0.8)
                 renderText(cx, scrollY - self:py(6)*s, 0.008 * fontMult * s, targetText)
             end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -32,6 +32,7 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed vanilla HERBICIDE spray type inadvertently stripped from HERBICIDE-only sprayer slots",
     "- Fixed all custom solid fertilizers (UREA, MAP, etc.) unable to fill spreaders via big bag",
     "- Organic dry types (COMPOST, PELLETIZED MANURE) now also accepted by dedicated manure spreaders",
+    "- Fixed herbicide: weed pressure and yield penalty now correctly respect active protection window",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -31,6 +31,7 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed liquid lime draining entire tank in seconds (spray type index corrected)",
     "- Updated Danish (da) guide translation — Guide dialog now fully in Danish",
     "- Fixed herbicide session coverage reset (second spray no longer instant-triggers on first tick)",
+    "- Fixed Weeds/Pests/Disease HUD bars rendering one row above their labels",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,18 +24,13 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed soil monitor HUD layout: compaction, coverage and hint rows overflowed the panel",
-    "- Fixed coverage % (Pass%) hidden when not in a fertilizer applicator",
-    "- Fixed liquid lime not writing lime ground layer to field (white overlay missing)",
-    "- Fixed OM-spreading products (COMPOST, MANURE, etc.) showing N/P/K targets in auto rate display",
-    "- Fixed edit mode camera orbit no longer drifts (scene node rotation now frozen)",
-    "- Fixed vanilla HERBICIDE spray type inadvertently stripped from HERBICIDE-only sprayer slots",
-    "- Fixed all custom solid fertilizers (UREA, MAP, etc.) unable to fill spreaders via big bag",
-    "- Organic dry types (COMPOST, PELLETIZED MANURE) now also accepted by dedicated manure spreaders",
-    "- Fixed herbicide: weed pressure and yield penalty now correctly respect active protection window",
-    "- Fixed herbicide: weeds now visually wither (turn brown) when protection threshold is reached",
-    "- Fixed boom sprayer coverage tracking now uses VWW section positions (no more instant full-pass)",
-    "- Fixed vanilla HERBICIDE spray visual effects no longer display when vehicle is stationary",
+    "- Fixed N and K starting at 90%+ on new saves (tuning defaults now start at fair range)",
+    "- Fixed Pass% capping at ~50% after a full-field spray (crop polygon area used as denominator)",
+    "- Fixed Partial Width mode crediting inactive boom sections toward Pass% coverage",
+    "- Fixed variable rate display oscillating rapidly with MAP / P-type fertilizers (smoothed)",
+    "- Fixed liquid lime draining entire tank in seconds (spray type index corrected)",
+    "- Updated Danish (da) guide translation — Guide dialog now fully in Danish",
+    "- Fixed herbicide session coverage reset (second spray no longer instant-triggers on first tick)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -33,6 +33,9 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed all custom solid fertilizers (UREA, MAP, etc.) unable to fill spreaders via big bag",
     "- Organic dry types (COMPOST, PELLETIZED MANURE) now also accepted by dedicated manure spreaders",
     "- Fixed herbicide: weed pressure and yield penalty now correctly respect active protection window",
+    "- Fixed herbicide: weeds now visually wither (turn brown) when protection threshold is reached",
+    "- Fixed boom sprayer coverage tracking now uses VWW section positions (no more instant full-pass)",
+    "- Fixed vanilla HERBICIDE spray visual effects no longer display when vehicle is stationary",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,11 +24,14 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed PDA tab icon invisible (transparent color fixed)",
-    "- Fixed PDA Farm Overview missing OM column (added between pH and Status)",
-    "- Fixed Field Detail dialog content clipping (dialog height increased to 700px)",
-    "- Fixed shop: all big bags and liquid tanks were missing (objects/ folder in build)",
-    "- Added full translation support for Soil Guide dialog (216 l10n keys, 26 languages)",
+    "- Fixed soil monitor HUD layout: compaction, coverage and hint rows overflowed the panel",
+    "- Fixed coverage % (Pass%) hidden when not in a fertilizer applicator",
+    "- Fixed liquid lime not writing lime ground layer to field (white overlay missing)",
+    "- Fixed OM-spreading products (COMPOST, MANURE, etc.) showing N/P/K targets in auto rate display",
+    "- Fixed edit mode camera orbit no longer drifts (scene node rotation now frozen)",
+    "- Fixed vanilla HERBICIDE spray type inadvertently stripped from HERBICIDE-only sprayer slots",
+    "- Fixed all custom solid fertilizers (UREA, MAP, etc.) unable to fill spreaders via big bag",
+    "- Organic dry types (COMPOST, PELLETIZED MANURE) now also accepted by dedicated manure spreaders",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Jord &amp; Gødning" eh="f31197fb" />
@@ -750,227 +750,227 @@
     <e k="sf_independent_panels_short" v="Frit panel-layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Tillad at smart systempaneler placeres individuelt i redigeringstilstand" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="Træk hvert panel frit med Shift+H redigeringstilstand. Fold paneler sammen med −-knappen i titellinjen." eh="7c60edfc" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
+    <e k="sf_guide_sub_1" v="Oversigt — Hvad denne mod sporer og hvorfor det er vigtigt" eh="81726806" />
+    <e k="sf_guide_sub_2" v="HUD-guide — Læsning af næringsstofsøjler og skærmindikatorer" eh="fd0a8c1d" />
+    <e k="sf_guide_sub_3" v="Arbejdsproces — Din daglige og sæsonmæssige jordstyringsrutine" eh="2dc26ccc" />
+    <e k="sf_guide_sub_4" v="Produkter — Hvad hver gødning påvirker og hvornår den bruges" eh="17ebc503" />
+    <e k="sf_guide_sub_5" v="F.A.Q. — Almindelige spørgsmål besvaret" eh="a9735b47" />
+    <e k="sf_guide_p1_01" v="HVAD ER DENNE MOD" eh="83468bd7" />
+    <e k="sf_guide_p1_02" v="Sporer 5 jordnæringsstoffer pr. mark over din" eh="94b33a56" />
+    <e k="sf_guide_p1_03" v="gård. Afgrøder tømmes for næringsstoffer ved høst." eh="8db042d2" />
+    <e k="sf_guide_p1_04" v="Gødning genopfylder dem. Vejr og" eh="abd05a9c" />
+    <e k="sf_guide_p1_05" v="sæsoner tilføjer realistisk pres over tid." eh="2173d584" />
+    <e k="sf_guide_p1_06" v="DE 5 JORDPARAMETRE" eh="5fde1343" />
+    <e k="sf_guide_p1_07" v="N   Nitrogen       Hurtig udtømning. Hver høst." eh="23d3ce22" />
+    <e k="sf_guide_p1_08" v="P   Fosfor         Langsom udtømning. Rodafgrøder." eh="e44502f1" />
+    <e k="sf_guide_p1_09" v="K   Kalium         Rodafgrøder forbruger denne kraftigt." eh="4edfc26d" />
+    <e k="sf_guide_p1_10" v="OM  Organisk stof  Bygger langsomt op over mange sæsoner." eh="cdb2d933" />
+    <e k="sf_guide_p1_11" v="pH  Jordens surhedsgrad.  Målområde: 6,5 – 7,0." eh="6dfd73f1" />
+    <e k="sf_guide_p1_12" v="STATUSNIVEAUER" eh="d1b157ef" />
+    <e k="sf_guide_p1_13" v="GODT (grøn)   På eller over afgrødens optimale mål." eh="36e7061f" />
+    <e k="sf_guide_p1_14" v="               Ingen handling nødvendig denne sæson." eh="fc3fe8cf" />
+    <e k="sf_guide_p1_15" v="TILFREDSSTILENDE (gul)  Under optimalt." eh="3a5f2343" />
+    <e k="sf_guide_p1_16" v="            -- Planlæg en opfyldning. Udbyttet er let reduceret." eh="8514a61e" />
+    <e k="sf_guide_p1_17" v="DÅRLIGT (rød)     Under minimumstersklen." eh="333c4fc2" />
+    <e k="sf_guide_p1_18" v="               Handl nu — udbyttet påvirkes alvorligt." eh="1b962d17" />
+    <e k="sf_guide_p1_19" v="HURTIG START (5 TRIN)" eh="5a9cb86e" />
+    <e k="sf_guide_p1_20" v="1. Åbn PDA (spilmenu) &gt; Jord &amp; Gødning." eh="8093628a" />
+    <e k="sf_guide_p1_21" v="2. Tjek Gårdoverblik for rødmarkede marker." eh="3bfda016" />
+    <e k="sf_guide_p1_22" v="3. Brug Behandlingsplanen for at se, hvad der er nødvendigt." eh="e19ebe2b" />
+    <e k="sf_guide_p1_23" v="4. Påfør det rette gødningsprodukt." eh="315ecea6" />
+    <e k="sf_guide_p1_24" v="5. Høst normalt — næringsstoffer trækkes automatisk fra." eh="6c78829c" />
+    <e k="sf_guide_p1_25" v="VÆRKTØJER I OVERSIGT" eh="0d78c5c6" />
+    <e k="sf_guide_p1_26" v="HUD-søjler      Jordniveauer for din aktuelle mark." eh="91a47705" />
+    <e k="sf_guide_p1_27" v="               Nøgle: SF Skift HUD (Kontroller &gt; Mods)" eh="71546634" />
+    <e k="sf_guide_p1_28" v="PDA-skærm      Fuld gårdoverblik + behandlingsplan." eh="84c5722b" />
+    <e k="sf_guide_p1_29" v="               Åbn via spillets tabletmenu." eh="3b2c80b5" />
+    <e k="sf_guide_p1_30" v="Jordkort        Næringsstoffarvelag per celle." eh="7c49f1b1" />
+    <e k="sf_guide_p1_31" v="               Nøgle: SF Skift cellekort" eh="4fed89d3" />
+    <e k="sf_guide_p1_32" v="Markrapport     Detaljeret opdeling af en enkelt mark." eh="5c3bfcdf" />
+    <e k="sf_guide_p1_33" v="               Nøgle: SF Jordrapport" eh="1d9047fa" />
+    <e k="sf_guide_p1_34" v="Smart sensor   Blokerer sektioner uden aktivt behov." eh="8f3e9d62" />
+    <e k="sf_guide_p1_35" v="               Skiftere: Alt+1/2/3 i en VWW-sprøjte." eh="0c364023" />
+    <e k="sf_guide_p1_36" v="Se &amp; Sprøjt   Live tryk pr. celle i køretøjet." eh="82c711b5" />
+    <e k="sf_guide_p1_37" v="               Skiftere: Alt+4/5/6 i en VWW-sprøjte." eh="c0740086" />
+    <e k="sf_guide_p1_38" v="Variabel dosering  Justerer automatisk bommængde fra underskud." eh="fbd7cfe0" />
+    <e k="sf_guide_p1_39" v="               Skifter: Alt+7. Aktivér i Admin." eh="00361557" />
+    <e k="sf_guide_p1_40" v="TASTATURGENVEJE" eh="cbc41ad0" />
+    <e k="sf_guide_p1_41" v="Alle taster leveres UDEFINEREDE for at undgå konflikter." eh="9652a447" />
+    <e k="sf_guide_p1_42" v="Gå til: Valg &gt; Kontroller &gt; Mods" eh="c9fea2e7" />
+    <e k="sf_guide_p1_43" v="Søg efter handlinger, der starter med SF_" eh="fe557f61" />
+    <e k="sf_guide_p1_44" v="Tildel taster, der ikke konflikter med andre mods." eh="b605a223" />
+    <e k="sf_guide_p2_01" v="NÆRINGSSTOF-SØJLERNE" eh="64bcec79" />
+    <e k="sf_guide_p2_02" v="HUD'en viser én søjle per næringsstof: N P K OM pH." eh="aeac112b" />
+    <e k="sf_guide_p2_03" v="Søjlen fyldes fra venstre (0) til højre (100 = maksimum)." eh="7f23737a" />
+    <e k="sf_guide_p2_04" v="Søjlefargen viser status med et blik." eh="33dcb4e1" />
+    <e k="sf_guide_p2_05" v="DE TRE MARKØRER" eh="d89a45ba" />
+    <e k="sf_guide_p2_06" v="Hver søjle har tre små lodrette markører." eh="4264137f" />
+    <e k="sf_guide_p2_07" v="ORANGE markør — grænsen mellem Dårlig og Tilfredsstillende." eh="99feda97" />
+    <e k="sf_guide_p2_08" v="  Søjlen er RØD under denne linje." eh="28547bc6" />
+    <e k="sf_guide_p2_09" v="  Din jord er i DÅRLIG tilstand." eh="2569c8ef" />
+    <e k="sf_guide_p2_10" v="  Handling: påfør gødning straks." eh="970de608" />
+    <e k="sf_guide_p2_11" v="GUL markør — grænsen mellem Tilfredsstillende og God." eh="f8f07ad1" />
+    <e k="sf_guide_p2_12" v="  Søjlen er GUL mellem orange og gule markører." eh="2eb1fb88" />
+    <e k="sf_guide_p2_13" v="  Din jord er TILFREDSSTILENDE — under afgrødens optimum." eh="7987bd5b" />
+    <e k="sf_guide_p2_14" v="  Handling: planlæg en opfyldning denne sæson." eh="00502703" />
+    <e k="sf_guide_p2_15" v="CYAN markør — din plantede afgrødes optimale mål." eh="a86164b4" />
+    <e k="sf_guide_p2_16" v="  Nå dette punkt for maksimal høst." eh="ae26a23a" />
+    <e k="sf_guide_p2_17" v="  Søjlen er GRØN, når du når det." eh="33a4e76b" />
+    <e k="sf_guide_p2_18" v="  Hver afgrøde har forskellige N/P/K-mål." eh="7922d64b" />
+    <e k="sf_guide_p2_19" v="SPØGELSES-SØJLEN" eh="1200754e" />
+    <e k="sf_guide_p2_20" v="En svag forlængelse af søjlen (samme farve, svagere)." eh="18f4e711" />
+    <e k="sf_guide_p2_21" v="Viser dit forventede niveau EFTER påføring af" eh="032d8f35" />
+    <e k="sf_guide_p2_22" v="den gødning, der i øjeblikket er lastet i din sprøjte." eh="8a82196e" />
+    <e k="sf_guide_p2_23" v="Kør til en mark med en lastet sprøjte for at se den." eh="bd0335a0" />
+    <e k="sf_guide_p2_24" v="Brug den for at undgå spild af gødning ved overdosering." eh="944b9e4b" />
+    <e k="sf_guide_p2_25" v="LÆSER TALENE" eh="9d84b9e8" />
+    <e k="sf_guide_p2_26" v="Format:  værdi  /  mål  ( +projekteret )" eh="df3bb7c7" />
+    <e k="sf_guide_p2_27" v="Eksempel: 245 / 320 (+85)" eh="136bd377" />
     <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
+    <e k="sf_guide_p2_29" v="245  = dit aktuelle kvælstofniveau i ppm" eh="dbfc1141" />
+    <e k="sf_guide_p2_30" v="320  = afgrødens optimale kvælstofmål" eh="ba949d8a" />
+    <e k="sf_guide_p2_31" v="+85  = hvor meget din sprøjtebeholdning vil tilføje" eh="92070ec8" />
+    <e k="sf_guide_p2_32" v="STATUSFARVER" eh="08d6340b" />
+    <e k="sf_guide_p2_33" v="RØD søjle    Under den orange markør (DÅRLIG)." eh="4b18cb90" />
+    <e k="sf_guide_p2_34" v="           Udbyttetab. Påfør nu." eh="b971b10b" />
+    <e k="sf_guide_p2_35" v="GUL søjle   Mellem orange og gule markører (TILFREDSSTILENDE)." eh="ca7536de" />
+    <e k="sf_guide_p2_36" v="           Let tab. Planlæg forud." eh="d54afa45" />
+    <e k="sf_guide_p2_37" v="GRØN søjle   Over den gule markør (GOD)." eh="8545d6fb" />
+    <e k="sf_guide_p2_38" v="           På eller over afgrødens optimale. Ingen handling." eh="e903aa78" />
+    <e k="sf_guide_p2_39" v="SMART SYSTEMPANELER (kræver VWW-sprøjte)" eh="88742d5e" />
+    <e k="sf_guide_p2_40" v="Tre paneler vises i en VWW-kompatibel sprøjte:" eh="9adaea6c" />
+    <e k="sf_guide_p2_41" v="Smart Sensor / Se &amp; Sprøjt / Variabel dosering." eh="85d1b46a" />
+    <e k="sf_guide_p2_42" v="Aktivér hver via Admin &gt; Smart Systems i Indstillinger." eh="ea9cbfd6" />
+    <e k="sf_guide_p2_43" v="FRIT PANELLAYOUT" eh="0638d758" />
+    <e k="sf_guide_p2_44" v="Aktivér i Indstillinger &gt; Skærm. Brug Shift+H til at trække." eh="4535e5c1" />
+    <e k="sf_guide_p2_45" v="Tryk [-] i en titelbjælke for at skjule et panel." eh="a40967e4" />
+    <e k="sf_guide_p3_01" v="LANDBRUGSCYKLUS" eh="2d6b6c00" />
+    <e k="sf_guide_p3_02" v="TØMME   Høst fjerner N/P/K fra jorden." eh="0c3219fb" />
+    <e k="sf_guide_p3_03" v="         Mængden afhænger af afgrøde og udbytte." eh="ab8adace" />
+    <e k="sf_guide_p3_04" v="GENOPFYLD  Påfør gødning for at genoprette næringsstoffer." eh="d07d37d2" />
+    <e k="sf_guide_p3_05" v="BALANCER  pH og OM ændrer sig langsomt over tid." eh="611caf83" />
+    <e k="sf_guide_p3_06" v="         Kræver langsigtet styring." eh="128117f3" />
+    <e k="sf_guide_p3_07" v="DAGLIGE VANER" eh="64d0c6d8" />
+    <e k="sf_guide_p3_08" v="1. Kast et blik på HUD'en før du arbejder på en mark." eh="5dce5025" />
+    <e k="sf_guide_p3_09" v="2. Rød søjle = påfør gødning før eller efter afgrøde." eh="83d55f7b" />
+    <e k="sf_guide_p3_10" v="3. Gul søjle = notér marken, behandl denne sæson." eh="f903dc7c" />
+    <e k="sf_guide_p3_11" v="4. Grøn søjle = fortsæt, intet nødvendigt." eh="f2109204" />
+    <e k="sf_guide_p3_12" v="UGENTLIG RUTINE" eh="24a8ef8e" />
+    <e k="sf_guide_p3_13" v="Åbn PDA &gt; fanen Behandlingsplan." eh="ad687f50" />
+    <e k="sf_guide_p3_14" v="Marker sorteres efter hastende grad (værst først)." eh="571786e6" />
+    <e k="sf_guide_p3_15" v="Arbejd top-down — behandl markerne med højeste prioritet først." eh="08e04adb" />
+    <e k="sf_guide_p3_16" v="Klik på en række for at åbne detaljeret markoversigt." eh="66ce4f4b" />
+    <e k="sf_guide_p3_17" v="LÆSER BEHANDLINGSPLANEN" eh="4412f706" />
+    <e k="sf_guide_p3_18" v="Prioritetspoeng vægter hvor langt under målet hvert" eh="32bc52d7" />
+    <e k="sf_guide_p3_19" v="næringsstof er. En mark i rødt på to næringsstoffer" eh="3382c3d2" />
+    <e k="sf_guide_p3_20" v="rangerer højere end en med kun ét tilfredsstillende niveau." eh="44e63815" />
+    <e k="sf_guide_p3_21" v="FORPLANTNINGSTJEKLISTE" eh="f703e663" />
+    <e k="sf_guide_p3_22" v="1. Tjek N-niveau — tømmes ved hver høst." eh="47054be2" />
+    <e k="sf_guide_p3_23" v="   Påfør kvælstof, hvis TILFREDSSTILENDE eller DÅRLIG." eh="697781ec" />
+    <e k="sf_guide_p3_24" v="2. Tjek P og K — ændrer sig langsommere." eh="636fd8d9" />
+    <e k="sf_guide_p3_25" v="   Top op, hvis det er under den tilfredsstillende grænse." eh="7d1a903b" />
+    <e k="sf_guide_p3_26" v="3. Tjek pH — kalk hvis surt, gips hvis alkalisk." eh="bb019f53" />
+    <e k="sf_guide_p3_27" v="4. Tjek OM — tilsæt gylle eller kompost, hvis lavt." eh="042cb8f2" />
+    <e k="sf_guide_p3_28" v="EFTER-HØST AKTIVITETER" eh="6a7f0fca" />
+    <e k="sf_guide_p3_29" v="1. Kvælstof er udtømt — påfør gødning snart." eh="577a017a" />
+    <e k="sf_guide_p3_30" v="2. Bælgplanter (soja, kløver) tilføjer gratis N" eh="fd08b3ce" />
+    <e k="sf_guide_p3_31" v="   bonus til den NÆSTE sæson automatisk." eh="83e833b3" />
+    <e k="sf_guide_p3_32" v="3. Tilføj gylle eller kompost for at opbygge OM på lang sigt." eh="575116a9" />
+    <e k="sf_guide_p3_33" v="SÆSONNOTER" eh="48553a52" />
+    <e k="sf_guide_p3_34" v="FORÅR  N-behovet topper. Påfør før plantning." eh="44d69bfd" />
+    <e k="sf_guide_p3_35" v="SOMMER  Overvåg skadedyr og sygdomspres." eh="14fd9b6f" />
+    <e k="sf_guide_p3_36" v="EFTERÅR  Undgå kraftig N før varslet regn" eh="0b6cb5e8" />
+    <e k="sf_guide_p3_37" v="        (regn udvasker N fra jorden)." eh="b2a5c269" />
+    <e k="sf_guide_p3_38" v="VINTER  Brakmarker genvinder langsomt næringsstoffer." eh="d76feedb" />
+    <e k="sf_guide_p3_39" v="        Lad en mark stå bar for at hvile." eh="42c72b66" />
+    <e k="sf_guide_p4_01" v="KVÆLSTOF (N) PRODUKTER" eh="bec40ce6" />
+    <e k="sf_guide_p4_02" v="UAN-opløsning   Høj N, hurtig frigivelse væske." eh="8b5a49c9" />
+    <e k="sf_guide_p4_03" v="Urea           Høj N, standard fast form." eh="a6a58cb1" />
+    <e k="sf_guide_p4_04" v="AMS            Kvælstof + mindre svovnbidrag." eh="6050bc15" />
+    <e k="sf_guide_p4_05" v="Gylle          Moderat N + stor OM-forøgelse." eh="f1b898f5" />
+    <e k="sf_guide_p4_06" v="Biosolids      N + P + stor OM-forøgelse." eh="3ecb89a1" />
+    <e k="sf_guide_p4_07" v="Digestat       Moderat N + let OM-fordel." eh="9a0e17d7" />
+    <e k="sf_guide_p4_08" v="FOSFOR (P) PRODUKTER" eh="f246b45f" />
+    <e k="sf_guide_p4_09" v="MAP            Høj P, lille N-bidrag." eh="f56b59c6" />
+    <e k="sf_guide_p4_10" v="DAP            Høj P + kvælstofblanding." eh="77fa32bc" />
+    <e k="sf_guide_p4_11" v="Flydende MAP   Høj P, hurtigere optag." eh="add91c6a" />
+    <e k="sf_guide_p4_12" v="Flydende DAP   Høj P + N, flydende form." eh="10f16c70" />
+    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Effektiv multi-næringsstof." eh="f65c9491" />
+    <e k="sf_guide_p4_14" v="KALIUM (K) PRODUKTER" eh="d4182e1d" />
+    <e k="sf_guide_p4_15" v="Kaliumsalt     Høj K, fast form." eh="9c2d1ef4" />
+    <e k="sf_guide_p4_16" v="Flydende kalium Høj K, flydende. Hurtigere optag." eh="07398747" />
+    <e k="sf_guide_p4_17" v="pH-KORREKTION" eh="4ffba02e" />
+    <e k="sf_guide_p4_18" v="Målområde: 6,5 – 7,0 for de fleste afgrøder." eh="fbb6a132" />
     <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
+    <e k="sf_guide_p4_20" v="pH for LAV (surt, under 6,5):" eh="68520f95" />
+    <e k="sf_guide_p4_21" v="  Påfør KALK — hæver pH mod neutral." eh="def9f79d" />
+    <e k="sf_guide_p4_22" v="pH for HØJ (alkalisk, over 7,5):" eh="247708ec" />
+    <e k="sf_guide_p4_23" v="  Påfør GIPS — sænker pH mod neutral." eh="2ad8d2d3" />
+    <e k="sf_guide_p4_24" v="Giv 1–2 sæsoner for fuld normalisering." eh="7c2ee55e" />
+    <e k="sf_guide_p4_25" v="ORGANISK STOF (OM)" eh="75512a9c" />
+    <e k="sf_guide_p4_26" v="Gylle          Bedst til at bygge OM. Tilføjer også N." eh="e6f7a9c4" />
+    <e k="sf_guide_p4_27" v="Kompost        Moderat OM, velafbalanceret." eh="2b996529" />
+    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Meget effektivt." eh="d380c89e" />
+    <e k="sf_guide_p4_29" v="Digestat       Let OM-fordel." eh="fd8e1c67" />
+    <e k="sf_guide_p4_30" v="Brak (bar mark) genopbygger OM langsomt over tid." eh="9d46f06c" />
+    <e k="sf_guide_p4_31" v="PÅFØRINGSTIPS" eh="5d514e44" />
+    <e k="sf_guide_p4_32" v="* Last gødning og check spøgelses-søjlen først." eh="35e05de8" />
+    <e k="sf_guide_p4_33" v="  Den viser dit forventede resultat før du påfører." eh="24ff5dde" />
+    <e k="sf_guide_p4_34" v="* Flydende produkter virker generelt hurtigere end faste." eh="7b2ad191" />
+    <e k="sf_guide_p4_35" v="* Gylle forbedrer OM OG tilføjer N — meget effektivt." eh="1d9c74bb" />
+    <e k="sf_guide_p4_36" v="* Påfør flydende N før regn, hvis muligt" eh="90305fce" />
+    <e k="sf_guide_p4_37" v="  (regn udvasker noget kvælstof efter påføring)." eh="dd45f06b" />
+    <e k="sf_guide_p4_38" v="* Tjek afgrødemål for det, du planter" eh="3444bb54" />
+    <e k="sf_guide_p4_39" v="  — forskellige afgrøder kræver forskellige NPK-ratioer." eh="60c366af" />
+    <e k="sf_guide_p5_01" v="MINE SØJLER ER ALTID TOMME — ER DET ØDELAGT?" eh="2d6aa6d2" />
+    <e k="sf_guide_p5_02" v="Nej. Jorden starter på lave grundniveauer i et nyt spil." eh="32490786" />
+    <e k="sf_guide_p5_03" v="En mark, der aldrig er gødet, viser reelle værdier." eh="f72b6313" />
+    <e k="sf_guide_p5_04" v="Påfør gødning for at opbygge niveauer over tid." eh="a2691642" />
+    <e k="sf_guide_p5_05" v="Det er tilsigtet — det afspejler reel jordudtømning." eh="67f5d0fc" />
+    <e k="sf_guide_p5_06" v="HVOR TILDELER JEG TASTATURGENVEJE?" eh="8171751f" />
+    <e k="sf_guide_p5_07" v="Valg &gt; Kontroller &gt; Mods" eh="134c4fb9" />
+    <e k="sf_guide_p5_08" v="Alle SF_-taster leveres udefinerede for at undgå konflikter" eh="658e7851" />
+    <e k="sf_guide_p5_09" v="med andre mods. Find SF_-handlingerne og" eh="8634e3c4" />
+    <e k="sf_guide_p5_10" v="tildel taster, der virker til din opsætning." eh="05c1324a" />
+    <e k="sf_guide_p5_11" v="HVORFOR FALD MIN KVÆLSTOF EFTER REGN?" eh="08c6cc44" />
+    <e k="sf_guide_p5_12" v="Kraftig regn udvasker kvælstof fra jorden." eh="e66f2a7b" />
+    <e k="sf_guide_p5_13" v="Dette er tilsigtet og realistisk." eh="844f3842" />
+    <e k="sf_guide_p5_14" v="Planlæg N-påføringer før tørt vejr," eh="5775d792" />
+    <e k="sf_guide_p5_15" v="ikke før kraftige regnvarsler." eh="51b331f3" />
+    <e k="sf_guide_p5_16" v="Du kan justere regnfølsomhed i Indstillinger." eh="db0521ab" />
+    <e k="sf_guide_p5_17" v="HVAD ER SPØGELSES-SØJLEN?" eh="b4ac2fb5" />
+    <e k="sf_guide_p5_18" v="Den svage forlængelse på en søjle viser hvor meget" eh="3bfd13cd" />
+    <e k="sf_guide_p5_19" v="din lastede sprøjte vil tilføje, hvis den påføres her." eh="3958b721" />
+    <e k="sf_guide_p5_20" v="Last gødning i en sprøjte, kør til en hvilken som helst" eh="f7ae557a" />
+    <e k="sf_guide_p5_21" v="mark, og spøgelses-søjlen vises automatisk." eh="549c15e6" />
+    <e k="sf_guide_p5_22" v="SKAL JEG GØDE HVER SÆSON?" eh="ff4edc94" />
+    <e k="sf_guide_p5_23" v="Kvælstof:   Ja, hver sæson hvis muligt." eh="53e7c92e" />
+    <e k="sf_guide_p5_24" v="             Det tømmes kraftigt ved hver høst." eh="bab86964" />
+    <e k="sf_guide_p5_25" v="P og K:      Hver 2–3 sæsoner er normalt tilstrækkeligt." eh="0bd8fa51" />
+    <e k="sf_guide_p5_26" v="Organisk OM: Langsigtet. Tilføj gylle en gang årligt." eh="eda4d593" />
+    <e k="sf_guide_p5_27" v="pH:          Kun når det er uden for 6,5–7,0 området." eh="48be5789" />
+    <e k="sf_guide_p5_28" v="HVORDAN FUNGERER SMART SENSOR-SYSTEMERNE?" eh="5ca9536b" />
+    <e k="sf_guide_p5_29" v="Smart Sensor blokerer enkelte bomsektioner når" eh="86ab0498" />
+    <e k="sf_guide_p5_30" v="intet behov registreres (ingen skadedyr, sygdom eller næringsstof" eh="90e912a2" />
+    <e k="sf_guide_p5_31" v="underskud). Se &amp; Sprøjt viser live tryk pr. celle." eh="30c72641" />
+    <e k="sf_guide_p5_32" v="Variabel dosering justerer bom-output fra jorddata." eh="a260d3d9" />
+    <e k="sf_guide_p5_33" v="Alle 3 har brug for en VWW-kompatibel sprøjte. Aktivér via" eh="51ea1a4a" />
+    <e k="sf_guide_p5_34" v="Indstillinger &gt; Admin &gt; Smart Systems." eh="37872bd2" />
+    <e k="sf_guide_p5_35" v="KAN JEG BRUGE DETTE I MULTIPLAYER?" eh="6f6ef016" />
+    <e k="sf_guide_p5_36" v="Ja. Mod'en er fuldt multiplayer-kompatibel." eh="24ab5ab7" />
+    <e k="sf_guide_p5_37" v="Jorddata er serverautoritative." eh="a9984593" />
+    <e k="sf_guide_p5_38" v="Klienter synkroniserer ved tilslutning. Indstillingsændringer kræver" eh="71e7653d" />
+    <e k="sf_guide_p5_39" v="administratorrettigheder i multiplayer-sessioner." eh="c884fdf4" />
+    <e k="sf_guide_p5_40" v="HVORDAN PÅVIRKER JORD UDbyttet?" eh="0bf98a17" />
+    <e k="sf_guide_p5_41" v="GOD jord: fuldt udbytte — ingen straf." eh="2bc128e5" />
+    <e k="sf_guide_p5_42" v="TILFREDSSTILENDE jord: ~5-15% udbyttetab pr. næringsstof." eh="b2127c34" />
+    <e k="sf_guide_p5_43" v="DÅRLIG jord: op til 40% straf. Ret det hurtigt." eh="a29f59e5" />
+    <e k="sf_guide_p5_44" v="Straffe lægges sammen: DÅRLIG N + TILFREDSSTILENDE P = stort tab." eh="5536d718" />
+    <e k="sf_guide_title" v="Jord &amp; Gødning — Feltguide" eh="e1bb101e" />
+    <e k="sf_guide_tab_1" v="OVERSIGT" eh="21f04df7" />
+    <e k="sf_guide_tab_2" v="HUD-GUIDE" eh="d285eed7" />
+    <e k="sf_guide_tab_3" v="ARBEJDSPROCES" eh="a3f6045a" />
+    <e k="sf_guide_tab_4" v="PRODUKTER" eh="7589c616" />
     <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
     </elements>
 </l10n>


### PR DESCRIPTION
## Summary

- **#489** Fixed N and K starting at 90%+ on new saves — `TUNING.DEFAULT_N[3]` and `DEFAULT_K[3]` corrected from 100 to 50/40 so fields start in the fair nutrient range
- **#475 / #476** Fixed Pass% capping at ~50% after full-field spray — `fieldArea` now uses the actual crop polygon area (`field.areaHa`) instead of farmland area (which includes roads/hedges at ~2× crop area). Fixed in 3 code paths: `initialize()` scan, `applyFertilizer()` runtime update, `getOrCreateField()` XML load refresh
- **#475 / #476** Fixed Partial Width mode crediting inactive boom sections — `getBoomCellPositions` now skips `section.isActive == false` sections
- **#479** Fixed variable rate "going crazy" with MAP/P-type fertilizers — per-section rates now exponentially smoothed (40% blend per tick) to eliminate zone-boundary flickering
- **#469** Applied community-contributed Danish guide translation — all `sf_guide_*` keys now in Danish
- **#488** Liquid lime drain rate — fixed in previous session (LIQUIDLIME `sprayTypeStr` + `sprayTypeIndex` override)
- **#474** Insecticide spray visual — fixed in previous session

## Test plan

- [ ] New save: open Soil Monitor on any field → N and K bars should be yellow (fair), not full green
- [ ] Spray full field with insecticide at full boom width → Pass% should reach 80%+ → protection granted
- [ ] Spray with Partial Width ON → only the active boom width counts toward Pass%
- [ ] Fill with Liquid MAP, enable variable rate, drive across field → rate display smoothly varies, no flickering
- [ ] Set game language to Danish → open Guide dialog → text in Danish
- [ ] No errors in log.txt after loading