### PR TITLE
v2.2.5.0 — Hotfix: weed pressure, HUD alignment, FR translation, version dialog, PF detection, startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.4.1
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.5.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.4.1</version>
+    <version>2.2.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1163,6 +1163,19 @@ function SoilFertilityManager:update(dt)
         end
     end
 
+    -- Deferred version dialog — fired 3s after mission start so the GUI is stable.
+    -- Must run BEFORE the settings.enabled guard so it shows even when mod is disabled.
+    if self._pendingVersionDialog then
+        self._pendingVersionDialogDelay = (self._pendingVersionDialogDelay or 0) - dt
+        if self._pendingVersionDialogDelay <= 0 then
+            local ver = self._pendingVersionDialog
+            self._pendingVersionDialog      = nil
+            self._pendingVersionDialogDelay = nil
+            SoilLogger.info("Showing version dialog for %s", ver)
+            SoilVersionDialog.show(ver)
+        end
+    end
+
     -- ── MANDATORY GUARD: Mod must be enabled ──────────────────
     if not (self.settings and self.settings.enabled) then
         return
@@ -1206,18 +1219,6 @@ function SoilFertilityManager:update(dt)
     -- Tuning panel camera-lock and cursor keepalive
     if self.tuningPanel then
         self.tuningPanel:update()
-    end
-
-    -- Deferred version dialog — fired 3s after mission start so the GUI is stable
-    if self._pendingVersionDialog then
-        self._pendingVersionDialogDelay = (self._pendingVersionDialogDelay or 0) - dt
-        if self._pendingVersionDialogDelay <= 0 then
-            local ver = self._pendingVersionDialog
-            self._pendingVersionDialog      = nil
-            self._pendingVersionDialogDelay = nil
-            SoilLogger.info("Showing version dialog for %s", ver)
-            SoilVersionDialog.show(ver)
-        end
     end
 
     -- Auto-rate control: adjust sprayer rate based on current field soil data

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -696,6 +696,18 @@ function SoilFertilityManager:onMissionStarted()
             end
         end
 
+        -- Queue version dialog before any risky init so a crash can't suppress it.
+        if SoilVersionDialog then
+            local modInfo = g_modManager and g_modManager:getModByName(self.modName)
+            local version = (modInfo and modInfo.version) or "?"
+            SoilLogger.info("Version check: save=%s mod=%s", tostring(self.lastSeenVersion), tostring(version))
+            if self.lastSeenVersion ~= version then
+                SoilLogger.info("New version detected — dialog queued (3s delay)")
+                self._pendingVersionDialog      = version
+                self._pendingVersionDialogDelay = 3000
+            end
+        end
+
         if not self.settings.enabled then
             SoilLogger.info("Mod disabled in settings — skipping soil system init")
             return
@@ -710,21 +722,6 @@ function SoilFertilityManager:onMissionStarted()
         end
 
         self:loadSoilData()
-
-        -- Show version dialog whenever the mod version doesn't match lastSeenVersion.
-        -- We do NOT save the version here — that's done only by "Don't Show Again".
-        -- "OK" just closes the dialog; the player will see it again next boot until
-        -- they explicitly dismiss it with "Don't Show Again".
-        if SoilVersionDialog then
-            local modInfo = g_modManager and g_modManager:getModByName(self.modName)
-            local version = (modInfo and modInfo.version) or "?"
-            SoilLogger.info("Version check: save=%s mod=%s", tostring(self.lastSeenVersion), tostring(version))
-            if self.lastSeenVersion ~= version then
-                SoilLogger.info("New version detected — dialog queued (3s delay)")
-                self._pendingVersionDialog      = version
-                self._pendingVersionDialogDelay = 3000
-            end
-        end
     end)
 
     if not ok then

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2962,13 +2962,13 @@ function HookManager:installFillUnitHook()
     local ok1, catFert = pcall(function() return fm:getFillTypesByCategoryNames("fertilizer") end)
     if ok1 and catFert then
         for _, ft in pairs(catFert) do
-            if ft and ft.index then table.insert(categoryFertIndices, ft.index) end
+            if ft then table.insert(categoryFertIndices, type(ft) == "table" and ft.index or ft) end
         end
     end
     local ok2, catLiq = pcall(function() return fm:getFillTypesByCategoryNames("liquidFertilizer") end)
     if ok2 and catLiq then
         for _, ft in pairs(catLiq) do
-            if ft and ft.index then table.insert(categoryLiqFertIndices, ft.index) end
+            if ft then table.insert(categoryLiqFertIndices, type(ft) == "table" and ft.index or ft) end
         end
     end
     if #categoryFertIndices > 0 or #categoryLiqFertIndices > 0 then

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -52,44 +52,43 @@ end
 --- Must be called after mission is fully ready (deferred init phase).
 ---@return boolean isActive
 function PrecisionFarmingBridge:initialize()
-    -- Primary: check g_modManager for an ENABLED (isLoaded=true) PF entry.
-    -- A mod in the mods folder but disabled will have isLoaded=false — we ignore it.
-    local pfEnabled = false
+    -- Primary: specialization registry check.
+    -- Disabled mods never run their Lua so extendedSprayer is only registered
+    -- when PF is actually enabled and loaded — this is the correct enabled/disabled signal.
+    local hasPFSpec = false
+    if g_specializationManager then
+        local ok, spec = pcall(function()
+            return g_specializationManager:getSpecializationByName("extendedSprayer")
+        end)
+        hasPFSpec = ok and spec ~= nil
+    end
+
+    if not hasPFSpec then
+        -- PF not running. Check if it's merely installed (in mods folder) for a better log message.
+        if g_modManager then
+            local ok, pfMod = pcall(function()
+                return g_modManager:getModByName("FS25_precisionFarming")
+            end)
+            if ok and pfMod then
+                SoilLogger.info("[PFBridge] Precision Farming installed but disabled — standalone mode")
+            else
+                SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
+            end
+        else
+            SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
+        end
+        return false
+    end
+
+    -- PF spec found — it is enabled and running.
+    local pfVersion = "?"
     if g_modManager then
         local ok, pfMod = pcall(function()
             return g_modManager:getModByName("FS25_precisionFarming")
         end)
-        if ok and pfMod and pfMod.isLoaded then
-            pfEnabled = true
-            SoilLogger.info("[PFBridge] PF enabled via mod manager: %s v%s isLoaded=%s",
-                tostring(pfMod.modName or pfMod.name or "?"),
-                tostring(pfMod.version or "?"),
-                tostring(pfMod.isLoaded))
-        elseif ok and pfMod then
-            SoilLogger.info("[PFBridge] Precision Farming in mods folder but disabled (isLoaded=%s) — standalone mode",
-                tostring(pfMod.isLoaded))
-            return false
-        end
+        if ok and pfMod then pfVersion = tostring(pfMod.version or "?") end
     end
-
-    -- Secondary: if g_modManager missed it, check the specialization registry.
-    -- Only an enabled, loaded mod registers its specializations at startup.
-    if not pfEnabled then
-        local hasPFSpec = false
-        if g_specializationManager then
-            local ok, spec = pcall(function()
-                return g_specializationManager:getSpecializationByName("extendedSprayer")
-            end)
-            hasPFSpec = ok and spec ~= nil
-        end
-
-        if not hasPFSpec then
-            SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
-            return false
-        end
-
-        SoilLogger.info("[PFBridge] PF detected via specialization registry (mod manager miss)")
-    end
+    SoilLogger.info("[PFBridge] Precision Farming detected and enabled (v%s)", pfVersion)
 
     -- PF is confirmed active. Map API is not cross-mod accessible (PF uses its
     -- own env). We set isActive for simulation gating; canReadMaps stays false

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -59,13 +59,15 @@ function PrecisionFarmingBridge:initialize()
         local ok, pfMod = pcall(function()
             return g_modManager:getModByName("FS25_precisionFarming")
         end)
-        if ok and pfMod and pfMod.isLoaded == true then
+        if ok and pfMod and pfMod.isLoaded then
             pfEnabled = true
-            SoilLogger.info("[PFBridge] PF enabled via mod manager: %s v%s",
+            SoilLogger.info("[PFBridge] PF enabled via mod manager: %s v%s isLoaded=%s",
                 tostring(pfMod.modName or pfMod.name or "?"),
-                tostring(pfMod.version or "?"))
+                tostring(pfMod.version or "?"),
+                tostring(pfMod.isLoaded))
         elseif ok and pfMod then
-            SoilLogger.info("[PFBridge] Precision Farming in mods folder but disabled — standalone mode")
+            SoilLogger.info("[PFBridge] Precision Farming in mods folder but disabled (isLoaded=%s) — standalone mode",
+                tostring(pfMod.isLoaded))
             return false
         end
     end

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -52,43 +52,24 @@ end
 --- Must be called after mission is fully ready (deferred init phase).
 ---@return boolean isActive
 function PrecisionFarmingBridge:initialize()
-    -- Primary: specialization registry check.
-    -- Disabled mods never run their Lua so extendedSprayer is only registered
-    -- when PF is actually enabled and loaded — this is the correct enabled/disabled signal.
-    local hasPFSpec = false
-    if g_specializationManager then
-        local ok, spec = pcall(function()
-            return g_specializationManager:getSpecializationByName("extendedSprayer")
+    -- Detection: check g_modManager for the PF mod entry.
+    -- getModByName returns non-nil only when the mod is present and loaded.
+    local pfMod = nil
+    if g_modManager then
+        local ok, result = pcall(function()
+            return g_modManager:getModByName("FS25_precisionFarming")
         end)
-        hasPFSpec = ok and spec ~= nil
+        if ok then pfMod = result end
     end
 
-    if not hasPFSpec then
-        -- PF not running. Check if it's merely installed (in mods folder) for a better log message.
-        if g_modManager then
-            local ok, pfMod = pcall(function()
-                return g_modManager:getModByName("FS25_precisionFarming")
-            end)
-            if ok and pfMod then
-                SoilLogger.info("[PFBridge] Precision Farming installed but disabled — standalone mode")
-            else
-                SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
-            end
-        else
-            SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
-        end
+    if pfMod == nil then
+        SoilLogger.info("[PFBridge] Precision Farming not detected — standalone mode")
         return false
     end
 
-    -- PF spec found — it is enabled and running.
-    local pfVersion = "?"
-    if g_modManager then
-        local ok, pfMod = pcall(function()
-            return g_modManager:getModByName("FS25_precisionFarming")
-        end)
-        if ok and pfMod then pfVersion = tostring(pfMod.version or "?") end
-    end
-    SoilLogger.info("[PFBridge] Precision Farming detected and enabled (v%s)", pfVersion)
+    SoilLogger.info("[PFBridge] Precision Farming detected: %s v%s",
+        tostring(pfMod.modName or pfMod.name or "?"),
+        tostring(pfMod.version or "?"))
 
     -- PF is confirmed active. Map API is not cross-mod accessible (PF uses its
     -- own env). We set isActive for simulation gating; canReadMaps stays false

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -52,18 +52,27 @@ end
 --- Must be called after mission is fully ready (deferred init phase).
 ---@return boolean isActive
 function PrecisionFarmingBridge:initialize()
-    -- Primary: check g_modManager for the PF mod entry
-    local pfMod = nil
+    -- Primary: check g_modManager for an ENABLED (isLoaded=true) PF entry.
+    -- A mod in the mods folder but disabled will have isLoaded=false — we ignore it.
+    local pfEnabled = false
     if g_modManager then
-        local ok, result = pcall(function()
+        local ok, pfMod = pcall(function()
             return g_modManager:getModByName("FS25_precisionFarming")
         end)
-        if ok then pfMod = result end
+        if ok and pfMod and pfMod.isLoaded == true then
+            pfEnabled = true
+            SoilLogger.info("[PFBridge] PF enabled via mod manager: %s v%s",
+                tostring(pfMod.modName or pfMod.name or "?"),
+                tostring(pfMod.version or "?"))
+        elseif ok and pfMod then
+            SoilLogger.info("[PFBridge] Precision Farming in mods folder but disabled — standalone mode")
+            return false
+        end
     end
 
-    if pfMod == nil then
-        -- Secondary: check if PF's specializations were registered (vehicle spec check)
-        -- g_specializationManager is shared and populated by all mods at load time
+    -- Secondary: if g_modManager missed it, check the specialization registry.
+    -- Only an enabled, loaded mod registers its specializations at startup.
+    if not pfEnabled then
         local hasPFSpec = false
         if g_specializationManager then
             local ok, spec = pcall(function()
@@ -77,11 +86,7 @@ function PrecisionFarmingBridge:initialize()
             return false
         end
 
-        SoilLogger.info("[PFBridge] PF detected via specialization registry (g_modManager miss)")
-    else
-        SoilLogger.info("[PFBridge] PF detected via g_modManager: %s v%s",
-            tostring(pfMod.modName or pfMod.name or "?"),
-            tostring(pfMod.version or "?"))
+        SoilLogger.info("[PFBridge] PF detected via specialization registry (mod manager miss)")
     end
 
     -- PF is confirmed active. Map API is not cross-mod accessible (PF uses its

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -32,6 +32,12 @@ SoilVersionDialog.CHANGELOG = {
     "- Updated Danish (da) guide translation — Guide dialog now fully in Danish",
     "- Fixed herbicide session coverage reset (second spray no longer instant-triggers on first tick)",
     "- Fixed Weeds/Pests/Disease HUD bars rendering one row above their labels",
+    "- Fixed weed pressure bar oscillating after partial herbicide spray (same-day application now sticky)",
+    "- Fixed Weeds/Pests/Disease % values misaligned — now left-aligned after their bar",
+    "- Updated French (fr) translation — contributed by community member",
+    "- Fixed version dialog not appearing on load when mod was previously disabled",
+    "- Fixed Precision Farming detection incorrectly triggering when PF is installed but disabled",
+    "- Fixed startup crash when fill type categories return indices instead of descriptors",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -816,228 +816,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -815,228 +815,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -815,228 +815,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Skift sygdomssensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Skift næringsstofsensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="Se &amp; Sprøjt: Skadedyr" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="Se &amp; Sprøjt: Sygdom" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="Se &amp; Sprøjt: Ukrudt" />
     <e k="input_SF_VARIABLE_RATE"     v="Skift variabel dosering" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Skift minikortzoom" />
@@ -242,7 +242,7 @@
     <e k="sf_report_yield_hint" v="Baseret på N/P/K vs. optimal grænse" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Udbytte ~-%d%%" eh="d64d5d59" />
     <e k="sf_incompatibility_pf_title" v="Inkompatibilitet opdaget" eh="89dbfc90" />
-    <e k="sf_incompatibility_pf_text" v="Soil &amp; Fertilizer-mod er blevet deaktiveret, fordi Precision Farming blev registreret. Disse to mods er ikke kompatible og kan ikke bruges samtidig." eh="8c645296" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together. Please remove the folder out of the mods folder." eh="9fb59f75" />
 
     <e k="helpLine_sf_cat_overview" v="Oversigt" eh="3b878279" />
     <e k="helpLine_sf_cat_started" v="Kom godt i gang" eh="bf647454" />
@@ -703,6 +703,7 @@
     <e k="sf_cell_sidebar_header" v="Celledetaljer" eh="6fc5243e" />
     <e k="sf_cell_coord" v="Koordinater" eh="99171d3a" />
     <e k="sf_cell_click_hint" v="Klik på kortet for at inspicere en jordcelle" eh="fc9d240b" />
+		<e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
         <!-- SMART SYSTEMS -->
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
@@ -750,227 +751,227 @@
     <e k="sf_independent_panels_short" v="Frit panel-layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Tillad at smart systempaneler placeres individuelt i redigeringstilstand" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="Træk hvert panel frit med Shift+H redigeringstilstand. Fold paneler sammen med −-knappen i titellinjen." eh="7c60edfc" />
-    <e k="sf_guide_sub_1" v="Oversigt — Hvad denne mod sporer og hvorfor det er vigtigt" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD-guide — Læsning af næringsstofsøjler og skærmindikatorer" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Arbejdsproces — Din daglige og sæsonmæssige jordstyringsrutine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Produkter — Hvad hver gødning påvirker og hvornår den bruges" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Almindelige spørgsmål besvaret" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="HVAD ER DENNE MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Sporer 5 jordnæringsstoffer pr. mark over din" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="gård. Afgrøder tømmes for næringsstoffer ved høst." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Gødning genopfylder dem. Vejr og" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="sæsoner tilføjer realistisk pres over tid." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="DE 5 JORDPARAMETRE" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Hurtig udtømning. Hver høst." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Fosfor         Langsom udtømning. Rodafgrøder." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Kalium         Rodafgrøder forbruger denne kraftigt." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organisk stof  Bygger langsomt op over mange sæsoner." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Jordens surhedsgrad.  Målområde: 6,5 – 7,0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUSNIVEAUER" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GODT (grøn)   På eller over afgrødens optimale mål." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="               Ingen handling nødvendig denne sæson." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="TILFREDSSTILENDE (gul)  Under optimalt." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="            -- Planlæg en opfyldning. Udbyttet er let reduceret." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="DÅRLIGT (rød)     Under minimumstersklen." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="               Handl nu — udbyttet påvirkes alvorligt." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="HURTIG START (5 TRIN)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Åbn PDA (spilmenu) &gt; Jord &amp; Gødning." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Tjek Gårdoverblik for rødmarkede marker." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Brug Behandlingsplanen for at se, hvad der er nødvendigt." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Påfør det rette gødningsprodukt." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Høst normalt — næringsstoffer trækkes automatisk fra." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="VÆRKTØJER I OVERSIGT" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD-søjler      Jordniveauer for din aktuelle mark." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="               Nøgle: SF Skift HUD (Kontroller &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA-skærm      Fuld gårdoverblik + behandlingsplan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="               Åbn via spillets tabletmenu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Jordkort        Næringsstoffarvelag per celle." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="               Nøgle: SF Skift cellekort" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Markrapport     Detaljeret opdeling af en enkelt mark." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="               Nøgle: SF Jordrapport" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart sensor   Blokerer sektioner uden aktivt behov." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="               Skiftere: Alt+1/2/3 i en VWW-sprøjte." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="Se &amp; Sprøjt   Live tryk pr. celle i køretøjet." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="               Skiftere: Alt+4/5/6 i en VWW-sprøjte." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variabel dosering  Justerer automatisk bommængde fra underskud." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="               Skifter: Alt+7. Aktivér i Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="TASTATURGENVEJE" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="Alle taster leveres UDEFINEREDE for at undgå konflikter." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Gå til: Valg &gt; Kontroller &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Søg efter handlinger, der starter med SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Tildel taster, der ikke konflikter med andre mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="NÆRINGSSTOF-SØJLERNE" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="HUD'en viser én søjle per næringsstof: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Søjlen fyldes fra venstre (0) til højre (100 = maksimum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Søjlefargen viser status med et blik." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="DE TRE MARKØRER" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Hver søjle har tre små lodrette markører." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE markør — grænsen mellem Dårlig og Tilfredsstillende." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Søjlen er RØD under denne linje." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Din jord er i DÅRLIG tilstand." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Handling: påfør gødning straks." eh="970de608" />
-    <e k="sf_guide_p2_11" v="GUL markør — grænsen mellem Tilfredsstillende og God." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Søjlen er GUL mellem orange og gule markører." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Din jord er TILFREDSSTILENDE — under afgrødens optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Handling: planlæg en opfyldning denne sæson." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN markør — din plantede afgrødes optimale mål." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Nå dette punkt for maksimal høst." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Søjlen er GRØN, når du når det." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Hver afgrøde har forskellige N/P/K-mål." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="SPØGELSES-SØJLEN" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="En svag forlængelse af søjlen (samme farve, svagere)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Viser dit forventede niveau EFTER påføring af" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="den gødning, der i øjeblikket er lastet i din sprøjte." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Kør til en mark med en lastet sprøjte for at se den." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Brug den for at undgå spild af gødning ved overdosering." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="LÆSER TALENE" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  værdi  /  mål  ( +projekteret )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Eksempel: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = dit aktuelle kvælstofniveau i ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = afgrødens optimale kvælstofmål" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = hvor meget din sprøjtebeholdning vil tilføje" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUSFARVER" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RØD søjle    Under den orange markør (DÅRLIG)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="           Udbyttetab. Påfør nu." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="GUL søjle   Mellem orange og gule markører (TILFREDSSTILENDE)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="           Let tab. Planlæg forud." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GRØN søjle   Over den gule markør (GOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="           På eller over afgrødens optimale. Ingen handling." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEMPANELER (kræver VWW-sprøjte)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Tre paneler vises i en VWW-kompatibel sprøjte:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / Se &amp; Sprøjt / Variabel dosering." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Aktivér hver via Admin &gt; Smart Systems i Indstillinger." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FRIT PANELLAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Aktivér i Indstillinger &gt; Skærm. Brug Shift+H til at trække." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Tryk [-] i en titelbjælke for at skjule et panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="LANDBRUGSCYKLUS" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="TØMME   Høst fjerner N/P/K fra jorden." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         Mængden afhænger af afgrøde og udbytte." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="GENOPFYLD  Påfør gødning for at genoprette næringsstoffer." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCER  pH og OM ændrer sig langsomt over tid." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Kræver langsigtet styring." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAGLIGE VANER" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Kast et blik på HUD'en før du arbejder på en mark." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Rød søjle = påfør gødning før eller efter afgrøde." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Gul søjle = notér marken, behandl denne sæson." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Grøn søjle = fortsæt, intet nødvendigt." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="UGENTLIG RUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Åbn PDA &gt; fanen Behandlingsplan." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Marker sorteres efter hastende grad (værst først)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Arbejd top-down — behandl markerne med højeste prioritet først." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Klik på en række for at åbne detaljeret markoversigt." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="LÆSER BEHANDLINGSPLANEN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Prioritetspoeng vægter hvor langt under målet hvert" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="næringsstof er. En mark i rødt på to næringsstoffer" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="rangerer højere end en med kun ét tilfredsstillende niveau." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="FORPLANTNINGSTJEKLISTE" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Tjek N-niveau — tømmes ved hver høst." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Påfør kvælstof, hvis TILFREDSSTILENDE eller DÅRLIG." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Tjek P og K — ændrer sig langsommere." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top op, hvis det er under den tilfredsstillende grænse." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Tjek pH — kalk hvis surt, gips hvis alkalisk." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Tjek OM — tilsæt gylle eller kompost, hvis lavt." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="EFTER-HØST AKTIVITETER" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Kvælstof er udtømt — påfør gødning snart." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Bælgplanter (soja, kløver) tilføjer gratis N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus til den NÆSTE sæson automatisk." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Tilføj gylle eller kompost for at opbygge OM på lang sigt." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SÆSONNOTER" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="FORÅR  N-behovet topper. Påfør før plantning." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SOMMER  Overvåg skadedyr og sygdomspres." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="EFTERÅR  Undgå kraftig N før varslet regn" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (regn udvasker N fra jorden)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="VINTER  Brakmarker genvinder langsomt næringsstoffer." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Lad en mark stå bar for at hvile." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="KVÆLSTOF (N) PRODUKTER" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN-opløsning   Høj N, hurtig frigivelse væske." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           Høj N, standard fast form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Kvælstof + mindre svovnbidrag." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Gylle          Moderat N + stor OM-forøgelse." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + stor OM-forøgelse." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestat       Moderat N + let OM-fordel." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="FOSFOR (P) PRODUKTER" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            Høj P, lille N-bidrag." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            Høj P + kvælstofblanding." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Flydende MAP   Høj P, hurtigere optag." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Flydende DAP   Høj P + N, flydende form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Effektiv multi-næringsstof." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="KALIUM (K) PRODUKTER" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Kaliumsalt     Høj K, fast form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Flydende kalium Høj K, flydende. Hurtigere optag." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH-KORREKTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Målområde: 6,5 – 7,0 for de fleste afgrøder." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH for LAV (surt, under 6,5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Påfør KALK — hæver pH mod neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH for HØJ (alkalisk, over 7,5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Påfør GIPS — sænker pH mod neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Giv 1–2 sæsoner for fuld normalisering." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANISK STOF (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Gylle          Bedst til at bygge OM. Tilføjer også N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Kompost        Moderat OM, velafbalanceret." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Meget effektivt." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestat       Let OM-fordel." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Brak (bar mark) genopbygger OM langsomt over tid." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="PÅFØRINGSTIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Last gødning og check spøgelses-søjlen først." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  Den viser dit forventede resultat før du påfører." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Flydende produkter virker generelt hurtigere end faste." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Gylle forbedrer OM OG tilføjer N — meget effektivt." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Påfør flydende N før regn, hvis muligt" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (regn udvasker noget kvælstof efter påføring)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Tjek afgrødemål for det, du planter" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — forskellige afgrøder kræver forskellige NPK-ratioer." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MINE SØJLER ER ALTID TOMME — ER DET ØDELAGT?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="Nej. Jorden starter på lave grundniveauer i et nyt spil." eh="32490786" />
-    <e k="sf_guide_p5_03" v="En mark, der aldrig er gødet, viser reelle værdier." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Påfør gødning for at opbygge niveauer over tid." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="Det er tilsigtet — det afspejler reel jordudtømning." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="HVOR TILDELER JEG TASTATURGENVEJE?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Valg &gt; Kontroller &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="Alle SF_-taster leveres udefinerede for at undgå konflikter" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="med andre mods. Find SF_-handlingerne og" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="tildel taster, der virker til din opsætning." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="HVORFOR FALD MIN KVÆLSTOF EFTER REGN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Kraftig regn udvasker kvælstof fra jorden." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="Dette er tilsigtet og realistisk." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Planlæg N-påføringer før tørt vejr," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="ikke før kraftige regnvarsler." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="Du kan justere regnfølsomhed i Indstillinger." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="HVAD ER SPØGELSES-SØJLEN?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="Den svage forlængelse på en søjle viser hvor meget" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="din lastede sprøjte vil tilføje, hvis den påføres her." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Last gødning i en sprøjte, kør til en hvilken som helst" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="mark, og spøgelses-søjlen vises automatisk." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="SKAL JEG GØDE HVER SÆSON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Kvælstof:   Ja, hver sæson hvis muligt." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="             Det tømmes kraftigt ved hver høst." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P og K:      Hver 2–3 sæsoner er normalt tilstrækkeligt." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organisk OM: Langsigtet. Tilføj gylle en gang årligt." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH:          Kun når det er uden for 6,5–7,0 området." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HVORDAN FUNGERER SMART SENSOR-SYSTEMERNE?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blokerer enkelte bomsektioner når" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="intet behov registreres (ingen skadedyr, sygdom eller næringsstof" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="underskud). Se &amp; Sprøjt viser live tryk pr. celle." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variabel dosering justerer bom-output fra jorddata." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="Alle 3 har brug for en VWW-kompatibel sprøjte. Aktivér via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Indstillinger &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="KAN JEG BRUGE DETTE I MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Ja. Mod'en er fuldt multiplayer-kompatibel." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Jorddata er serverautoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Klienter synkroniserer ved tilslutning. Indstillingsændringer kræver" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="administratorrettigheder i multiplayer-sessioner." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HVORDAN PÅVIRKER JORD UDbyttet?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOD jord: fuldt udbytte — ingen straf." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="TILFREDSSTILENDE jord: ~5-15% udbyttetab pr. næringsstof." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="DÅRLIG jord: op til 40% straf. Ret det hurtigt." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Straffe lægges sammen: DÅRLIG N + TILFREDSSTILENDE P = stort tab." eh="5536d718" />
-    <e k="sf_guide_title" v="Jord &amp; Gødning — Feltguide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERSIGT" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD-GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="ARBEJDSPROCES" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUKTER" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="Ingen handling nødvendig denne sæson." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="-- Planlæg en opfyldning. Udbyttet er let reduceret." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Handl nu — udbyttet påvirkes alvorligt." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Nøgle: SF Skift HUD (Kontroller &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Åbn via spillets tabletmenu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Nøgle: SF Skift cellekort" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Nøgle: SF Jordrapport" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Skiftere: Alt+1/2/3 i en VWW-sprøjte." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Skiftere: Alt+4/5/6 i en VWW-sprøjte." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Skifter: Alt+7. Aktivér i Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Søjlen er RØD under denne linje." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Din jord er i DÅRLIG tilstand." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Handling: påfør gødning straks." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Søjlen er GUL mellem orange og gule markører." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Din jord er TILFREDSSTILENDE — under afgrødens optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Handling: planlæg en opfyldning denne sæson." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Nå dette punkt for maksimal høst." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Søjlen er GRØN, når du når det." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Hver afgrøde har forskellige N/P/K-mål." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Udbyttetab. Påfør nu." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Let tab. Planlæg forud." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="På eller over afgrødens optimale. Ingen handling." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="Mængden afhænger af afgrøde og udbytte." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Kræver langsigtet styring." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Påfør kvælstof, hvis TILFREDSSTILENDE eller DÅRLIG." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top op, hvis det er under den tilfredsstillende grænse." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus til den NÆSTE sæson automatisk." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(regn udvasker N fra jorden)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Lad en mark stå bar for at hvile." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Påfør KALK — hæver pH mod neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Påfør GIPS — sænker pH mod neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="Den viser dit forventede resultat før du påfører." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(regn udvasker noget kvælstof efter påføring)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— forskellige afgrøder kræver forskellige NPK-ratioer." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="Det tømmes kraftigt ved hver høst." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -242,7 +242,7 @@
     <e k="sf_report_yield_hint" v="Based on N/P/K vs optimal threshold" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Yield ~-%d%%" eh="d64d5d59" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
-    <e k="sf_incompatibility_pf_text" v="Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
+    <e k="sf_incompatibility_pf_text" v="Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together. Please remove the folder out of the mods folder." eh="9fb59f75" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -812,227 +812,227 @@
     <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Toggle See &amp; Spray Disease" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"   v="SF: Toggle See &amp; Spray Weed" />
     <e k="action_SF_VARIABLE_RATE"    v="SF: Toggle Variable Rate" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="  No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="" eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="F.A.Q." eh="a922ea47" />
     </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -769,228 +769,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -20,8 +20,6 @@
     <e k="sf_pest_pressure_long" v="Activer/désactiver le système d'infestation d'insectes et de ravageurs" eh="2ba11abc" />
     <e k="sf_disease_pressure_short" v="Pression des maladies" eh="2b805cc9" />
     <e k="sf_disease_pressure_long" v="Activer/désactiver le système de maladies fongiques des cultures" eh="9080edbc" />
-	<e k="sf_disease_moisture_short" v="Humidité / maladies" />
-    <e k="sf_disease_moisture_long" v="Influence l’apparition et la propagation des maladies en fonction de l’humidité." />
     <e k="sf_compaction_short" v="Tassement du sol" eh="68734a56" />
     <e k="sf_compaction_long" v="Activer/désactiver le système de compaction du sol par les véhicules lourds" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Système de fertilité" eh="f7e27d58" />
@@ -106,14 +104,7 @@
     <e k="input_SF_TOGGLE_AUTO" v="Basculer le mode automatique" eh="a8642cf0" />
     <e k="input_SF_CYCLE_MAP_LAYER" v="Changer la couche de carte du sol" eh="8e4a716c" />
     <e k="input_SF_SOIL_PDA" v="Ouvrir le PDA du sol" eh="7d70f7b4" />
-    <e k="input_SF_SENSOR_PEST" v="Basculer capteur ravageurs" />
-    <e k="input_SF_SENSOR_DISEASE" v="Basculer capteur maladies" />
-    <e k="input_SF_SENSOR_NUTRIENT" v="Basculer capteur nutriments" />
-    <e k="input_SF_SEE_SPRAY_PEST" v="See &amp; Spray : ravageurs" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray : maladies" />
-    <e k="input_SF_SEE_SPRAY_WEED" v="See &amp; Spray : mauvaises herbes" />
-    <e k="input_SF_VARIABLE_RATE" v="Basculer taux variable" />
-    <e k="input_SF_MINIMAP_ZOOM" v="Changer le zoom de la mini-carte" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="sf_report_title" v="Rapport Sol &amp; Engrais" eh="3b4e9448" />
     <e k="sf_report_fields_tracked" v="Champs suivis :" eh="7b1e59b8" />
     <e k="sf_report_need_fert" v="Besoin d'engrais :" eh="110b60f2" />
@@ -244,49 +235,49 @@
     <e k="sf_report_yield_hint" v="Basé sur N/P/K vs seuil optimal" eh="022663e0" />
     <e k="sf_report_yield_loss" v="Rendement ~-%d%%" eh="d64d5d59" />
     <e k="sf_incompatibility_pf_title" v="Incompatibilité détectée" eh="89dbfc90" />
-    <e k="sf_incompatibility_pf_text" v="Le mod Soil &amp; Fertilizer a été désactivé car Precision Farming a été détecté. Ces deux mods ne sont pas compatibles et ne peuvent pas être utilisés ensemble." eh="8c645296" />
+    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together. Please remove the folder out of the mods folder." eh="9fb59f75" />
 
     <!-- ======================================================
          LIGNES D’AIDE (ESC > Aide > Sol & Fertilisant réaliste)
          ====================================================== -->
 
    <!-- Titres des catégories -->
-    <e k="helpLine_sf_cat_overview" v="Vue d'ensemble" />
-    <e k="helpLine_sf_cat_started" v="Prise en main" />
-    <e k="helpLine_sf_cat_nutrients" v="Nutriments du sol" />
-    <e k="helpLine_sf_cat_fertilizers" v="Engrais" />
-    <e k="helpLine_sf_cat_hud" v="HUD & Rapport de sol" />
-    <e k="helpLine_sf_cat_settings" v="Paramètres" />
-    <e k="helpLine_sf_cat_multiplayer" v="Multijoueur" />
+    <e k="helpLine_sf_cat_overview" v="[EN] Overview" eh="3b878279" />
+    <e k="helpLine_sf_cat_started" v="[EN] Getting Started" eh="bf647454" />
+    <e k="helpLine_sf_cat_nutrients" v="[EN] Soil Nutrients" eh="64377acf" />
+    <e k="helpLine_sf_cat_fertilizers" v="[EN] Fertilizers" eh="754d59bd" />
+    <e k="helpLine_sf_cat_hud" v="[EN] HUD &amp; Soil Report" eh="655b1b40" />
+    <e k="helpLine_sf_cat_settings" v="[EN] Settings" eh="f4f70727" />
+    <e k="helpLine_sf_cat_multiplayer" v="[EN] Multiplayer" eh="901a7320" />
 
     <!-- Catégorie 1 : Vue d'ensemble -->
-    <e k="helpLine_sf_ov_p1_title" v="Ce que fait le mod" />
-    <e k="helpLine_sf_ov_p1_intro_title" v="Suivi du sol par champ" />
-    <e k="helpLine_sf_ov_p1_intro_text" v="Chaque champ suit indépendamment cinq propriétés : Azote (N), Phosphore (P), Potassium (K), Matière organique (MO) et pH. Les valeurs sont sauvegardées dans votre partie et persistent entre les sessions." />
-    <e k="helpLine_sf_ov_p1_flow_title" v="Le cycle des nutriments" />
-    <e k="helpLine_sf_ov_p1_flow_text" v="Les cultures retirent des nutriments à la récolte. Les engrais, le fumier, le lisier et la chaux les rétablissent. Le mod simule un bilan réaliste : ce que les cultures retirent doit être compensé." />
-    <e k="helpLine_sf_ov_p2_title" v="Effets environnementaux" />
-    <e k="helpLine_sf_ov_p2_rain_title" v="Pluie et lessivage" />
-    <e k="helpLine_sf_ov_p2_rain_text" v="La pluie lessive principalement l’azote, puis le potassium, puis le phosphore. Elle acidifie également lentement le pH avec le temps. Les effets de la pluie peuvent être désactivés dans les paramètres." />
-    <e k="helpLine_sf_ov_p2_season_title" v="Saisons et récupération des jachères" />
-    <e k="helpLine_sf_ov_p2_season_text" v="Le printemps ajoute +0,03 N par jour (activité biologique). L’automne retire 0,02 N par jour. Les champs laissés sans culture pendant plus de 7 jours récupèrent lentement tous les nutriments." />
+    <e k="helpLine_sf_ov_p1_title" v="[EN] What It Does" eh="46cbb25b" />
+    <e k="helpLine_sf_ov_p1_intro_title" v="[EN] Per-Field Soil Tracking" eh="8fe3248d" />
+    <e k="helpLine_sf_ov_p1_intro_text" v="[EN] Every field independently tracks five properties: Nitrogen (N), Phosphorus (P), Potassium (K), Organic Matter (OM), and pH. Values are saved with your savegame and persist across sessions." eh="c30216e6" />
+    <e k="helpLine_sf_ov_p1_flow_title" v="[EN] The Nutrient Cycle" eh="15b0d408" />
+    <e k="helpLine_sf_ov_p1_flow_text" v="[EN] Crops remove nutrients at harvest. Fertilizer, manure, slurry, and lime restore them. The mod tracks a realistic nutrient budget - what crops take out, you must put back." eh="418041f0" />
+    <e k="helpLine_sf_ov_p2_title" v="[EN] Environmental Effects" eh="e139e84f" />
+    <e k="helpLine_sf_ov_p2_rain_title" v="[EN] Rain and Leaching" eh="33e0d8ea" />
+    <e k="helpLine_sf_ov_p2_rain_text" v="[EN] Rain leaches Nitrogen most heavily, then Potassium, then Phosphorus. It also slowly acidifies pH over time. Rain effects can be toggled off in Settings." eh="91e39cc6" />
+    <e k="helpLine_sf_ov_p2_season_title" v="[EN] Seasons and Fallow Recovery" eh="ad2009c8" />
+    <e k="helpLine_sf_ov_p2_season_text" v="[EN] Spring adds +0.03 N per day (biological activity). Fall removes 0.02 N per day. Fields left unplanted for more than 7 days slowly recover all nutrients on their own." eh="e5ebb3b2" />
 
     <!-- Catégorie 2 : Prise en main -->
-    <e k="helpLine_sf_gs_p1_title" v="Vos premiers pas" />
-    <e k="helpLine_sf_gs_p1_hud_title" v="Ouvrir le HUD (touche J)" />
-    <e k="helpLine_sf_gs_p1_hud_text" v="Appuyez sur J pour activer/désactiver l’affichage du sol en direct. Il affiche N, P, K, pH et MO pour le champ dans lequel vous vous trouvez. Les indicateurs Bon / Moyen / Mauvais vous montrent rapidement ce qui nécessite une attention." />
-    <e k="helpLine_sf_gs_p1_report_title" v="Ouvrir le rapport de sol (touche K)" />
-    <e k="helpLine_sf_gs_p1_report_text" v="Appuyez sur K pour ouvrir le rapport complet de la ferme. Tous les champs sont listés avec un état coloré des nutriments, triés par priorité. Cliquez sur la flèche d’une ligne pour voir les détails et recommandations." />
-    <e k="helpLine_sf_gs_p2_title" v="Fertilisation et récolte" />
-    <e k="helpLine_sf_gs_p2_fert_title" v="Fertilisation des champs" />
-    <e k="helpLine_sf_gs_p2_fert_text" v="Appliquez l’engrais avec n’importe quel épandeur ou pulvérisateur du jeu de base. Le mod reconnaît tous les types du jeu ainsi que 9 types personnalisés (UAN-32, MAP, Potasse, etc.). Chaque type restitue différents nutriments - voir la catégorie Engrais pour plus de détails." />
-    <e k="helpLine_sf_gs_p2_harvest_title" v="Appauvrissement à la récolte" />
-    <e k="helpLine_sf_gs_p2_harvest_text" v="Chaque récolte retire des nutriments du champ. Les cultures exigeantes (pomme de terre, betterave sucrière, soja) épuisent beaucoup plus le sol que les cultures légères (orge, avoine). Consultez le HUD ou le rapport de sol après chaque récolte." />
-    <e k="helpLine_sf_gs_p3_title" v="Difficulté" />
-    <e k="helpLine_sf_gs_p3_levels_title" v="Trois niveaux de difficulté" />
-    <e k="helpLine_sf_gs_p3_levels_text" v="Simple (0,7x) : 30 % de pertes en moins - idéal pour les nouveaux joueurs. Réaliste (1,0x) : équilibré, basé sur des valeurs agricoles réelles. Hardcore (1,5x) : 50 % de pertes en plus - gestion du sol très exigeante." />
-    <e k="helpLine_sf_gs_p3_access_title" v="Modifier les paramètres" />
-    <e k="helpLine_sf_gs_p3_access_text" v="Ouvrez les paramètres via ESC &gt; Paramètres &gt; Sol &amp; Fertilisant. En multijoueur, seul l’administrateur du serveur peut modifier les réglages de simulation. Les options d’affichage du HUD sont propres à chaque joueur." />
+    <e k="helpLine_sf_gs_p1_title" v="[EN] Your First Steps" eh="bdd0e0a7" />
+    <e k="helpLine_sf_gs_p1_hud_title" v="[EN] Open the HUD (J key)" eh="e1bdea72" />
+    <e k="helpLine_sf_gs_p1_hud_text" v="[EN] Press J to toggle the live soil overlay. It shows N, P, K, pH, and OM for the field you are standing in. Good / Fair / Poor status labels tell you what needs attention at a glance." eh="53cef520" />
+    <e k="helpLine_sf_gs_p1_report_title" v="[EN] Open the Soil Report (K key)" eh="e71446cd" />
+    <e k="helpLine_sf_gs_p1_report_text" v="[EN] Press K to open the full farm soil report. Every field is listed with color-coded nutrient status, sorted by urgency. Click the arrow on any row for a detailed view with recommendations." eh="9a0d32a6" />
+    <e k="helpLine_sf_gs_p2_title" v="[EN] Fertilize and Harvest" eh="1a52ac04" />
+    <e k="helpLine_sf_gs_p2_fert_title" v="[EN] Fertilizing Fields" eh="ea52ec26" />
+    <e k="helpLine_sf_gs_p2_fert_text" v="[EN] Apply fertilizer with any standard sprayer or spreader. The mod recognizes all base-game types plus 9 custom types (UAN-32, MAP, Potash, etc.). Each type restores different nutrients - see the Fertilizers category for full profiles." eh="fe906e29" />
+    <e k="helpLine_sf_gs_p2_harvest_title" v="[EN] Harvest Depletion" eh="a67b6cb5" />
+    <e k="helpLine_sf_gs_p2_harvest_text" v="[EN] Every harvest removes nutrients from the field. Demanding crops (potato, sugar beet, soybean) deplete significantly more than light feeders (barley, oats). Re-check the HUD or soil report after each harvest cycle." eh="63f90ed4" />
+    <e k="helpLine_sf_gs_p3_title" v="[EN] Difficulty" eh="7b29ca96" />
+    <e k="helpLine_sf_gs_p3_levels_title" v="[EN] Three Difficulty Levels" eh="52611188" />
+    <e k="helpLine_sf_gs_p3_levels_text" v="[EN] Simple (0.7x): 30% less depletion - good for new players. Realistic (1.0x): balanced, calibrated to real agricultural rates. Hardcore (1.5x): 50% more depletion - intensive soil management required." eh="f4f1ea30" />
+    <e k="helpLine_sf_gs_p3_access_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_gs_p3_access_text" v="[EN] Open settings at ESC &gt; Settings &gt; Soil &amp; Fertilizer. In multiplayer, only the server admin can change simulation settings. All HUD display options are per-player and not shared." eh="4ba9d860" />
 
     <!-- Catégorie 3 : Nutriments du sol -->
     <e k="helpLine_sf_nu_p1_title" v="Azote et Phosphore" eh="27d37372" />
@@ -436,7 +427,7 @@
     <e k="sf_pda_map_legend_poor" v="Faible / Mauvais" eh="32aa75ff" />
     <e k="sf_pda_map_legend_low" v="Faible" eh="28d0edd0" />
     <e k="sf_pda_map_legend_medium" v="Moyen" eh="87f8a6ab" />
-    <e k="sf_pda_map_legend_high" v="Élevé" eh="655c20c1" />
+    <e k="sf_pda_map_legend_high" v="[EN] High" eh="655d20c1" />
     <e k="sf_pda_map_legend_excess" v="Excès" eh="d1d25b9f" />
     <e k="sf_pda_map_instructions" v="Sélectionnez une couche dans la barre latérale pour l’afficher sur la carte." eh="eee76c81" />
     <e k="sf_pda_map_jump_hint" v="Cliquez sur un champ pour vous y déplacer sur la carte" eh="006d5371" />
@@ -563,7 +554,7 @@
          ====================================================== -->
     <e k="sf_sprayer_auto_on" v="DÉBIT  ( AUTO : ACTIVÉ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="DÉBIT  AUTO : DÉSACTIVÉ [%s]" eh="848cc106" />
-    <e k="sf_sprayer_target" v="Cible : " eh="31d43504" />
+    <e k="sf_sprayer_target" v="Cible :" eh="31d43504" />
     <e k="sf_sprayer_burn_guaranteed" v="RISQUE DE BRÛLURE : GARANTI" eh="422601c4" />
     <e k="sf_sprayer_burn_possible" v="RISQUE DE BRÛLURE : POSSIBLE" eh="25b251b6" />
 
@@ -793,189 +784,228 @@
     <e k="sf_var_rate_label"       v="Taux var." />
 
     <!-- noms d’affichage des actions d’entrée -->
-    <e k="action_SF_SENSOR_PEST" v="SF : Activer/Désactiver le capteur de ravageurs" />
-    <e k="action_SF_SENSOR_DISEASE" v="SF : Activer/Désactiver le capteur de maladies" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF : Activer/Désactiver le capteur de nutriments" />
-    <e k="action_SF_SEE_SPRAY_PEST" v="SF : Activer/Désactiver See &amp; Spray Ravageurs" />
     <e k="action_SF_SEE_SPRAY_DISEASE" v="SF : Activer/Désactiver See &amp; Spray Maladies" eh="205a3668" />
-    <e k="action_SF_SEE_SPRAY_WEED" v="SF : Activer/Désactiver See &amp; Spray Mauvaises herbes" />
-    <e k="action_SF_VARIABLE_RATE" v="SF : Activer/Désactiver le débit variable" />
-    <e k="sf_guide_sub_1" v="Vue d'ensemble — Ce que ce mod suit et pourquoi c'est important" eh="81726806" />
-    <e k="sf_guide_sub_2" v="Guide HUD — Comprendre les barres de nutriments et les indicateurs à l'écran" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Flux de travail — Votre routine quotidienne et saisonnière de gestion des sols" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Produits — Effets de chaque engrais et quand les utiliser" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Réponses aux questions fréquentes" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="QU'EST-CE QUE CE MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Suit 5 nutriments du sol par champ sur votre" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="exploitation. Les cultures épuisent les nutriments à la récolte." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Les engrais les reconstituent. La météo et les" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="saisons ajoutent une pression réaliste au fil du temps." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="LES 5 PARAMÈTRES DU SOL" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Azote          Épuisement rapide. Chaque récolte." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphore      Épuisement lent. Cultures racinaires." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Les cultures racinaires l'épuisent fortement." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="MO  Matière organique Augmente lentement sur plusieurs saisons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Acidité du sol. Plage cible : 6,5 – 7,0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="NIVEAUX D'ÉTAT" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="BON (vert)  Au niveau ou au-dessus de la cible optimale." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  Aucune action nécessaire cette saison." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="MOYEN (jaune) En dessous de l'optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Prévoir un apport. Rendement légèrement réduit." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="FAIBLE (rouge) Sous le seuil minimum." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Agissez maintenant — impact sévère sur le rendement." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="DÉMARRAGE RAPIDE (5 ÉTAPES)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Ouvrez le PDA (menu du jeu) &gt; Sol &amp; Engrais." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Vérifiez l'aperçu de la ferme pour les champs en rouge." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Utilisez le plan de traitement pour voir les besoins." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Appliquez le bon produit fertilisant." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Récoltez normalement — les nutriments sont déduits automatiquement." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="OUTILS EN UN COUP D'ŒIL" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="Barres HUD     Niveaux du sol pour votre champ actuel." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Touche : SF Afficher/Masquer HUD (Contrôles &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="Écran PDA   Aperçu complet de la ferme + plan de traitement." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Accessible depuis le menu tablette du jeu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Carte du sol     Superposition colorée des nutriments par cellule." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Touche : SF Afficher/Masquer la carte des cellules" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Rapport de champ Analyse détaillée d'un champ." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Touche : Rapport du sol SF" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Capteur intelligent Masque les sections sans besoin actif." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Commandes : Alt+1/2/3 dans un pulvérisateur VWW." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Pression en direct par cellule dans le véhicule." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Commandes : Alt+4/5/6 dans un pulvérisateur VWW." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Débit variable Ajuste automatiquement le débit selon les déficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Commande : Alt+7. Activer dans Administration." eh="00361557" />
-    <e k="sf_guide_p1_40" v="RACCOURCIS CLAVIER" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="Toutes les touches sont non attribuées par défaut pour éviter les conflits." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Allez dans : Options &gt; Contrôles &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Recherchez les actions commençant par SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Attribuez des touches qui ne sont pas utilisées par d'autres mods." eh="b605a223" />
-    <e k="sf_guide_p3_01" v="LE CYCLE AGRICOLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="ÉPUISEMENT  La récolte retire N/P/K du sol." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         La quantité dépend du type de culture et du rendement." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="RECONSTITUTION  Appliquez de l'engrais pour restaurer les nutriments." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="ÉQUILIBRE  Le pH et la MO évoluent lentement au fil du temps." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Nécessite une gestion à long terme." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="HABITUDES QUOTIDIENNES" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Jetez un œil au HUD avant de travailler un champ." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Barre rouge = appliquez de l'engrais avant ou après la culture." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Barre jaune = notez le champ, traitez-le cette saison." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Barre verte = continuez, aucune intervention nécessaire." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="ROUTINE HEBDOMADAIRE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Ouvrez le PDA > onglet Plan de traitement." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Les champs sont classés par urgence (du pire au meilleur)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Travaillez du haut vers le bas — traitez d'abord les champs prioritaires." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Cliquez sur une ligne pour ouvrir la vue détaillée du champ." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="LIRE LE PLAN DE TRAITEMENT" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Les scores de priorité évaluent à quel point chaque" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutriment est sous son objectif. Un champ dans le rouge sur deux nutriments" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="sera classé plus haut qu'un champ avec un seul niveau moyen." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="LISTE DE CONTRÔLE AVANT SEMIS" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Vérifiez le niveau d'azote — il diminue à chaque récolte." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Appliquez de l'azote s'il est MOYEN ou FAIBLE." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Vérifiez le P et le K — ils évoluent plus lentement." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Faites un apport s'ils sont sous le seuil moyen." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Vérifiez le pH — chaux si acide, gypse si alcalin." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Vérifiez la MO — ajoutez fumier ou compost si faible." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="ACTIONS APRÈS RÉCOLTE" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. L'azote est épuisé — appliquez de l'engrais rapidement." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Les légumineuses (soja, trèfle) ajoutent gratuitement de l'azote" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   pour la saison SUIVANTE automatiquement." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Ajoutez fumier ou compost pour augmenter la MO à long terme." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="NOTES SAISONNIÈRES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="PRINTEMPS  La demande en azote atteint son pic. Appliquez avant le semis." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="ÉTÉ  Surveillez la pression des ravageurs et des maladies." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTOMNE  Évitez les fortes doses d'azote avant une pluie annoncée" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (la pluie lessive l'azote du sol)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="HIVER  Les champs en jachère récupèrent lentement leurs nutriments." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Laissez un champ nu pour le laisser se reposer." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="PRODUITS AZOTÉS (N)" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="Solution UAN   Azote élevé, liquide à libération rapide." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urée           Azote élevé, forme solide standard." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Azote + léger apport en soufre." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Fumier         Azote modéré + fort apport de MO." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Boues biosolides      N + P + fort apport de MO." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestat      Azote modéré + léger apport de MO." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PRODUITS PHOSPHORÉS (P)" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            Phosphore élevé, faible apport d'azote." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            Phosphore élevé + mélange azoté." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="MAP liquide     Phosphore élevé, absorption plus rapide." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="DAP liquide     Phosphore élevé + N, forme liquide." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Boues biosolides      P + N + MO. Très efficace." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="PRODUITS POTASSIQUES (K)" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potasse         Potassium élevé, forme solide." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Potasse liquide  Potassium élevé, liquide. Absorption plus rapide." eh="07398747" />
-    <e k="sf_guide_p4_17" v="CORRECTION DU pH" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Plage cible : 6.5 – 7.0 pour la plupart des cultures." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH trop BAS (acide, inférieur à 6.5) :" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Appliquez de la CHAUX — augmente le pH vers la neutralité." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH trop ÉLEVÉ (alcalin, supérieur à 7.5) :" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Appliquez du GYPSE — réduit le pH vers la neutralité." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Comptez 1 à 2 saisons pour une normalisation complète." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="MATIÈRE ORGANIQUE (MO)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Fumier         Meilleur apport de MO. Ajoute aussi de l'azote." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        MO modérée, bien équilibrée." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Boues biosolides      MO + N + P. Très efficace." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestat      Léger apport de MO." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="La jachère (champ nu) restaure lentement la MO avec le temps." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="CONSEILS D'APPLICATION" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Chargez l'engrais et vérifiez d'abord la barre fantôme." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  Elle montre le résultat prévu avant application." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Les produits liquides agissent généralement plus vite que les solides." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Le fumier améliore la MO ET ajoute de l'azote — très efficace." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Appliquez l'azote liquide avant la pluie si possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (la pluie lessive une partie de l'azote après application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Vérifiez les objectifs de la culture que vous allez semer" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — chaque culture nécessite des ratios NPK différents." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MES BARRES SONT TOUJOURS VIDES — LE MOD EST-IL CASSÉ ?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="Non. Le sol commence avec des niveaux de base faibles dans une nouvelle sauvegarde." eh="32490786" />
-    <e k="sf_guide_p5_03" v="Un champ qui n'a jamais été fertilisé affiche des valeurs réelles." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Appliquez de l'engrais pour augmenter les niveaux au fil du temps." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="C'est volontaire — cela reflète l'épuisement réel du sol." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="OÙ ATTRIBUER LES RACCOURCIS CLAVIER ?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options > Commandes > Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="Toutes les touches SF_ sont non attribuées par défaut pour éviter les conflits" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="avec d'autres mods. Recherchez les actions SF_ et" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="attribuez les touches qui conviennent à votre configuration." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="POURQUOI MON AZOTE A-T-IL BAISSÉ APRÈS LA PLUIE ?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Les fortes pluies lessivent l'azote du sol." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="C'est volontaire et réaliste." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Planifiez les apports d'azote avant une période sèche," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="et non avant de fortes pluies annoncées." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="Vous pouvez ajuster la sensibilité à la pluie dans les paramètres." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="QU'EST-CE QUE LA BARRE FANTÔME ?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="L'extension pâle d'une barre indique combien" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="votre pulvérisateur chargé ajoutera si vous appliquez ici." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Chargez un engrais dans un pulvérisateur, rendez-vous sur un" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="champ et la barre fantôme apparaîtra automatiquement." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DOIS-JE FERTILISER À CHAQUE SAISON ?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Azote : Oui, chaque saison si possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  Il s'épuise fortement à chaque récolte." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P et K : Tous les 2 à 3 saisons suffisent généralement." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="MO organique : À long terme. Ajoutez du fumier une fois par an." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH : Seulement lorsqu'il est hors de la plage 6.5–7.0." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="COMMENT FONCTIONNENT LES SYSTÈMES SMART SENSOR ?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Le Smart Sensor coupe individuellement les sections de rampe lorsque" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="aucun besoin n'est détecté (pas de ravageur, maladie ou déficit" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="nutritif). See & Spray affiche la pression en direct par cellule." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Le Débit Variable ajuste la sortie de la rampe selon les données du sol." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="Les 3 nécessitent un pulvérisateur compatible VWW. Activez-les via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Paramètres > Administration > Systèmes intelligents." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="PUIS-JE UTILISER CE MOD EN MULTIJOUEUR ?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Oui. Le mod est entièrement compatible multijoueur." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Les données du sol sont gérées par le serveur." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Les clients se synchronisent à la connexion. Les modifications des paramètres nécessitent" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="des droits administrateur dans les sessions multijoueurs." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="COMMENT LE SOL INFLUENCE-T-IL LE RENDEMENT ?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="Sol BON : rendement maximal — aucune pénalité." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="Sol MOYEN : ~5 à 15 % de pénalité de rendement par nutriment." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="Sol MAUVAIS : jusqu'à 40 % de pénalité. Corrigez rapidement." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Les pénalités se cumulent : N MAUVAIS + P MOYEN = perte importante." eh="5536d718" />
-    <e k="sf_guide_title" v="Sol &amp; Engrais — Guide du terrain" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="VUE D'ENSEMBLE" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="GUIDE HUD" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="FLUX DE TRAVAIL" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUITS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="Aucune action nécessaire cette saison." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Prévoir un apport. Rendement légèrement réduit." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Agissez maintenant — impact sévère sur le rendement." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Touche : SF Afficher/Masquer HUD (Contrôles &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Accessible depuis le menu tablette du jeu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Touche : SF Afficher/Masquer la carte des cellules" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Touche : Rapport du sol SF" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Commandes : Alt+1/2/3 dans un pulvérisateur VWW." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Commandes : Alt+4/5/6 dans un pulvérisateur VWW." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Commande : Alt+7. Activer dans Administration." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+		<e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+		<e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+		<e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+		<e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+		<e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+		<e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+		<e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+		<e k="sf_guide_p2_08" v="[EN]   Bar is RED below this line." eh="4cebe452" />
+		<e k="sf_guide_p2_09" v="[EN]   Your soil is in POOR condition." eh="7a3175e4" />
+		<e k="sf_guide_p2_10" v="[EN]   Action: apply fertilizer immediately." eh="209e2635" />
+		<e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+		<e k="sf_guide_p2_12" v="[EN]   Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+		<e k="sf_guide_p2_13" v="[EN]   Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+		<e k="sf_guide_p2_14" v="[EN]   Action: plan a top-up this season." eh="3cf7dfa3" />
+		<e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+		<e k="sf_guide_p2_16" v="[EN]   Reach this point for maximum yield." eh="cc7c263f" />
+		<e k="sf_guide_p2_17" v="[EN]   Bar is GREEN when you reach it." eh="b5e669ea" />
+		<e k="sf_guide_p2_18" v="[EN]   Each crop has different N/P/K targets." eh="d25b96a5" />
+		<e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+		<e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+		<e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+		<e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+		<e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+		<e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+		<e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+		<e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+		<e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+		<e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+		<e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+		<e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+		<e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+		<e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+		<e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+		<e k="sf_guide_p2_34" v="[EN]   Yield penalty. Apply now." eh="121691a9" />
+		<e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+		<e k="sf_guide_p2_36" v="[EN]   Slight penalty. Plan ahead." eh="74d99045" />
+		<e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+		<e k="sf_guide_p2_38" v="[EN]   At or above crop optimal. No action." eh="37eb57bb" />
+		<e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+		<e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+		<e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+		<e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+		<e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+		<e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+		<e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="La quantité dépend du type de culture et du rendement." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Nécessite une gestion à long terme." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Appliquez de l'azote s'il est MOYEN ou FAIBLE." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Faites un apport s'ils sont sous le seuil moyen." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="pour la saison SUIVANTE automatiquement." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(la pluie lessive l'azote du sol)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Laissez un champ nu pour le laisser se reposer." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Appliquez de la CHAUX — augmente le pH vers la neutralité." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Appliquez du GYPSE — réduit le pH vers la neutralité." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="Elle montre le résultat prévu avant application." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(la pluie lessive une partie de l'azote après application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— chaque culture nécessite des ratios NPK différents." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="Il s'épuise fortement à chaque récolte." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -788,228 +788,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -815,228 +815,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -815,228 +815,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -795,228 +795,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -796,228 +796,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -797,228 +797,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -797,228 +797,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -797,228 +797,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -816,228 +816,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -816,228 +816,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -757,228 +757,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -769,228 +769,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -108,7 +108,7 @@
     <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
     <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
     <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Disease" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
     <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
     <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
@@ -768,228 +768,228 @@
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
     <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
     <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="Overview — What this mod tracks and why it matters" eh="81726806" />
-    <e k="sf_guide_sub_2" v="HUD Guide — Reading the nutrient bars and on-screen indicators" eh="fd0a8c1d" />
-    <e k="sf_guide_sub_3" v="Workflow — Your daily and seasonal soil management routine" eh="2dc26ccc" />
-    <e k="sf_guide_sub_4" v="Products — What each fertilizer affects and when to use it" eh="17ebc503" />
-    <e k="sf_guide_sub_5" v="F.A.Q. — Common questions answered" eh="a9735b47" />
-    <e k="sf_guide_p1_01" v="WHAT IS THIS MOD" eh="83468bd7" />
-    <e k="sf_guide_p1_02" v="Tracks 5 soil nutrients per field across your" eh="94b33a56" />
-    <e k="sf_guide_p1_03" v="farm. Crops deplete nutrients on harvest." eh="8db042d2" />
-    <e k="sf_guide_p1_04" v="Fertilizer replenishes them. Weather and" eh="abd05a9c" />
-    <e k="sf_guide_p1_05" v="seasons add realistic pressure over time." eh="2173d584" />
-    <e k="sf_guide_p1_06" v="THE 5 SOIL PARAMETERS" eh="5fde1343" />
-    <e k="sf_guide_p1_07" v="N   Nitrogen       Fast depletion. Every harvest." eh="23d3ce22" />
-    <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="e44502f1" />
-    <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="4edfc26d" />
-    <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="cdb2d933" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="6dfd73f1" />
-    <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="d1b157ef" />
-    <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="36e7061f" />
-    <e k="sf_guide_p1_14" v="  No action needed this season." eh="fc3fe8cf" />
-    <e k="sf_guide_p1_15" v="FAIR (yellow) Below optimal." eh="3a5f2343" />
-    <e k="sf_guide_p1_16" v="  Plan a top-up. Yield slightly reduced." eh="8514a61e" />
-    <e k="sf_guide_p1_17" v="POOR (red)    Below minimum threshold." eh="333c4fc2" />
-    <e k="sf_guide_p1_18" v="  Act now — yield impact is severe." eh="1b962d17" />
-    <e k="sf_guide_p1_19" v="QUICK START (5 STEPS)" eh="5a9cb86e" />
-    <e k="sf_guide_p1_20" v="1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="8093628a" />
-    <e k="sf_guide_p1_21" v="2. Check Farm Overview for red-flagged fields." eh="3bfda016" />
-    <e k="sf_guide_p1_22" v="3. Use Treatment Plan to see what's needed." eh="e19ebe2b" />
-    <e k="sf_guide_p1_23" v="4. Apply the right fertilizer product." eh="315ecea6" />
-    <e k="sf_guide_p1_24" v="5. Harvest normally — nutrients auto-deduct." eh="6c78829c" />
-    <e k="sf_guide_p1_25" v="TOOLS AT A GLANCE" eh="0d78c5c6" />
-    <e k="sf_guide_p1_26" v="HUD Bars     Soil levels for your current field." eh="91a47705" />
-    <e k="sf_guide_p1_27" v="  Key: SF Toggle HUD (Controls &gt; Mods)" eh="71546634" />
-    <e k="sf_guide_p1_28" v="PDA Screen   Full farm overview + treatment plan." eh="84c5722b" />
-    <e k="sf_guide_p1_29" v="  Open via the game's tablet menu." eh="3b2c80b5" />
-    <e k="sf_guide_p1_30" v="Soil Map     Per-cell nutrient colour overlay." eh="7c49f1b1" />
-    <e k="sf_guide_p1_31" v="  Key: SF Toggle Cell Map" eh="4fed89d3" />
-    <e k="sf_guide_p1_32" v="Field Report Detailed single-field breakdown." eh="5c3bfcdf" />
-    <e k="sf_guide_p1_33" v="  Key: SF Soil Report" eh="1d9047fa" />
-    <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="8f3e9d62" />
-    <e k="sf_guide_p1_35" v="  Toggles: Alt+1/2/3 in a VWW sprayer." eh="0c364023" />
-    <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="82c711b5" />
-    <e k="sf_guide_p1_37" v="  Toggles: Alt+4/5/6 in a VWW sprayer." eh="c0740086" />
-    <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="fbd7cfe0" />
-    <e k="sf_guide_p1_39" v="  Toggle:  Alt+7.  Enable in Admin." eh="00361557" />
-    <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="cbc41ad0" />
-    <e k="sf_guide_p1_41" v="All keys ship UNBOUND to avoid conflicts." eh="9652a447" />
-    <e k="sf_guide_p1_42" v="Go to: Options &gt; Controls &gt; Mods" eh="c9fea2e7" />
-    <e k="sf_guide_p1_43" v="Look for actions starting with SF_" eh="fe557f61" />
-    <e k="sf_guide_p1_44" v="Assign keys that don't clash with other mods." eh="b605a223" />
-    <e k="sf_guide_p2_01" v="THE NUTRIENT BARS" eh="64bcec79" />
-    <e k="sf_guide_p2_02" v="The HUD shows one bar per nutrient: N P K OM pH." eh="aeac112b" />
-    <e k="sf_guide_p2_03" v="Bar fills left (0) to right (100 = maximum)." eh="7f23737a" />
-    <e k="sf_guide_p2_04" v="Bar colour tells you status at a glance." eh="33dcb4e1" />
-    <e k="sf_guide_p2_05" v="THE THREE TICK MARKS" eh="d89a45ba" />
-    <e k="sf_guide_p2_06" v="Every bar has three small vertical tick marks." eh="4264137f" />
-    <e k="sf_guide_p2_07" v="ORANGE tick — Poor/Fair boundary." eh="99feda97" />
-    <e k="sf_guide_p2_08" v="  Bar is RED below this line." eh="28547bc6" />
-    <e k="sf_guide_p2_09" v="  Your soil is in POOR condition." eh="2569c8ef" />
-    <e k="sf_guide_p2_10" v="  Action: apply fertilizer immediately." eh="970de608" />
-    <e k="sf_guide_p2_11" v="YELLOW tick — Fair/Good boundary." eh="f8f07ad1" />
-    <e k="sf_guide_p2_12" v="  Bar is YELLOW between orange and yellow ticks." eh="2eb1fb88" />
-    <e k="sf_guide_p2_13" v="  Your soil is FAIR — below the crop's optimum." eh="7987bd5b" />
-    <e k="sf_guide_p2_14" v="  Action: plan a top-up this season." eh="00502703" />
-    <e k="sf_guide_p2_15" v="CYAN tick — Your planted crop's optimal target." eh="a86164b4" />
-    <e k="sf_guide_p2_16" v="  Reach this point for maximum yield." eh="ae26a23a" />
-    <e k="sf_guide_p2_17" v="  Bar is GREEN when you reach it." eh="33a4e76b" />
-    <e k="sf_guide_p2_18" v="  Each crop has different N/P/K targets." eh="7922d64b" />
-    <e k="sf_guide_p2_19" v="THE GHOST BAR" eh="1200754e" />
-    <e k="sf_guide_p2_20" v="A faint extension of the bar (same colour, dimmer)." eh="18f4e711" />
-    <e k="sf_guide_p2_21" v="Shows your projected level AFTER applying the" eh="032d8f35" />
-    <e k="sf_guide_p2_22" v="fertilizer currently loaded in your sprayer." eh="8a82196e" />
-    <e k="sf_guide_p2_23" v="Drive to a field with a loaded sprayer to see it." eh="bd0335a0" />
-    <e k="sf_guide_p2_24" v="Use it to avoid wasting fertilizer by over-applying." eh="944b9e4b" />
-    <e k="sf_guide_p2_25" v="READING THE NUMBERS" eh="9d84b9e8" />
-    <e k="sf_guide_p2_26" v="Format:  value  /  target  ( +projected )" eh="df3bb7c7" />
-    <e k="sf_guide_p2_27" v="Example: 245 / 320 (+85)" eh="136bd377" />
-    <e k="sf_guide_p2_28" v="" eh="00000000" />
-    <e k="sf_guide_p2_29" v="245  = your current nitrogen level in ppm" eh="dbfc1141" />
-    <e k="sf_guide_p2_30" v="320  = the crop's optimal nitrogen target" eh="ba949d8a" />
-    <e k="sf_guide_p2_31" v="+85  = how much your sprayer load will add" eh="92070ec8" />
-    <e k="sf_guide_p2_32" v="STATUS COLOURS" eh="08d6340b" />
-    <e k="sf_guide_p2_33" v="RED bar    Below the orange tick (POOR)." eh="4b18cb90" />
-    <e k="sf_guide_p2_34" v="  Yield penalty. Apply now." eh="b971b10b" />
-    <e k="sf_guide_p2_35" v="YELLOW bar Between orange and yellow ticks (FAIR)." eh="ca7536de" />
-    <e k="sf_guide_p2_36" v="  Slight penalty. Plan ahead." eh="d54afa45" />
-    <e k="sf_guide_p2_37" v="GREEN bar  Above the yellow tick (GOOD)." eh="8545d6fb" />
-    <e k="sf_guide_p2_38" v="  At or above crop optimal. No action." eh="e903aa78" />
-    <e k="sf_guide_p2_39" v="SMART SYSTEM PANELS (VWW sprayer required)" eh="88742d5e" />
-    <e k="sf_guide_p2_40" v="Three panels appear when in a VWW-capable sprayer:" eh="9adaea6c" />
-    <e k="sf_guide_p2_41" v="Smart Sensor / See &amp; Spray / Variable Rate." eh="85d1b46a" />
-    <e k="sf_guide_p2_42" v="Enable each via Admin &gt; Smart Systems in Settings." eh="ea9cbfd6" />
-    <e k="sf_guide_p2_43" v="FREE PANEL LAYOUT" eh="0638d758" />
-    <e k="sf_guide_p2_44" v="Enable in Settings &gt; Display. Use Shift+H to drag." eh="4535e5c1" />
-    <e k="sf_guide_p2_45" v="Press [-] in any title bar to collapse a panel." eh="a40967e4" />
-    <e k="sf_guide_p3_01" v="THE FARMING CYCLE" eh="2d6b6c00" />
-    <e k="sf_guide_p3_02" v="DEPLETE  Harvest removes N/P/K from soil." eh="0c3219fb" />
-    <e k="sf_guide_p3_03" v="         The amount depends on crop type and yield." eh="ab8adace" />
-    <e k="sf_guide_p3_04" v="REPLENISH Apply fertilizer to restore nutrients." eh="d07d37d2" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH and OM change slowly over time." eh="611caf83" />
-    <e k="sf_guide_p3_06" v="         Requires long-term management." eh="128117f3" />
-    <e k="sf_guide_p3_07" v="DAILY HABITS" eh="64d0c6d8" />
-    <e k="sf_guide_p3_08" v="1. Glance at the HUD before working a field." eh="5dce5025" />
-    <e k="sf_guide_p3_09" v="2. Red bar = apply fertilizer before or after crop." eh="83d55f7b" />
-    <e k="sf_guide_p3_10" v="3. Yellow bar = note the field, treat this season." eh="f903dc7c" />
-    <e k="sf_guide_p3_11" v="4. Green bar = carry on, nothing needed." eh="f2109204" />
-    <e k="sf_guide_p3_12" v="WEEKLY ROUTINE" eh="24a8ef8e" />
-    <e k="sf_guide_p3_13" v="Open PDA &gt; Treatment Plan tab." eh="ad687f50" />
-    <e k="sf_guide_p3_14" v="Fields are sorted by urgency (worst first)." eh="571786e6" />
-    <e k="sf_guide_p3_15" v="Work top-down — treat highest-priority fields first." eh="08e04adb" />
-    <e k="sf_guide_p3_16" v="Click a row to open detailed field view." eh="66ce4f4b" />
-    <e k="sf_guide_p3_17" v="READING THE TREATMENT PLAN" eh="4412f706" />
-    <e k="sf_guide_p3_18" v="Priority scores weigh how far below target each" eh="32bc52d7" />
-    <e k="sf_guide_p3_19" v="nutrient is. A field in the red on two nutrients" eh="3382c3d2" />
-    <e k="sf_guide_p3_20" v="ranks higher than one with a single fair level." eh="44e63815" />
-    <e k="sf_guide_p3_21" v="PRE-PLANTING CHECKLIST" eh="f703e663" />
-    <e k="sf_guide_p3_22" v="1. Check N level — depletes every harvest." eh="47054be2" />
-    <e k="sf_guide_p3_23" v="   Apply nitrogen if FAIR or POOR." eh="697781ec" />
-    <e k="sf_guide_p3_24" v="2. Check P and K — change more slowly." eh="636fd8d9" />
-    <e k="sf_guide_p3_25" v="   Top up if below the fair threshold." eh="7d1a903b" />
-    <e k="sf_guide_p3_26" v="3. Check pH — lime if acidic, gypsum if alkaline." eh="bb019f53" />
-    <e k="sf_guide_p3_27" v="4. Check OM — add manure or compost if low." eh="042cb8f2" />
-    <e k="sf_guide_p3_28" v="POST-HARVEST ACTIONS" eh="6a7f0fca" />
-    <e k="sf_guide_p3_29" v="1. Nitrogen is depleted — apply fertilizer soon." eh="577a017a" />
-    <e k="sf_guide_p3_30" v="2. Legume crops (soy, clover) add free N" eh="fd08b3ce" />
-    <e k="sf_guide_p3_31" v="   bonus for the NEXT season automatically." eh="83e833b3" />
-    <e k="sf_guide_p3_32" v="3. Add manure or compost to build OM long-term." eh="575116a9" />
-    <e k="sf_guide_p3_33" v="SEASONAL NOTES" eh="48553a52" />
-    <e k="sf_guide_p3_34" v="SPRING  N demand peaks. Apply before planting." eh="44d69bfd" />
-    <e k="sf_guide_p3_35" v="SUMMER  Monitor pest and disease pressure." eh="14fd9b6f" />
-    <e k="sf_guide_p3_36" v="AUTUMN  Avoid heavy N before forecast rain" eh="0b6cb5e8" />
-    <e k="sf_guide_p3_37" v="        (rain leaches N from soil)." eh="b2a5c269" />
-    <e k="sf_guide_p3_38" v="WINTER  Fallow fields slowly recover nutrients." eh="d76feedb" />
-    <e k="sf_guide_p3_39" v="        Leave a field bare to let it rest." eh="42c72b66" />
-    <e k="sf_guide_p4_01" v="NITROGEN (N) PRODUCTS" eh="bec40ce6" />
-    <e k="sf_guide_p4_02" v="UAN Solution   High N, fast release liquid." eh="8b5a49c9" />
-    <e k="sf_guide_p4_03" v="Urea           High N, standard solid form." eh="a6a58cb1" />
-    <e k="sf_guide_p4_04" v="AMS            Nitrogen + minor sulphur benefit." eh="6050bc15" />
-    <e k="sf_guide_p4_05" v="Manure         Moderate N + large OM boost." eh="f1b898f5" />
-    <e k="sf_guide_p4_06" v="Biosolids      N + P + large OM boost." eh="3ecb89a1" />
-    <e k="sf_guide_p4_07" v="Digestate      Moderate N + light OM benefit." eh="9a0e17d7" />
-    <e k="sf_guide_p4_08" v="PHOSPHORUS (P) PRODUCTS" eh="f246b45f" />
-    <e k="sf_guide_p4_09" v="MAP            High P, small N contribution." eh="f56b59c6" />
-    <e k="sf_guide_p4_10" v="DAP            High P + nitrogen blend." eh="77fa32bc" />
-    <e k="sf_guide_p4_11" v="Liquid MAP     High P, faster uptake." eh="add91c6a" />
-    <e k="sf_guide_p4_12" v="Liquid DAP     High P + N, liquid form." eh="10f16c70" />
-    <e k="sf_guide_p4_13" v="Biosolids      P + N + OM. Efficient multi-nutrient." eh="f65c9491" />
-    <e k="sf_guide_p4_14" v="POTASSIUM (K) PRODUCTS" eh="d4182e1d" />
-    <e k="sf_guide_p4_15" v="Potash         High K, solid form." eh="9c2d1ef4" />
-    <e k="sf_guide_p4_16" v="Liquid Potash  High K, liquid. Faster uptake." eh="07398747" />
-    <e k="sf_guide_p4_17" v="pH CORRECTION" eh="4ffba02e" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="fbb6a132" />
-    <e k="sf_guide_p4_19" v="" eh="00000000" />
-    <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="68520f95" />
-    <e k="sf_guide_p4_21" v="  Apply LIME — raises pH toward neutral." eh="def9f79d" />
-    <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="247708ec" />
-    <e k="sf_guide_p4_23" v="  Apply GYPSUM — lowers pH toward neutral." eh="2ad8d2d3" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="7c2ee55e" />
-    <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="75512a9c" />
-    <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="e6f7a9c4" />
-    <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="2b996529" />
-    <e k="sf_guide_p4_28" v="Biosolids      OM + N + P. Very efficient." eh="d380c89e" />
-    <e k="sf_guide_p4_29" v="Digestate      Light OM benefit." eh="fd8e1c67" />
-    <e k="sf_guide_p4_30" v="Fallow (bare field) slowly recovers OM over time." eh="9d46f06c" />
-    <e k="sf_guide_p4_31" v="APPLICATION TIPS" eh="5d514e44" />
-    <e k="sf_guide_p4_32" v="* Load fertilizer and check the ghost bar first." eh="35e05de8" />
-    <e k="sf_guide_p4_33" v="  It shows your projected result before you apply." eh="24ff5dde" />
-    <e k="sf_guide_p4_34" v="* Liquid products generally work faster than solid." eh="7b2ad191" />
-    <e k="sf_guide_p4_35" v="* Manure improves OM AND adds N — very efficient." eh="1d9c74bb" />
-    <e k="sf_guide_p4_36" v="* Apply liquid N before rain if possible" eh="90305fce" />
-    <e k="sf_guide_p4_37" v="  (rain leaches some nitrogen after application)." eh="dd45f06b" />
-    <e k="sf_guide_p4_38" v="* Check crop targets for what you're planting" eh="3444bb54" />
-    <e k="sf_guide_p4_39" v="  — different crops need different NPK ratios." eh="60c366af" />
-    <e k="sf_guide_p5_01" v="MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="2d6aa6d2" />
-    <e k="sf_guide_p5_02" v="No. Soil starts at low base levels on a new save." eh="32490786" />
-    <e k="sf_guide_p5_03" v="A field that was never fertilized shows real values." eh="f72b6313" />
-    <e k="sf_guide_p5_04" v="Apply fertilizer to build levels over time." eh="a2691642" />
-    <e k="sf_guide_p5_05" v="This is intentional — it reflects real soil depletion." eh="67f5d0fc" />
-    <e k="sf_guide_p5_06" v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="8171751f" />
-    <e k="sf_guide_p5_07" v="Options &gt; Controls &gt; Mods" eh="134c4fb9" />
-    <e k="sf_guide_p5_08" v="All SF_ keys ship unbound to avoid conflicts" eh="658e7851" />
-    <e k="sf_guide_p5_09" v="with other mods. Find the SF_ actions and" eh="8634e3c4" />
-    <e k="sf_guide_p5_10" v="assign keys that work for your setup." eh="05c1324a" />
-    <e k="sf_guide_p5_11" v="WHY DID MY NITROGEN DROP AFTER RAIN?" eh="08c6cc44" />
-    <e k="sf_guide_p5_12" v="Heavy rain leaches nitrogen from soil." eh="e66f2a7b" />
-    <e k="sf_guide_p5_13" v="This is intentional and realistic." eh="844f3842" />
-    <e k="sf_guide_p5_14" v="Plan N applications before dry weather," eh="5775d792" />
-    <e k="sf_guide_p5_15" v="not before heavy rain forecasts." eh="51b331f3" />
-    <e k="sf_guide_p5_16" v="You can adjust rain sensitivity in Settings." eh="db0521ab" />
-    <e k="sf_guide_p5_17" v="WHAT IS THE GHOST BAR?" eh="b4ac2fb5" />
-    <e k="sf_guide_p5_18" v="The faint extension on a bar shows how much" eh="3bfd13cd" />
-    <e k="sf_guide_p5_19" v="your loaded sprayer will add if applied here." eh="3958b721" />
-    <e k="sf_guide_p5_20" v="Load a fertilizer into a sprayer, drive to any" eh="f7ae557a" />
-    <e k="sf_guide_p5_21" v="field, and the ghost bar appears automatically." eh="549c15e6" />
-    <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="ff4edc94" />
-    <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="53e7c92e" />
-    <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="bab86964" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0bd8fa51" />
-    <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="eda4d593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="48be5789" />
-    <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="5ca9536b" />
-    <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="86ab0498" />
-    <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="90e912a2" />
-    <e k="sf_guide_p5_31" v="deficit). See &amp; Spray shows live pressure per cell." eh="30c72641" />
-    <e k="sf_guide_p5_32" v="Variable Rate adjusts boom output from soil data." eh="a260d3d9" />
-    <e k="sf_guide_p5_33" v="All 3 need a VWW-capable sprayer. Enable via" eh="51ea1a4a" />
-    <e k="sf_guide_p5_34" v="Settings &gt; Admin &gt; Smart Systems." eh="37872bd2" />
-    <e k="sf_guide_p5_35" v="CAN I USE THIS IN MULTIPLAYER?" eh="6f6ef016" />
-    <e k="sf_guide_p5_36" v="Yes. The mod is fully multiplayer-compatible." eh="24ab5ab7" />
-    <e k="sf_guide_p5_37" v="Soil data is server-authoritative." eh="a9984593" />
-    <e k="sf_guide_p5_38" v="Clients sync on join. Settings changes require" eh="71e7653d" />
-    <e k="sf_guide_p5_39" v="admin permissions in multiplayer sessions." eh="c884fdf4" />
-    <e k="sf_guide_p5_40" v="HOW DOES SOIL AFFECT YIELD?" eh="0bf98a17" />
-    <e k="sf_guide_p5_41" v="GOOD soil: full yield — no penalty." eh="2bc128e5" />
-    <e k="sf_guide_p5_42" v="FAIR soil: ~5-15% yield penalty per nutrient." eh="b2127c34" />
-    <e k="sf_guide_p5_43" v="POOR soil: up to 40% penalty. Correct it fast." eh="a29f59e5" />
-    <e k="sf_guide_p5_44" v="Penalties stack: POOR N + FAIR P = severe loss." eh="5536d718" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer — Field Guide" eh="e1bb101e" />
-    <e k="sf_guide_tab_1" v="OVERVIEW" eh="21f04df7" />
-    <e k="sf_guide_tab_2" v="HUD GUIDE" eh="d285eed7" />
-    <e k="sf_guide_tab_3" v="WORKFLOW" eh="a3f6045a" />
-    <e k="sf_guide_tab_4" v="PRODUCTS" eh="7589c616" />
-    <e k="sf_guide_tab_5" v="F.A.Q." eh="783fecdf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
+    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
+    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
+    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
+    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
+    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
+    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
     </elements>
 
 


### PR DESCRIPTION
## Summary

- Fixed weed pressure bar oscillating after partial herbicide spray (same-day application sticky against daily weedFactor read)
- Fixed Weeds/Pests/Disease % values misaligned — left-aligned after bar, matching N/P/K layout
- Updated French (fr) translation — community contribution by Seb
- Fixed version dialog not appearing when mod was previously disabled by PF incompatibility gate
- Fixed Precision Farming detection incorrectly triggering for users with PF installed but disabled in mod manager
- Fixed startup crash: `getFillTypesByCategoryNames` returns indices not descriptors — defensive handling added
- Fixed version dialog queued after risky init code — now queued first so crashes can't suppress it

## Test plan

- [ ] Load savegame — version dialog appears on first load after update
- [ ] With PF installed but disabled: mod runs normally, no incompatibility dialog
- [ ] With PF installed and enabled: incompatibility dialog fires correctly
- [ ] Weed pressure bar holds reduced value after herbicide spray (no oscillation)
- [ ] Weeds/Pests/Disease % text aligned left after bar
- [ ] No startup errors in log.txt