### PR TITLE
v2.2.5.0 hotfix + camera orbit fix + docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.2.5.0]
+
+### Fixed
+- Fixed weed pressure bar oscillating after partial herbicide spray (same-day sticky fix)
+- Fixed Weeds/Pests/Disease % values misaligned in HUD — values are now left-aligned after their bar, not offset by one row
+- Fixed version dialog not appearing when mod was previously disabled
+- Fixed Precision Farming detection incorrectly triggering for users with PF installed but disabled in mod manager
+- Fixed startup crash in fill type category lookup
+- Fixed version dialog suppressed by crashes during mod initialization
+
+### Translations
+- **French (fr)** — Community translation update
+
+---
+
+## [2.2.4.1]
+
+### Fixed
+- Fixed Weeds/Pests/Disease HUD bars rendering one row above their row labels (visual alignment regression from 2.2.4.0)
+
+---
+
+## [2.2.4.0]
+
+### Fixed
+- Fixed N and K starting at 90%+ on new saves (nutrient defaults now correctly initialize at N=50, P=33, K=38)
+- Fixed Pass% capping at ~50% after a full-field spray
+- Fixed Partial Width mode crediting inactive boom sections toward coverage
+- Fixed variable rate display oscillating when using MAP/P-type fertilizers
+- Fixed liquid lime draining the entire tank instantly
+- Fixed herbicide session coverage resetting between spray sessions
+- Fixed LIQUIDLIME remapping to the correct spray type
+- Fixed herbicide weed browning and protection window
+
+### Translations
+- **Danish (da)** — Translation update
+
+---
+
 ## [2.2.3.6]
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,9 @@ Thanks for your interest in contributing! This mod has a specific architecture �
 
 If you skip these and submit a PR that adds a setting without updating `SettingsSchema.lua`, or uses `goto` in Lua 5.1, the review will just send you back.
 
+> [!WARNING]
+> **This mod is NOT compatible with Precision Farming (FS25_precisionFarming).** The mod auto-detects PF and disables itself when PF is enabled. Do NOT submit PRs attempting to add PF compatibility — this is a permanent architectural decision. Players must choose one or the other. If PF is installed but disabled in the mod manager, our mod will run normally.
+
 ---
 
 ## Architecture in a Nutshell
@@ -67,7 +70,7 @@ Wrap anything that could fail in `pcall()`. Don't let hook errors propagate to t
 - Submit a PR that rewrites files you weren't asked to touch
 - Reorder existing entries in `SettingsSchema.definitions` — this breaks saves
 - Add a setting without its `_short` and `_long` translation keys in `modDesc.xml` (all 26 languages)
-- Commit the `.zip` directly — use `build.py` and let the release process handle it
+- Commit the `.zip` directly — use `py build.py --deploy` and let the release process handle it
 - Use `assert()` — use graceful error handling with user-facing dialogs instead
 
 ---

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 2.1.7.0
-**Last Updated**: 2026-05-14
+**Version**: 2.2.5.0
+**Last Updated**: 2026-05-30
 
 ---
 
@@ -34,7 +34,7 @@
 
 2. **Install to FS25**
    - Copy entire folder to `%USERPROFILE%\Documents\My Games\FarmingSimulator2025\mods\`
-   - Or run `bash build.sh --deploy` to build the zip and deploy automatically
+   - Or run `py build.py --deploy` to build the zip and deploy automatically
 
 3. **Enable Developer Console**
    - Edit `game.xml` in FS25 root
@@ -562,7 +562,7 @@ To create them:
 
 ```bash
 # Build zip and deploy to FS25 mods folder
-bash build.sh --deploy
+py build.py --deploy
 ```
 
 Check `log.txt` after launching — search for `[SoilFertilizer]` to verify load.
@@ -574,7 +574,7 @@ Check `log.txt` after launching — search for `[SoilFertilizer]` to verify load
 3. **Update version in `CLAUDE.md` Project Overview**
 4. **Update `CHANGELOG.md`** with all changes since last release
 5. **Update `README.md`** version line at the bottom
-6. **Build**: `bash build.sh --deploy`
+6. **Build**: `py build.py --deploy`
 7. **Test** in singleplayer and multiplayer
 8. **Commit** to `development` branch
 9. **PR** `development` → `main`

--- a/README.md
+++ b/README.md
@@ -27,33 +27,34 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 > [!TIP]
 > Want to be part of our community? Share tips, report issues, and chat with other farmers on the **[FS25 Modding Community Discord](https://discord.gg/Th2pnq36)**!
 
+> [!WARNING]
+> **Not compatible with Precision Farming (FS25_precisionFarming).** The mod automatically detects when Precision Farming is active and disables itself to prevent conflicts and data corruption. You must choose one or the other — they cannot run at the same time. If PF is installed but disabled in the mod manager, this mod will run normally.
+
 ---
 
-## 🆕 What's New in v2.2.3.x
+## 🆕 What's New in v2.2.5.0
 
-### Smart Sensor System
-A new in-vehicle panel appears when you're in a VWW-capable sprayer. It shows pest, disease, and nutrient sensor states for each boom section — and **blocks spraying on sections where no active need is detected**. Each sensor type (pest / disease / nutrient) has its own toggle via keybinds (Alt+1/2/3 by default, rebindable). Enable in **Settings → Admin → Smart Systems**.
+These are hotfixes over v2.2.4.1:
 
-### See & Spray System
-A second vehicle panel shows live per-cell pressure readings at the sprayer's current position — coloured bars that tell you in real time which sections of the boom are over cells that actually need treatment. Toggles per type via Alt+4/5/6.
+- Fixed weed pressure bar oscillating after partial herbicide spray (same-day sticky fix)
+- Fixed Weeds/Pests/Disease % values misaligned in HUD — values now correctly left-align after their bar
+- Updated French (fr) translation (community contribution)
+- Fixed version dialog not appearing when the mod was previously disabled
+- Fixed Precision Farming detection incorrectly triggering for users with PF installed but disabled in the mod manager
+- Fixed startup crash in fill type category lookup
+- Fixed version dialog being suppressed by crashes during mod initialization
 
-### Variable Rate Application
-A third vehicle panel shows per-section rate bars (green → yellow → red) and **automatically adjusts boom output rate** based on the soil deficit for the currently loaded product. Sections over well-stocked soil spray less; sections over depleted soil spray more. Toggle via Alt+7.
-
-### Free Panel Layout
-Enable **Free Panel Layout** in Settings → Display → Position to unlock independent positioning for all three smart system panels. Enter Shift+H edit mode and drag each panel to wherever you want it. Press **[−]** in any panel's title bar to collapse it to just the title bar — state is saved to `hud.xml` and restored on load.
-
-### v2.2.3.2 — Hotfix
-- System panels now collapse cleanly — stacked panels below no longer overlap when a panel above them is collapsed
-- System panels now hide when the main HUD is toggled off with the H key
-- Third-party fertilizers registered in the `fertilizer` fill category by map mods (e.g. POLIFOSKA on Etruria) now load into and refill from spreaders correctly
-
-### v2.2.3.1 — Hotfix
-- Fixed `sensorPanel` naming mismatch that prevented Smart Sensor panel from being dragged independently
-- Admin page Smart Systems / Vehicle Tools nav buttons moved to the top — they were previously cut off below the visible area
-- Disabled system panels now correctly contribute 0 height to stacked layout (no gaps)
-- System panels are now visible and draggable in Shift+H edit mode even without being in a sprayer
-- System panels are now correctly hidden when the SF settings panel (Shift+O) is open
+### v2.2.4.0 / v2.2.4.1
+- Fixed N and K starting at 90%+ on new saves (defaults now correctly N=50, P=33, K=38)
+- Fixed Pass% capping at ~50% after a full-field spray
+- Fixed Partial Width mode crediting inactive boom sections
+- Fixed variable rate display oscillating with MAP/P-type fertilizers
+- Fixed liquid lime draining entire tank instantly
+- Fixed herbicide session coverage reset between sessions
+- Fixed Weeds/Pests/Disease HUD bars rendering one row above their labels
+- Fixed LIQUIDLIME remapping to the correct spray type
+- Fixed herbicide weed browning and protection window
+- Danish (da) translation update
 
 ---
 
@@ -358,6 +359,7 @@ All integrations are detected automatically at runtime and fail gracefully if th
 
 | Mod | Behaviour |
 |---|---|
+| **FS25_precisionFarming** | **Incompatible.** When Precision Farming is detected as active, this mod automatically disables itself at startup to prevent data corruption. Disable PF in the mod manager to use this mod instead. |
 | **FS25_SeasonalCropStress** | Soil pH and organic matter influence evapotranspiration rates per field. |
 | **FS25_NPCFavor** | NPC neighbour favour quests can reference your fields' soil state. |
 | **FS25_MoistureSystem** | Compatible — both mods use independent hooks. No conflicts. |

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -634,6 +634,10 @@ function SoilHUD:update(dt)
 
 
     if self.editMode then
+        -- Re-apply cursor lock every frame — the game resets cursor state each tick
+        if g_inputBinding and g_inputBinding.setShowMouseCursor then
+            g_inputBinding:setShowMouseCursor(true, true)
+        end
         if self.savedCamRotX ~= nil and getCamera and setRotation then
             local ok, cam = pcall(getCamera)
             if ok and cam and cam ~= 0 then

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,12 +24,6 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed N and K starting at 90%+ on new saves (tuning defaults now start at fair range)",
-    "- Fixed Pass% capping at ~50% after a full-field spray (crop polygon area used as denominator)",
-    "- Fixed Partial Width mode crediting inactive boom sections toward Pass% coverage",
-    "- Fixed variable rate display oscillating rapidly with MAP / P-type fertilizers (smoothed)",
-    "- Fixed liquid lime draining entire tank in seconds (spray type index corrected)",
-    "- Updated Danish (da) guide translation — Guide dialog now fully in Danish",
     "- Fixed herbicide session coverage reset (second spray no longer instant-triggers on first tick)",
     "- Fixed Weeds/Pests/Disease HUD bars rendering one row above their labels",
     "- Fixed weed pressure bar oscillating after partial herbicide spray (same-day application now sticky)",


### PR DESCRIPTION
## Summary

- Fixed HUD edit mode camera orbiting — cursor lock now re-applied every frame (matches SoilSettingsPanel pattern)
- Fixed weed pressure bar oscillating after partial herbicide spray
- Fixed Weeds/Pests/Disease % value alignment in HUD
- Fixed version dialog not appearing when mod was previously disabled
- Fixed Precision Farming detection for installed-but-disabled PF
- Fixed startup crash in fill type category lookup
- Updated French translation (community contribution)
- Full documentation update: README, CHANGELOG, CONTRIBUTING, DEVELOPMENT, all 14 wiki pages

## Test plan

- [ ] Enter HUD edit mode (Shift+H) — camera should not orbit when moving mouse
- [ ] Load savegame — version dialog appears
- [ ] PF installed but disabled — mod runs normally, no incompatibility dialog
- [ ] PF installed and enabled — incompatibility dialog fires correctly
- [ ] No errors in log.txt on load