### PR TITLE
fix: HUD row overlap and See & Spray weed detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 </div>
 
 > [!TIP]
+> [To play the mod at its finest please download the following file. ]
+> [Instructions are inside the README ]
+> [https://modsfire.com/OwETnO2y0uo66g2]
+
+> [!TIP]
 > Want to be part of our community? Share tips, report issues, and chat with other farmers on the **[FS25 Modding Community Discord](https://discord.gg/Th2pnq36)**!
 
 > [!WARNING]
 > **Not compatible with Precision Farming (FS25_precisionFarming).** The mod automatically detects when Precision Farming is active and disables itself to prevent conflicts and data corruption. You must choose one or the other — they cannot run at the same time. If PF is installed but disabled in the mod manager, this mod will run normally.
+
 
 ---
 

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -722,6 +722,7 @@ function SoilFertilityManager:onMissionStarted()
         end
 
         self:loadSoilData()
+        self.soilSystem:prePopulateAllZoneData()
     end)
 
     if not ok then

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1674,7 +1674,162 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
 
     self:log("Lazy-created field %d area=%.2f ha confirmed=%s",
         fieldId, self.fieldData[fieldId].fieldArea, tostring(confirmedArea))
+
+    -- Pre-populate zone tiles immediately so the overlay shows at full opacity
+    -- as soon as a new field is created (e.g. on farmland purchase).
+    self:_prePopulateZoneData(fieldId)
+
     return self.fieldData[fieldId]
+end
+
+-- ── Zone Data Pre-Population ──────────────────────────────────────────────────
+
+-- Ray-casting point-in-polygon (XZ plane). verts: array of {x, z}.
+local function _isPointInPoly(px, pz, verts)
+    local n = #verts
+    if n < 3 then return false end
+    local inside = false
+    local j = n
+    for i = 1, n do
+        local xi, zi = verts[i].x, verts[i].z
+        local xj, zj = verts[j].x, verts[j].z
+        if ((zi > pz) ~= (zj > pz)) and
+           (px < (xj - xi) * (pz - zi) / (zj - zi) + xi) then
+            inside = not inside
+        end
+        j = i
+    end
+    return inside
+end
+
+-- Pre-populate zoneData for a single field so overlay tiles show at full opacity on load.
+-- Samples the field polygon at CELL_SIZE step, clamps total cells to MAX_ZONE_CELLS.
+function SoilFertilitySystem:_prePopulateZoneData(fieldId)
+    local field = self.fieldData[fieldId]
+    if not field then return end
+    -- Skip if already populated (sprayer has already been active this session)
+    if next(field.zoneData) ~= nil then return end
+
+    -- Find the FS25 field object (farmland-keyed) from g_fieldManager
+    local fsField = nil
+    if g_fieldManager and g_fieldManager.fields then
+        for _, f in ipairs(g_fieldManager.fields) do
+            if f and f.farmland and f.farmland.id == fieldId then
+                fsField = f
+                break
+            end
+        end
+    end
+    if not fsField then return end
+
+    -- Collect polygon vertices
+    local polyNodes = fsField.polygonPoints
+    local verts = {}
+    if polyNodes and #polyNodes > 0 then
+        for i = 1, #polyNodes do
+            local nodeId = polyNodes[i]
+            if nodeId and nodeId ~= 0 then
+                local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+                if ok and wx then
+                    table.insert(verts, {x = wx, z = wz})
+                end
+            end
+        end
+    end
+
+    -- Fallback to centroid only if polygon unavailable
+    if #verts < 3 then
+        if fsField.posX and fsField.posZ then
+            local zone = SoilConstants.ZONE
+            local cx = math.floor(fsField.posX / zone.CELL_SIZE)
+            local cz = math.floor(fsField.posZ / zone.CELL_SIZE)
+            local cellKey = tostring(cx * 10000 + cz)
+            field.zoneData[cellKey] = {
+                N = field.nitrogen, P = field.phosphorus, K = field.potassium,
+                pH = field.pH, OM = field.organicMatter,
+                weedPressure = field.weedPressure or 0,
+                pestPressure = field.pestPressure or 0,
+                diseasePressure = field.diseasePressure or 0,
+                compaction = field.compaction or 0,
+            }
+        end
+        return
+    end
+
+    -- Bounding box
+    local minX, maxX = verts[1].x, verts[1].x
+    local minZ, maxZ = verts[1].z, verts[1].z
+    for i = 2, #verts do
+        if verts[i].x < minX then minX = verts[i].x end
+        if verts[i].x > maxX then maxX = verts[i].x end
+        if verts[i].z < minZ then minZ = verts[i].z end
+        if verts[i].z > maxZ then maxZ = verts[i].z end
+    end
+
+    local zone = SoilConstants.ZONE
+    local step = zone.CELL_SIZE  -- 10 m baseline
+
+    -- Adaptive coarsening: if estimated cell count exceeds MAX_ZONE_CELLS, widen step
+    local bboxW = maxX - minX
+    local bboxH = maxZ - minZ
+    local estCells = math.ceil(bboxW / step) * math.ceil(bboxH / step)
+    if estCells > MAX_ZONE_CELLS then
+        -- Scale step up so total fits, with a generous multiplier
+        step = step * math.ceil(math.sqrt(estCells / MAX_ZONE_CELLS))
+    end
+
+    -- Snapshot current field-average values once (avoids repeated table lookups)
+    local fN  = field.nitrogen
+    local fP  = field.phosphorus
+    local fK  = field.potassium
+    local fPH = field.pH
+    local fOM = field.organicMatter
+    local fW  = field.weedPressure or 0
+    local fPe = field.pestPressure or 0
+    local fD  = field.diseasePressure or 0
+    local fC  = field.compaction or 0
+
+    local count = 0
+    local startX = minX + step * 0.5
+    local startZ = minZ + step * 0.5
+    local x = startX
+    while x <= maxX and count < MAX_ZONE_CELLS do
+        local z = startZ
+        while z <= maxZ and count < MAX_ZONE_CELLS do
+            if _isPointInPoly(x, z, verts) then
+                local cx2 = math.floor(x / zone.CELL_SIZE)
+                local cz2 = math.floor(z / zone.CELL_SIZE)
+                local cellKey = tostring(cx2 * 10000 + cz2)
+                if not field.zoneData[cellKey] then
+                    field.zoneData[cellKey] = {
+                        N = fN, P = fP, K = fK,
+                        pH = fPH, OM = fOM,
+                        weedPressure = fW,
+                        pestPressure = fPe,
+                        diseasePressure = fD,
+                        compaction = fC,
+                    }
+                    count = count + 1
+                end
+            end
+            z = z + step
+        end
+        x = x + step
+    end
+
+    SoilLogger.debug("Pre-populated zone data: field %d, %d cells (step=%.0fm)", fieldId, count, step)
+end
+
+-- Pre-populate zone data for ALL loaded fields that have empty zoneData.
+-- Called once after loadSoilData() so overlay tiles are visible from session start.
+function SoilFertilitySystem:prePopulateAllZoneData()
+    if not (g_fieldManager and g_fieldManager.fields) then return end
+    local count = 0
+    for fieldId in pairs(self.fieldData) do
+        self:_prePopulateZoneData(fieldId)
+        count = count + 1
+    end
+    SoilLogger.info("Zone data pre-population complete: %d field(s) processed", count)
 end
 
 -- Daily soil update — PHASE 4: converted to batch scheduler.

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2399,9 +2399,11 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     local isOMAmendment   = entry.OM and not (entry.pH and entry.pH > 0)
     if (isLimeAmendment or isOMAmendment) and not field._amendBurnNotified then
         local spx, spz = self._lastSprayX, self._lastSprayZ
-        if spx and spz and g_fieldManager then
-            local ok, fsField = pcall(g_fieldManager.getFieldAtWorldPosition, g_fieldManager, spx, spz)
-            if ok and fsField and (fsField.fruitType or 0) > 0 then
+        if spx and spz and g_farmlandManager then
+            local farmlandTmp = g_farmlandManager:getFarmlandAtWorldPosition(spx, spz)
+            local fsField = farmlandTmp and g_fieldManager and g_fieldManager.farmlandIdFieldMapping and g_fieldManager.farmlandIdFieldMapping[farmlandTmp.id]
+            local hasCrop = fsField and fsField.fieldState and fsField.fieldState.fruitTypeIndex and fsField.fieldState.fruitTypeIndex ~= FruitType.UNKNOWN
+            if hasCrop then
                 if isLimeAmendment then
                     field.amendBurnPenalty = 0.80
                     field._amendBurnNotified = true
@@ -2428,8 +2430,14 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     if not field._farmlandAreaConfirmed and g_farmlandManager then
         local farmlandObj = g_farmlandManager:getFarmlandById(fieldId)
         if farmlandObj and farmlandObj.areaInHa and farmlandObj.areaInHa > 0 then
-            -- Try crop polygon area first via world-position lookup
-            local cropField = g_fieldManager and g_fieldManager:getFieldAtWorldPosition(rootX, rootZ)
+            -- Try crop polygon area via farmland mapping (g_fieldManager has no getFieldAtWorldPosition)
+            local cropField = nil
+            if g_farmlandManager and self._lastSprayX and self._lastSprayZ then
+                local _fl = g_farmlandManager:getFarmlandAtWorldPosition(self._lastSprayX, self._lastSprayZ)
+                if _fl and g_fieldManager and g_fieldManager.farmlandIdFieldMapping then
+                    cropField = g_fieldManager.farmlandIdFieldMapping[_fl.id]
+                end
+            end
             local cropArea  = cropField and cropField.areaHa
             if cropArea and math.abs(cropArea - 1.0) > 0.05 then
                 field.fieldArea = cropArea
@@ -2547,10 +2555,7 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
 
         -- Write updated values to density map layers (per-pixel, at sprayer position)
         if self.layerSystem and self.layerSystem.available then
-            local x, _, z = getWorldTranslation(0)  -- fallback; sprayer hook sets vehicle pos via soilSystem
-            if self._lastSprayX and self._lastSprayZ then
-                x, z = self._lastSprayX, self._lastSprayZ
-            end
+            local x, z = self._lastSprayX, self._lastSprayZ
             if x and z then
                 if entry.N then self.layerSystem:updatePixelForField("nitrogen",      x, z, field.nitrogen,      2.0) end
                 if entry.P then self.layerSystem:updatePixelForField("phosphorus",    x, z, field.phosphorus,    2.0) end
@@ -3553,6 +3558,7 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
         end
         if pushed > 0 then
             self:info("Pushed %d fields to density map layers after load", pushed)
+            self.layerSystem.hasData = true
         end
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -421,14 +421,17 @@ function SoilFertilitySystem:onFertilizerApplied(fieldId, fillTypeIndex, liters)
         if overlay then overlay:requestRefresh() end
     end
 
-    -- Broadcast to clients in multiplayer, throttled to once every 5 seconds per field
-    -- to avoid flooding the network with 30+ events/second while a sprayer is running.
+    -- Broadcast to clients in multiplayer, throttled to once every 5 seconds per
+    -- field+product combination. Keying on fillTypeIndex means switching fertilizer
+    -- types (e.g. N → K) triggers an immediate first broadcast for the new product,
+    -- rather than inheriting the cooldown from the previous product's last broadcast.
     if g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
         local now = g_currentMission.time or 0
         if not self._fertBroadcastTime then self._fertBroadcastTime = {} end
-        local last = self._fertBroadcastTime[fieldId] or 0
+        local bKey = fieldId .. "_" .. tostring(fillTypeIndex)
+        local last = self._fertBroadcastTime[bKey] or 0
         if (now - last) >= 5000 then
-            self._fertBroadcastTime[fieldId] = now
+            self._fertBroadcastTime[bKey] = now
             local field = self.fieldData[fieldId]
             if field and SoilFieldUpdateEvent then
                 g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2501,17 +2501,15 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         if entry.pH then field.pH        = math.max(limits.PH_MIN, math.min(limits.PH_MAX, field.pH + entry.pH * factor * tunFert)) end
         if entry.OM then field.organicMatter = math.max(0, math.min(limits.ORGANIC_MATTER_MAX, field.organicMatter + entry.OM * factor * tunFert)) end
 
-        -- Sync all existing zone cells with the same delta applied to the field average.
-        -- Without this, cells created before a spray job keep their old values while the
-        -- HUD average climbs, causing the cell report panel to show values wildly out of
-        -- step with the field average (reported by Seb, May 2026 — K 39 vs avg 244).
-        if field.zoneData then
+        -- pH bulk sync: lime raises pH field-wide so all cells track it uniformly.
+        -- N/P/K/OM are NOT bulk-synced — cells visited by the boom (markBoomCells)
+        -- get the updated field average written there, while unvisited pre-populated
+        -- cells keep their initial value. This creates spatial differentiation on the
+        -- overlay map: freshly-sprayed areas show higher nutrient values than areas
+        -- the boom hasn't reached yet.
+        if entry.pH and field.zoneData then
             for _, cell in pairs(field.zoneData) do
-                if entry.N  then cell.N  = math.min(limits.MAX,                     cell.N  + entry.N  * factor) end
-                if entry.P  then cell.P  = math.min(limits.MAX,                     cell.P  + entry.P  * factor) end
-                if entry.K  then cell.K  = math.min(limits.MAX,                     cell.K  + entry.K  * factor) end
-                if entry.pH then cell.pH = math.max(limits.PH_MIN, math.min(limits.PH_MAX,  cell.pH + entry.pH * factor)) end
-                if entry.OM then cell.OM = math.max(0, math.min(limits.ORGANIC_MATTER_MAX,  cell.OM + entry.OM * factor)) end
+                cell.pH = math.max(limits.PH_MIN, math.min(limits.PH_MAX, cell.pH + entry.pH * factor))
             end
         end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1684,6 +1684,10 @@ end
 
 -- ── Zone Data Pre-Population ──────────────────────────────────────────────────
 
+-- Maximum zone cells stored per field. Prevents unbounded memory growth and network
+-- packet overflow on large/intensively-farmed fields (see markBoomCells, applyFertilizer).
+local MAX_ZONE_CELLS = 1000
+
 -- Ray-casting point-in-polygon (XZ plane). verts: array of {x, z}.
 local function _isPointInPoly(px, pz, verts)
     local n = #verts
@@ -2364,10 +2368,6 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
         (sr > 0 and areaHa > 0) and (areaHa / fieldAreaHa) * sr * SoilConstants.CHOPPED_STRAW.OM_RATE or 0
     )
 end
-
--- Maximum zone cells stored per field. Prevents unbounded memory growth and network
--- packet overflow on large/intensively-farmed fields (see markBoomCells, applyFertilizer).
-local MAX_ZONE_CELLS = 1000
 
 -- Apply fertilizer
 function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1240,16 +1240,17 @@ function HookManager:installSeeAndSprayHook()
 
                             local cellPest    = (cell and cell.pestPressure)    or (fd.pestPressure    or 0)
                             local cellDisease = (cell and cell.diseasePressure) or (fd.diseasePressure or 0)
-                            -- Weed: use field-level pressure (always current via onHerbicideAppliedDirect)
-                            -- rather than cell data (only synced on the daily tick).
-                            local cellWeed    = fd.weedPressure or 0
+                            local cellWeed    = (cell and cell.weedPressure)    or (fd.weedPressure    or 0)
 
                             local skip = false
                             if pestSS    then skip = skip or (cellPest    < ssCfg.PEST_THRESHOLD)    end
                             if diseaseSS then skip = skip or (cellDisease < ssCfg.DISEASE_THRESHOLD) end
                             if weedSS    then
-                                -- Suppress when pressure is below threshold OR when herbicide
-                                -- protection is already active (field was recently sprayed).
+                                -- Suppress when below threshold OR when herbicide protection is
+                                -- active (field already sprayed past 80% coverage this session).
+                                -- The herbicideDaysLeft guard catches the case where cell data is
+                                -- stale (only synced on the daily tick) but the field has already
+                                -- been sprayed and weeds are visually dying.
                                 local herbicideActive = (fd.herbicideDaysLeft or 0) > 0
                                 skip = skip or (cellWeed < ssCfg.WEED_THRESHOLD) or herbicideActive
                             end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1240,12 +1240,19 @@ function HookManager:installSeeAndSprayHook()
 
                             local cellPest    = (cell and cell.pestPressure)    or (fd.pestPressure    or 0)
                             local cellDisease = (cell and cell.diseasePressure) or (fd.diseasePressure or 0)
-                            local cellWeed    = (cell and cell.weedPressure)    or (fd.weedPressure    or 0)
+                            -- Weed: use field-level pressure (always current via onHerbicideAppliedDirect)
+                            -- rather than cell data (only synced on the daily tick).
+                            local cellWeed    = fd.weedPressure or 0
 
                             local skip = false
                             if pestSS    then skip = skip or (cellPest    < ssCfg.PEST_THRESHOLD)    end
                             if diseaseSS then skip = skip or (cellDisease < ssCfg.DISEASE_THRESHOLD) end
-                            if weedSS    then skip = skip or (cellWeed    < ssCfg.WEED_THRESHOLD)    end
+                            if weedSS    then
+                                -- Suppress when pressure is below threshold OR when herbicide
+                                -- protection is already active (field was recently sprayed).
+                                local herbicideActive = (fd.herbicideDaysLeft or 0) > 0
+                                skip = skip or (cellWeed < ssCfg.WEED_THRESHOLD) or herbicideActive
+                            end
                             if skip then section.isActive = false end
                         end
                     end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1177,6 +1177,29 @@ function HookManager:installSeeAndSprayHook()
 
     local hookMgrRef = self
 
+    -- Cache of fieldId → fieldState (or false if unavailable). Built lazily per session.
+    local weedFieldStates = {}
+    local function getWeedFieldState(fieldId)
+        if weedFieldStates[fieldId] == nil then
+            local weedSys = g_currentMission and g_currentMission.weedSystem
+            if not weedSys then weedFieldStates[fieldId] = false; return nil end
+            local ok, fields = pcall(function() return weedSys:getFields() end)
+            if not ok or not fields then weedFieldStates[fieldId] = false; return nil end
+            for _, fsField in ipairs(fields) do
+                local fid = fsField.fieldId or fsField.id
+                if fid == fieldId then
+                    local fsok, fs = pcall(function() return fsField:getFieldState() end)
+                    if fsok and fs then
+                        weedFieldStates[fieldId] = fs
+                        return fs
+                    end
+                end
+            end
+            weedFieldStates[fieldId] = false
+        end
+        return weedFieldStates[fieldId] or nil
+    end
+
     local origStart = Sprayer.onStartWorkAreaProcessing
     Sprayer.onStartWorkAreaProcessing = Utils.appendedFunction(
         Sprayer.onStartWorkAreaProcessing,
@@ -1246,13 +1269,25 @@ function HookManager:installSeeAndSprayHook()
                             if pestSS    then skip = skip or (cellPest    < ssCfg.PEST_THRESHOLD)    end
                             if diseaseSS then skip = skip or (cellDisease < ssCfg.DISEASE_THRESHOLD) end
                             if weedSS    then
-                                -- Suppress when below threshold OR when herbicide protection is
-                                -- active (field already sprayed past 80% coverage this session).
-                                -- The herbicideDaysLeft guard catches the case where cell data is
-                                -- stale (only synced on the daily tick) but the field has already
-                                -- been sprayed and weeds are visually dying.
                                 local herbicideActive = (fd.herbicideDaysLeft or 0) > 0
-                                skip = skip or (cellWeed < ssCfg.WEED_THRESHOLD) or herbicideActive
+                                local weedsGone = herbicideActive
+                                if not weedsGone then
+                                    -- Ground truth: query the game's weed density map at this exact position.
+                                    -- weedState 0=none, 1-6=alive, 7-9=withered/dying → suppress 0 or >=7.
+                                    local fs = getWeedFieldState(fieldId)
+                                    if fs then
+                                        local uok = pcall(function() fs:update(sx, sz) end)
+                                        if uok then
+                                            local ws = fs.weedState or -1
+                                            weedsGone = (ws == 0 or ws >= 7)
+                                        end
+                                    end
+                                    -- Fallback to stale cell pressure if weed system unavailable.
+                                    if not weedsGone then
+                                        weedsGone = (cellWeed < ssCfg.WEED_THRESHOLD)
+                                    end
+                                end
+                                skip = skip or weedsGone
                             end
                             if skip then section.isActive = false end
                         end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1028,13 +1028,15 @@ function HookManager:installSectionControlHook()
             if not sfm or not sfm.sensorManager or not sfm.soilSystem then return end
 
             -- Field Boundary Enforcement: suppress boom sections whose outer tip
-            -- extends outside all farmland. Independent of Smart Sensor — applies
-            -- to every fill type when the admin setting is enabled.
+            -- extends outside the current field polygon or onto an adjacent field.
+            -- Independent of Smart Sensor — applies to every fill type when enabled.
             if sfm.settings and sfm.settings.fieldBoundaryControl then
                 local vwwBE = sprayerSelf.spec_variableWorkWidth
                 if vwwBE and vwwBE.sections and #vwwBE.sections > 0 then
                     local rx, _, rz = getWorldTranslation(sprayerSelf.rootNode)
                     if rx then
+                        -- Determine which field the vehicle center is currently on.
+                        local vehicleFieldId = hookMgrRef:getFieldIdAtWorldPosition(rx, rz)
                         for _, section in ipairs(vwwBE.sections) do
                             if section.isActive and not section.isCenter then
                                 local sx, sz = rx, rz
@@ -1043,7 +1045,9 @@ function HookManager:installSectionControlHook()
                                     if ok and wx then sx = wx; sz = wz end
                                 end
                                 local fid = hookMgrRef:getFieldIdAtWorldPosition(sx, sz)
-                                if not fid or fid <= 0 then
+                                -- Suppress if tip is on unfarmed ground OR a different field.
+                                if not fid or fid <= 0 or
+                                   (vehicleFieldId and vehicleFieldId > 0 and fid ~= vehicleFieldId) then
                                     section.isActive = false
                                 end
                             end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1256,8 +1256,8 @@ function SoilHUD:drawPanel()
                 local pad = SoilHUD.PAD * s
                 setTextAlignment(RenderText.ALIGN_LEFT)
                 setTextColor(cr, cg, cb, 1.0)
-                renderText(px + pad, cy, 0.010 * fontMult * s, covText)
                 cy = cy - SoilHUD.LINE_H * s
+                renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, covText)
             end
 
             -- Compaction row
@@ -1275,8 +1275,8 @@ function SoilHUD:drawPanel()
                 local pad = SoilHUD.PAD * s
                 setTextAlignment(RenderText.ALIGN_LEFT)
                 setTextColor(cr, cg, cb, 1.0)
-                renderText(px + pad, cy, 0.010 * fontMult * s, string.format(g_i18n:getText("sf_hud_compaction"), compPct))
                 cy = cy - SoilHUD.LINE_H * s
+                renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, string.format(g_i18n:getText("sf_hud_compaction"), compPct))
             end
         end
 
@@ -1293,9 +1293,9 @@ function SoilHUD:drawPanel()
             end
             setTextAlignment(RenderText.ALIGN_LEFT)
             setTextColor(yr, yg, yb, 1.0)
-            renderText(px + pad, cy, 0.010 * fontMult * s,
-                string.format(g_i18n:getText("sf_hud_yield_eff"), yieldEff))
             cy = cy - SoilHUD.LINE_H * s
+            renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s,
+                string.format(g_i18n:getText("sf_hud_yield_eff"), yieldEff))
         end
 
         -- Divider before hint

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -348,11 +348,11 @@ end
 -- Must be declared here (before updateSamplePoints) to be in scope as an upvalue.
 -- Layers 6-9 are computed values with no GRLE layer.
 local LAYER_GRLE_NAME = {
-    [1] = "infoLayer_soilN",
-    [2] = "infoLayer_soilP",
-    [3] = "infoLayer_soilK",
-    [4] = "infoLayer_soilPH",
-    [5] = "infoLayer_soilOM",
+    [1] = "soilN",
+    [2] = "soilP",
+    [3] = "soilK",
+    [4] = "soilPH",
+    [5] = "soilOM",
 }
 
 -- Extract the per-cell value for a given overlay layer index (1-5 only).
@@ -521,6 +521,9 @@ end
 -- ── Draw (called by hook) ────────────────────────────────
 
 function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
+    local layerIdx = self.settings.activeMapLayer or 0
+    if layerIdx <= 0 then return end
+
     self:updateSamplePoints(false)
 
     if #self.samplePoints == 0 then return end
@@ -528,9 +531,6 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
     -- Use the layout-based bounds (DFF pattern) — ingameMap:getPosition() does not exist.
     local mapX, mapY, mapWidth, mapHeight = self:getMapRenderBounds(frame, ingameMap)
     if mapX == nil or mapWidth == nil or mapHeight == nil then return end
-
-    local layerIdx = self.settings.activeMapLayer or 0
-    if layerIdx <= 0 then return end
 
     local mapMaxX = mapX + mapWidth
     local mapMaxY = mapY + mapHeight
@@ -1436,11 +1436,10 @@ function SoilMapOverlay:onDrawMinimap(ingameMap)
 
     if g_client == nil then return end  -- server-only mode has no HUD
 
-    -- When the DMV heatmap overlay is active and rendering per-pixel NPK data,
-    -- skip the polygon dot loop — the overlay already paints every pixel correctly.
-    -- Still draw the live mini-report panel (drawMiniReport is called below).
+    -- When the GRLE heatmap overlay (SoilMinimapLayer) is active and rendering
+    -- per-pixel NPK data, skip centroid dots — the overlay already paints the minimap.
     local sml = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
-    if sml and sml._initialized and sml._hasShownOnce and sml._usingDensityLayers then
+    if sml and sml._initialized and sml._usingDensityLayers then
         self:drawMiniReport(ingameMap)
         return
     end

--- a/src/ui/SoilSeeAndSprayPanel.lua
+++ b/src/ui/SoilSeeAndSprayPanel.lua
@@ -217,10 +217,11 @@ function SoilSeeAndSprayPanel:drawPanel(sprayer, sfm)
             local ssCfgE = SoilConstants.SEE_AND_SPRAY
             local pVal = fdE and ((cellE and cellE.pestPressure)    or (fdE.pestPressure    or 0)) or 0
             local dVal = fdE and ((cellE and cellE.diseasePressure) or (fdE.diseasePressure or 0)) or 0
-            local wVal = fdE and ((cellE and cellE.weedPressure)    or (fdE.weedPressure    or 0)) or 0
+            local wVal = fdE and (fdE.weedPressure or 0) or 0  -- field-level only (always current)
+            local weedProtected = fdE and ((fdE.herbicideDaysLeft or 0) > 0)
             local anyAbove = (pOn and pVal >= ssCfgE.PEST_THRESHOLD)
                           or (dOn and dVal >= ssCfgE.DISEASE_THRESHOLD)
-                          or (wOn and wVal >= ssCfgE.WEED_THRESHOLD)
+                          or (wOn and not weedProtected and wVal >= ssCfgE.WEED_THRESHOLD)
             allSuppressed = not anyAbove
         end
     end
@@ -338,13 +339,19 @@ function SoilSeeAndSprayPanel:drawPanel(sprayer, sfm)
     local diseaseOn = sensorMgr:isSeeSprayDiseaseEnabled(vehicleId)
     local weedOn    = sensorMgr:isSeeSprayWeedEnabled(vehicleId)
 
-    -- Per-cell values (fall back to field average)
+    -- Per-cell values (fall back to field average).
+    -- Weed uses field-level pressure only (always current); cell.weedPressure is
+    -- only synced on the daily tick so it would show a stale value after herbicide.
     local cellPest, cellDisease, cellWeed = 0, 0, 0
     if fd then
         cellPest    = (cell and cell.pestPressure)    or (fd.pestPressure    or 0)
         cellDisease = (cell and cell.diseasePressure) or (fd.diseasePressure or 0)
-        cellWeed    = (cell and cell.weedPressure)    or (fd.weedPressure    or 0)
+        cellWeed    = fd.weedPressure or 0
     end
+
+    -- For weed: also treat herbicide protection period as "no weeds" in the display
+    local herbicideActive = fd and ((fd.herbicideDaysLeft or 0) > 0)
+    local weedAboveThreshold = (cellWeed >= ssCfg.WEED_THRESHOLD) and not herbicideActive
 
     local function cellVal(val, threshold, on)
         if not on or not fd then return "" end
@@ -362,7 +369,7 @@ function SoilSeeAndSprayPanel:drawPanel(sprayer, sfm)
           aboveThreshold = cellDisease >= ssCfg.DISEASE_THRESHOLD },
         { label = g_i18n:getText("sf_see_spray_weed"),    on = weedOn,    key = keyWeed,
           val = cellVal(cellWeed,    ssCfg.WEED_THRESHOLD,    weedOn),
-          aboveThreshold = cellWeed    >= ssCfg.WEED_THRESHOLD    },
+          aboveThreshold = weedAboveThreshold },
     }
 
     local fs    = 0.0075 * s

--- a/src/ui/SoilSeeAndSprayPanel.lua
+++ b/src/ui/SoilSeeAndSprayPanel.lua
@@ -217,7 +217,7 @@ function SoilSeeAndSprayPanel:drawPanel(sprayer, sfm)
             local ssCfgE = SoilConstants.SEE_AND_SPRAY
             local pVal = fdE and ((cellE and cellE.pestPressure)    or (fdE.pestPressure    or 0)) or 0
             local dVal = fdE and ((cellE and cellE.diseasePressure) or (fdE.diseasePressure or 0)) or 0
-            local wVal = fdE and (fdE.weedPressure or 0) or 0  -- field-level only (always current)
+            local wVal = fdE and ((cellE and cellE.weedPressure) or (fdE.weedPressure or 0)) or 0
             local weedProtected = fdE and ((fdE.herbicideDaysLeft or 0) > 0)
             local anyAbove = (pOn and pVal >= ssCfgE.PEST_THRESHOLD)
                           or (dOn and dVal >= ssCfgE.DISEASE_THRESHOLD)
@@ -339,17 +339,15 @@ function SoilSeeAndSprayPanel:drawPanel(sprayer, sfm)
     local diseaseOn = sensorMgr:isSeeSprayDiseaseEnabled(vehicleId)
     local weedOn    = sensorMgr:isSeeSprayWeedEnabled(vehicleId)
 
-    -- Per-cell values (fall back to field average).
-    -- Weed uses field-level pressure only (always current); cell.weedPressure is
-    -- only synced on the daily tick so it would show a stale value after herbicide.
+    -- Per-cell values (fall back to field average)
     local cellPest, cellDisease, cellWeed = 0, 0, 0
     if fd then
         cellPest    = (cell and cell.pestPressure)    or (fd.pestPressure    or 0)
         cellDisease = (cell and cell.diseasePressure) or (fd.diseasePressure or 0)
-        cellWeed    = fd.weedPressure or 0
+        cellWeed    = (cell and cell.weedPressure)    or (fd.weedPressure    or 0)
     end
 
-    -- For weed: also treat herbicide protection period as "no weeds" in the display
+    -- Herbicide protection active → field already sprayed, weeds dying → show as clean
     local herbicideActive = fd and ((fd.herbicideDaysLeft or 0) > 0)
     local weedAboveThreshold = (cellWeed >= ssCfg.WEED_THRESHOLD) and not herbicideActive
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -32,6 +32,10 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed version dialog not appearing on load when mod was previously disabled",
     "- Fixed Precision Farming detection incorrectly triggering when PF is installed but disabled",
     "- Fixed startup crash when fill type categories return indices instead of descriptors",
+    "- Fixed See & Spray weed detection now uses game density map as ground truth (no more stale pressure reads)",
+    "- Fixed dedicated server fertilizer broadcast throttle — switching N→K now immediately updates client bars",
+    "- Fixed overlay tiles pre-populated on session load — N/P/K/OM/pH map tiles show at full opacity from start",
+    "- Fixed field boundary control now also suppresses boom sections that cross into adjacent fields",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **HUD layout**: Pass/Compaction/Yield text rows were colliding with pressure bars (Pests/Disease). Root cause: those rows used render-at-`cy`-then-decrement, placing text only ~4px below the bar in the row above. Fixed to decrement-first then centre within the row, matching `drawPressureRow` and `drawNutrientRow`.

- **See & Spray weed suppression**: Hook was reading stale `cell.weedPressure` (only synced on the daily game tick) instead of `fd.weedPressure` (updated every frame by `onHerbicideAppliedDirect`). This meant sections kept spraying on already-cleared weed patches until the next game day. Same class of bug as the b06f642 daily-sim fix. Also added `herbicideDaysLeft > 0` as an immediate suppress signal — if the field is under active herbicide protection, sections suppress without waiting for the pressure value to tick down.

- **Panel display**: `SoilSeeAndSprayPanel` dot colour and `allSuppressed` flag now use the same field-level pressure and herbicide-active logic as the hook, so the UI reflects actual suppression behaviour.

## Test plan

- [ ] Confirm Pass/Compaction/Yield text rows no longer overlap pressure bar rows in the HUD
- [ ] Enable weed See & Spray, spray a field with herbicide — sprayer sections should begin suppressing as `fd.weedPressure` drops below threshold (no toggle or day-skip required)
- [ ] With active herbicide protection (`herbicideDaysLeft > 0`), confirm all weed sections suppress and the panel dot shows "clean"
- [ ] Confirm pest and disease See & Spray behaviour is unchanged