### PR TITLE
v2.2.6.0 — overlay fixes, HUD polish, crash fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.5.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.6.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 
 </div>
 
-> [!TIP]
-> [To play the mod at its finest please download the following file. ]
-> [Instructions are inside the README ]
-> [https://modsfire.com/OwETnO2y0uo66g2]
+> [!WARNING]
+> **Companion asset pack required for the full experience.**
+> Custom fertilizer bag models and additional assets are not bundled in the main mod download.
+> [Download the companion pack here](https://modsfire.com/OwETnO2y0uo66g2) — installation instructions are included inside the archive.
 
 > [!TIP]
 > Want to be part of our community? Share tips, report issues, and chat with other farmers on the **[FS25 Modding Community Discord](https://discord.gg/Th2pnq36)**!
 
-> [!WARNING]
-> **Not compatible with Precision Farming (FS25_precisionFarming).** The mod automatically detects when Precision Farming is active and disables itself to prevent conflicts and data corruption. You must choose one or the other — they cannot run at the same time. If PF is installed but disabled in the mod manager, this mod will run normally.
+> [!CAUTION]
+> **Not compatible with Precision Farming (FS25_precisionFarming).** The mod automatically detects when Precision Farming is active and disables itself to prevent conflicts and data corruption. You must choose one or the other — they cannot run at the same time.
 
 
 ---

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.5.0</version>
+    <version>2.2.6.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -171,7 +171,7 @@ SettingsSchema.definitions = {
         default = 2,  -- 1=Arid, 2=Temperate, 3=Humid, 4=Wet
         min = 1,
         max = 4,
-        uiId = "sf_disease_moisture",
+        uiId = "sf_dm",
     },
     {
         id = "compactionEnabled",

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1222,16 +1222,16 @@ function SoilHUD:drawPanel()
         -- Weed / pest / disease pressure rows
         local mgr = g_SoilFertilityManager
         if mgr then
-            if mgr.settings.weedPressure then
-                cy = self:drawPressureRow("sf_hud_weeds", info.weedPressure or 0,
+            if mgr.settings.weedPressure and (info.weedPressure or 0) > 0 then
+                cy = self:drawPressureRow("sf_hud_weeds", info.weedPressure,
                     info.herbicideActive, px, cy, pw, s, fontMult)
             end
-            if mgr.settings.pestPressure then
-                cy = self:drawPressureRow("sf_hud_pests", info.pestPressure or 0,
+            if mgr.settings.pestPressure and (info.pestPressure or 0) > 0 then
+                cy = self:drawPressureRow("sf_hud_pests", info.pestPressure,
                     info.insecticideActive, px, cy, pw, s, fontMult)
             end
-            if mgr.settings.diseasePressure then
-                cy = self:drawPressureRow("sf_hud_disease", info.diseasePressure or 0,
+            if mgr.settings.diseasePressure and (info.diseasePressure or 0) > 0 then
+                cy = self:drawPressureRow("sf_hud_disease", info.diseasePressure,
                     info.fungicideActive, px, cy, pw, s, fontMult)
             end
 

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -40,7 +40,7 @@ local SoilLayerSystem_mt = Class(SoilLayerSystem)
 -- ─────────────────────────────────────────────────────────
 local LAYER_DEFS = {
     {
-        name        = "infoLayer_soilN",
+        name        = "soilN",          -- i3d short name; engine saves as infoLayer_soilN.grle
         field       = "nitrogen",       -- key in fieldData
         minVal      = 0,
         maxVal      = 100,
@@ -48,7 +48,7 @@ local LAYER_DEFS = {
         numChannels = 8,
     },
     {
-        name        = "infoLayer_soilP",
+        name        = "soilP",
         field       = "phosphorus",
         minVal      = 0,
         maxVal      = 100,
@@ -56,7 +56,7 @@ local LAYER_DEFS = {
         numChannels = 8,
     },
     {
-        name        = "infoLayer_soilK",
+        name        = "soilK",
         field       = "potassium",
         minVal      = 0,
         maxVal      = 100,
@@ -64,7 +64,7 @@ local LAYER_DEFS = {
         numChannels = 8,
     },
     {
-        name        = "infoLayer_soilPH",
+        name        = "soilPH",
         field       = "pH",
         minVal      = 5.0,              -- FS25 soil pH never goes below 5
         maxVal      = 7.5,
@@ -72,7 +72,7 @@ local LAYER_DEFS = {
         numChannels = 8,
     },
     {
-        name        = "infoLayer_soilOM",
+        name        = "soilOM",
         field       = "organicMatter",
         minVal      = 0,
         maxVal      = 10,
@@ -196,7 +196,7 @@ function SoilLayerSystem:writeValueAtWorld(layerName, worldX, worldZ, value, rad
     local modifier  = entry.modifier
     local filter    = DensityMapFilter.new(modifier)
     -- No filter — write unconditionally to all pixels in radius
-    modifier:setParallelogramWorldCoords(worldX - r, worldZ - r, worldX + r, worldZ - r, worldX - r, worldZ + r, DensityCoordType.POINT)
+    modifier:setParallelogramWorldCoords(worldX - r, worldZ - r, worldX + r, worldZ - r, worldX - r, worldZ + r, DensityCoordType.POINT_POINT_POINT)
     modifier:executeSet(encoded, filter, nil)
 end
 
@@ -222,7 +222,7 @@ function SoilLayerSystem:readValueAtWorld(layerName, worldX, worldZ)
         worldX, worldZ,
         worldX + 0.1, worldZ,
         worldX, worldZ + 0.1,
-        DensityCoordType.POINT
+        DensityCoordType.POINT_POINT_POINT
     )
     local val, _, _ = modifier:executeGet(filter, nil)
     if val == nil then return nil end
@@ -289,7 +289,7 @@ function SoilLayerSystem:readAverageForFarmland(layerName, farmland)
             local wx = (cx - hw) + (xi / (STEPS - 1)) * (hw * 2)
             local wz = (cz - hh) + (zi / (STEPS - 1)) * (hh * 2)
 
-            modifier:setParallelogramWorldCoords(wx, wz, wx + 0.1, wz, wx, wz + 0.1, DensityCoordType.POINT)
+            modifier:setParallelogramWorldCoords(wx, wz, wx + 0.1, wz, wx, wz + 0.1, DensityCoordType.POINT_POINT_POINT)
             local val, _, _ = modifier:executeGet(filter, nil)
             if val ~= nil then
                 sum   = sum + val
@@ -356,7 +356,7 @@ function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, farmland)
                 cx - hw, cz - hh,
                 cx + hw, cz - hh,
                 cx - hw, cz + hh,
-                DensityCoordType.POINT
+                DensityCoordType.POINT_POINT_POINT
             )
             modifier:executeSet(encoded, filter, nil)
         end
@@ -399,7 +399,7 @@ function SoilLayerSystem:updatePixelForField(fieldKey, worldX, worldZ, newValue,
         worldX - radius, worldZ - radius,
         worldX + radius, worldZ - radius,
         worldX - radius, worldZ + radius,
-        DensityCoordType.POINT
+        DensityCoordType.POINT_POINT_POINT
     )
     modifier:executeSet(encoded, filter, nil)
 end

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -151,7 +151,7 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     local layerSystem = self.soilSystem and self.soilSystem.layerSystem
     local fieldKey    = LAYER_FIELD_KEYS[layerIdx]
 
-    if layerSystem and layerSystem.available and fieldKey then
+    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -36,6 +36,9 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed dedicated server fertilizer broadcast throttle — switching N→K now immediately updates client bars",
     "- Fixed overlay tiles pre-populated on session load — N/P/K/OM/pH map tiles show at full opacity from start",
     "- Fixed field boundary control now also suppresses boom sections that cross into adjacent fields",
+    "- Fixed nil comparison crash: zone cell pre-population constants now defined before use",
+    "- Fixed overlay zones now reflect true spatial differences — removed erroneous bulk N/P/K/OM sync",
+    "- Fixed FarmlandManager crash from nil world coordinates in sprayer boundary check",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## What's in this release

**Overlay & density map fixes**
- Layer names corrected to short form (`soilN`, `soilP`, etc.) matching the engine i3d convention
- `DensityCoordType.POINT` → `POINT_POINT_POINT` across all modifier calls — fixes incorrect write/read behaviour on density maps
- Removed erroneous bulk N/P/K/OM zone sync that was flattening spatial differentiation across the overlay
- Zone cell constants (`MAX_ZONE_CELLS`) now defined before pre-population functions — fixes nil comparison crash on session load
- Overlay tiles pre-populated for all fields on load — map shows correct values at full opacity from the start

**Sprayer & field boundary fixes**
- FarmlandManager crash from nil world coordinates in sprayer boundary check — resolved
- Boom sections that cross into adjacent fields are now suppressed correctly

**HUD improvements**
- Weed/pest/disease pressure rows hidden when pressure is 0 — cleaner HUD with no empty bars
- `sf_disease_moisture` setting uiId renamed to `sf_dm`
- Minimap layer build now guarded by `layerSystem.hasData` to prevent premature rendering

**README**
- Companion pack warning rewritten — clearer language and proper link text

## Save compatibility
No save migration needed — existing saves continue to work.