### PR TITLE
v2.3.0.0 — Per-pixel DMV rendering for PDA map + new GRLE layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 </div>
 
 > [!WARNING]
-> **Companion asset pack required for the full experience.**
-> Custom fertilizer bag models and additional assets are not bundled in the main mod download.
-> [Download the companion pack here](https://modsfire.com/OwETnO2y0uo66g2) — installation instructions are included inside the archive.
+> To play the mod at its finest please download the following file.
+> https://modsfire.com/OwETnO2y0uo66g2
+> Instructions are inside the README
 
 > [!TIP]
 > Want to be part of our community? Share tips, report issues, and chat with other farmers on the **[FS25 Modding Community Discord](https://discord.gg/Th2pnq36)**!

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.2.6.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.0.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.2.6.0</version>
+    <version>2.3.0.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2190,9 +2190,31 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         end
     end
 
+    -- ── Sync weed pressure from game's native weed density map ──────────────
+    -- If the WeedSystem is present, derive weed pressure from actual terrain
+    -- weed coverage rather than our internal simulation value.
+    local layerSys = self.layerSystem
+    if layerSys and layerSys.hasWeedLayer then
+        local farmland = g_farmlandManager and g_farmlandManager:getFarmlandById(fieldId)
+        if farmland then
+            local coverage = layerSys:readWeedCoverageForFarmland(farmland)
+            if coverage ~= nil then
+                field.weedPressure = math.min(100, coverage * 100)
+            end
+        end
+    end
+
+    -- ── Sync pest/disease/compaction to density map layers ───────────────────
+    -- Paint the field AABB with the current daily values so the minimap and
+    -- PDA overlay stay in sync without needing per-setter hooks everywhere.
+    if layerSys and layerSys.available then
+        local farmland = farmland or (g_farmlandManager and g_farmlandManager:getFarmlandById(fieldId))
+        if farmland then
+            layerSys:writeFieldToLayers(fieldId, field, farmland)
+        end
+    end
+
     -- ── Broadcast to MP clients ──────────────────────────────────────────────
-    -- Daily simulation is server-only; push the updated field data so client
-    -- HUDs reflect nutrient changes, weed/pest/disease pressure, etc.
     if SoilFieldUpdateEvent then
         g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
     end
@@ -3646,6 +3668,11 @@ function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ)
     end
     field.compaction = field.compactionSum / field.compactionTotalCells
 
+    -- 3. Write per-pixel to compaction density map layer
+    if self.layerSystem and self.layerSystem.available then
+        self.layerSystem:updatePixelForField("compaction", worldX, worldZ, newVal, zone.CELL_SIZE * 0.5)
+    end
+
     SoilLogger.debug("Compaction: field=%d cell=%s  %.0f→%.0f%%  avg=%.1f%%",
         farmlandId, cellKey, prev, newVal, field.compaction)
 end
@@ -3685,6 +3712,11 @@ function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ)
     field.compactionSum = math.max(0, (field.compactionSum or 0) - (prev - newVal))
     local tc = field.compactionTotalCells or 0
     field.compaction = tc > 0 and (field.compactionSum / tc) or 0
+
+    -- Write per-pixel to compaction density map layer
+    if self.layerSystem and self.layerSystem.available then
+        self.layerSystem:updatePixelForField("compaction", worldX, worldZ, newVal, zone.CELL_SIZE * 0.5)
+    end
 
     SoilLogger.debug("Subsoiler: field=%d cell=%s  %.0f→%.0f%%  avg=%.1f%%",
         farmlandId, cellKey, prev, newVal, field.compaction)

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -39,6 +39,7 @@ local SoilLayerSystem_mt = Class(SoilLayerSystem)
 -- the semantic float value used by the rest of the mod.
 -- ─────────────────────────────────────────────────────────
 local LAYER_DEFS = {
+    -- ── Nutrients ────────────────────────────────────────────
     {
         name        = "soilN",          -- i3d short name; engine saves as infoLayer_soilN.grle
         field       = "nitrogen",       -- key in fieldData
@@ -66,7 +67,7 @@ local LAYER_DEFS = {
     {
         name        = "soilPH",
         field       = "pH",
-        minVal      = 5.0,              -- FS25 soil pH never goes below 5
+        minVal      = 5.0,
         maxVal      = 7.5,
         numBits     = 8,
         numChannels = 8,
@@ -79,6 +80,33 @@ local LAYER_DEFS = {
         numBits     = 8,
         numChannels = 8,
     },
+    -- ── Biotic / physical pressure ───────────────────────────
+    {
+        name        = "soilPest",
+        field       = "pestPressure",
+        minVal      = 0,
+        maxVal      = 100,
+        numBits     = 8,
+        numChannels = 8,
+    },
+    {
+        name        = "soilDisease",
+        field       = "diseasePressure",
+        minVal      = 0,
+        maxVal      = 100,
+        numBits     = 8,
+        numChannels = 8,
+    },
+    {
+        name        = "soilCompaction",
+        field       = "compaction",
+        minVal      = 0,
+        maxVal      = 100,
+        numBits     = 8,
+        numChannels = 8,
+    },
+    -- Note: weed is NOT in LAYER_DEFS — it is read from the game's
+    -- native WeedSystem foliage density map (see weed* fields below).
 }
 
 local MAX_ENCODED = 255  -- (2^8) - 1
@@ -90,9 +118,14 @@ local MAX_ENCODED = 255  -- (2^8) - 1
 function SoilLayerSystem.new()
     local self = setmetatable({}, SoilLayerSystem_mt)
     -- layerHandles[layerDef.name] = { handle, modifier, def }
-    self.layerHandles = {}
-    self.initialized  = false
-    self.available    = false   -- true when ≥1 layer successfully registered
+    self.layerHandles    = {}
+    self.initialized     = false
+    self.available       = false   -- true when ≥1 layer successfully registered
+    -- Weed layer (game-native foliage density map — read-only)
+    self.hasWeedLayer    = false
+    self.weedMapId       = nil     -- raw density map id from weedSystem:getDensityMapData()
+    self.weedFirstCh     = nil
+    self.weedNumCh       = nil
     return self
 end
 
@@ -170,6 +203,103 @@ function SoilLayerSystem:initialize()
     else
         SoilLogger.info("SoilLayerSystem: No terrain layers — using fieldData storage (normal for most maps)")
     end
+
+    -- ── Weed layer (game-native, read-only) ───────────────────────────────────
+    -- FS25 tracks weed presence via WeedSystem which owns a foliage density map.
+    -- We sample it to derive per-field weed pressure rather than simulating it.
+    local weedSystem = g_currentMission and g_currentMission.weedSystem
+    if weedSystem ~= nil then
+        local ok, mapId, firstCh, numCh = pcall(function()
+            return weedSystem:getDensityMapData()
+        end)
+        if ok and mapId and mapId ~= 0 then
+            self.hasWeedLayer = true
+            self.weedMapId    = mapId
+            self.weedFirstCh  = firstCh or 0
+            self.weedNumCh    = numCh   or 4
+            SoilLogger.info("[OK] Weed density map found (mapId=%s, ch=%d+%d)",
+                tostring(mapId), self.weedFirstCh, self.weedNumCh)
+        else
+            SoilLogger.debug("SoilLayerSystem: WeedSystem present but getDensityMapData failed — weed pressure uses simulation")
+        end
+    else
+        SoilLogger.debug("SoilLayerSystem: No WeedSystem — weed pressure uses simulation fallback")
+    end
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Sample the game's native weed density map across a farmland
+-- bounding box and return the fraction of pixels that have any
+-- weed present (non-zero state), as a value 0.0–1.0.
+-- Returns nil if the weed layer is not available.
+-- ─────────────────────────────────────────────────────────
+
+---@param farmland table  FS25 farmland object
+---@return number|nil  0.0–1.0 weed coverage fraction, or nil
+function SoilLayerSystem:readWeedCoverageForFarmland(farmland)
+    if not self.hasWeedLayer or not self.weedMapId then return nil end
+
+    local cx, cz, hw, hh
+    if farmland.x and farmland.z then
+        cx = farmland.x
+        cz = farmland.z
+        hw = (farmland.width  and farmland.width  / 2) or 50
+        hh = (farmland.height and farmland.height / 2) or 50
+    elseif farmland.polygon and #farmland.polygon >= 2 then
+        local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
+        for i = 1, #farmland.polygon, 2 do
+            local px = farmland.polygon[i]
+            local pz = farmland.polygon[i + 1]
+            if px and pz then
+                if px < minX then minX = px end
+                if px > maxX then maxX = px end
+                if pz < minZ then minZ = pz end
+                if pz > maxZ then maxZ = pz end
+            end
+        end
+        if minX == math.huge then return nil end
+        cx = (minX + maxX) / 2
+        cz = (minZ + maxZ) / 2
+        hw = (maxX - minX) / 2
+        hh = (maxZ - minZ) / 2
+    else
+        return nil
+    end
+
+    local ok, modifier = pcall(function()
+        return DensityMapModifier.new(self.weedMapId, self.weedFirstCh, self.weedNumCh, g_terrainNode)
+    end)
+    if not ok or not modifier then return nil end
+
+    local STEPS  = 8
+    local weedCount = 0
+    local total     = 0
+
+    for xi = 0, STEPS - 1 do
+        for zi = 0, STEPS - 1 do
+            local wx = (cx - hw) + (xi / (STEPS - 1)) * (hw * 2)
+            local wz = (cz - hh) + (zi / (STEPS - 1)) * (hh * 2)
+            modifier:setParallelogramWorldCoords(wx, wz, wx + 0.1, wz, wx, wz + 0.1, DensityCoordType.POINT_POINT_POINT)
+            local val, _, _ = modifier:executeGet(DensityMapFilter.new(modifier), nil)
+            if val ~= nil then
+                total = total + 1
+                if val > 0 then weedCount = weedCount + 1 end
+            end
+        end
+    end
+
+    if total == 0 then return 0 end
+    return weedCount / total
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Expose weed map data for minimap/PDA overlay rendering.
+-- Returns (mapId, firstChannel, numChannels) or nil.
+-- ─────────────────────────────────────────────────────────
+
+function SoilLayerSystem:getWeedMapData()
+    if not self.hasWeedLayer then return nil end
+    return self.weedMapId, self.weedFirstCh, self.weedNumCh
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -142,6 +142,18 @@ function SoilMapOverlay.new(soilSystem, settings)
     -- Cell inspection tooltip: set by onMapClick, cleared on layer change or re-click
     self.selectedCell = nil   -- { worldX, worldZ, farmlandId, info }
 
+    -- PDA DMV double-buffer overlay (async density-map visualization)
+    self._pdaDMVAvailable  = false
+    self._pdaOverlays      = {nil, nil}
+    self._pdaShowIdx       = 1
+    self._pdaBuildIdx      = 2
+    self._pdaBuildInFlight = false
+    self._pdaBuildHandle   = nil
+    self._pdaHasShownOnce  = false
+    self._pdaUsingDMV      = false
+    self._pdaActiveLayer   = -1
+    self._pdaNextBuildMs   = 0
+
     return self
 end
 
@@ -150,12 +162,32 @@ end
 function SoilMapOverlay:initialize()
     SoilLogger.info("SoilMapOverlay: initialized (DMF Heatmap Mode)")
     self:installMinimapZoomHooks()
+
+    if createDensityMapVisualizationOverlay and not g_dedicatedServer then
+        local resX, resY = 1024, 1024
+        local mog = g_currentMission and g_currentMission.mapOverlayGenerator
+        if mog and MapOverlayGenerator and MapOverlayGenerator.OVERLAY_RESOLUTION then
+            local fsRes = MapOverlayGenerator.OVERLAY_RESOLUTION.FOLIAGE_STATE
+            if fsRes and fsRes[1] and fsRes[2] then resX, resY = fsRes[1], fsRes[2] end
+        end
+        self._pdaOverlays[1] = createDensityMapVisualizationOverlay("SF_PDAHeatmapA", resX, resY)
+        self._pdaOverlays[2] = createDensityMapVisualizationOverlay("SF_PDAHeatmapB", resX, resY)
+        self._pdaDMVAvailable = (self._pdaOverlays[1] ~= nil and self._pdaOverlays[2] ~= nil)
+        if self._pdaDMVAvailable then
+            SoilLogger.info("[OK] SoilMapOverlay PDA DMV overlays created (%dx%d)", resX, resY)
+        else
+            SoilLogger.warning("SoilMapOverlay: PDA DMV overlay creation failed — polygon fallback active")
+        end
+    end
 end
 
 -- ── Delete ────────────────────────────────────────────────
 
 function SoilMapOverlay:delete()
-    self.samplePoints = {}
+    self.samplePoints      = {}
+    self._pdaOverlays      = {nil, nil}
+    self._pdaBuildInFlight = false
+    self._pdaBuildHandle   = nil
     SoilLogger.info("SoilMapOverlay: deleted")
 end
 
@@ -191,9 +223,11 @@ function SoilMapOverlay:getSelectedFilterCount(filterStates)
 end
 
 function SoilMapOverlay:requestRefresh()
-    self.nextSampleUpdateTime = 0
+    self.nextSampleUpdateTime  = 0
     self.nextMinimapUpdateTime = 0
-    self.fieldPolyCache = {}
+    self.fieldPolyCache        = {}
+    self._pdaNextBuildMs       = 0
+    self._pdaActiveLayer       = -1   -- force DMV rebuild on next draw
 end
 
 -- ── Layer selection ───────────────────────────────────────
@@ -215,6 +249,88 @@ end
 -- Alias used by SoilMapFrame; equivalent to requestRefresh
 function SoilMapOverlay:requestGenerate()
     self:requestRefresh()
+end
+
+-- ── PDA DMV overlay (density-map visualization) ───────────
+
+-- Maps SoilMapOverlay layer index → SoilLayerSystem field key for GRLE layers.
+-- Layer 6 (urgency) is computed and has no GRLE; layer 7 (weed) uses WeedSystem.
+local PDA_LAYER_GRLE = {
+    [1]  = "nitrogen",
+    [2]  = "phosphorus",
+    [3]  = "potassium",
+    [4]  = "pH",
+    [5]  = "organicMatter",
+    [8]  = "pestPressure",
+    [9]  = "diseasePressure",
+    [10] = "compaction",
+}
+
+function SoilMapOverlay:_pdaPollBuildFinished()
+    if not self._pdaBuildInFlight or not self._pdaBuildHandle then return end
+    if not getIsDensityMapVisualizationOverlayReady then return end
+    if getIsDensityMapVisualizationOverlayReady(self._pdaBuildHandle) then
+        self._pdaShowIdx, self._pdaBuildIdx = self._pdaBuildIdx, self._pdaShowIdx
+        self._pdaBuildInFlight = false
+        self._pdaBuildHandle   = nil
+        self._pdaHasShownOnce  = true
+    end
+end
+
+function SoilMapOverlay:_pdaKickBuild(layerIdx)
+    local ov = self._pdaOverlays[self._pdaBuildIdx]
+    if not ov then return end
+
+    if resetDensityMapVisualizationOverlay then
+        resetDensityMapVisualizationOverlay(ov)
+    end
+
+    local layerSystem = self.soilSystem and self.soilSystem.layerSystem
+
+    -- Weed layer: game-native foliage density map
+    if layerIdx == 7 and layerSystem and layerSystem.hasWeedLayer then
+        local mapId, firstCh, numCh = layerSystem:getWeedMapData()
+        if mapId then
+            local weedColors = {
+                {0.95, 0.85, 0.20}, {0.95, 0.70, 0.10}, {0.90, 0.55, 0.05},
+                {0.85, 0.35, 0.05}, {0.80, 0.20, 0.05},
+            }
+            local maxState = math.max(1, (2 ^ (numCh or 4)) - 1)
+            for state = 1, maxState do
+                local ci = math.min(state, #weedColors)
+                local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, firstCh or 0, 0, numCh or 4, state, r, g, b, 0.85)
+            end
+            self._pdaUsingDMV = true
+            generateDensityMapVisualizationOverlay(ov)
+            self._pdaBuildHandle   = ov
+            self._pdaBuildInFlight = true
+            return
+        end
+    end
+
+    -- GRLE-backed layers (N/P/K/pH/OM/Pest/Disease/Compaction)
+    local fieldKey = PDA_LAYER_GRLE[layerIdx]
+    if fieldKey and layerSystem and layerSystem.available and layerSystem.hasData then
+        local entry = layerSystem:getLayerEntryForField(fieldKey)
+        if entry then
+            local handle = entry.handle
+            local def    = entry.def
+            for i = 1, 255 do
+                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
+                local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 8, i, r, g, b, 1.0)
+            end
+            self._pdaUsingDMV = true
+            generateDensityMapVisualizationOverlay(ov)
+            self._pdaBuildHandle   = ov
+            self._pdaBuildInFlight = true
+            return
+        end
+    end
+
+    -- No DMV for this layer (urgency = layer 6, or GRLE not yet available)
+    self._pdaUsingDMV = false
 end
 
 -- ── Sidebar Clicks ────────────────────────────────────────
@@ -524,55 +640,67 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
     local layerIdx = self.settings.activeMapLayer or 0
     if layerIdx <= 0 then return end
 
-    self:updateSamplePoints(false)
+    -- Poll async DMV build
+    self:_pdaPollBuildFinished()
 
-    if #self.samplePoints == 0 then return end
-
-    -- Use the layout-based bounds (DFF pattern) — ingameMap:getPosition() does not exist.
     local mapX, mapY, mapWidth, mapHeight = self:getMapRenderBounds(frame, ingameMap)
     if mapX == nil or mapWidth == nil or mapHeight == nil then return end
 
-    local mapMaxX = mapX + mapWidth
-    local mapMaxY = mapY + mapHeight
-
-    -- Tile draw size = zone cell size so each rendered tile covers exactly one data cell.
-    local drawStep = SoilConstants.ZONE.CELL_SIZE
-    local sizeX, sizeY
-    local probeX, probeZ = 0, 0
-    local ax, ay = self:worldToScreenPosition(ingameMap, probeX, probeZ)
-    local bx, by = self:worldToScreenPosition(ingameMap, probeX + drawStep, probeZ)
-    local cx, cy = self:worldToScreenPosition(ingameMap, probeX, probeZ + drawStep)
-    if ax and bx and cx then
-        local dxX = math.abs(bx - ax)
-        local dyZ = math.abs(cy - ay)
-        -- Add 15% overlap so adjacent tiles don't leave hairline gaps
-        sizeX = math.max(dxX * 1.15, 0.0005)
-        sizeY = math.max(dyZ * 1.15, 0.0005)
-    else
-        sizeX, sizeY = getNormalizedScreenValues(10, 10)
+    -- Kick a new DMV build when layer changed or refresh interval elapsed
+    local now = (g_currentMission and g_currentMission.time) or 0
+    if self._pdaDMVAvailable and not self._pdaBuildInFlight
+       and (self._pdaActiveLayer ~= layerIdx or now >= self._pdaNextBuildMs) then
+        self._pdaNextBuildMs  = now + SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS
+        self._pdaActiveLayer  = layerIdx
+        self:_pdaKickBuild(layerIdx)
     end
-    local halfX, halfY = sizeX * 0.5, sizeY * 0.5
 
-    -- Derive affine transform coefficients from the 3 probe points.
-    -- The map is a linear projection so this is exact at any zoom/pan level.
-    -- Replaces a per-point worldToScreenPosition() engine call with arithmetic,
-    -- cutting ~40k Lua→C++ calls per frame down to the 3 probes above.
-    local scaleXX = (bx - ax) / drawStep
-    local scaleYX = (by - ay) / drawStep
-    local scaleXZ = (cx - ax) / drawStep
-    local scaleYZ = (cy - ay) / drawStep
+    if self._pdaHasShownOnce and self._pdaUsingDMV then
+        -- ── Per-pixel DMV path ────────────────────────────────────
+        local ov = self._pdaOverlays[self._pdaShowIdx]
+        if ov then
+            setOverlayColor(ov, 1, 1, 1, SoilMapOverlay.ALPHA)
+            renderOverlay(ov, mapX, mapY, mapWidth, mapHeight)
+        end
+    else
+        -- ── Polygon dot fallback (urgency layer, or DMV not yet ready) ──
+        self:updateSamplePoints(false)
 
-    for _, point in ipairs(self.samplePoints) do
-        local screenX = ax + point.x * scaleXX + point.z * scaleXZ
-        local screenY = ay + point.x * scaleYX + point.z * scaleYZ
-        if screenX >= mapX and screenX <= mapMaxX
-           and screenY >= mapY and screenY <= mapMaxY then
-            drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
-                           point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
+        if #self.samplePoints > 0 then
+            local mapMaxX = mapX + mapWidth
+            local mapMaxY = mapY + mapHeight
+
+            local drawStep = SoilConstants.ZONE.CELL_SIZE
+            local ax, ay = self:worldToScreenPosition(ingameMap, 0, 0)
+            local bx, by = self:worldToScreenPosition(ingameMap, drawStep, 0)
+            local cx, cy = self:worldToScreenPosition(ingameMap, 0, drawStep)
+            local sizeX, sizeY
+            if ax and bx and cx then
+                sizeX = math.max(math.abs(bx - ax) * 1.15, 0.0005)
+                sizeY = math.max(math.abs(cy - ay) * 1.15, 0.0005)
+            else
+                sizeX, sizeY = getNormalizedScreenValues(10, 10)
+            end
+            local halfX, halfY = sizeX * 0.5, sizeY * 0.5
+
+            local scaleXX = (bx - ax) / drawStep
+            local scaleYX = (by - ay) / drawStep
+            local scaleXZ = (cx - ax) / drawStep
+            local scaleYZ = (cy - ay) / drawStep
+
+            for _, point in ipairs(self.samplePoints) do
+                local screenX = ax + point.x * scaleXX + point.z * scaleXZ
+                local screenY = ay + point.x * scaleYX + point.z * scaleYZ
+                if screenX >= mapX and screenX <= mapMaxX
+                   and screenY >= mapY and screenY <= mapMaxY then
+                    drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
+                                   point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
+                end
+            end
         end
     end
 
-    -- Draw the cell inspection tooltip on top of tiles
+    -- Draw the cell inspection tooltip on top of the overlay
     self:drawCellTooltip(ingameMap, mapX, mapY, mapWidth, mapHeight)
 end
 

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -125,18 +125,20 @@ function SoilMinimapLayer:_pollBuildFinished()
     end
 end
 
--- Maps PDA layer index to the SoilLayerSystem field key.
--- All 9 layers have per-pixel density map support; weed is special (game-native map).
+-- Maps settings.activeMapLayer index → SoilLayerSystem field key.
+-- Indices must match SoilMapOverlay.LAYER_KEYS exactly.
+-- [6] urgency is computed (no GRLE); [7] weed uses the game WeedSystem foliage map.
 local LAYER_FIELD_KEYS = {
-    [1] = "nitrogen",
-    [2] = "phosphorus",
-    [3] = "potassium",
-    [4] = "pH",
-    [5] = "organicMatter",
-    [6] = "pestPressure",
-    [7] = "diseasePressure",
-    [8] = "compaction",
-    [9] = "weed",           -- sentinel: rendered from game's WeedSystem map
+    [1]  = "nitrogen",
+    [2]  = "phosphorus",
+    [3]  = "potassium",
+    [4]  = "pH",
+    [5]  = "organicMatter",
+    -- [6] = urgency: computed from N/P/K — no density map layer
+    [7]  = "weed",              -- WeedSystem foliage density map (read-only)
+    [8]  = "pestPressure",      -- soilPest GRLE
+    [9]  = "diseasePressure",   -- soilDisease GRLE
+    [10] = "compaction",        -- soilCompaction GRLE
 }
 
 function SoilMinimapLayer:_startBuild(soilMapOverlay)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -125,14 +125,18 @@ function SoilMinimapLayer:_pollBuildFinished()
     end
 end
 
--- Maps PDA layer index to the SoilLayerSystem field key and GRLE layer name.
--- Layers 1-5 have per-pixel GRLE density maps; layers 6+ fall back to farmland coloring.
+-- Maps PDA layer index to the SoilLayerSystem field key.
+-- All 9 layers have per-pixel density map support; weed is special (game-native map).
 local LAYER_FIELD_KEYS = {
     [1] = "nitrogen",
     [2] = "phosphorus",
     [3] = "potassium",
     [4] = "pH",
     [5] = "organicMatter",
+    [6] = "pestPressure",
+    [7] = "diseasePressure",
+    [8] = "compaction",
+    [9] = "weed",           -- sentinel: rendered from game's WeedSystem map
 }
 
 function SoilMinimapLayer:_startBuild(soilMapOverlay)
@@ -142,27 +146,31 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     local ov = self._overlays[self._buildIdx]
     if not ov then return end
 
-    -- Clear previously-painted state colors so old data doesn't bleed through.
     if resetDensityMapVisualizationOverlay then
         resetDensityMapVisualizationOverlay(ov)
     end
 
-    -- ── Per-pixel path (layers 1-5 with GRLE density maps) ───────────────────
     local layerSystem = self.soilSystem and self.soilSystem.layerSystem
     local fieldKey    = LAYER_FIELD_KEYS[layerIdx]
 
-    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey then
-        local entry = layerSystem:getLayerEntryForField(fieldKey)
-        if entry then
-            local handle = entry.handle
-            local def    = entry.def
-            -- Assign a color to every possible encoded value 0-255.
-            -- Encoded value 0 means "no data written to this pixel" — keep transparent.
-            -- Values 1-255 map to a decoded semantic float which gets a status color.
-            for i = 1, 255 do
-                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
-                local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 0, 8, i, r, g, b, 1.0)
+    -- ── Weed layer (game-native foliage density map) ──────────────────────────
+    if fieldKey == "weed" and layerSystem and layerSystem.hasWeedLayer then
+        local mapId, firstCh, numCh = layerSystem:getWeedMapData()
+        if mapId then
+            -- State 0 = no weed → transparent.
+            -- States 1-N = weed present → yellow → orange-red by growth stage.
+            local weedColors = {
+                {0.95, 0.85, 0.20},  -- state 1: seedling — yellow
+                {0.95, 0.70, 0.10},  -- state 2
+                {0.90, 0.55, 0.05},  -- state 3
+                {0.85, 0.35, 0.05},  -- state 4
+                {0.80, 0.20, 0.05},  -- state 5+: mature — deep red-orange
+            }
+            local maxState = math.max(1, (2 ^ (numCh or 4)) - 1)
+            for state = 1, maxState do
+                local ci  = math.min(state, #weedColors)
+                local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, firstCh or 0, 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -172,11 +180,28 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
         end
     end
 
-    -- ── Farmland-map fallback (layers 6-10, or maps without GRLE files) ───────
-    -- SoilMapOverlay.onDrawMinimap already renders field polygon fill dots for
-    -- this case (it skips only when _usingDensityLayers = true). We intentionally
-    -- do NOT generate a DMV overlay here because the farmland ownership BVM covers
-    -- entire purchased parcels including buildings, not just field polygons.
+    -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
+    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
+        local entry = layerSystem:getLayerEntryForField(fieldKey)
+        if entry then
+            local handle = entry.handle
+            local def    = entry.def
+            -- Value 0 = unwritten pixel → transparent.
+            -- Values 1-255 → decode to semantic float → status color.
+            for i = 1, 255 do
+                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
+                local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 8, i, r, g, b, 1.0)
+            end
+            self._usingDensityLayers = true
+            generateDensityMapVisualizationOverlay(ov)
+            self._buildHandle   = ov
+            self._buildInFlight = true
+            return
+        end
+    end
+
+    -- ── Fallback: polygon-fill dots via SoilMapOverlay ────────────────────────
     self._usingDensityLayers = false
 end
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,20 +24,11 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed soil map layer names to match engine convention (soilN, soilP, soilK, soilPH, soilOM)",
-    "- Fixed density map coordinate type across all read/write calls — values now land correctly",
-    "- Fixed overlay zones showing identical values — bulk zone sync removed, each zone is now spatial",
-    "- Fixed nil crash: zone cell constants now defined before pre-population runs",
-    "- Fixed overlay tiles pre-populated for all fields on load — map is fully visible from the start",
-    "- Fixed FarmlandManager crash from nil world coordinates in sprayer boundary check",
-    "- Fixed boom sections crossing into adjacent fields are now correctly suppressed",
-    "- Fixed dedicated server fertilizer broadcast keyed per field+product — N→K switch now immediate",
-    "- Fixed See & Spray weed detection now reads from the game density map, not stale cell data",
-    "- Fixed HUD row overlap — Weeds/Pests/Disease bars now render at the correct position",
-    "- Fixed HUD edit mode camera orbit — cursor re-locked every frame during pan",
-    "- Fixed Weed/Pest/Disease HUD rows hidden when pressure is zero (no more empty bars)",
-    "- Fixed admin settings panel missing translation label (sf_dm uiId mismatch resolved)",
-    "- Fixed minimap layer build now guarded until soil layer data is actually available",
+    "v2.3.0.0",
+    "- New: PDA fullscreen map now uses per-pixel density map rendering (same quality as minimap)",
+    "- New: soilPest, soilDisease, soilCompaction density map layers — true per-pixel precision",
+    "- New: Weed pressure synced live from the game's native WeedSystem density map",
+    "- Fixed: Minimap layer indices for pest/disease/compaction now match correctly",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- PDA fullscreen soil map now uses async DMV overlay rendering (same per-pixel quality as the minimap) — replaces polygon fill dot approach
- Added soilPest, soilDisease, soilCompaction GRLE density map layers for true sub-field precision
- Weed pressure synced live from game's native WeedSystem density map
- Fixed minimap LAYER_FIELD_KEYS indices so pest/disease/compaction render under the correct layer buttons
- Layer 6 (Urgency, computed) keeps polygon dot fallback since it has no GRLE backing

## Test plan
- [ ] Open PDA map → select N/P/K/pH/OM layers → confirm per-pixel gradient fills map area
- [ ] Select Weed layer → confirm weed growth-state colors render correctly
- [ ] Select Pest/Disease/Compaction layers → confirm per-pixel rendering
- [ ] Select Urgency layer → confirm polygon dot fallback still works
- [ ] Minimap: cycle layers → confirm pest/disease/compaction show on correct buttons