### PR TITLE
fix: restore minimap and revert PDA to polygon tiles (2.3.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.1.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.1.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.2.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.0.0</version>
+    <version>2.3.1.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.1.0</version>
+    <version>2.3.2.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -311,7 +311,7 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
 
     -- GRLE-backed layers (N/P/K/pH/OM/Pest/Disease/Compaction)
     local fieldKey = PDA_LAYER_GRLE[layerIdx]
-    if fieldKey and layerSystem and layerSystem.available and layerSystem.hasData then
+    if fieldKey and layerSystem and layerSystem.available then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -299,7 +299,7 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
             for state = 1, maxState do
                 local ci = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, firstCh or 0, 0, numCh or 4, state, r, g, b, 0.85)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)
@@ -316,14 +316,15 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Engine limit: 16 state color sets max. Read top 4 bits of 8-bit value
-            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
+            -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
+            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
             -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -299,7 +299,8 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
             for state = 1, maxState do
                 local ci = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
+                -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)
@@ -310,21 +311,23 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
     end
 
     -- GRLE-backed layers (N/P/K/pH/OM/Pest/Disease/Compaction)
+    -- Require hasData so we don't generate a fully-transparent overlay before
+    -- writeFieldToLayers has run — that would suppress the polygon-dot fallback.
     local fieldKey = PDA_LAYER_GRLE[layerIdx]
-    if fieldKey and layerSystem and layerSystem.available then
+    if fieldKey and layerSystem and layerSystem.available and layerSystem.hasData then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle
             local def    = entry.def
             -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
-            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
-            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
+            -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0, fieldMask=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states.
             -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)
@@ -645,62 +648,41 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
     local layerIdx = self.settings.activeMapLayer or 0
     if layerIdx <= 0 then return end
 
-    -- Poll async DMV build
-    self:_pdaPollBuildFinished()
-
     local mapX, mapY, mapWidth, mapHeight = self:getMapRenderBounds(frame, ingameMap)
     if mapX == nil or mapWidth == nil or mapHeight == nil then return end
 
-    -- Kick a new DMV build when layer changed or refresh interval elapsed
-    local now = (g_currentMission and g_currentMission.time) or 0
-    if self._pdaDMVAvailable and not self._pdaBuildInFlight
-       and (self._pdaActiveLayer ~= layerIdx or now >= self._pdaNextBuildMs) then
-        self._pdaNextBuildMs  = now + SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS
-        self._pdaActiveLayer  = layerIdx
-        self:_pdaKickBuild(layerIdx)
-    end
+    -- PDA always uses polygon tiles (field-clamped, works without GRLE data)
+    self:updateSamplePoints(false)
 
-    if self._pdaHasShownOnce and self._pdaUsingDMV then
-        -- ── Per-pixel DMV path ────────────────────────────────────
-        local ov = self._pdaOverlays[self._pdaShowIdx]
-        if ov then
-            setOverlayColor(ov, 1, 1, 1, SoilMapOverlay.ALPHA)
-            renderOverlay(ov, mapX, mapY, mapWidth, mapHeight)
+    if #self.samplePoints > 0 then
+        local mapMaxX = mapX + mapWidth
+        local mapMaxY = mapY + mapHeight
+
+        local drawStep = SoilConstants.ZONE.CELL_SIZE
+        local ax, ay = self:worldToScreenPosition(ingameMap, 0, 0)
+        local bx, by = self:worldToScreenPosition(ingameMap, drawStep, 0)
+        local cx, cy = self:worldToScreenPosition(ingameMap, 0, drawStep)
+        local sizeX, sizeY
+        if ax and bx and cx then
+            sizeX = math.max(math.abs(bx - ax) * 1.15, 0.0005)
+            sizeY = math.max(math.abs(cy - ay) * 1.15, 0.0005)
+        else
+            sizeX, sizeY = getNormalizedScreenValues(10, 10)
         end
-    else
-        -- ── Polygon dot fallback (urgency layer, or DMV not yet ready) ──
-        self:updateSamplePoints(false)
+        local halfX, halfY = sizeX * 0.5, sizeY * 0.5
 
-        if #self.samplePoints > 0 then
-            local mapMaxX = mapX + mapWidth
-            local mapMaxY = mapY + mapHeight
+        local scaleXX = (bx - ax) / drawStep
+        local scaleYX = (by - ay) / drawStep
+        local scaleXZ = (cx - ax) / drawStep
+        local scaleYZ = (cy - ay) / drawStep
 
-            local drawStep = SoilConstants.ZONE.CELL_SIZE
-            local ax, ay = self:worldToScreenPosition(ingameMap, 0, 0)
-            local bx, by = self:worldToScreenPosition(ingameMap, drawStep, 0)
-            local cx, cy = self:worldToScreenPosition(ingameMap, 0, drawStep)
-            local sizeX, sizeY
-            if ax and bx and cx then
-                sizeX = math.max(math.abs(bx - ax) * 1.15, 0.0005)
-                sizeY = math.max(math.abs(cy - ay) * 1.15, 0.0005)
-            else
-                sizeX, sizeY = getNormalizedScreenValues(10, 10)
-            end
-            local halfX, halfY = sizeX * 0.5, sizeY * 0.5
-
-            local scaleXX = (bx - ax) / drawStep
-            local scaleYX = (by - ay) / drawStep
-            local scaleXZ = (cx - ax) / drawStep
-            local scaleYZ = (cy - ay) / drawStep
-
-            for _, point in ipairs(self.samplePoints) do
-                local screenX = ax + point.x * scaleXX + point.z * scaleXZ
-                local screenY = ay + point.x * scaleYX + point.z * scaleYZ
-                if screenX >= mapX and screenX <= mapMaxX
-                   and screenY >= mapY and screenY <= mapMaxY then
-                    drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
-                                   point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
-                end
+        for _, point in ipairs(self.samplePoints) do
+            local screenX = ax + point.x * scaleXX + point.z * scaleXZ
+            local screenY = ay + point.x * scaleYX + point.z * scaleYZ
+            if screenX >= mapX and screenX <= mapMaxX
+               and screenY >= mapY and screenY <= mapMaxY then
+                drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
+                               point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
             end
         end
     end

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -316,10 +316,14 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            for i = 1, 255 do
-                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
+            -- Engine limit: 16 state color sets max. Read top 4 bits of 8-bit value
+            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
+            -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            for i = 1, 15 do
+                local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 8, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -183,7 +183,7 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     end
 
     -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
-    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
+    if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -172,7 +172,7 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             for state = 1, maxState do
                 local ci  = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, firstCh or 0, 0, numCh or 4, state, r, g, b, 0.85)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -188,15 +188,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Engine limit: 16 state color sets max. Read top 4 bits of the 8-bit value
-            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
-            -- State 0 = raw value 0-15 (unwritten or near-zero) → transparent.
-            -- States 1-15 = monotonically increasing semantic value → gradient.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
+            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
+            -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -172,7 +172,8 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             for state = 1, maxState do
                 local ci  = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
+                -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -183,20 +184,24 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     end
 
     -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
-    if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
+    -- layerSystem.hasData is set true only after writeFieldToLayers has pushed real
+    -- soil values into the GRLE.  Without this guard the overlay generates but shows
+    -- nothing (all pixels state 0 = transparent) and the polygon-dot fallback is
+    -- suppressed, leaving the minimap blank for new or not-yet-loaded games.
+    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle
             local def    = entry.def
             -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
-            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
-            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
+            -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0, fieldMask=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states.
             -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -212,16 +217,18 @@ end
 
 -- ── Rendering ─────────────────────────────────────────────
 
--- Called from IngameMap.drawFields (or FSBaseMission.draw as fallback).
--- mapSelf is the IngameMap instance.
+-- Called from IngameMap.drawFields with the actual IngameMap instance being drawn.
+-- Fires for both the HUD minimap and the PDA fullscreen map — guards handle each.
 function SoilMinimapLayer:draw(mapSelf)
     if not self._initialized then return end
-    if not self._hasShownOnce then return end
-    if not self._usingDensityLayers then return end
     if not mapSelf then return end
 
-    -- Only render on the HUD minimap, never on the PDA fullscreen map.
-    -- g_currentMission.hud.ingameMap is the authoritative HUD minimap instance.
+    -- PDA fullscreen map has isFullscreen as a truthy integer (1) while the HUD minimap has nil.
+    -- Using a truthy check (not == true) correctly blocks PDA without blocking HUD.
+    if mapSelf.isFullscreen then return end
+    if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
+
+    -- Secondary identity guard: when the HUD minimap ref is resolvable, only draw on that instance.
     local hudMap = nil
     if g_currentMission and g_currentMission.hud then
         local hud = g_currentMission.hud
@@ -229,8 +236,18 @@ function SoilMinimapLayer:draw(mapSelf)
     end
     if hudMap ~= nil and mapSelf ~= hudMap then return end
 
-    if mapSelf.isFullscreen == true then return end
-    if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
+    if not self._usingDensityLayers then
+        -- No GRLE density-map layers on this terrain — hand off to polygon centroid dots.
+        -- mapSelf is the correct HUD minimap instance here (from drawFields hook),
+        -- unlike the PDA ref stored in ingameMapRef which would hit the isFullscreen guard.
+        local sfm = g_SoilFertilityManager
+        if sfm and sfm.soilMapOverlay then
+            sfm.soilMapOverlay:onDrawMinimap(mapSelf)
+        end
+        return
+    end
+
+    if not self._hasShownOnce then return end
 
     local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
     if layerIdx <= 0 then return end

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -188,12 +188,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Value 0 = unwritten pixel → transparent.
-            -- Values 1-255 → decode to semantic float → status color.
-            for i = 1, 255 do
-                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
+            -- Engine limit: 16 state color sets max. Read top 4 bits of the 8-bit value
+            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
+            -- State 0 = raw value 0-15 (unwritten or near-zero) → transparent.
+            -- States 1-15 = monotonically increasing semantic value → gradient.
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            for i = 1, 15 do
+                local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 8, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,11 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.3.0.0",
-    "- New: PDA fullscreen map now uses per-pixel density map rendering (same quality as minimap)",
-    "- New: soilPest, soilDisease, soilCompaction density map layers — true per-pixel precision",
-    "- New: Weed pressure synced live from the game's native WeedSystem density map",
-    "- Fixed: Minimap layer indices for pest/disease/compaction now match correctly",
+    "v2.3.2.0",
+    "- Fixed: HUD minimap soil overlay now renders correctly again",
+    "- Fixed: PDA map reverted to reliable field-polygon tile rendering",
+    "- Fixed: PDA no longer shows minimap content at wrong scale",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Restores HUD minimap soil overlay (was broken by incorrect `isFullscreen == true` strict equality guard — PDA's value is integer `1`, not boolean `true`)
- Reverts PDA map to reliable field-polygon tile rendering from 2.2.5 (DMV path caused sprayed-strip-only rendering, wrong scale on PDA)
- PDA no longer renders the minimap's DMV overlay content at wrong coordinates

## Test plan
- [ ] HUD minimap shows soil nutrient heatmap overlay
- [ ] PDA soil page shows field-polygon tiles covering all owned fields
- [ ] Switching nutrient layers updates both minimap and PDA correctly
- [ ] No visual artifacts on either view