### PR TITLE
v2.3.3.0 — Hotfix: minimap DMV heatmap ownership filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.1.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.2.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.3.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.1.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.2.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.0.0</version>
+    <version>2.3.1.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.1.0</version>
+    <version>2.3.2.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.2.0</version>
+    <version>2.3.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1128,14 +1128,19 @@ function SoilFertilityManager:loadSoilData()
         local ls = self.soilSystem and self.soilSystem.layerSystem
         if ls and ls.available and not ls.hasData then
             local pushed = 0
+            local cleared = 0
+            local activeIds = self.soilSystem.activeFieldIds or {}
             for fid, data in pairs(self.soilSystem.fieldData) do
-                ls:writeFieldToLayers(fid, data, nil)  -- nil → function looks up Field by fid
-                pushed = pushed + 1
+                if activeIds[fid] then
+                    ls:writeFieldToLayers(fid, data, nil)
+                    pushed = pushed + 1
+                else
+                    ls:clearFieldFromLayers(fid, nil)
+                    cleared = cleared + 1
+                end
             end
-            if pushed > 0 then
-                ls.hasData = true
-                SoilLogger.info("Fresh start: pushed %d GRLE-seeded fields to density layers", pushed)
-            end
+            ls.hasData = true
+            SoilLogger.info("Fresh start: pushed %d owned, cleared %d unowned fields to density layers", pushed, cleared)
         end
     end
 end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1122,6 +1122,21 @@ function SoilFertilityManager:loadSoilData()
         end
     else
         SoilLogger.info("No saved soil data found at %s, using defaults", xmlPath)
+        -- Fresh start: scanFields already seeded fieldData from GRLE layers (if available).
+        -- Push that data to the density map layers now so the PDA DMV overlay and minimap
+        -- heatmap show real values immediately rather than after the first fertilizer event.
+        local ls = self.soilSystem and self.soilSystem.layerSystem
+        if ls and ls.available and not ls.hasData then
+            local pushed = 0
+            for fid, data in pairs(self.soilSystem.fieldData) do
+                ls:writeFieldToLayers(fid, data, nil)  -- nil → function looks up Field by fid
+                pushed = pushed + 1
+            end
+            if pushed > 0 then
+                ls.hasData = true
+                SoilLogger.info("Fresh start: pushed %d GRLE-seeded fields to density layers", pushed)
+            end
+        end
     end
 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -110,17 +110,8 @@ function SoilFertilitySystem:initialize()
             mapSize, scale, self.cellSize, self.cellAreaHa)
     end
 
-    -- Scan fields using real FieldManager
-    if g_fieldManager then
-        self:scanFields()
-    else
-        self:warning("FieldManager not available - will try delayed initialization")
-    end
-
-    -- Install hooks via HookManager
-    self.hookManager:installAll(self)
-
-    -- Initialize density map layer integration (per-pixel soil maps)
+    -- Initialize density map layer integration FIRST so scanFields can read from GRLE.
+    -- layerSystem.available must be true before scanFields runs or the GRLE seed is skipped.
     if self.layerSystem then
         self.layerSystem:initialize()
     end
@@ -129,6 +120,16 @@ function SoilFertilitySystem:initialize()
     if self.bundledMaps then
         self.bundledMaps:initialize()
     end
+
+    -- Scan fields using real FieldManager (now runs with layerSystem ready)
+    if g_fieldManager then
+        self:scanFields()
+    else
+        self:warning("FieldManager not available - will try delayed initialization")
+    end
+
+    -- Install hooks via HookManager
+    self.hookManager:installAll(self)
 
     self.isInitialized = true
     self:info("Soil Fertility System initialized successfully")
@@ -1350,8 +1351,9 @@ function SoilFertilitySystem:scanFields()
 
                 -- If this is a newly created field and density layers are available,
                 -- read existing layer values (pre-seeded GRLE) instead of using defaults.
-                if isNew and self.layerSystem and self.layerSystem.available and field.farmland then
-                    self.layerSystem:readFieldFromLayers(actualFieldId, self.fieldData[actualFieldId], field.farmland)
+                if isNew and self.layerSystem and self.layerSystem.available then
+                    -- Pass the Field object (not field.farmland) — Field has polygonPoints for AABB
+                    self.layerSystem:readFieldFromLayers(actualFieldId, self.fieldData[actualFieldId], field)
                 end
 
                 -- PHASE 1: only owned farmlands enter the active simulation set.
@@ -1375,6 +1377,9 @@ function SoilFertilitySystem:scanFields()
             if type(farmlandId) == "number" and farmlandId > 0 and not self.fieldData[farmlandId] then
                 local flArea = (farmlandObj and farmlandObj.areaInHa) or 1.0
                 self:getOrCreateField(farmlandId, true, flArea)
+                if self.layerSystem and self.layerSystem.available and farmlandObj then
+                    self.layerSystem:readFieldFromLayers(farmlandId, self.fieldData[farmlandId], farmlandObj)
+                end
                 fieldCount = fieldCount + 1
                 SoilLogger.debug("Secondary scan caught missed farmland %d (%.2f ha)", farmlandId, flArea)
             end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2690,22 +2690,18 @@ function SoilFertilitySystem:onInsecticideAppliedIncremental(fieldId, reduction)
         field.insecticideDaysLeft = pp.INSECTICIDE_DURATION_DAYS * daysPerMonth
     end
 
-    -- Local zoneData update
+    -- Update per-cell pest pressure for existing zoneData entries only.
+    -- Do NOT create new entries here — doing so would stamp N/P/K/pH/OM field-average
+    -- values onto cells the insecticide boom passes over, making those cells appear
+    -- "treated with nutrients" on the soil map overlay (issue #517 root cause).
     local x, z = self._lastSprayX, self._lastSprayZ
-    if x and z then
+    if x and z and field.zoneData then
         local zone = SoilConstants.ZONE
         local cellKey = tostring(math.floor(x / zone.CELL_SIZE) * 10000 + math.floor(z / zone.CELL_SIZE))
-        if not field.zoneData then field.zoneData = {} end
-        if not field.zoneData[cellKey] then
-            field.zoneData[cellKey] = {
-                N = field.nitrogen, P = field.phosphorus, K = field.potassium,
-                pH = field.pH, OM = field.organicMatter,
-                weedPressure = field.weedPressure, pestPressure = field.pestPressure,
-                diseasePressure = field.diseasePressure, compaction = field.compaction
-            }
-        end
         local cell = field.zoneData[cellKey]
-        cell.pestPressure = math.max(0, (cell.pestPressure or field.pestPressure or 0) - reduction)
+        if cell then
+            cell.pestPressure = math.max(0, (cell.pestPressure or field.pestPressure or 0) - reduction)
+        end
     end
 end
 
@@ -2724,22 +2720,18 @@ function SoilFertilitySystem:onFungicideAppliedIncremental(fieldId, reduction)
         field.fungicideDaysLeft = dp.FUNGICIDE_DURATION_DAYS * daysPerMonth
     end
 
-    -- Local zoneData update
+    -- Update per-cell disease pressure for existing zoneData entries only.
+    -- Do NOT create new entries here — doing so would stamp N/P/K/pH/OM field-average
+    -- values onto cells the fungicide boom passes over, making those cells appear
+    -- "treated with nutrients" on the soil map overlay (issue #517 root cause).
     local x, z = self._lastSprayX, self._lastSprayZ
-    if x and z then
+    if x and z and field.zoneData then
         local zone = SoilConstants.ZONE
         local cellKey = tostring(math.floor(x / zone.CELL_SIZE) * 10000 + math.floor(z / zone.CELL_SIZE))
-        if not field.zoneData then field.zoneData = {} end
-        if not field.zoneData[cellKey] then
-            field.zoneData[cellKey] = {
-                N = field.nitrogen, P = field.phosphorus, K = field.potassium,
-                pH = field.pH, OM = field.organicMatter,
-                weedPressure = field.weedPressure, pestPressure = field.pestPressure,
-                diseasePressure = field.diseasePressure, compaction = field.compaction
-            }
-        end
         local cell = field.zoneData[cellKey]
-        cell.diseasePressure = math.max(0, (cell.diseasePressure or field.diseasePressure or 0) - reduction)
+        if cell then
+            cell.diseasePressure = math.max(0, (cell.diseasePressure or field.diseasePressure or 0) - reduction)
+        end
     end
 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -451,6 +451,10 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
         -- Field sold / abandoned — pull it out of the active simulation set.
         -- fieldData intentionally kept: new owner inherits the soil conditions.
         self:_removeFromActiveSet(fieldId)
+        -- Clear GRLE so unmasked DMV no longer colours this unowned field.
+        if self.layerSystem and self.layerSystem.available then
+            self.layerSystem:clearFieldFromLayers(fieldId, nil)
+        end
         SoilLogger.debug("[PERF-P1] Field %d released by farm — removed from active set (data preserved)", fieldId)
         return
     end
@@ -459,6 +463,10 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
     local field = self:getOrCreateField(fieldId, true)
     if field then
         self:_addToActiveSet(fieldId)
+        -- Write GRLE so unmasked DMV shows this newly-owned field on next rebuild.
+        if self.layerSystem and self.layerSystem.available then
+            self.layerSystem:writeFieldToLayers(fieldId, field, nil)
+        end
         SoilLogger.debug("[PERF-P1] Field %d acquired by farm %d — added to active set", fieldId, farmId)
     end
 end
@@ -3568,17 +3576,21 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
     -- Guard: only run if the layer system is available.
     if self.layerSystem and self.layerSystem.available and g_farmlandManager then
         local pushed = 0
+        local cleared = 0
         for fieldId, data in pairs(self.fieldData) do
             local farmland = g_farmlandManager:getFarmlandById(fieldId)
             if farmland then
-                self.layerSystem:writeFieldToLayers(fieldId, data, farmland)
-                pushed = pushed + 1
+                if self.activeFieldIds[fieldId] then
+                    self.layerSystem:writeFieldToLayers(fieldId, data, farmland)
+                    pushed = pushed + 1
+                else
+                    self.layerSystem:clearFieldFromLayers(fieldId, farmland)
+                    cleared = cleared + 1
+                end
             end
         end
-        if pushed > 0 then
-            self:info("Pushed %d fields to density map layers after load", pushed)
-            self.layerSystem.hasData = true
-        end
+        self.layerSystem.hasData = true
+        self:info("Pushed %d owned fields, cleared %d unowned fields to density map layers after load", pushed, cleared)
     end
 
     -- Re-broadcast after load so clients that were connected during a

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -364,9 +364,9 @@ function SoilHUD:calculateHeight()
         
         local mgr = g_SoilFertilityManager
         if mgr and mgr.settings then
-            if mgr.settings.weedPressure and (info.weedPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
-            if mgr.settings.pestPressure and (info.pestPressure or 0) > 0 then h = h + SoilHUD.LINE_H end
-            if mgr.settings.diseasePressure and (info.diseasePressure or 0) > 0 then h = h + SoilHUD.LINE_H end
+            if mgr.settings.weedPressure    and ((info.weedPressure    or 0) > 0 or info.herbicideActive)  then h = h + SoilHUD.LINE_H end
+            if mgr.settings.pestPressure    and ((info.pestPressure    or 0) > 0 or info.insecticideActive) then h = h + SoilHUD.LINE_H end
+            if mgr.settings.diseasePressure and ((info.diseasePressure or 0) > 0 or info.fungicideActive)   then h = h + SoilHUD.LINE_H end
             if self._cachedSprayer and (info.sessionCoverageFraction or info.coverageFraction or 0) > 0 then h = h + SoilHUD.LINE_H end
             if mgr.settings.compactionEnabled and (info.compaction or 0) > 0 then h = h + SoilHUD.LINE_H end
         end
@@ -1223,16 +1223,16 @@ function SoilHUD:drawPanel()
         -- Weed / pest / disease pressure rows
         local mgr = g_SoilFertilityManager
         if mgr then
-            if mgr.settings.weedPressure and (info.weedPressure or 0) > 0 then
-                cy = self:drawPressureRow("sf_hud_weeds", info.weedPressure,
+            if mgr.settings.weedPressure    and ((info.weedPressure    or 0) > 0 or info.herbicideActive) then
+                cy = self:drawPressureRow("sf_hud_weeds", info.weedPressure or 0,
                     info.herbicideActive, px, cy, pw, s, fontMult)
             end
-            if mgr.settings.pestPressure and (info.pestPressure or 0) > 0 then
-                cy = self:drawPressureRow("sf_hud_pests", info.pestPressure,
+            if mgr.settings.pestPressure    and ((info.pestPressure    or 0) > 0 or info.insecticideActive) then
+                cy = self:drawPressureRow("sf_hud_pests", info.pestPressure or 0,
                     info.insecticideActive, px, cy, pw, s, fontMult)
             end
-            if mgr.settings.diseasePressure and (info.diseasePressure or 0) > 0 then
-                cy = self:drawPressureRow("sf_hud_disease", info.diseasePressure,
+            if mgr.settings.diseasePressure and ((info.diseasePressure or 0) > 0 or info.fungicideActive) then
+                cy = self:drawPressureRow("sf_hud_disease", info.diseasePressure or 0,
                     info.fungicideActive, px, cy, pw, s, fontMult)
             end
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -850,7 +850,7 @@ function SoilHUD:refreshFieldData()
     self.cachedPlayerZ = z
 
     if fieldId then
-        self.cachedFieldInfo = soilSys:getFieldInfo(fieldId)
+        self.cachedFieldInfo = soilSys:getFieldInfo(fieldId, x, z)
 
         if fieldId ~= prevId and self.cachedFieldInfo then
             local info = self.cachedFieldInfo
@@ -882,7 +882,8 @@ function SoilHUD:refreshFieldData()
     -- Pre-format display strings so draw() at 60 FPS never calls string.format
     local info = self.cachedFieldInfo
     if info and fieldId then
-        self._fmt_fieldText = string.format(g_i18n:getText("sf_hud_field"), fieldId) .. " (Avg)"
+        local dataSuffix = info.fromZoneCell and " (Local)" or " (Avg)"
+        self._fmt_fieldText = string.format(g_i18n:getText("sf_hud_field"), fieldId) .. dataSuffix
         local crop = info.lastCrop
         if crop and crop ~= "" then
             self._fmt_cropText = crop:sub(1,1):upper() .. crop:sub(2)

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -360,52 +360,82 @@ function SoilLayerSystem:readValueAtWorld(layerName, worldX, worldZ)
 end
 
 -- ─────────────────────────────────────────────────────────
--- Read back the AVERAGE encoded value across a farmland
--- polygon and return the decoded semantic float.
--- Samples a grid of world points across the farmland AABB.
+-- Derive the AABB (cx, cz, hw, hh) for a FS25 Field object.
+-- FS25 Field objects have polygonPoints (scene node IDs) and
+-- posX/posZ (centroid).  Farmland objects have NO geometry.
+-- Returns cx, cz, hw, hh or nil on failure.
+-- ─────────────────────────────────────────────────────────
+local function getFieldAABB(fsField)
+    if not fsField then return nil end
+
+    -- Primary: derive AABB from polygon node world positions
+    local polyNodes = fsField.polygonPoints
+    if polyNodes and #polyNodes >= 3 then
+        local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
+        for i = 1, #polyNodes do
+            local nodeId = polyNodes[i]
+            if nodeId and nodeId ~= 0 then
+                local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+                if ok and wx then
+                    if wx < minX then minX = wx end
+                    if wx > maxX then maxX = wx end
+                    if wz < minZ then minZ = wz end
+                    if wz > maxZ then maxZ = wz end
+                end
+            end
+        end
+        if minX ~= math.huge then
+            return (minX + maxX) / 2, (minZ + maxZ) / 2,
+                   (maxX - minX) / 2, (maxZ - minZ) / 2
+        end
+    end
+
+    -- Fallback: use centroid + area-based half-extents
+    local cx = fsField.posX
+    local cz = fsField.posZ
+    if cx and cz then
+        local area   = fsField.areaHa or (fsField.farmland and fsField.farmland.areaInHa) or 1.0
+        local halfSide = math.sqrt(area * 10000) / 2
+        return cx, cz, halfSide, halfSide
+    end
+
+    return nil
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Look up the FS25 Field object for a given farmland ID.
+-- Returns nil when g_fieldManager is unavailable.
+-- ─────────────────────────────────────────────────────────
+local function getFieldByFarmlandId(farmlandId)
+    if not g_fieldManager or not g_fieldManager.fields then return nil end
+    for _, f in ipairs(g_fieldManager.fields) do
+        if f and f.farmland and f.farmland.id == farmlandId then
+            return f
+        end
+    end
+    return nil
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Read back the AVERAGE encoded value across a field polygon
+-- and return the decoded semantic float.
+-- Samples a grid of world points across the field AABB.
 -- Used during scanFields to initialise fieldData from an
 -- existing GRLE (e.g. a fresh savegame or a pre-seeded map).
+-- fsField must be a FS25 Field object (has polygonPoints).
 -- ─────────────────────────────────────────────────────────
 
 ---@param layerName string
----@param farmland  table    FS25 farmland object (has .x .z .width .height or polygon)
+---@param fsField   table    FS25 Field object (field.farmland.id is the key)
 ---@return number|nil  Semantic average, or nil if layer missing / no valid reads
-function SoilLayerSystem:readAverageForFarmland(layerName, farmland)
+function SoilLayerSystem:readAverageForFarmland(layerName, fsField)
     if not self.available then return nil end
 
     local entry = self.layerHandles[layerName]
     if not entry then return nil end
 
-    -- Determine bounding box from farmland fields
-    local cx, cz, hw, hh
-    if farmland.x and farmland.z then
-        -- Some maps expose world-space center + half-extents
-        cx = farmland.x
-        cz = farmland.z
-        hw = (farmland.width  and farmland.width  / 2) or 50
-        hh = (farmland.height and farmland.height / 2) or 50
-    elseif farmland.polygon and #farmland.polygon >= 2 then
-        -- Derive AABB from polygon points (format: {x1, z1, x2, z2, ...})
-        local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
-        for i = 1, #farmland.polygon, 2 do
-            local px = farmland.polygon[i]
-            local pz = farmland.polygon[i + 1]
-            if px and pz then
-                if px < minX then minX = px end
-                if px > maxX then maxX = px end
-                if pz < minZ then minZ = pz end
-                if pz > maxZ then maxZ = pz end
-            end
-        end
-        if minX == math.huge then return nil end
-        cx = (minX + maxX) / 2
-        cz = (minZ + maxZ) / 2
-        hw = (maxX - minX) / 2
-        hh = (maxZ - minZ) / 2
-    else
-        -- Absolute fallback: can't determine farmland boundary
-        return nil
-    end
+    local cx, cz, hw, hh = getFieldAABB(fsField)
+    if not cx then return nil end
 
     -- Sample a 5×5 grid across the AABB
     local STEPS = 5
@@ -439,38 +469,25 @@ end
 -- visual heatmap matches what's stored).
 -- ─────────────────────────────────────────────────────────
 
----@param fieldId  number
----@param fieldData table  The fieldData[fieldId] table
----@param farmland  table  FS25 farmland object for the field
-function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, farmland)
+---@param fieldId   number
+---@param fieldData table   The fieldData[fieldId] table
+---@param fsFieldOrFarmland table  FS25 Field object preferred; farmland ID used to look up Field if needed
+function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmland)
     if not self.available then return end
-    if not fieldData or not farmland then return end
+    if not fieldData then return end
 
-    -- Determine bounding box (same logic as readAverageForFarmland)
-    local cx, cz, hw, hh
-    if farmland.x and farmland.z then
-        cx = farmland.x
-        cz = farmland.z
-        hw = (farmland.width  and farmland.width  / 2) or 50
-        hh = (farmland.height and farmland.height / 2) or 50
-    elseif farmland.polygon and #farmland.polygon >= 2 then
-        local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
-        for i = 1, #farmland.polygon, 2 do
-            local px = farmland.polygon[i]
-            local pz = farmland.polygon[i + 1]
-            if px and pz then
-                if px < minX then minX = px end
-                if px > maxX then maxX = px end
-                if pz < minZ then minZ = pz end
-                if pz > maxZ then maxZ = pz end
-            end
-        end
-        if minX == math.huge then return end
-        cx = (minX + maxX) / 2
-        cz = (minZ + maxZ) / 2
-        hw = (maxX - minX) / 2
-        hh = (maxZ - minZ) / 2
-    else
+    -- Resolve to a Field object (which has polygonPoints for AABB).
+    -- Callers may pass a Field object directly, or a farmland object (which has no geometry).
+    -- When a farmland object is passed, look up the Field via g_fieldManager.
+    local fsField = fsFieldOrFarmland
+    if fsField and not fsField.polygonPoints and not fsField.posX then
+        -- Likely a farmland object — look up the corresponding Field
+        fsField = getFieldByFarmlandId(fieldId)
+    end
+
+    local cx, cz, hw, hh = getFieldAABB(fsField)
+    if not cx then
+        SoilLogger.debug("SoilLayerSystem: writeFieldToLayers skipped field %d (no geometry)", fieldId)
         return
     end
 
@@ -546,14 +563,20 @@ end
 ---@param fieldData table  The fieldData[fieldId] table (modified in-place)
 ---@param farmland  table  FS25 farmland object
 ---@return boolean
-function SoilLayerSystem:readFieldFromLayers(fieldId, fieldData, farmland)
+function SoilLayerSystem:readFieldFromLayers(fieldId, fieldData, fsField)
     if not self.available then return false end
+
+    -- Resolve to a Field object if a farmland was passed
+    if fsField and not fsField.polygonPoints and not fsField.posX then
+        fsField = getFieldByFarmlandId(fieldId)
+    end
+    if not fsField then return false end
 
     local anyRead = false
     for _, def in ipairs(LAYER_DEFS) do
         local entry = self.layerHandles[def.name]
         if entry then
-            local avg = self:readAverageForFarmland(def.name, farmland)
+            local avg = self:readAverageForFarmland(def.name, fsField)
             if avg ~= nil then
                 fieldData[def.field] = avg
                 anyRead = true

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -513,6 +513,45 @@ function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmlan
 end
 
 -- ─────────────────────────────────────────────────────────
+-- Clear ALL nutrient layers for a field (write 0 to entire
+-- AABB).  Call this for unowned fields so the unmasked DMV
+-- only colours owned field areas.
+-- ─────────────────────────────────────────────────────────
+
+---@param fieldId          number
+---@param fsFieldOrFarmland table|nil  Field or farmland object; nil → looks up by fieldId
+function SoilLayerSystem:clearFieldFromLayers(fieldId, fsFieldOrFarmland)
+    if not self.available then return end
+
+    local fsField = fsFieldOrFarmland
+    if fsField and not fsField.polygonPoints and not fsField.posX then
+        fsField = getFieldByFarmlandId(fieldId)
+    elseif not fsField then
+        fsField = getFieldByFarmlandId(fieldId)
+    end
+
+    local cx, cz, hw, hh = getFieldAABB(fsField)
+    if not cx then return end
+
+    for _, def in ipairs(LAYER_DEFS) do
+        local entry = self.layerHandles[def.name]
+        if entry then
+            local modifier = entry.modifier
+            local filter   = DensityMapFilter.new(modifier)
+            modifier:setParallelogramWorldCoords(
+                cx - hw, cz - hh,
+                cx + hw, cz - hh,
+                cx - hw, cz + hh,
+                DensityCoordType.POINT_POINT_POINT
+            )
+            modifier:executeSet(0, filter, nil)
+        end
+    end
+
+    SoilLogger.debug("SoilLayerSystem: cleared GRLE for field %d", fieldId)
+end
+
+-- ─────────────────────────────────────────────────────────
 -- Incremental write at a world position for a specific
 -- nutrient layer.  Use this inside applyFertilizer /
 -- onHarvest for per-pixel real-time updates.

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -311,10 +311,10 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
     end
 
     -- GRLE-backed layers (N/P/K/pH/OM/Pest/Disease/Compaction)
-    -- Require hasData so we don't generate a fully-transparent overlay before
-    -- writeFieldToLayers has run — that would suppress the polygon-dot fallback.
+    -- State 0 (unwritten GRLE pixels) is mapped to transparent, so generating the
+    -- overlay early is safe — unpopulated areas stay invisible until data is written.
     local fieldKey = PDA_LAYER_GRLE[layerIdx]
-    if fieldKey and layerSystem and layerSystem.available and layerSystem.hasData then
+    if fieldKey and layerSystem and layerSystem.available then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle
@@ -1542,7 +1542,7 @@ end
 function SoilMapOverlay:onDrawMinimap(ingameMap)
     if ingameMap == nil then return end
     if ingameMap.isFullscreen then return end
-    if ingameMap.state == nil or ingameMap.state <= 1 then return end
+    if ingameMap.state == nil then return end
     -- Suppress minimap dots when any full-screen GUI is open (pause menu, dialogs, etc.)
     if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
 

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -311,7 +311,7 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
 
     -- GRLE-backed layers (N/P/K/pH/OM/Pest/Disease/Compaction)
     local fieldKey = PDA_LAYER_GRLE[layerIdx]
-    if fieldKey and layerSystem and layerSystem.available and layerSystem.hasData then
+    if fieldKey and layerSystem and layerSystem.available then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -1700,7 +1700,7 @@ function SoilMapOverlay:installMinimapZoomHooks()
 
         local origSet = layoutClass.setWorldSize
         layoutClass.setWorldSize = function(layout, ...)
-            origSet(layout, ...)
+            if origSet then origSet(layout, ...) end
             layout._sfOrigWorldSizeFactor = layout.worldSizeFactor
         end
 
@@ -1709,7 +1709,7 @@ function SoilMapOverlay:installMinimapZoomHooks()
             if layout._sfOrigWorldSizeFactor ~= nil then
                 layout.worldSizeFactor = layout._sfOrigWorldSizeFactor * SoilMapOverlay.minimapZoomSmoothed
             end
-            origUpdate(layout, ...)
+            if origUpdate then origUpdate(layout, ...) end
         end
 
         layoutClass._sfZoomHooked = true

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -299,7 +299,7 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
             for state = 1, maxState do
                 local ci = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, firstCh or 0, 0, numCh or 4, state, r, g, b, 0.85)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)
@@ -316,14 +316,15 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Engine limit: 16 state color sets max. Read top 4 bits of 8-bit value
-            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
+            -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
+            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
             -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -299,7 +299,8 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
             for state = 1, maxState do
                 local ci = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
+                -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)
@@ -310,21 +311,23 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
     end
 
     -- GRLE-backed layers (N/P/K/pH/OM/Pest/Disease/Compaction)
+    -- Require hasData so we don't generate a fully-transparent overlay before
+    -- writeFieldToLayers has run — that would suppress the polygon-dot fallback.
     local fieldKey = PDA_LAYER_GRLE[layerIdx]
-    if fieldKey and layerSystem and layerSystem.available then
+    if fieldKey and layerSystem and layerSystem.available and layerSystem.hasData then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle
             local def    = entry.def
             -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
-            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
-            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
+            -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0, fieldMask=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states.
             -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)
@@ -645,62 +648,41 @@ function SoilMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
     local layerIdx = self.settings.activeMapLayer or 0
     if layerIdx <= 0 then return end
 
-    -- Poll async DMV build
-    self:_pdaPollBuildFinished()
-
     local mapX, mapY, mapWidth, mapHeight = self:getMapRenderBounds(frame, ingameMap)
     if mapX == nil or mapWidth == nil or mapHeight == nil then return end
 
-    -- Kick a new DMV build when layer changed or refresh interval elapsed
-    local now = (g_currentMission and g_currentMission.time) or 0
-    if self._pdaDMVAvailable and not self._pdaBuildInFlight
-       and (self._pdaActiveLayer ~= layerIdx or now >= self._pdaNextBuildMs) then
-        self._pdaNextBuildMs  = now + SoilMapOverlay.SAMPLE_UPDATE_INTERVAL_MS
-        self._pdaActiveLayer  = layerIdx
-        self:_pdaKickBuild(layerIdx)
-    end
+    -- PDA always uses polygon tiles (field-clamped, works without GRLE data)
+    self:updateSamplePoints(false)
 
-    if self._pdaHasShownOnce and self._pdaUsingDMV then
-        -- ── Per-pixel DMV path ────────────────────────────────────
-        local ov = self._pdaOverlays[self._pdaShowIdx]
-        if ov then
-            setOverlayColor(ov, 1, 1, 1, SoilMapOverlay.ALPHA)
-            renderOverlay(ov, mapX, mapY, mapWidth, mapHeight)
+    if #self.samplePoints > 0 then
+        local mapMaxX = mapX + mapWidth
+        local mapMaxY = mapY + mapHeight
+
+        local drawStep = SoilConstants.ZONE.CELL_SIZE
+        local ax, ay = self:worldToScreenPosition(ingameMap, 0, 0)
+        local bx, by = self:worldToScreenPosition(ingameMap, drawStep, 0)
+        local cx, cy = self:worldToScreenPosition(ingameMap, 0, drawStep)
+        local sizeX, sizeY
+        if ax and bx and cx then
+            sizeX = math.max(math.abs(bx - ax) * 1.15, 0.0005)
+            sizeY = math.max(math.abs(cy - ay) * 1.15, 0.0005)
+        else
+            sizeX, sizeY = getNormalizedScreenValues(10, 10)
         end
-    else
-        -- ── Polygon dot fallback (urgency layer, or DMV not yet ready) ──
-        self:updateSamplePoints(false)
+        local halfX, halfY = sizeX * 0.5, sizeY * 0.5
 
-        if #self.samplePoints > 0 then
-            local mapMaxX = mapX + mapWidth
-            local mapMaxY = mapY + mapHeight
+        local scaleXX = (bx - ax) / drawStep
+        local scaleYX = (by - ay) / drawStep
+        local scaleXZ = (cx - ax) / drawStep
+        local scaleYZ = (cy - ay) / drawStep
 
-            local drawStep = SoilConstants.ZONE.CELL_SIZE
-            local ax, ay = self:worldToScreenPosition(ingameMap, 0, 0)
-            local bx, by = self:worldToScreenPosition(ingameMap, drawStep, 0)
-            local cx, cy = self:worldToScreenPosition(ingameMap, 0, drawStep)
-            local sizeX, sizeY
-            if ax and bx and cx then
-                sizeX = math.max(math.abs(bx - ax) * 1.15, 0.0005)
-                sizeY = math.max(math.abs(cy - ay) * 1.15, 0.0005)
-            else
-                sizeX, sizeY = getNormalizedScreenValues(10, 10)
-            end
-            local halfX, halfY = sizeX * 0.5, sizeY * 0.5
-
-            local scaleXX = (bx - ax) / drawStep
-            local scaleYX = (by - ay) / drawStep
-            local scaleXZ = (cx - ax) / drawStep
-            local scaleYZ = (cy - ay) / drawStep
-
-            for _, point in ipairs(self.samplePoints) do
-                local screenX = ax + point.x * scaleXX + point.z * scaleXZ
-                local screenY = ay + point.x * scaleYX + point.z * scaleYZ
-                if screenX >= mapX and screenX <= mapMaxX
-                   and screenY >= mapY and screenY <= mapMaxY then
-                    drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
-                                   point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
-                end
+        for _, point in ipairs(self.samplePoints) do
+            local screenX = ax + point.x * scaleXX + point.z * scaleXZ
+            local screenY = ay + point.x * scaleYX + point.z * scaleYZ
+            if screenX >= mapX and screenX <= mapMaxX
+               and screenY >= mapY and screenY <= mapMaxY then
+                drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
+                               point.r, point.g, point.b, (point.a or 1.0) * SoilMapOverlay.ALPHA)
             end
         end
     end

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -1542,7 +1542,7 @@ end
 function SoilMapOverlay:onDrawMinimap(ingameMap)
     if ingameMap == nil then return end
     if ingameMap.isFullscreen then return end
-    if ingameMap.state == nil then return end
+    if ingameMap.state == nil or ingameMap.state <= 1 then return end
     -- Suppress minimap dots when any full-screen GUI is open (pause menu, dialogs, etc.)
     if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
 

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -316,10 +316,14 @@ function SoilMapOverlay:_pdaKickBuild(layerIdx)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            for i = 1, 255 do
-                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
+            -- Engine limit: 16 state color sets max. Read top 4 bits of 8-bit value
+            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
+            -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            for i = 1, 15 do
+                local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = self:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 8, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
             end
             self._pdaUsingDMV = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -183,7 +183,7 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     end
 
     -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
-    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
+    if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -184,10 +184,11 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     end
 
     -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
-    -- State 0 (unwritten GRLE pixels) is mapped to transparent, so generating the
-    -- overlay before soil data is written is safe — fields without data just show
-    -- nothing and the overlay populates on the next rebuild after writeFieldToLayers runs.
-    if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
+    -- layerSystem.hasData is set true only after writeFieldToLayers has pushed real
+    -- soil values into the GRLE.  Without this guard the overlay generates but shows
+    -- nothing (all pixels state 0 = transparent) and the polygon-dot fallback is
+    -- suppressed, leaving the minimap blank for new or not-yet-loaded games.
+    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -195,13 +195,29 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             local def    = entry.def
             -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
             -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
-            -- maskMapId=0, fieldMask=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states.
-            -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
+            -- State 0 = raw bits 4-7 = 0 (unwritten/near-zero) → always transparent.
             setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, 0, 0, 0, 0, 0)
-            for i = 1, 15 do
-                local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
-                local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
+            -- Use the farmland bit-vector map as a mask so the DMV only renders on
+            -- owned farmland pixels (generic.grle seeds values everywhere on the terrain,
+            -- so without masking the whole map gets coloured).
+            -- Each call adds a render rule: "state i visible where farmland map = farmlandId".
+            local farmlandMap  = self._farmlandMap
+            local activeFields = self.soilSystem and self.soilSystem.activeFieldIds or {}
+            if farmlandMap and next(activeFields) ~= nil then
+                for farmlandId, _ in pairs(activeFields) do
+                    for i = 1, 15 do
+                        local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
+                        local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
+                        setDensityMapVisualizationOverlayStateColor(ov, handle, farmlandMap, farmlandId, 4, 4, i, r, g, b, 1.0)
+                    end
+                end
+            else
+                -- No farmland map or nothing owned — unmasked fallback (shows everywhere).
+                for i = 1, 15 do
+                    local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
+                    local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
+                    setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
+                end
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -184,11 +184,10 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     end
 
     -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
-    -- layerSystem.hasData is set true only after writeFieldToLayers has pushed real
-    -- soil values into the GRLE.  Without this guard the overlay generates but shows
-    -- nothing (all pixels state 0 = transparent) and the polygon-dot fallback is
-    -- suppressed, leaving the minimap blank for new or not-yet-loaded games.
-    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
+    -- State 0 (unwritten GRLE pixels) is mapped to transparent, so generating the
+    -- overlay before soil data is written is safe — fields without data just show
+    -- nothing and the overlay populates on the next rebuild after writeFieldToLayers runs.
+    if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle
@@ -271,48 +270,57 @@ function SoilMinimapLayer:draw(mapSelf)
     local ov = self._overlays[self._showIdx]
     if not ov then return end
 
-    -- Map world-rect → screen rect using the same layout helpers BMP uses
+    -- Map world-rect to screen rect using the layout helpers.
+    -- The DMV overlay covers the full terrain in UV space (0,0)→(1,1).
+    -- We use UV mapping to select only the visible window defined by
+    -- mapExtensionOffsetX/Z (pan) and mapExtensionScaleFactor (zoom),
+    -- rendering the result at the full minimap screen rect.
     local layout = mapSelf.layout
     if not layout then return end
 
     local w, h = layout:getMapSize()
     local x, y = layout:getMapPosition()
-    local px, py = layout:getMapPivot()
 
     local extX = mapSelf.mapExtensionOffsetX    or 0
     local extZ = mapSelf.mapExtensionOffsetZ    or 0
     local scl  = mapSelf.mapExtensionScaleFactor or 1
 
-    local mx = x + w * extX
-    local my = y + h * extZ
-    local mw = w * scl
-    local mh = h * scl
-    local rx = (px + x) - mx
-    local ry = (py + y) - my
+    -- Visible terrain window in UV space (U = east-west, V = south-north)
+    local uL = extX
+    local uR = extX + scl
+    local vB = extZ
+    local vT = extZ + scl
 
-    -- Clip rect (circle minimap, etc.)
-    local didClip  = false
-    local uL, vT, uR, vB = 0, 0, 1, 1
+    -- Render destination: full minimap screen rect
+    local rx, ry, rw, rh = x, y, w, h
+
+    -- Clip rect (circular minimap mask) — adjust screen rect and UV together
+    local didClip = false
     if mapSelf.clipX1 ~= nil then
-        local x1, y1 = mx, my
-        local x2, y2 = mx + mw, my + mh
         local cx1, cy1 = mapSelf.clipX1, mapSelf.clipY1
         local cx2, cy2 = mapSelf.clipX2, mapSelf.clipY2
-        local rx1 = math.max(x1, cx1); local ry1 = math.max(y1, cy1)
-        local rx2 = math.min(x2, cx2); local ry2 = math.min(y2, cy2)
-        if (rx2 - rx1) <= 0 or (ry2 - ry1) <= 0 then return end
-        uL = (rx1 - x1) / (x2 - x1); vT = (ry1 - y1) / (y2 - y1)
-        uR = (rx2 - x1) / (x2 - x1); vB = (ry2 - y1) / (y2 - y1)
-        mx, my, mw, mh = rx1, ry1, rx2 - rx1, ry2 - ry1
+        local sx1 = math.max(x, cx1); local sy1 = math.max(y, cy1)
+        local sx2 = math.min(x + w, cx2); local sy2 = math.min(y + h, cy2)
+        if (sx2 - sx1) <= 0 or (sy2 - sy1) <= 0 then return end
+        -- Remap UV to the clipped sub-region of the full minimap
+        local uPerPx = scl / w
+        local vPerPx = scl / h
+        uL = extX + (sx1 - x) * uPerPx
+        uR = extX + (sx2 - x) * uPerPx
+        vB = extZ + (sy1 - y) * vPerPx
+        vT = extZ + (sy2 - y) * vPerPx
+        rx, ry, rw, rh = sx1, sy1, sx2 - sx1, sy2 - sy1
         didClip = true
     end
 
-    if didClip then
-        setOverlayUVs(ov, uL, vT, uL, vB, uR, vT, uR, vB)
-    end
+    -- UV corners: (bottom-left, top-left, bottom-right, top-right)
+    setOverlayUVs(ov, uL, vB, uL, vT, uR, vB, uR, vT)
 
     if layout.getMapRotation then
-        setOverlayRotation(ov, layout:getMapRotation(), rx, ry)
+        local rot = layout:getMapRotation()
+        if rot and rot ~= 0 then
+            setOverlayRotation(ov, rot, x + w * 0.5, y + h * 0.5)
+        end
     end
 
     local alpha = 0.72
@@ -321,9 +329,9 @@ function SoilMinimapLayer:draw(mapSelf)
         if a then alpha = math.sqrt(a) * 0.72 end
     end
     setOverlayColor(ov, 1, 1, 1, alpha)
-    renderOverlay(ov, mx, my, mw, mh)
+    renderOverlay(ov, rx, ry, rw, rh)
 
-    if didClip and Overlay ~= nil and Overlay.DEFAULT_UVS ~= nil then
+    if Overlay ~= nil and Overlay.DEFAULT_UVS ~= nil then
         setOverlayUVs(ov, unpack(Overlay.DEFAULT_UVS))
     end
 end

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -172,7 +172,7 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             for state = 1, maxState do
                 local ci  = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, firstCh or 0, 0, numCh or 4, state, r, g, b, 0.85)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -188,15 +188,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Engine limit: 16 state color sets max. Read top 4 bits of the 8-bit value
-            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
-            -- State 0 = raw value 0-15 (unwritten or near-zero) → transparent.
-            -- States 1-15 = monotonically increasing semantic value → gradient.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
+            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
+            -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -172,7 +172,8 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             for state = 1, maxState do
                 local ci  = math.min(state, #weedColors)
                 local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
+                -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -183,20 +184,24 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     end
 
     -- ── Per-pixel path (nutrients + pest/disease/compaction GRLE layers) ──────
-    if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
+    -- layerSystem.hasData is set true only after writeFieldToLayers has pushed real
+    -- soil values into the GRLE.  Without this guard the overlay generates but shows
+    -- nothing (all pixels state 0 = transparent) and the polygon-dot fallback is
+    -- suppressed, leaving the minimap blank for new or not-yet-loaded games.
+    if layerSystem and layerSystem.available and layerSystem.hasData and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
         if entry then
             local handle = entry.handle
             local def    = entry.def
             -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
-            -- Signature: (overlay, mapId, maskMapId, firstChannel, numChannels, state, r, g, b, a)
-            -- maskMapId=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states (top nibble).
+            -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
+            -- maskMapId=0, fieldMask=0 (no mask), firstChannel=4 reads bits 4-7 → 16 states.
             -- State 0 = raw 0-15 (unwritten/near-zero) → transparent.
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, 0, 0, 0, 0, 0)
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, 0, 0, 0, 0, 0)
             for i = 1, 15 do
                 local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 4, 4, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
@@ -212,16 +217,18 @@ end
 
 -- ── Rendering ─────────────────────────────────────────────
 
--- Called from IngameMap.drawFields (or FSBaseMission.draw as fallback).
--- mapSelf is the IngameMap instance.
+-- Called from IngameMap.drawFields with the actual IngameMap instance being drawn.
+-- Fires for both the HUD minimap and the PDA fullscreen map — guards handle each.
 function SoilMinimapLayer:draw(mapSelf)
     if not self._initialized then return end
-    if not self._hasShownOnce then return end
-    if not self._usingDensityLayers then return end
     if not mapSelf then return end
 
-    -- Only render on the HUD minimap, never on the PDA fullscreen map.
-    -- g_currentMission.hud.ingameMap is the authoritative HUD minimap instance.
+    -- PDA fullscreen map has isFullscreen as a truthy integer (1) while the HUD minimap has nil.
+    -- Using a truthy check (not == true) correctly blocks PDA without blocking HUD.
+    if mapSelf.isFullscreen then return end
+    if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
+
+    -- Secondary identity guard: when the HUD minimap ref is resolvable, only draw on that instance.
     local hudMap = nil
     if g_currentMission and g_currentMission.hud then
         local hud = g_currentMission.hud
@@ -229,8 +236,18 @@ function SoilMinimapLayer:draw(mapSelf)
     end
     if hudMap ~= nil and mapSelf ~= hudMap then return end
 
-    if mapSelf.isFullscreen == true then return end
-    if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
+    if not self._usingDensityLayers then
+        -- No GRLE density-map layers on this terrain — hand off to polygon centroid dots.
+        -- mapSelf is the correct HUD minimap instance here (from drawFields hook),
+        -- unlike the PDA ref stored in ingameMapRef which would hit the isFullscreen guard.
+        local sfm = g_SoilFertilityManager
+        if sfm and sfm.soilMapOverlay then
+            sfm.soilMapOverlay:onDrawMinimap(mapSelf)
+        end
+        return
+    end
+
+    if not self._hasShownOnce then return end
 
     local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
     if layerIdx <= 0 then return end

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -196,28 +196,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             -- Engine limit: 16 state color sets. Read top 4 bits of the 8-bit value.
             -- Signature: (overlay, mapId, maskMapId, fieldMask, firstChannel, numChannels, state, r, g, b, a)
             -- State 0 = raw bits 4-7 = 0 (unwritten/near-zero) → always transparent.
+            -- State 0 = raw bits 4-7 = 0 (unwritten/near-zero) → always transparent.
+            -- No masking: our GRLE starts as all-zeros; writeFieldToLayers only paints
+            -- field AABBs, so only field areas ever have non-zero state values.
+            -- Unmasked rendering therefore naturally restricts coloring to field areas.
             setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, 0, 0, 0, 0, 0)
-            -- Use the farmland bit-vector map as a mask so the DMV only renders on
-            -- owned farmland pixels (generic.grle seeds values everywhere on the terrain,
-            -- so without masking the whole map gets coloured).
-            -- Each call adds a render rule: "state i visible where farmland map = farmlandId".
-            local farmlandMap  = self._farmlandMap
-            local activeFields = self.soilSystem and self.soilSystem.activeFieldIds or {}
-            if farmlandMap and next(activeFields) ~= nil then
-                for farmlandId, _ in pairs(activeFields) do
-                    for i = 1, 15 do
-                        local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
-                        local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                        setDensityMapVisualizationOverlayStateColor(ov, handle, farmlandMap, farmlandId, 4, 4, i, r, g, b, 1.0)
-                    end
-                end
-            else
-                -- No farmland map or nothing owned — unmasked fallback (shows everywhere).
-                for i = 1, 15 do
-                    local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
-                    local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                    setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
-                end
+            for i = 1, 15 do
+                local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
+                local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 4, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -188,12 +188,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Value 0 = unwritten pixel → transparent.
-            -- Values 1-255 → decode to semantic float → status color.
-            for i = 1, 255 do
-                local semanticVal = def.minVal + (i / 255.0) * (def.maxVal - def.minVal)
+            -- Engine limit: 16 state color sets max. Read top 4 bits of the 8-bit value
+            -- (firstChannel=4, numChannels=4 → states 0-15 = top nibble).
+            -- State 0 = raw value 0-15 (unwritten or near-zero) → transparent.
+            -- States 1-15 = monotonically increasing semantic value → gradient.
+            setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, 0, 0, 0, 0, 0)
+            for i = 1, 15 do
+                local semanticVal = def.minVal + (i / 15.0) * (def.maxVal - def.minVal)
                 local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, 8, i, r, g, b, 1.0)
+                setDensityMapVisualizationOverlayStateColor(ov, handle, 4, 0, 4, i, r, g, b, 1.0)
             end
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)

--- a/src/ui/SoilSeeAndSprayPanel.lua
+++ b/src/ui/SoilSeeAndSprayPanel.lua
@@ -229,7 +229,10 @@ function SoilSeeAndSprayPanel:drawPanel(sprayer, sfm)
             local anyAbove = (pOn and pVal >= ssCfgE.PEST_THRESHOLD)
                           or (dOn and dVal >= ssCfgE.DISEASE_THRESHOLD)
                           or (wOn and not weedProtected and wVal >= ssCfgE.WEED_THRESHOLD)
-            allSuppressed = not anyAbove
+            -- Only show "all suppressed" when we have valid field data.
+            -- Without field data all pressures default to 0, which would incorrectly
+            -- show the suppressed notice on every road or grass area.
+            allSuppressed = fdE ~= nil and not anyAbove
         end
     end
 

--- a/src/ui/SoilSeeAndSprayPanel.lua
+++ b/src/ui/SoilSeeAndSprayPanel.lua
@@ -101,13 +101,20 @@ function SoilSeeAndSprayPanel:getCellData(vehicle)
     if not ok or not x then return nil, nil, nil end
     local sfm = g_SoilFertilityManager
     if not sfm or not sfm.soilSystem then return nil, nil, nil end
-    local field = nil
+
+    -- Tier 1: field lookup → farmland.id (field.fieldId is nil in FS25)
+    local fieldId = nil
     if g_fieldManager then
         local fok, f = pcall(function() return g_fieldManager:getFieldAtWorldPosition(x, z) end)
-        if fok and f then field = f end
+        if fok and f and f.farmland then fieldId = f.farmland.id end
     end
-    local fieldId = field and field.fieldId
+    -- Tier 2: farmland object fallback
+    if not fieldId and g_farmlandManager then
+        local fok, farmland = pcall(function() return g_farmlandManager:getFarmlandAtWorldPosition(x, z) end)
+        if fok and farmland and farmland.id and farmland.id > 0 then fieldId = farmland.id end
+    end
     if not fieldId or fieldId <= 0 then return nil, nil, nil end
+
     local fd = sfm.soilSystem.fieldData[fieldId]
     if not fd then return nil, nil, nil end
     local zone = SoilConstants.ZONE

--- a/src/ui/SoilSmartSensorPanel.lua
+++ b/src/ui/SoilSmartSensorPanel.lua
@@ -110,22 +110,34 @@ function SoilSmartSensorPanel:getActiveSprayer()
     return nil
 end
 
--- Returns the field ID and soil data for the vehicle's current position.
+-- Returns the field ID and field info for the vehicle's current position.
 function SoilSmartSensorPanel:getFieldData(vehicle)
     if not vehicle or not vehicle.rootNode then return nil, nil end
     local ok, x, _, z = pcall(getWorldTranslation, vehicle.rootNode)
     if not ok or not x then return nil, nil end
     local sfm = g_SoilFertilityManager
     if not sfm or not sfm.soilSystem then return nil, nil end
-    local field = nil
+
+    -- Tier 1: field lookup → farmland.id (field.fieldId is nil in FS25)
+    local fieldId = nil
     if g_fieldManager then
-        local fok, f = pcall(function() return g_fieldManager:getFieldAtWorldPosition(x, z) end)
-        if fok and f then field = f end
+        local fok, field = pcall(function() return g_fieldManager:getFieldAtWorldPosition(x, z) end)
+        if fok and field and field.farmland then
+            fieldId = field.farmland.id
+        end
     end
-    local fieldId = field and field.fieldId
+    -- Tier 2: farmland object fallback
+    if not fieldId and g_farmlandManager then
+        local fok, farmland = pcall(function() return g_farmlandManager:getFarmlandAtWorldPosition(x, z) end)
+        if fok and farmland and farmland.id and farmland.id > 0 then
+            fieldId = farmland.id
+        end
+    end
     if not fieldId or fieldId <= 0 then return nil, nil end
-    local fd = sfm.soilSystem.fieldData[fieldId]
-    return fieldId, fd
+
+    -- Use getFieldInfo so per-cell zone data is included when available
+    local info = sfm.soilSystem:getFieldInfo(fieldId, x, z)
+    return fieldId, info
 end
 
 -- Returns sensor key display string from input binding, or fallback.
@@ -320,24 +332,27 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
     local diseaseOn = sensorMgr:isDiseaseEnabled(vehicleId)
     local nutrientOn = sensorMgr:isNutrientEnabled(vehicleId)
 
-    -- Build value strings
+    -- Build value strings (fd is a getFieldInfo table, not raw fieldData)
     local pestVal, diseaseVal, nutVal = "", "", ""
     if fd then
         local pest = fd.pestPressure    or 0
         local dis  = fd.diseasePressure or 0
-        local k    = fd.potassium  or 0
-        local p    = fd.phosphorus or 0
+        local k    = fd.potassium  and fd.potassium.value  or 0
+        local p    = fd.phosphorus and fd.phosphorus.value or 0
+        local ppm  = SoilConstants.PPM_DISPLAY or { P = 1, K = 1 }
         if pest <= 0 then
-            pestVal = "No pressure - field is clean"
+            pestVal = g_i18n:getText("sf_sensor_no_pressure") or "No pressure"
         else
             pestVal = string.format("%.0f%%", pest)
         end
         if dis <= 0 then
-            diseaseVal = "No pressure - field is clean"
+            diseaseVal = g_i18n:getText("sf_sensor_no_pressure") or "No pressure"
         else
             diseaseVal = string.format("%.0f%%", dis)
         end
-        nutVal = string.format("K=%d  P=%d", math.floor(k), math.floor(p))
+        nutVal = string.format("K=%d  P=%d",
+            math.floor(k * (ppm.K or 1) + 0.5),
+            math.floor(p * (ppm.P or 1) + 0.5))
     end
 
     local rows = {

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,10 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.3.2.0",
-    "- Fixed: HUD minimap soil overlay now renders correctly again",
-    "- Fixed: PDA map reverted to reliable field-polygon tile rendering",
-    "- Fixed: PDA no longer shows minimap content at wrong scale",
+    "v2.3.3.0",
+    "- Fixed: DMV heatmap minimap now shows only owned fields (not entire terrain)",
+    "- Fixed: Minimap heatmap no longer disappears after first render",
+    "- Fixed: GRLE cleared for unowned fields on load and on ownership change",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,11 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.3.0.0",
-    "- New: PDA fullscreen map now uses per-pixel density map rendering (same quality as minimap)",
-    "- New: soilPest, soilDisease, soilCompaction density map layers — true per-pixel precision",
-    "- New: Weed pressure synced live from the game's native WeedSystem density map",
-    "- Fixed: Minimap layer indices for pest/disease/compaction now match correctly",
+    "v2.3.2.0",
+    "- Fixed: HUD minimap soil overlay now renders correctly again",
+    "- Fixed: PDA map reverted to reliable field-polygon tile rendering",
+    "- Fixed: PDA no longer shows minimap content at wrong scale",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- DMV minimap heatmap now only colours **owned** fields — unowned field GRLE is cleared on load and on ownership changes
- Minimap heatmap no longer disappears after the first render cycle
- Added `SoilLayerSystem:clearFieldFromLayers()` for targeted GRLE zeroing

## Root Cause

The previous approach wrote GRLE data for **all** fields (owned + unowned), then rendered the DMV unmasked. Since `SoilLayerInstaller` seeds GRLE values across all field areas, the result was the entire terrain lighting up. Between build cycles the owned/unowned state could change, causing the overlay to switch from showing data to transparent — the "bail out" effect.

## Fix

At load time (both save-game and fresh-start paths), GRLE is now written **only for owned fields** (`activeFieldIds`). All other field AABBs are zeroed. When ownership changes mid-game, the acquired field is written and the sold field is cleared immediately.

## Test plan

- [ ] Load a save with owned fields — minimap heatmap shows only owned field areas in correct colour
- [ ] Buy a new field — it appears on the heatmap within 2 seconds
- [ ] Sell a field — it disappears from the heatmap within 2 seconds
- [ ] Switch soil layers — heatmap updates correctly per layer