### PR TITLE
v2.3.4.0 - Fix FPS drops during spraying

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.3.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.4.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.3.0</version>
+    <version>2.3.4.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -43,6 +43,13 @@ function SoilFertilitySystem.new(settings)
     -- Stores the game day, not a timestamp, so the notification fires at most once per field per in-game day.
     self.fertNotifyShown = {}
 
+    -- Per-field throttle for GRLE pixel writes (fieldId → mission time of last write, ms).
+    -- The spray hook fires many times per second; writing to DensityMapModifier on every
+    -- call costs 5 GPU terrain writes per section per tick. We only need to update the GRLE
+    -- fast enough for the minimap (3 s rebuild interval), so 2.5 s per field is sufficient.
+    self._pixelWriteLastMs = {}
+    self._pixelWriteIntervalMs = 2500
+
     -- Per-day throttle tables for crop protection pressure reductions (fieldId → game day last applied).
     -- The sprayer hook fires every frame while the sprayer is active. Without throttling, a single
     -- pass across a field applies the full pressure reduction 60+ times per second, instantly
@@ -2584,18 +2591,27 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
             end
         end
 
-        -- Write updated values to density map layers (per-pixel, at sprayer position)
+        -- Write updated values to density map layers (per-pixel, at sprayer position).
+        -- Throttled to once per 2.5 s per field — the spray hook fires many times per
+        -- second (one call per VWW section per tick), but DensityMapModifier GPU writes
+        -- only need to keep pace with the minimap rebuild interval (3 s).
+        -- markDirty() is always called so the minimap queues a rebuild regardless.
         if self.layerSystem and self.layerSystem.available then
             local x, z = self._lastSprayX, self._lastSprayZ
             if x and z then
-                if entry.N then self.layerSystem:updatePixelForField("nitrogen",      x, z, field.nitrogen,      2.0) end
-                if entry.P then self.layerSystem:updatePixelForField("phosphorus",    x, z, field.phosphorus,    2.0) end
-                if entry.K then self.layerSystem:updatePixelForField("potassium",     x, z, field.potassium,     2.0) end
-                if entry.pH then self.layerSystem:updatePixelForField("pH",           x, z, field.pH,            2.0) end
-                if entry.OM then self.layerSystem:updatePixelForField("organicMatter",x, z, field.organicMatter, 2.0) end
-                -- Notify minimap that GRLE data changed
                 local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
                 if minimapLayer then minimapLayer:markDirty() end
+
+                local now = g_currentMission and g_currentMission.time or 0
+                local lastWrite = self._pixelWriteLastMs[fieldId] or 0
+                if (now - lastWrite) >= self._pixelWriteIntervalMs then
+                    self._pixelWriteLastMs[fieldId] = now
+                    if entry.N then self.layerSystem:updatePixelForField("nitrogen",      x, z, field.nitrogen,      2.0) end
+                    if entry.P then self.layerSystem:updatePixelForField("phosphorus",    x, z, field.phosphorus,    2.0) end
+                    if entry.K then self.layerSystem:updatePixelForField("potassium",     x, z, field.potassium,     2.0) end
+                    if entry.pH then self.layerSystem:updatePixelForField("pH",           x, z, field.pH,            2.0) end
+                    if entry.OM then self.layerSystem:updatePixelForField("organicMatter",x, z, field.organicMatter, 2.0) end
+                end
             end
         end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1033,19 +1033,19 @@ function HookManager:installSectionControlHook()
             if sfm.settings and sfm.settings.fieldBoundaryControl then
                 local vwwBE = sprayerSelf.spec_variableWorkWidth
                 if vwwBE and vwwBE.sections and #vwwBE.sections > 0 then
-                    local rx, _, rz = getWorldTranslation(sprayerSelf.rootNode)
+                    -- Use preserver-cached root position (avoids redundant getWorldTranslation)
+                    local rx = sprayerSelf._sfRootX
+                    local rz = sprayerSelf._sfRootZ
                     if rx then
-                        -- Determine which field the vehicle center is currently on.
                         local vehicleFieldId = hookMgrRef:getFieldIdAtWorldPosition(rx, rz)
-                        for _, section in ipairs(vwwBE.sections) do
+                        local tips = sprayerSelf._sfSectionTip
+                        for i, section in ipairs(vwwBE.sections) do
                             if section.isActive and not section.isCenter then
-                                local sx, sz = rx, rz
-                                if section.maxWidthNode then
-                                    local ok, wx, _, wz = pcall(getWorldTranslation, section.maxWidthNode)
-                                    if ok and wx then sx = wx; sz = wz end
-                                end
+                                -- Boundary uses full tip position (not midpoint)
+                                local tip = tips and tips[i]
+                                local sx = tip and tip[1] or rx
+                                local sz = tip and tip[2] or rz
                                 local fid = hookMgrRef:getFieldIdAtWorldPosition(sx, sz)
-                                -- Suppress if tip is on unfarmed ground OR a different field.
                                 if not fid or fid <= 0 or
                                    (vehicleFieldId and vehicleFieldId > 0 and fid ~= vehicleFieldId) then
                                     section.isActive = false
@@ -1096,26 +1096,23 @@ function HookManager:installSectionControlHook()
 
             if not pestOn and not diseaseOn and not nutrientOn then return end
 
-            -- Pre-fetch root position (fallback for sections without a width node)
-            local rootX, _, rootZ = getWorldTranslation(sprayerSelf.rootNode)
+            -- Use preserver-cached root position (computed once before all hooks)
+            local rootX = sprayerSelf._sfRootX
+            local rootZ = sprayerSelf._sfRootZ
             if not rootX then return end
 
             local soilSys = sfm.soilSystem
+            local tips = sprayerSelf._sfSectionTip
 
-            for _, section in ipairs(vww.sections) do
+            for i, section in ipairs(vww.sections) do
                 -- Only suppress sections VWW has activated. isCenter sections are never
                 -- added to sectionsLeft/Right so VWW never touches them — leave them alone.
                 -- installSectionStatePreserver() restores isActive after work areas process.
                 if section.isActive and not section.isCenter then
-                    -- Estimate section world position (midpoint between root and outer edge)
-                    local sx, sz = rootX, rootZ
-                    if section.maxWidthNode then
-                        local ok, wx, _, wz = pcall(getWorldTranslation, section.maxWidthNode)
-                        if ok and wx then
-                            sx = (rootX + wx) * 0.5
-                            sz = (rootZ + wz) * 0.5
-                        end
-                    end
+                    -- Midpoint between root and section outer edge (from preserver cache)
+                    local tip = tips and tips[i]
+                    local sx = tip and ((rootX + tip[1]) * 0.5) or rootX
+                    local sz = tip and ((rootZ + tip[2]) * 0.5) or rootZ
 
                     local fieldId = hookMgrRef:getFieldIdAtWorldPosition(sx, sz)
                     if fieldId and fieldId > 0 then
@@ -1238,23 +1235,21 @@ function HookManager:installSeeAndSprayHook()
             local weedSS    = isWeed    and sensorMgr:isSeeSprayWeedEnabled(vehicleId)
             if not pestSS and not diseaseSS and not weedSS then return end
 
-            local rootX, _, rootZ = getWorldTranslation(sprayerSelf.rootNode)
+            -- Use preserver-cached root position (computed once before all hooks)
+            local rootX = sprayerSelf._sfRootX
+            local rootZ = sprayerSelf._sfRootZ
             if not rootX then return end
 
             local soilSys = sfm.soilSystem
             local ssCfg   = SoilConstants.SEE_AND_SPRAY
             local zone    = SoilConstants.ZONE
+            local tips    = sprayerSelf._sfSectionTip
 
-            for _, section in ipairs(vww.sections) do
+            for i, section in ipairs(vww.sections) do
                 if section.isActive and not section.isCenter then
-                    local sx, sz = rootX, rootZ
-                    if section.maxWidthNode then
-                        local ok, wx, _, wz = pcall(getWorldTranslation, section.maxWidthNode)
-                        if ok and wx then
-                            sx = (rootX + wx) * 0.5
-                            sz = (rootZ + wz) * 0.5
-                        end
-                    end
+                    local tip = tips and tips[i]
+                    local sx = tip and ((rootX + tip[1]) * 0.5) or rootX
+                    local sz = tip and ((rootZ + tip[2]) * 0.5) or rootZ
 
                     local fieldId = hookMgrRef:getFieldIdAtWorldPosition(sx, sz)
                     if fieldId and fieldId > 0 then
@@ -1388,26 +1383,24 @@ function HookManager:installVariableRateHook()
             local rm = sfm.sprayerRateManager
             local manualMult = rm and rm:getMultiplier(vehicleId) or 1.0
 
-            local rootX, _, rootZ = getWorldTranslation(sprayerSelf.rootNode)
+            -- Use preserver-cached root position (computed once before all hooks)
+            local rootX = sprayerSelf._sfRootX
+            local rootZ = sprayerSelf._sfRootZ
             if not rootX then return end
 
             local soilSys = sfm.soilSystem
             local vrCfg   = SoilConstants.VARIABLE_RATE
             local target  = vrCfg.NUTRIENT_TARGET
             local zone    = SoilConstants.ZONE
+            local tips    = sprayerSelf._sfSectionTip
 
             sensorMgr:clearSectionRates(vehicleId)
 
-            for _, section in ipairs(vww.sections) do
+            for i, section in ipairs(vww.sections) do
                 if section.isActive and not section.isCenter then
-                    local sx, sz = rootX, rootZ
-                    if section.maxWidthNode then
-                        local ok, wx, _, wz = pcall(getWorldTranslation, section.maxWidthNode)
-                        if ok and wx then
-                            sx = (rootX + wx) * 0.5
-                            sz = (rootZ + wz) * 0.5
-                        end
-                    end
+                    local tip = tips and tips[i]
+                    local sx = tip and ((rootX + tip[1]) * 0.5) or rootX
+                    local sz = tip and ((rootZ + tip[2]) * 0.5) or rootZ
 
                     local fieldId = hookMgrRef:getFieldIdAtWorldPosition(sx, sz)
                     local rate = vrCfg.MIN_RATE + (vrCfg.MAX_RATE - vrCfg.MIN_RATE) * 0.5  -- default mid
@@ -1487,11 +1480,48 @@ function HookManager:installSectionStatePreserver()
         function(sprayerSelf, dt)
             local vww = sprayerSelf.spec_variableWorkWidth
             if not vww or not vww.sections or #vww.sections == 0 then return end
-            local saved = {}
-            for i, section in ipairs(vww.sections) do
-                saved[i] = section.isActive
+
+            -- Reuse existing table to avoid per-tick allocation
+            local saved = sprayerSelf._sfSavedSectionStates
+            if not saved then
+                saved = {}
+                sprayerSelf._sfSavedSectionStates = saved
             end
-            sprayerSelf._sfSavedSectionStates = saved
+
+            -- Cache root world position once; the three appended hooks read this
+            -- cache instead of calling getWorldTranslation independently.
+            local rx, _, rz = getWorldTranslation(sprayerSelf.rootNode)
+            sprayerSelf._sfRootX = rx
+            sprayerSelf._sfRootZ = rz
+
+            -- Cache each section's tip node world position so all hooks can
+            -- reuse it without redundant pcall(getWorldTranslation) calls.
+            if rx then
+                local tips = sprayerSelf._sfSectionTip
+                if not tips then
+                    tips = {}
+                    sprayerSelf._sfSectionTip = tips
+                end
+                for i, section in ipairs(vww.sections) do
+                    saved[i] = section.isActive
+                    if section.maxWidthNode then
+                        local ok, wx, _, wz = pcall(getWorldTranslation, section.maxWidthNode)
+                        if ok and wx then
+                            local t = tips[i]
+                            if not t then t = {}; tips[i] = t end
+                            t[1] = wx; t[2] = wz
+                        else
+                            tips[i] = nil
+                        end
+                    else
+                        tips[i] = nil
+                    end
+                end
+            else
+                for i, section in ipairs(vww.sections) do
+                    saved[i] = section.isActive
+                end
+            end
         end
     )
     self:register(Sprayer, "onStartWorkAreaProcessing", origStart,

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -683,6 +683,48 @@ function SoilHUD:update(dt)
     self._cachedRateMult = (rm and sprayer) and rm:getMultiplier(sprayer.id) or 1.0
 
     self:updateFieldInfoBox()
+
+    -- Pre-format draw() strings that depend on both field info and sprayer state.
+    -- Doing this in update() (5 Hz for field data, every frame for sprayer state)
+    -- avoids string.format calls inside draw() which runs at 60 FPS.
+    local info = self.cachedFieldInfo
+    if info then
+        -- Coverage text
+        local cov = info.sessionCoverageFraction or info.coverageFraction or 0
+        if sprayer and cov > 0 then
+            local minCov = SoilConstants.COVERAGE and SoilConstants.COVERAGE.MIN_FULL_CREDIT or 0.70
+            local covPct = math.floor(cov * 100 + 0.5)
+            local lastProd = info.sessionLastProduct
+            if lastProd then
+                local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByName(lastProd)
+                local productLabel = (ft and ft.title) or lastProd
+                self._fmt_covText = string.format(g_i18n:getText("sf_hud_pass_coverage"), covPct, productLabel)
+            else
+                local minPct = math.floor(minCov * 100 + 0.5)
+                self._fmt_covText = string.format(g_i18n:getText("sf_hud_coverage"), covPct, minPct)
+            end
+        else
+            self._fmt_covText = nil
+        end
+        -- Compaction text
+        local comp = info.compaction or 0
+        if comp > 0 then
+            self._fmt_compText = string.format(g_i18n:getText("sf_hud_compaction"), math.floor(comp + 0.5))
+        else
+            self._fmt_compText = nil
+        end
+        -- Yield efficiency text
+        local yieldEff = info.yieldEfficiency
+        if yieldEff then
+            self._fmt_yieldText = string.format(g_i18n:getText("sf_hud_yield_eff"), yieldEff)
+        else
+            self._fmt_yieldText = nil
+        end
+    else
+        self._fmt_covText   = nil
+        self._fmt_compText  = nil
+        self._fmt_yieldText = nil
+    end
 end
 
 -- ── Native FIELD INFO box ────────────────────────────────
@@ -905,6 +947,9 @@ function SoilHUD:refreshFieldData()
         self._fmt_N         = nil
         self._fmt_P         = nil
         self._fmt_K         = nil
+        self._fmt_covText   = nil
+        self._fmt_compText  = nil
+        self._fmt_yieldText = nil
     end
 
     self._heightDirty = true
@@ -1237,20 +1282,10 @@ function SoilHUD:drawPanel()
             end
 
             -- Coverage row: only show when player is actively in a fertilizer applicator
-            local cov = info.sessionCoverageFraction or info.coverageFraction or 0
-            if self._cachedSprayer and cov > 0 then
+            local covText = self._fmt_covText
+            if self._cachedSprayer and covText then
+                local cov = info.sessionCoverageFraction or info.coverageFraction or 0
                 local minCov = SoilConstants.COVERAGE and SoilConstants.COVERAGE.MIN_FULL_CREDIT or 0.70
-                local covPct = math.floor(cov * 100 + 0.5)
-                local covText
-                local lastProd = info.sessionLastProduct
-                if lastProd then
-                    local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByName(lastProd)
-                    local productLabel = (ft and ft.title) or lastProd
-                    covText = string.format(g_i18n:getText("sf_hud_pass_coverage"), covPct, productLabel)
-                else
-                    local minPct = math.floor(minCov * 100 + 0.5)
-                    covText = string.format(g_i18n:getText("sf_hud_coverage"), covPct, minPct)
-                end
                 local covPoor, _, covGood = self:palette()
                 local cr, cg, cb = covPoor[1], covPoor[2], covPoor[3]
                 if cov >= minCov then cr, cg, cb = covGood[1], covGood[2], covGood[3] end
@@ -1262,41 +1297,41 @@ function SoilHUD:drawPanel()
             end
 
             -- Compaction row
-            local comp = info.compaction or 0
-            if mgr.settings.compactionEnabled and comp > 0 then
-                local compPct = math.floor(comp + 0.5)
+            local compText = self._fmt_compText
+            if mgr.settings.compactionEnabled and compText then
+                local comp = info.compaction or 0
                 local cr, cg, cb
                 if comp > 60 then
-                    cr, cg, cb = 0.88, 0.25, 0.25   -- red: severe
+                    cr, cg, cb = 0.88, 0.25, 0.25
                 elseif comp > 20 then
-                    cr, cg, cb = 0.90, 0.55, 0.10   -- amber: moderate
+                    cr, cg, cb = 0.90, 0.55, 0.10
                 else
-                    cr, cg, cb = 0.32, 0.88, 0.44   -- green: low
+                    cr, cg, cb = 0.32, 0.88, 0.44
                 end
                 local pad = SoilHUD.PAD * s
                 setTextAlignment(RenderText.ALIGN_LEFT)
                 setTextColor(cr, cg, cb, 1.0)
                 cy = cy - SoilHUD.LINE_H * s
-                renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, string.format(g_i18n:getText("sf_hud_compaction"), compPct))
+                renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, compText)
             end
         end
 
         -- Yield efficiency summary (nil when no managed crop)
-        local yieldEff = info.yieldEfficiency
-        if yieldEff then
+        local yieldText = self._fmt_yieldText
+        if yieldText then
+            local yieldEff = info.yieldEfficiency or 0
             local yr, yg, yb
             if yieldEff >= 90 then
-                yr, yg, yb = 0.32, 0.88, 0.44   -- green: at or near optimal
+                yr, yg, yb = 0.32, 0.88, 0.44
             elseif yieldEff >= 70 then
-                yr, yg, yb = 0.90, 0.82, 0.18   -- yellow: noticeable penalty
+                yr, yg, yb = 0.90, 0.82, 0.18
             else
-                yr, yg, yb = 0.88, 0.25, 0.25   -- red: significant penalty
+                yr, yg, yb = 0.88, 0.25, 0.25
             end
             setTextAlignment(RenderText.ALIGN_LEFT)
             setTextColor(yr, yg, yb, 1.0)
             cy = cy - SoilHUD.LINE_H * s
-            renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s,
-                string.format(g_i18n:getText("sf_hud_yield_eff"), yieldEff))
+            renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, yieldText)
         end
 
         -- Divider before hint

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,10 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "v2.3.3.0",
-    "- Fixed: DMV heatmap minimap now shows only owned fields (not entire terrain)",
-    "- Fixed: Minimap heatmap no longer disappears after first render",
-    "- Fixed: GRLE cleared for unowned fields on load and on ownership change",
+    "v2.3.4.0",
+    "- Fixed: significant FPS drops when spraying with wide boom sprayers",
+    "- Fixed: frame rate drops while actively fertilizing large fields",
+    "- Improved: much smoother gameplay during all spraying operations",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Eliminated ~27 redundant `getWorldTranslation`/`pcall` calls per sprayer tick — section world positions are now computed once in the preserver hook and shared across SmartSensor, SeeAndSpray, VariableRate, and FieldBoundaryControl
- Throttled GRLE density-map GPU writes to once per 2.5 s per field (was every spray event per section)
- Moved HUD `string.format` calls for coverage/compaction/yield text from `draw()` at 60 FPS to `update()` at 5 Hz
- Reused section state table across ticks instead of allocating a new one each frame

## Test plan

- [ ] Spray a field with a 9-section wide boom — verify FPS is stable (target: back to ~60)
- [ ] Smart Sensor still suppresses sections correctly on pest/disease/nutrient fields
- [ ] See & Spray still suppresses sections where weeds/pests/disease are absent
- [ ] Variable Rate still adjusts per-section rate based on cell nutrient values
- [ ] Field Boundary Control still cuts off boom sections that cross field boundaries
- [ ] Minimap heatmap still updates during spraying (may have up to 2.5 s lag on GRLE)
- [ ] HUD coverage, compaction, and yield efficiency rows still display correctly