### PR TITLE
fix: #519 #521 #524 #525 - P threshold, fallow rate, report %, compost OM rate

### DIFF
--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -412,7 +412,7 @@ SoilConstants.PURCHASABLE_SINGLE_NUTRIENT = {
 -- ========================================
 SoilConstants.STATUS_THRESHOLDS = {
     nitrogen   = { poor = 30, fair = 50 },
-    phosphorus = { poor = 25, fair = 45 },
+    phosphorus = { poor = 25, fair = 40 },  -- was 45; lowered to match CROP_NUTRIENT_TARGETS default P.opt (40)
     potassium  = { poor = 20, fair = 40 },
 }
 
@@ -722,7 +722,7 @@ SoilConstants.SPRAYER_RATE = {
     -- Used when SF_TOGGLE_AUTO is active on a sprayer
     AUTO_RATE_TARGETS = {
         N  = 80,
-        P  = 70,
+        P  = 50,   -- was 70 (42 ppm); lowered to 50 (30 ppm) — above most crop P optima without over-shooting
         K  = 75,
         -- Aligned to PH_OPTIMAL (6.5) so auto-lime stops at the agronomic optimum.
         pH = 6.5,

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1318,12 +1318,14 @@ function HookManager:installVariableRateHook()
     end
 
     -- Classify fill types at install time
-    local nFerts  = {}   -- N-dominant (UAN, liquid urea, etc.)
-    local pFerts  = {}   -- P-dominant (MAP, DAP, etc.)
-    local kFerts  = {}   -- K-only (POTASH, etc.)
-    local npkFerts = {}  -- multi-nutrient (all N/P/K fertilizers)
+    local nFerts   = {}   -- N-dominant (UAN, liquid urea, etc.)
+    local pFerts   = {}   -- P-dominant (MAP, DAP, etc.)
+    local kFerts   = {}   -- K-only (POTASH, etc.)
+    local npkFerts = {}   -- multi-nutrient (all N/P/K fertilizers)
+    local omFerts  = {}   -- OM-primary (compost, manure, digestate — target organic matter)
 
     local profs = SoilConstants.FERTILIZER_PROFILES
+    local omPrimarySet = SoilConstants.SPRAYER_RATE and SoilConstants.SPRAYER_RATE.OM_PRIMARY_PRODUCTS
     if profs then
         for name, prof in pairs(profs) do
             local n = prof.N or 0
@@ -1334,6 +1336,9 @@ function HookManager:installVariableRateHook()
                 if n > 0 and p == 0 and k == 0 then nFerts[name] = true end
                 if p > 0 and k == 0             then pFerts[name] = true end
                 if k > 0 and p == 0             then kFerts[name] = true end
+            end
+            if omPrimarySet and omPrimarySet[name] then
+                omFerts[name] = true
             end
         end
     end
@@ -1370,7 +1375,7 @@ function HookManager:installVariableRateHook()
                 return
             end
             local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
-            if not ft or not npkFerts[ft.name] then
+            if not ft or (not npkFerts[ft.name] and not omFerts[ft.name]) then
                 sensorMgr:clearSectionRates(vehicleId)
                 return
             end
@@ -1378,6 +1383,7 @@ function HookManager:installVariableRateHook()
             local isN   = nFerts[ft.name]  == true
             local isP   = pFerts[ft.name]  == true
             local isK   = kFerts[ft.name]  == true
+            local isOM  = omFerts[ft.name] == true
 
             -- Manual rate ceiling
             local rm = sfm.sprayerRateManager
@@ -1413,7 +1419,15 @@ function HookManager:installVariableRateHook()
                             local cell = fd.zoneData and fd.zoneData[cellKey]
 
                             local nutrientVal
-                            if isN then
+                            local effTarget = target
+                            if isOM then
+                                -- OM-primary products (compost, manure, digestate): target organic matter
+                                local omTarget = SoilConstants.SPRAYER_RATE and
+                                    SoilConstants.SPRAYER_RATE.AUTO_RATE_TARGETS and
+                                    SoilConstants.SPRAYER_RATE.AUTO_RATE_TARGETS.OM or 5.0
+                                nutrientVal = (cell and cell.OM) or fd.organicMatter or omTarget
+                                effTarget   = omTarget
+                            elseif isN then
                                 nutrientVal = (cell and cell.N) or fd.nitrogen or target
                             elseif isP then
                                 nutrientVal = (cell and cell.P) or fd.phosphorus or target
@@ -1427,7 +1441,7 @@ function HookManager:installVariableRateHook()
                                 nutrientVal = math.min(n, p, k)
                             end
 
-                            local deficit = math.max(0, target - nutrientVal) / target
+                            local deficit = math.max(0, effTarget - nutrientVal) / effTarget
                             rate = vrCfg.MIN_RATE + deficit * (vrCfg.MAX_RATE - vrCfg.MIN_RATE)
                         end
                     end

--- a/src/ui/SoilReportDialog.lua
+++ b/src/ui/SoilReportDialog.lua
@@ -594,10 +594,10 @@ function SoilReportDialog:updateFieldRows()
                     -- Field ID
                     if row.id then row.id:setText(tostring(fieldId)) end
 
-                    -- N / P / K (ppm, color-coded)
-                    setColoredText(row.n, tostring(math.floor(info.nitrogen.value   * ppm.N + 0.5)), getStatusColor(info.nitrogen.status))
-                    setColoredText(row.p, tostring(math.floor(info.phosphorus.value * ppm.P + 0.5)), getStatusColor(info.phosphorus.status))
-                    setColoredText(row.k, tostring(math.floor(info.potassium.value  * ppm.K + 0.5)), getStatusColor(info.potassium.status))
+                    -- N / P / K (% of bar, 0-100, color-coded — consistent with weed/pest display)
+                    setColoredText(row.n, string.format("%d%%", math.floor(info.nitrogen.value   + 0.5)), getStatusColor(info.nitrogen.status))
+                    setColoredText(row.p, string.format("%d%%", math.floor(info.phosphorus.value + 0.5)), getStatusColor(info.phosphorus.status))
+                    setColoredText(row.k, string.format("%d%%", math.floor(info.potassium.value  + 0.5)), getStatusColor(info.potassium.status))
 
                     -- pH
                     setColoredText(row.ph, string.format("%.1f", info.pH), getPHColor(info.pH))


### PR DESCRIPTION
## Summary

- **#525** — Fixed: fields at crop-optimal phosphorus now show 'Good' instead of 'Fair'. Lowered `STATUS_THRESHOLDS.phosphorus.fair` from 45 to 40 to match default crop P optimum.
- **#519** — Fixed: auto-rate P target on fallow fields lowered from 70 (42 ppm) to 50 (30 ppm), preventing over-application when prepping fallow for spring crops.
- **#524** — Fixed: N/P/K values in the field report grid now show bar % (e.g. 45%) with % suffix instead of ppm, consistent with how weed/pest pressure is displayed.
- **#521** — Fixed: compost, manure, digestate, and other OM-primary products now use organic matter deficit for variable rate calculation instead of N/P/K deficit.

## Test plan

- [ ] Phosphorus at internal value 40-44 should now show 'Good' status (was 'Fair')
- [ ] Auto-rate with MAP on a fallow field targets ~30 ppm P, not 42 ppm
- [ ] Field report grid shows 'N 50% / P 40% / K 40%' style values with % symbol
- [ ] Spreading compost with variable rate active uses OM deficit (low OM field → higher rate)