### PR TITLE
v2.3.5.0 — fix per-pixel GRLE spray trail preserved across daily updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.4.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.5.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.4.0</version>
+    <version>2.3.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1146,9 +1146,9 @@ function SoilFertilityManager:seedGRLEFromFieldData()
 
     local count = 0
     for fieldId, field in pairs(fieldData) do
-        local farmland = g_farmlandManager and g_farmlandManager:getFarmlandById(fieldId)
-        if farmland then
-            layerSys:writeFieldToLayers(fieldId, field, farmland)
+        local fsField = g_fieldManager and g_fieldManager.fields and g_fieldManager.fields[fieldId]
+        if fsField then
+            layerSys:writeFieldToLayers(fieldId, field, fsField)
             count = count + 1
         end
     end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -723,6 +723,7 @@ function SoilFertilityManager:onMissionStarted()
 
         self:loadSoilData()
         self.soilSystem:prePopulateAllZoneData()
+        self:seedGRLEFromFieldData()
     end)
 
     if not ok then
@@ -1128,6 +1129,35 @@ function SoilFertilityManager:loadSoilData()
         -- GRLE minimap heatmap fills in per-pixel from sprayer events.
         -- No bulk AABB seed here — see SoilFertilitySystem.lua loadFromXMLFile note.
     end
+end
+
+-- Seed all GRLE layers (including N/P/K/pH/OM) with the current fieldData values
+-- so the DMV minimap heatmap shows a full field heatmap on session start.
+-- Called once after loadSoilData() has populated fieldData.
+function SoilFertilityManager:seedGRLEFromFieldData()
+    local soilSys = self.soilSystem
+    if not soilSys then return end
+    local layerSys = soilSys.layerSystem
+    if not layerSys or not layerSys.available then return end
+    if g_dedicatedServer then return end
+
+    local fieldData = soilSys.fieldData
+    if not fieldData then return end
+
+    local count = 0
+    for fieldId, field in pairs(fieldData) do
+        local farmland = g_farmlandManager and g_farmlandManager:getFarmlandById(fieldId)
+        if farmland then
+            layerSys:writeFieldToLayers(fieldId, field, farmland)
+            count = count + 1
+        end
+    end
+
+    if self.soilMinimapLayer then
+        self.soilMinimapLayer:markDirty()
+    end
+
+    SoilLogger.info("GRLE startup seed complete: %d field(s) seeded to all layers", count)
 end
 
 --- Update loop called every frame

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2220,13 +2220,13 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         end
     end
 
-    -- ── Sync pest/disease/compaction to density map layers ───────────────────
-    -- Paint the field AABB with the current daily values so the minimap and
-    -- PDA overlay stay in sync without needing per-setter hooks everywhere.
+    -- ── Sync all nutrient/pressure layers to density maps ───────────────────
+    -- Paint the exact field polygon with current daily values so the minimap
+    -- heatmap stays current after harvest depletion, rain, and seasonal changes.
     if layerSys and layerSys.available then
-        local farmland = farmland or (g_farmlandManager and g_farmlandManager:getFarmlandById(fieldId))
-        if farmland then
-            layerSys:writeFieldToLayers(fieldId, field, farmland)
+        local fsField = g_fieldManager and g_fieldManager.fields and g_fieldManager.fields[fieldId]
+        if fsField then
+            layerSys:writeFieldToLayers(fieldId, field, fsField)
         end
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -328,6 +328,7 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField.sessionCoverageFraction = 0
         harvestField.sessionCoverageCells    = {}
         harvestField.sessionLastProduct      = nil
+        harvestField._farmlandAreaConfirmed  = nil  -- re-confirm on next session's first spray (#507)
     end
 
     SoilLogger.debug("Harvest: Field %d, Crop %d, %.0fL (biological), area=%.1f", fieldId, fruitTypeIndex, liters, area or 0)
@@ -2440,7 +2441,16 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         if spx and spz and g_farmlandManager then
             local farmlandTmp = g_farmlandManager:getFarmlandAtWorldPosition(spx, spz)
             local fsField = farmlandTmp and g_fieldManager and g_fieldManager.farmlandIdFieldMapping and g_fieldManager.farmlandIdFieldMapping[farmlandTmp.id]
-            local hasCrop = fsField and fsField.fieldState and fsField.fieldState.fruitTypeIndex and fsField.fieldState.fruitTypeIndex ~= FruitType.UNKNOWN
+            -- Issue #532: use live FieldState query (fsField.fieldState is stale on freshly-plowed/fallow fields)
+            local hasCrop = false
+            if fsField and fsField.posX and fsField.posZ then
+                local ok, fs = pcall(function()
+                    local s = FieldState.new()
+                    s:update(fsField.posX, fsField.posZ)
+                    return s
+                end)
+                hasCrop = ok and fs and fs.fruitTypeIndex ~= nil and fs.fruitTypeIndex ~= FruitType.UNKNOWN
+            end
             if hasCrop then
                 if isLimeAmendment then
                     field.amendBurnPenalty = 0.80
@@ -2462,10 +2472,12 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     local limits = SoilConstants.NUTRIENT_LIMITS
 
     -- AREA NORMALIZATION: Calculate hectares for this field.
-    -- Confirm area on first spray — prefer the actual crop polygon area (field.areaHa)
+    -- Confirm area on first spray of each session — prefer the actual crop polygon area (field.areaHa)
     -- because farmland.areaInHa includes roads/hedges (~2× crop area), which causes
     -- Pass% to cap at ~50% after a full field pass (issue #475/#476).
-    if not field._farmlandAreaConfirmed and g_farmlandManager then
+    -- Also re-confirm at the start of every new session so field-size changes (issue #507) take effect.
+    local _isNewSession = not next(field.sessionCoverageCells or {})
+    if (not field._farmlandAreaConfirmed or _isNewSession) and g_farmlandManager then
         local farmlandObj = g_farmlandManager:getFarmlandById(fieldId)
         if farmlandObj and farmlandObj.areaInHa and farmlandObj.areaInHa > 0 then
             -- Try crop polygon area via farmland mapping (g_fieldManager has no getFieldAtWorldPosition)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2222,12 +2222,13 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     end
 
     -- ── Sync all nutrient/pressure layers to density maps ───────────────────
-    -- Paint the exact field polygon with current daily values so the minimap
-    -- heatmap stays current after harvest depletion, rain, and seasonal changes.
+    -- Paint non-perPixel layers (pest/disease/compaction) with the daily average.
+    -- N/P/K/pH/OM are skipped (skipPerPixel=true) so per-pixel spray history is
+    -- preserved between daily updates.
     if layerSys and layerSys.available then
         local fsField = g_fieldManager and g_fieldManager.fields and g_fieldManager.fields[fieldId]
         if fsField then
-            layerSys:writeFieldToLayers(fieldId, field, fsField)
+            layerSys:writeFieldToLayers(fieldId, field, fsField, true)
         end
     end
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -128,6 +128,12 @@ function SoilHUD.new(soilSystem, settings)
     -- Height dirty flag: set by refreshFieldData, cleared after calculateHeight()
     self._heightDirty = true
 
+    -- Mini-report display-mode stabilizer: prevents rapid cell↔field-avg flipping (#531)
+    self._miniLastIsCell      = nil
+    self._miniModePendingAt   = nil
+    self._miniStableSamples   = nil
+    self._miniStableCellLabel = nil
+
     -- Single overlay handle
     self.fillOverlay = nil
 
@@ -1779,8 +1785,9 @@ function SoilHUD:drawMiniReport()
     local wx = self.cachedPlayerX
     local wz = self.cachedPlayerZ
 
-    local samples = nil
+    local samples  = nil
     local cellLabel = nil
+    local isCell   = false
 
     -- 1. Try to get per-cell zoneData first; fall back to field-level averages.
     if wx and wz and self.cachedFieldId and self.cachedFieldId > 0 then
@@ -1797,6 +1804,7 @@ function SoilHUD:drawMiniReport()
                     cell = field.zoneData[cellKey]
                     if cell then
                         cellLabel = string.format("C %d\xC2\xB7%d", cx, cz)
+                        isCell = true
                     end
                 end
 
@@ -1819,6 +1827,33 @@ function SoilHUD:drawMiniReport()
                 end
             end
         end
+    end
+
+    -- Debounce (#531): only switch between cell and field-avg display after 2 seconds of stability.
+    -- As a sprayer drives over unsprayed cells the source would otherwise flip every few seconds.
+    if samples then
+        local DEBOUNCE_MS = 2000
+        if self._miniLastIsCell ~= isCell then
+            if not self._miniModePendingAt then
+                self._miniModePendingAt = self.animTimer
+            end
+            if (self.animTimer - self._miniModePendingAt) < DEBOUNCE_MS and self._miniStableSamples then
+                samples   = self._miniStableSamples
+                cellLabel = self._miniStableCellLabel
+            else
+                self._miniLastIsCell      = isCell
+                self._miniModePendingAt   = nil
+                self._miniStableSamples   = samples
+                self._miniStableCellLabel = cellLabel
+            end
+        else
+            self._miniModePendingAt   = nil
+            self._miniStableSamples   = samples
+            self._miniStableCellLabel = cellLabel
+        end
+    else
+        self._miniModePendingAt = nil
+        self._miniLastIsCell    = nil
     end
 
     -- 2. If still no data, samples remains nil (player off-field or system not ready).

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -484,37 +484,65 @@ function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmlan
     if not self.available then return end
     if not fieldData then return end
 
-    -- Resolve to a Field object (which has polygonPoints for AABB).
-    -- Callers may pass a Field object directly, or a farmland object (which has no geometry).
-    -- When a farmland object is passed, look up the Field via g_fieldManager.
+    -- Resolve to a Field object (which has polygonPoints for polygon painting).
     local fsField = fsFieldOrFarmland
     if fsField and not fsField.polygonPoints and not fsField.posX then
-        -- Likely a farmland object — look up the corresponding Field
         fsField = getFieldByFarmlandId(fieldId)
     end
 
-    local cx, cz, hw, hh = getFieldAABB(fsField)
-    if not cx then
-        SoilLogger.debug("SoilLayerSystem: writeFieldToLayers skipped field %d (no geometry)", fieldId)
-        return
+    -- Gather polygon points from the Field object.
+    -- Prefer field:getPolygonPoints() method; fall back to the .polygonPoints table.
+    local polyNodes
+    if fsField then
+        if type(fsField.getPolygonPoints) == "function" then
+            local ok, pts = pcall(function() return fsField:getPolygonPoints() end)
+            if ok then polyNodes = pts end
+        end
+        if not polyNodes then polyNodes = fsField.polygonPoints end
     end
 
-    -- Paint entire AABB with the current field-average value for ALL layers.
-    -- perPixel layers (N/P/K/pH/OM) use field averages here; spray events then
-    -- overlay precise per-pixel values on top.  Writing the average each day
-    -- keeps the heatmap accurate after harvest depletion and seasonal changes.
+    local usePolygon = polyNodes and #polyNodes >= 3
+
+    -- AABB fallback for fields whose polygon data is unavailable.
+    local cx, cz, hw, hh
+    if not usePolygon then
+        cx, cz, hw, hh = getFieldAABB(fsField)
+        if not cx then
+            SoilLogger.debug("SoilLayerSystem: writeFieldToLayers skipped field %d (no geometry)", fieldId)
+            return
+        end
+    end
+
+    -- Paint the field polygon (or AABB fallback) for ALL layers.
+    -- perPixel layers (N/P/K/pH/OM) are painted with the field-average value so the
+    -- heatmap stays accurate after harvest depletion and seasonal changes.
+    -- Spray events then overlay precise per-pixel values on top.
     for _, def in ipairs(LAYER_DEFS) do
         local entry = self.layerHandles[def.name]
         if entry and fieldData[def.field] ~= nil then
             local encoded = encode(fieldData[def.field], def)
             local modifier = entry.modifier
             local filter   = DensityMapFilter.new(modifier)
-            modifier:setParallelogramWorldCoords(
-                cx - hw, cz - hh,
-                cx + hw, cz - hh,
-                cx - hw, cz + hh,
-                DensityCoordType.POINT_POINT_POINT
-            )
+
+            if usePolygon then
+                modifier:clearPolygonPoints()
+                for _, nodeId in ipairs(polyNodes) do
+                    if nodeId and nodeId ~= 0 then
+                        local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+                        if ok and wx then
+                            modifier:addPolygonPointWorldCoords(wx, wz)
+                        end
+                    end
+                end
+            else
+                modifier:setParallelogramWorldCoords(
+                    cx - hw, cz - hh,
+                    cx + hw, cz - hh,
+                    cx - hw, cz + hh,
+                    DensityCoordType.POINT_POINT_POINT
+                )
+            end
+
             modifier:executeSet(encoded, filter, nil)
         end
     end
@@ -540,20 +568,43 @@ function SoilLayerSystem:clearFieldFromLayers(fieldId, fsFieldOrFarmland)
         fsField = getFieldByFarmlandId(fieldId)
     end
 
-    local cx, cz, hw, hh = getFieldAABB(fsField)
-    if not cx then return end
+    local polyNodes
+    if fsField then
+        if type(fsField.getPolygonPoints) == "function" then
+            local ok, pts = pcall(function() return fsField:getPolygonPoints() end)
+            if ok then polyNodes = pts end
+        end
+        if not polyNodes then polyNodes = fsField.polygonPoints end
+    end
+
+    local usePolygon = polyNodes and #polyNodes >= 3
+    local cx, cz, hw, hh
+    if not usePolygon then
+        cx, cz, hw, hh = getFieldAABB(fsField)
+        if not cx then return end
+    end
 
     for _, def in ipairs(LAYER_DEFS) do
         local entry = self.layerHandles[def.name]
         if entry then
             local modifier = entry.modifier
             local filter   = DensityMapFilter.new(modifier)
-            modifier:setParallelogramWorldCoords(
-                cx - hw, cz - hh,
-                cx + hw, cz - hh,
-                cx - hw, cz + hh,
-                DensityCoordType.POINT_POINT_POINT
-            )
+            if usePolygon then
+                modifier:clearPolygonPoints()
+                for _, nodeId in ipairs(polyNodes) do
+                    if nodeId and nodeId ~= 0 then
+                        local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+                        if ok and wx then modifier:addPolygonPointWorldCoords(wx, wz) end
+                    end
+                end
+            else
+                modifier:setParallelogramWorldCoords(
+                    cx - hw, cz - hh,
+                    cx + hw, cz - hh,
+                    cx - hw, cz + hh,
+                    DensityCoordType.POINT_POINT_POINT
+                )
+            end
             modifier:executeSet(0, filter, nil)
         end
     end

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -499,24 +499,23 @@ function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmlan
         return
     end
 
-    -- Paint entire AABB with the current field value for non-perPixel layers only.
-    -- perPixel layers (N/P/K/pH/OM) are written per-pixel by spray events and must
-    -- not be bulk-overwritten here or the per-pixel precision is lost.
+    -- Paint entire AABB with the current field-average value for ALL layers.
+    -- perPixel layers (N/P/K/pH/OM) use field averages here; spray events then
+    -- overlay precise per-pixel values on top.  Writing the average each day
+    -- keeps the heatmap accurate after harvest depletion and seasonal changes.
     for _, def in ipairs(LAYER_DEFS) do
-        if not def.perPixel then
-            local entry = self.layerHandles[def.name]
-            if entry and fieldData[def.field] ~= nil then
-                local encoded = encode(fieldData[def.field], def)
-                local modifier = entry.modifier
-                local filter   = DensityMapFilter.new(modifier)
-                modifier:setParallelogramWorldCoords(
-                    cx - hw, cz - hh,
-                    cx + hw, cz - hh,
-                    cx - hw, cz + hh,
-                    DensityCoordType.POINT_POINT_POINT
-                )
-                modifier:executeSet(encoded, filter, nil)
-            end
+        local entry = self.layerHandles[def.name]
+        if entry and fieldData[def.field] ~= nil then
+            local encoded = encode(fieldData[def.field], def)
+            local modifier = entry.modifier
+            local filter   = DensityMapFilter.new(modifier)
+            modifier:setParallelogramWorldCoords(
+                cx - hw, cz - hh,
+                cx + hw, cz - hh,
+                cx - hw, cz + hh,
+                DensityCoordType.POINT_POINT_POINT
+            )
+            modifier:executeSet(encoded, filter, nil)
         end
     end
 

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -480,7 +480,7 @@ end
 ---@param fieldId   number
 ---@param fieldData table   The fieldData[fieldId] table
 ---@param fsFieldOrFarmland table  FS25 Field object preferred; farmland ID used to look up Field if needed
-function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmland)
+function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmland, skipPerPixel)
     if not self.available then return end
     if not fieldData then return end
 
@@ -513,11 +513,13 @@ function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmlan
         end
     end
 
-    -- Paint the field polygon (or AABB fallback) for ALL layers.
-    -- perPixel layers (N/P/K/pH/OM) are painted with the field-average value so the
-    -- heatmap stays accurate after harvest depletion and seasonal changes.
-    -- Spray events then overlay precise per-pixel values on top.
+    -- Paint the field polygon (or AABB fallback) for the appropriate layers.
+    -- When skipPerPixel=true (daily update), N/P/K/pH/OM are skipped so that
+    -- per-pixel spray history written by updatePixelForField is preserved.
+    -- When skipPerPixel=false/nil (startup seed), all layers are written to
+    -- initialize the GRLE from the loaded save data.
     for _, def in ipairs(LAYER_DEFS) do
+        if not (skipPerPixel and def.perPixel) then
         local entry = self.layerHandles[def.name]
         if entry and fieldData[def.field] ~= nil then
             local encoded = encode(fieldData[def.field], def)
@@ -545,6 +547,7 @@ function SoilLayerSystem:writeFieldToLayers(fieldId, fieldData, fsFieldOrFarmlan
 
             modifier:executeSet(encoded, filter, nil)
         end
+        end  -- if not (skipPerPixel and def.perPixel)
     end
 
     SoilLogger.debug("SoilLayerSystem: painted field %d to density layers", fieldId)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -234,18 +234,10 @@ function SoilMinimapLayer:draw(mapSelf)
     if not self._initialized then return end
     if not mapSelf then return end
 
-    -- PDA fullscreen map has isFullscreen as a truthy integer (1) while the HUD minimap has nil.
-    -- Using a truthy check (not == true) correctly blocks PDA without blocking HUD.
+    -- IngameMap:setFullscreen(true) is used for the M-key / PDA full map view.
+    -- Minimap size states (1=small, 2=medium, 3=large) keep isFullscreen=false.
     if mapSelf.isFullscreen then return end
     if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
-
-    -- Secondary identity guard: when the HUD minimap ref is resolvable, only draw on that instance.
-    local hudMap = nil
-    if g_currentMission and g_currentMission.hud then
-        local hud = g_currentMission.hud
-        hudMap = hud.ingameMap or hud.inGameMap or hud.minimap or hud.miniMap
-    end
-    if hudMap ~= nil and mapSelf ~= hudMap then return end
 
     if not self._usingDensityLayers then
         -- No GRLE density-map layers on this terrain — hand off to polygon centroid dots.

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -45,6 +45,8 @@ function SoilMinimapLayer.new(soilSystem, settings)
     self._usingDensityLayers = false
     self._dirty          = true    -- force first build on init
     self._lastLayerIdx   = -1      -- detect layer-switch → force rebuild
+    self._prevMW         = nil     -- animation-skip: previous frame's terrain width
+    self._prevMH         = nil     -- animation-skip: previous frame's terrain height
     self._farmlandMap    = nil
     self._farmlandNumCh  = nil
     self._nextRebuildMs  = 0
@@ -124,9 +126,11 @@ function SoilMinimapLayer:update(dt, soilMapOverlay)
     -- Detect layer change → mark dirty so we rebuild with the new layer's overlay
     local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
     if layerIdx ~= self._lastLayerIdx then
-        self._lastLayerIdx = layerIdx
-        self._dirty        = true
+        self._lastLayerIdx  = layerIdx
+        self._dirty         = true
         self._buildInFlight = false  -- cancel any in-flight build from the previous layer
+        self._prevMW        = nil    -- reset animation baseline for the new layer
+        self._prevMH        = nil
     end
 
     -- Only rebuild when dirty and the previous build has finished
@@ -320,7 +324,17 @@ function SoilMinimapLayer:draw(mapSelf)
     local rx = (px + x) - mx
     local ry = (py + y) - my
 
-    -- Clip rect (circular minimap mask)
+    -- Skip rendering while the minimap layout is animating between states.
+    local prevMW = self._prevMW
+    local prevMH = self._prevMH
+    self._prevMW = mw
+    self._prevMH = mh
+    if prevMW ~= nil and (math.abs(mw - prevMW) > 0.003 or math.abs(mh - prevMH) > 0.003) then
+        return
+    end
+
+    setOverlayUVs(ov, 0, 0, 0, 1, 1, 0, 1, 1)
+
     local didClip = false
     local uL, vT, uR, vB = 0, 0, 1, 1
     if mapSelf.clipX1 ~= nil then

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -5,16 +5,24 @@
 -- the engine-native DensityMap Visualization Overlay API.
 --
 -- Strategy:
---   • Single overlay; generateDensityMapVisualizationOverlay is called
---     in-place — the engine keeps the previous result visible while the
---     new generation runs async, so there is no flicker.
---   • Only regenerates when spray data has changed (_dirty flag) or the
+--   • One DMV overlay per layer, created lazily on first switch.
+--     The engine allows max 8 unique GRLE handles per overlay;
+--     using separate overlays means each overlay only ever sees
+--     its own single handle — no accumulation, no engine limit hit.
+--   • State colours are configured once per overlay and never
+--     change at runtime, so re-generation after field data changes
+--     is just generateDensityMapVisualizationOverlay(ov) with no
+--     colour reconfiguration needed.
+--   • generateDensityMapVisualizationOverlay is called in-place —
+--     the engine keeps the previous result visible while the new
+--     generation runs async, so there is no flicker.
+--   • Only regenerates when data has changed (_dirty flag) or the
 --     active layer changes — idle play costs nothing.
---   • getIsDensityMapVisualizationOverlayReady is polled every 200 ms,
---     not every frame, to avoid per-frame overhead.
+--   • getIsDensityMapVisualizationOverlayReady is polled every
+--     200 ms, not every frame, to avoid per-frame overhead.
 --
--- Fallback: if createDensityMapVisualizationOverlay is unavailable (older
--- engine builds) SoilMapOverlay falls back to polygon-fill dots.
+-- Fallback: if createDensityMapVisualizationOverlay is unavailable
+-- (older engine builds) SoilMapOverlay falls back to polygon dots.
 -- =========================================================
 
 SoilMinimapLayer = {}
@@ -29,16 +37,18 @@ function SoilMinimapLayer.new(soilSystem, settings)
     self.soilSystem = soilSystem
     self.settings   = settings
     self._initialized    = false
-    self._overlay        = nil           -- single overlay; regenerated in-place
-    self._buildInFlight  = false
-    self._hasShownOnce   = false
-    self._dirty          = true          -- force first build on init
-    self._lastLayerIdx   = -1            -- detect layer-switch → force rebuild
+    -- Per-layer overlay table: [layerIdx] = { ov, configured, inFlight, hasShown }
+    self._overlays       = {}
+    self._resX           = SoilMinimapLayer.OVERLAY_RESOLUTION
+    self._resY           = SoilMinimapLayer.OVERLAY_RESOLUTION
+    self._buildInFlight  = false   -- tracks the CURRENT layer's in-flight state
+    self._usingDensityLayers = false
+    self._dirty          = true    -- force first build on init
+    self._lastLayerIdx   = -1      -- detect layer-switch → force rebuild
     self._farmlandMap    = nil
     self._farmlandNumCh  = nil
     self._nextRebuildMs  = 0
     self._nextPollMs     = 0
-    self._lastOverlayHandle = nil  -- track previous DMV handle to clear its state colors on layer switch
     return self
 end
 
@@ -77,28 +87,23 @@ function SoilMinimapLayer:initialize()
             end
         end
     end
-
-    self._overlay = createDensityMapVisualizationOverlay("SF_SoilHeatmap", resX, resY)
-
-    if not self._overlay then
-        SoilLogger.warning("SoilMinimapLayer: failed to create DMV overlay")
-        return false
-    end
+    self._resX = resX
+    self._resY = resY
 
     self._initialized = true
-    SoilLogger.info("[OK] SoilMinimapLayer initialized (DMV overlay %dx%d, single-buffer)", resX, resY)
+    SoilLogger.info("[OK] SoilMinimapLayer initialized (per-layer DMV overlays %dx%d, lazy-created)", resX, resY)
     return true
 end
 
 function SoilMinimapLayer:delete()
     -- Overlay handles are managed by the engine; nothing to free from Lua.
-    self._initialized   = false
-    self._overlay       = nil
+    self._initialized = false
+    self._overlays    = {}
     self._buildInFlight = false
 end
 
--- Call this whenever spray data has been written to the GRLE (updatePixelForField).
--- Marks the overlay dirty so the next rebuild cycle will regenerate it.
+-- Mark the current layer's overlay dirty so the next rebuild cycle regenerates it.
+-- Call this whenever GRLE data has been updated (spray, harvest, daily tick).
 function SoilMinimapLayer:markDirty()
     self._dirty = true
 end
@@ -116,11 +121,12 @@ function SoilMinimapLayer:update(dt, soilMapOverlay)
         self:_pollBuildFinished()
     end
 
-    -- Detect layer change → mark dirty so we rebuild with the new colour ramp
+    -- Detect layer change → mark dirty so we rebuild with the new layer's overlay
     local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
     if layerIdx ~= self._lastLayerIdx then
         self._lastLayerIdx = layerIdx
-        self._dirty = true
+        self._dirty        = true
+        self._buildInFlight = false  -- cancel any in-flight build from the previous layer
     end
 
     -- Only rebuild when dirty and the previous build has finished
@@ -133,9 +139,13 @@ end
 function SoilMinimapLayer:_pollBuildFinished()
     if not self._buildInFlight then return end
     if not getIsDensityMapVisualizationOverlayReady then return end
-    if getIsDensityMapVisualizationOverlayReady(self._overlay) then
+    local layerIdx = self._lastLayerIdx
+    local entry = self._overlays[layerIdx]
+    if not entry then return end
+    if getIsDensityMapVisualizationOverlayReady(entry.ov) then
+        entry.inFlight    = false
+        entry.hasShown    = true
         self._buildInFlight = false
-        self._hasShownOnce  = true
     end
 end
 
@@ -158,91 +168,100 @@ local LAYER_FIELD_KEYS = {
 -- Engine limit: 16 state colour entries per DMV overlay configuration.
 -- We read only the top 4 bits of each 8-bit GRLE byte (firstChannel=4, numChannels=4)
 -- which maps the full 0-255 byte range to 16 coarser states (0=transparent, 1-15=colour).
--- The GRLE is written with full 8-bit precision by updatePixelForField; the DMV just
--- reads fewer bits so all 16 state slots are used meaningfully.
 local GRLE_FIRST_CH  = 4
 local GRLE_NUM_CH    = 4
 local GRLE_STATE_MAX = 15
 
+-- Returns or lazily creates the overlay entry for layerIdx.
+-- Each overlay is dedicated to exactly one GRLE handle, avoiding the engine's
+-- 8-unique-handle-per-overlay limit when cycling through all soil layers.
+function SoilMinimapLayer:_getOrCreateOverlay(layerIdx)
+    if self._overlays[layerIdx] then return self._overlays[layerIdx] end
+    local ov = createDensityMapVisualizationOverlay("SF_Heatmap_" .. layerIdx, self._resX, self._resY)
+    if not ov then
+        SoilLogger.warning("SoilMinimapLayer: failed to create overlay for layer %d", layerIdx)
+        return nil
+    end
+    local entry = { ov = ov, configured = false, inFlight = false, hasShown = false }
+    self._overlays[layerIdx] = entry
+    SoilLogger.info("SoilMinimapLayer: created overlay for layer %d", layerIdx)
+    return entry
+end
+
 function SoilMinimapLayer:_startBuild(soilMapOverlay)
     local layerIdx = self._lastLayerIdx
     if layerIdx <= 0 then return end
-
-    local ov = self._overlay
-    if not ov then return end
 
     self._dirty = false  -- clear before build; markDirty() during flight re-queues next cycle
 
     local layerSystem = self.soilSystem and self.soilSystem.layerSystem
     local fieldKey    = LAYER_FIELD_KEYS[layerIdx]
 
-    SoilLogger.info("SoilMinimapLayer: _startBuild layerIdx=%d fieldKey=%s layerSysAvail=%s lastHandle=%s",
-        layerIdx, tostring(fieldKey),
-        tostring(layerSystem and layerSystem.available),
-        tostring(self._lastOverlayHandle))
-
     -- ── Weed layer (game-native foliage density map) ──────────────────────────
     if fieldKey == "weed" and layerSystem and layerSystem.hasWeedLayer then
         local mapId, firstCh, numCh = layerSystem:getWeedMapData()
-        SoilLogger.info("SoilMinimapLayer: weed path — mapId=%s firstCh=%s numCh=%s", tostring(mapId), tostring(firstCh), tostring(numCh))
         if mapId then
-            if self._lastOverlayHandle and self._lastOverlayHandle ~= mapId then
-                for s = 0, GRLE_STATE_MAX do
-                    setDensityMapVisualizationOverlayStateColor(ov, self._lastOverlayHandle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, s, 0, 0, 0, 0)
+            local entry = self:_getOrCreateOverlay(layerIdx)
+            if entry then
+                local ov = entry.ov
+                if not entry.configured then
+                    local weedColors = {
+                        {0.95, 0.85, 0.20},
+                        {0.95, 0.70, 0.10},
+                        {0.90, 0.55, 0.05},
+                        {0.85, 0.35, 0.05},
+                        {0.80, 0.20, 0.05},
+                    }
+                    local maxState = math.max(1, (2 ^ (numCh or 4)) - 1)
+                    for state = 1, maxState do
+                        local ci  = math.min(state, #weedColors)
+                        local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
+                        setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
+                    end
+                    entry.configured = true
+                    SoilLogger.info("SoilMinimapLayer: weed overlay configured (mapId=%s firstCh=%s numCh=%s)", tostring(mapId), tostring(firstCh), tostring(numCh))
                 end
+                self._usingDensityLayers = true
+                generateDensityMapVisualizationOverlay(ov)
+                entry.inFlight    = true
+                self._buildInFlight = true
+                return
             end
-            self._lastOverlayHandle = mapId
-            local weedColors = {
-                {0.95, 0.85, 0.20},
-                {0.95, 0.70, 0.10},
-                {0.90, 0.55, 0.05},
-                {0.85, 0.35, 0.05},
-                {0.80, 0.20, 0.05},
-            }
-            local maxState = math.max(1, (2 ^ (numCh or 4)) - 1)
-            for state = 1, maxState do
-                local ci  = math.min(state, #weedColors)
-                local r, g, b = weedColors[ci][1], weedColors[ci][2], weedColors[ci][3]
-                setDensityMapVisualizationOverlayStateColor(ov, mapId, 0, 0, firstCh or 0, numCh or 4, state, r, g, b, 0.85)
-            end
-            self._usingDensityLayers = true
-            generateDensityMapVisualizationOverlay(ov)
-            self._buildInFlight = true
-            SoilLogger.info("SoilMinimapLayer: weed DMV generate triggered (mapId=%s)", tostring(mapId))
-            return
         end
     end
 
     -- ── Per-pixel GRLE path (nutrients + pest/disease/compaction) ─────────────
+    -- Each layer gets its own dedicated overlay so each overlay only ever has
+    -- one GRLE handle registered — avoids the engine's 8-handle-per-overlay limit.
     if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
-        local entry = layerSystem:getLayerEntryForField(fieldKey)
-        SoilLogger.info("SoilMinimapLayer: GRLE path — entry=%s", entry and ("handle="..tostring(entry.handle)) or "NIL")
-        if entry then
-            local handle = entry.handle
-            local def    = entry.def
-            if self._lastOverlayHandle and self._lastOverlayHandle ~= handle then
-                SoilLogger.info("SoilMinimapLayer: clearing prev handle %s states before configuring handle %s", tostring(self._lastOverlayHandle), tostring(handle))
-                for s = 0, GRLE_STATE_MAX do
-                    setDensityMapVisualizationOverlayStateColor(ov, self._lastOverlayHandle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, s, 0, 0, 0, 0)
+        local grleEntry = layerSystem:getLayerEntryForField(fieldKey)
+        if grleEntry then
+            local ovEntry = self:_getOrCreateOverlay(layerIdx)
+            if ovEntry then
+                local ov     = ovEntry.ov
+                local handle = grleEntry.handle
+                local def    = grleEntry.def
+                -- Configure state colours once; they don't change at runtime.
+                if not ovEntry.configured then
+                    setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, 0, 0, 0, 0, 0)
+                    for i = 1, GRLE_STATE_MAX do
+                        local semanticVal = def.minVal + (i / GRLE_STATE_MAX) * (def.maxVal - def.minVal)
+                        local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
+                        setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, i, r, g, b, 1.0)
+                    end
+                    ovEntry.configured = true
+                    SoilLogger.info("SoilMinimapLayer: GRLE overlay configured handle=%s key=%s firstCh=%d numCh=%d", tostring(handle), tostring(fieldKey), GRLE_FIRST_CH, GRLE_NUM_CH)
                 end
+                self._usingDensityLayers = true
+                generateDensityMapVisualizationOverlay(ov)
+                ovEntry.inFlight    = true
+                self._buildInFlight = true
+                return
             end
-            self._lastOverlayHandle = handle
-            setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, 0, 0, 0, 0, 0)
-            for i = 1, GRLE_STATE_MAX do
-                local semanticVal = def.minVal + (i / GRLE_STATE_MAX) * (def.maxVal - def.minVal)
-                local r, g, b = soilMapOverlay:valueToLayerColor(layerIdx, semanticVal)
-                setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, i, r, g, b, 1.0)
-            end
-            self._usingDensityLayers = true
-            generateDensityMapVisualizationOverlay(ov)
-            self._buildInFlight = true
-            SoilLogger.info("SoilMinimapLayer: GRLE DMV generate triggered handle=%s key=%s firstCh=%d numCh=%d", tostring(handle), tostring(fieldKey), GRLE_FIRST_CH, GRLE_NUM_CH)
-            return
         end
     end
 
     -- ── Fallback: polygon-fill dots via SoilMapOverlay ────────────────────────
-    SoilLogger.info("SoilMinimapLayer: fallback path — layerSysAvail=%s fieldKey=%s", tostring(layerSystem and layerSystem.available), tostring(fieldKey))
     self._usingDensityLayers = false
 end
 
@@ -261,8 +280,6 @@ function SoilMinimapLayer:draw(mapSelf)
 
     if not self._usingDensityLayers then
         -- No GRLE density-map layers on this terrain — hand off to polygon centroid dots.
-        -- mapSelf is the correct HUD minimap instance here (from drawFields hook),
-        -- unlike the PDA ref stored in ingameMapRef which would hit the isFullscreen guard.
         local sfm = g_SoilFertilityManager
         if sfm and sfm.soilMapOverlay then
             sfm.soilMapOverlay:onDrawMinimap(mapSelf)
@@ -270,19 +287,17 @@ function SoilMinimapLayer:draw(mapSelf)
         return
     end
 
-    if not self._hasShownOnce then return end
-
     local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
     if layerIdx <= 0 then return end
 
-    local ov = self._overlay
+    local ovEntry = self._overlays[layerIdx]
+    if not ovEntry or not ovEntry.hasShown then return end
+
+    local ov = ovEntry.ov
     if not ov then return end
 
     -- Map terrain-space → screen rect using the same math the game uses for
     -- its built-in BMP overlay layers (proven in v2.2.5).
-    -- The DMV overlay covers the full terrain; mapExtension* describe the
-    -- visible window.  We position + scale the overlay so the visible window
-    -- exactly fills the minimap widget rect, then let the minimap clip it.
     local layout = mapSelf.layout
     if not layout then return end
 

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -176,9 +176,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     local layerSystem = self.soilSystem and self.soilSystem.layerSystem
     local fieldKey    = LAYER_FIELD_KEYS[layerIdx]
 
+    SoilLogger.info("SoilMinimapLayer: _startBuild layerIdx=%d fieldKey=%s layerSysAvail=%s lastHandle=%s",
+        layerIdx, tostring(fieldKey),
+        tostring(layerSystem and layerSystem.available),
+        tostring(self._lastOverlayHandle))
+
     -- ── Weed layer (game-native foliage density map) ──────────────────────────
     if fieldKey == "weed" and layerSystem and layerSystem.hasWeedLayer then
         local mapId, firstCh, numCh = layerSystem:getWeedMapData()
+        SoilLogger.info("SoilMinimapLayer: weed path — mapId=%s firstCh=%s numCh=%s", tostring(mapId), tostring(firstCh), tostring(numCh))
         if mapId then
             if self._lastOverlayHandle and self._lastOverlayHandle ~= mapId then
                 for s = 0, GRLE_STATE_MAX do
@@ -202,24 +208,20 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
             self._buildInFlight = true
+            SoilLogger.info("SoilMinimapLayer: weed DMV generate triggered (mapId=%s)", tostring(mapId))
             return
         end
     end
 
     -- ── Per-pixel GRLE path (nutrients + pest/disease/compaction) ─────────────
-    -- Reads top 4 bits of each 8-bit GRLE byte (firstChannel=4, numChannels=4)
-    -- → 16 states. State 0 = transparent (zero GRLE byte = never sprayed).
-    -- Regenerating in-place: the async DMV engine keeps the previous result
-    -- visible until the new generation completes — no double-buffer needed.
     if layerSystem and layerSystem.available and fieldKey and fieldKey ~= "weed" then
         local entry = layerSystem:getLayerEntryForField(fieldKey)
+        SoilLogger.info("SoilMinimapLayer: GRLE path — entry=%s", entry and ("handle="..tostring(entry.handle)) or "NIL")
         if entry then
             local handle = entry.handle
             local def    = entry.def
-            -- Zero out the previous layer's handle states before configuring the new one.
-            -- setDensityMapVisualizationOverlayStateColor is additive per handle; old entries
-            -- remain active in the overlay until explicitly cleared.
             if self._lastOverlayHandle and self._lastOverlayHandle ~= handle then
+                SoilLogger.info("SoilMinimapLayer: clearing prev handle %s states before configuring handle %s", tostring(self._lastOverlayHandle), tostring(handle))
                 for s = 0, GRLE_STATE_MAX do
                     setDensityMapVisualizationOverlayStateColor(ov, self._lastOverlayHandle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, s, 0, 0, 0, 0)
                 end
@@ -234,11 +236,13 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
             self._usingDensityLayers = true
             generateDensityMapVisualizationOverlay(ov)
             self._buildInFlight = true
+            SoilLogger.info("SoilMinimapLayer: GRLE DMV generate triggered handle=%s key=%s firstCh=%d numCh=%d", tostring(handle), tostring(fieldKey), GRLE_FIRST_CH, GRLE_NUM_CH)
             return
         end
     end
 
     -- ── Fallback: polygon-fill dots via SoilMapOverlay ────────────────────────
+    SoilLogger.info("SoilMinimapLayer: fallback path — layerSysAvail=%s fieldKey=%s", tostring(layerSystem and layerSystem.available), tostring(fieldKey))
     self._usingDensityLayers = false
 end
 

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -38,6 +38,7 @@ function SoilMinimapLayer.new(soilSystem, settings)
     self._farmlandNumCh  = nil
     self._nextRebuildMs  = 0
     self._nextPollMs     = 0
+    self._lastOverlayHandle = nil  -- track previous DMV handle to clear its state colors on layer switch
     return self
 end
 
@@ -179,6 +180,12 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
     if fieldKey == "weed" and layerSystem and layerSystem.hasWeedLayer then
         local mapId, firstCh, numCh = layerSystem:getWeedMapData()
         if mapId then
+            if self._lastOverlayHandle and self._lastOverlayHandle ~= mapId then
+                for s = 0, GRLE_STATE_MAX do
+                    setDensityMapVisualizationOverlayStateColor(ov, self._lastOverlayHandle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, s, 0, 0, 0, 0)
+                end
+            end
+            self._lastOverlayHandle = mapId
             local weedColors = {
                 {0.95, 0.85, 0.20},
                 {0.95, 0.70, 0.10},
@@ -209,6 +216,15 @@ function SoilMinimapLayer:_startBuild(soilMapOverlay)
         if entry then
             local handle = entry.handle
             local def    = entry.def
+            -- Zero out the previous layer's handle states before configuring the new one.
+            -- setDensityMapVisualizationOverlayStateColor is additive per handle; old entries
+            -- remain active in the overlay until explicitly cleared.
+            if self._lastOverlayHandle and self._lastOverlayHandle ~= handle then
+                for s = 0, GRLE_STATE_MAX do
+                    setDensityMapVisualizationOverlayStateColor(ov, self._lastOverlayHandle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, s, 0, 0, 0, 0)
+                end
+            end
+            self._lastOverlayHandle = handle
             setDensityMapVisualizationOverlayStateColor(ov, handle, 0, 0, GRLE_FIRST_CH, GRLE_NUM_CH, 0, 0, 0, 0, 0)
             for i = 1, GRLE_STATE_MAX do
                 local semanticVal = def.minVal + (i / GRLE_STATE_MAX) * (def.maxVal - def.minVal)

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "v2.3.5.0",
+    "- Fixed: minimap heatmap spray trail — daily updates no longer wipe",
+    "  per-pixel nutrient data, so sprayed areas now visually differ from",
+    "  unsprayed areas on the soil layer overlay",
     "v2.3.4.0",
     "- Fixed: significant FPS drops when spraying with wide boom sprayers",
     "- Fixed: frame rate drops while actively fertilizing large fields",


### PR DESCRIPTION
## Summary

- **Fixed:** daily soil updates were overwriting N/P/K/pH/OM GRLE pixels with the field average each game day, erasing any per-pixel spray history accumulated via `updatePixelForField`. Sprayed areas now visually differ from unsprayed areas on the minimap heatmap overlay.
- **Fixed:** minimap animation flicker — overlay now skips rendering during minimap size-state transitions.

## Changes

- `SoilLayerSystem:writeFieldToLayers` gains a `skipPerPixel` parameter; daily updates pass `true`, startup seed passes nothing (writes all layers to initialize from save).
- `SoilMinimapLayer`: track previous frame dimensions to suppress overlay during resize animation.

## Test plan

- [ ] Load savegame, activate nitrogen layer on HUD minimap (Shift+M)
- [ ] Spray half a field — sprayed area should gradually diverge in color from unsprayed area as field average rises past a state boundary
- [ ] Let a game day tick — verify daily update no longer resets pixel colors
- [ ] Confirm PDA polygon tiles unaffected
- [ ] No regressions on pest/disease/compaction layers (still painted by daily update)