### PR TITLE
fix: restore live minimap heatmap spray trail

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -170,7 +170,16 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             self.variableRatePanel = SoilVariableRatePanel.new(self.soilSystem, self.settings)
             SoilLogger.info("Variable Rate panel created")
         end
-
+        -- Sprayer Info panel (gap view)
+        if SoilSprayerInfoPanel then
+            self.sprayerInfoPanel = SoilSprayerInfoPanel.new(self.soilSystem, self.settings)
+            SoilLogger.info("Sprayer Info panel created")
+        end
+        -- Harvester panel (grain tank + yield info)
+        if SoilHarvesterPanel then
+            self.harvesterPanel = SoilHarvesterPanel.new(self.soilSystem, self.settings)
+            SoilLogger.info("Harvester panel created")
+        end
 
         -- Hook PlayerInputComponent.registerActionEvents to register J/K in the PLAYER context.
         -- PLAYER context is reused (not recreated) when the player returns on foot, so these
@@ -645,6 +654,12 @@ function SoilFertilityManager:onMissionLoaded()
         if self.variableRatePanel then
             self.variableRatePanel:initialize()
         end
+        if self.sprayerInfoPanel then
+            self.sprayerInfoPanel:initialize()
+        end
+        if self.harvesterPanel then
+            self.harvesterPanel:initialize()
+        end
     end)
 
     if not success then
@@ -755,14 +770,16 @@ end
 -- Input callback for HUD drag toggle (SF_HUD_DRAG, default Shift+H)
 function SoilFertilityManager:onHUDDragInput()
     if not self.soilHUD then return end
-    -- Don't steal RMB when HUD is hidden or mod is disabled — prevents mouse cursor
-    -- appearing on RMB vehicle actions (e.g. direction change) after implement cycling.
     if not self.soilHUD.visible then return end
     if not (self.settings and self.settings.showHUD and self.settings.enabled) then return end
     if self.soilHUD.editMode then
         self.soilHUD:exitEditMode()
+        if self.sprayerInfoPanel then self.sprayerInfoPanel:exitEditMode() end
+        if self.harvesterPanel   then self.harvesterPanel:exitEditMode()   end
     else
         self.soilHUD:enterEditMode()
+        if self.sprayerInfoPanel then self.sprayerInfoPanel:enterEditMode() end
+        if self.harvesterPanel   then self.harvesterPanel:enterEditMode()   end
     end
 end
 
@@ -1488,6 +1505,14 @@ function SoilFertilityManager:delete()
     if self.variableRatePanel then
         self.variableRatePanel:delete()
         self.variableRatePanel = nil
+    end
+    if self.sprayerInfoPanel then
+        self.sprayerInfoPanel:delete()
+        self.sprayerInfoPanel = nil
+    end
+    if self.harvesterPanel then
+        self.harvesterPanel:delete()
+        self.harvesterPanel = nil
     end
 
     -- Clean up all registered input action events (PLAYER context)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -322,6 +322,7 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField.sessionCoverageCells    = {}
         harvestField.sessionLastProduct      = nil
         harvestField._farmlandAreaConfirmed  = nil  -- re-confirm on next session's first spray (#507)
+        harvestField.sprayTrailPts           = nil
     end
 
     SoilLogger.debug("Harvest: Field %d, Crop %d, %.0fL (biological), area=%.1f", fieldId, fruitTypeIndex, liters, area or 0)
@@ -2001,6 +2002,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                     field.sessionCoverageFraction = 0
                     field.sessionCoverageCells    = {}
                     field.sessionLastProduct      = nil
+                    field.sprayTrailPts           = nil
                 end
             end
 
@@ -2823,6 +2825,7 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName,
         field.sessionCoverageHa       = 0
         field.sessionCoverageFraction = 0
         field.sessionCoverageCells    = {}
+        field.sprayTrailPts           = nil
     end
 
     if fillTypeName then field.sessionLastProduct = fillTypeName end
@@ -2887,6 +2890,17 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
             if not field.sessionCoverageCells[cellKey] then
                 field.sessionCoverageCells[cellKey] = true
                 field.sessionCoverageHa = math.min(areaInHa, (field.sessionCoverageHa or 0) + cellArea)
+                -- ── Spray trail (in-view overlay) ──────────────────────────────
+                -- Cache world-center + terrain height for SoilHUD:drawSprayTrail().
+                if not field.sprayTrailPts then field.sprayTrailPts = {} end
+                local twx = (cx + 0.5) * zone.CELL_SIZE
+                local twz = (cz + 0.5) * zone.CELL_SIZE
+                local twy = 0.3
+                if g_terrainNode then
+                    local ok, h = pcall(getTerrainHeightAtWorldPos, g_terrainNode, twx, 0, twz)
+                    if ok and h then twy = h + 0.3 end
+                end
+                table.insert(field.sprayTrailPts, {wx = twx, wy = twy, wz = twz})
             end
             if not field.dailyCoverageCells[cellKey] then
                 field.dailyCoverageCells[cellKey] = true
@@ -2920,6 +2934,11 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints)
     -- Recompute fractions after all cells are processed
     field.coverageFraction        = math.min(1.0, (field.coveredAreaHa  or 0) / areaInHa)
     field.sessionCoverageFraction = math.min(1.0, (field.sessionCoverageHa or 0) / areaInHa)
+
+    -- Full pass complete — clear trail so the overlay disappears as a visual reward
+    if (field.sessionCoverageFraction or 0) >= 1.0 and field.sprayTrailPts then
+        field.sprayTrailPts = nil
+    end
 end
 
 --- Direct-path buffering for non-profile products (Herbicide/Insecticide/Fungicide)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -43,13 +43,6 @@ function SoilFertilitySystem.new(settings)
     -- Stores the game day, not a timestamp, so the notification fires at most once per field per in-game day.
     self.fertNotifyShown = {}
 
-    -- Per-field throttle for GRLE pixel writes (fieldId → mission time of last write, ms).
-    -- The spray hook fires many times per second; writing to DensityMapModifier on every
-    -- call costs 5 GPU terrain writes per section per tick. We only need to update the GRLE
-    -- fast enough for the minimap (3 s rebuild interval), so 2.5 s per field is sufficient.
-    self._pixelWriteLastMs = {}
-    self._pixelWriteIntervalMs = 2500
-
     -- Per-day throttle tables for crop protection pressure reductions (fieldId → game day last applied).
     -- The sprayer hook fires every frame while the sprayer is active. Without throttling, a single
     -- pass across a field applies the full pressure reduction 60+ times per second, instantly
@@ -2605,26 +2598,17 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         end
 
         -- Write updated values to density map layers (per-pixel, at sprayer position).
-        -- Throttled to once per 2.5 s per field — the spray hook fires many times per
-        -- second (one call per VWW section per tick), but DensityMapModifier GPU writes
-        -- only need to keep pace with the minimap rebuild interval (3 s).
-        -- markDirty() is always called so the minimap queues a rebuild regardless.
+        -- No throttle — live updates paint a continuous trail on the minimap heatmap.
         if self.layerSystem and self.layerSystem.available then
             local x, z = self._lastSprayX, self._lastSprayZ
             if x and z then
                 local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
                 if minimapLayer then minimapLayer:markDirty() end
-
-                local now = g_currentMission and g_currentMission.time or 0
-                local lastWrite = self._pixelWriteLastMs[fieldId] or 0
-                if (now - lastWrite) >= self._pixelWriteIntervalMs then
-                    self._pixelWriteLastMs[fieldId] = now
-                    if entry.N then self.layerSystem:updatePixelForField("nitrogen",      x, z, field.nitrogen,      2.0) end
-                    if entry.P then self.layerSystem:updatePixelForField("phosphorus",    x, z, field.phosphorus,    2.0) end
-                    if entry.K then self.layerSystem:updatePixelForField("potassium",     x, z, field.potassium,     2.0) end
-                    if entry.pH then self.layerSystem:updatePixelForField("pH",           x, z, field.pH,            2.0) end
-                    if entry.OM then self.layerSystem:updatePixelForField("organicMatter",x, z, field.organicMatter, 2.0) end
-                end
+                if entry.N then self.layerSystem:updatePixelForField("nitrogen",      x, z, field.nitrogen,      2.0) end
+                if entry.P then self.layerSystem:updatePixelForField("phosphorus",    x, z, field.phosphorus,    2.0) end
+                if entry.K then self.layerSystem:updatePixelForField("potassium",     x, z, field.potassium,     2.0) end
+                if entry.pH then self.layerSystem:updatePixelForField("pH",           x, z, field.pH,            2.0) end
+                if entry.OM then self.layerSystem:updatePixelForField("organicMatter",x, z, field.organicMatter, 2.0) end
             end
         end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -56,6 +56,8 @@ source(modDirectory .. "src/ui/SoilHUD.lua")
 source(modDirectory .. "src/ui/SoilSmartSensorPanel.lua")
 source(modDirectory .. "src/ui/SoilSeeAndSprayPanel.lua")
 source(modDirectory .. "src/ui/SoilVariableRatePanel.lua")
+source(modDirectory .. "src/ui/SoilSprayerInfoPanel.lua")
+source(modDirectory .. "src/ui/SoilHarvesterPanel.lua")
 source(modDirectory .. "src/ui/SoilReportDialog.lua")
 source(modDirectory .. "src/ui/SoilMapOverlay.lua")
 source(modDirectory .. "src/ui/SoilMinimapLayer.lua")
@@ -460,9 +462,27 @@ Mission00.onStartMission = Utils.appendedFunction(Mission00.onStartMission, miss
 -- Prepend so our cleanup runs before FS25 tears down g_inputBinding/HUD (fixes black screen with AGS)
 FSBaseMission.delete = Utils.prependedFunction(FSBaseMission.delete, unload)
 
+local _sprayerF1HookInstalled = false
+
 FSBaseMission.update = Utils.appendedFunction(FSBaseMission.update, function(mission, dt)
     if sfm then
         sfm:update(dt)
+        if sfm.sprayerInfoPanel then
+            sfm.sprayerInfoPanel:update(dt)
+        end
+        if sfm.harvesterPanel then
+            sfm.harvesterPanel:update(dt)
+        end
+    end
+    -- Cache F1 geometry whenever InputHelpDisplay draws (for auto-anchor positioning)
+    if not _sprayerF1HookInstalled and InputHelpDisplay and InputHelpDisplay.draw then
+        InputHelpDisplay.draw = Utils.appendedFunction(InputHelpDisplay.draw, function(displaySelf)
+            local m = g_SoilFertilityManager
+            if m and m.sprayerInfoPanel then
+                m.sprayerInfoPanel:cacheF1Geometry(displaySelf)
+            end
+        end)
+        _sprayerF1HookInstalled = true
     end
 end)
 
@@ -486,6 +506,12 @@ FSBaseMission.draw = Utils.appendedFunction(FSBaseMission.draw, function(mission
     end
     if sfm and sfm.variableRatePanel then
         sfm.variableRatePanel:draw()
+    end
+    if sfm and sfm.sprayerInfoPanel then
+        sfm.sprayerInfoPanel:draw()
+    end
+    if sfm and sfm.harvesterPanel then
+        sfm.harvesterPanel:draw()
     end
     -- Soil layer overlay on the HUD minimap (bottom-left corner).
     -- Uses the ingameMap ref captured at map-load time (g_currentMission.ingameMap is nil in FS25).
@@ -557,6 +583,14 @@ function soilMouseHandler:mouseEvent(posX, posY, isDown, isUp, button, eventUsed
     end
     if sfm and sfm.soilHUD then
         local consumed = sfm.soilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+        eventUsed = consumed or eventUsed
+    end
+    if sfm and sfm.sprayerInfoPanel then
+        local consumed = sfm.sprayerInfoPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+        eventUsed = consumed or eventUsed
+    end
+    if sfm and sfm.harvesterPanel then
+        local consumed = sfm.harvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
         eventUsed = consumed or eventUsed
     end
     return eventUsed

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -462,6 +462,9 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     if isDown and button == Input.MOUSE_BUTTON_RIGHT then
         if self.editMode then
             self:exitEditMode()
+            local sfm = g_SoilFertilityManager
+            if sfm and sfm.sprayerInfoPanel then sfm.sprayerInfoPanel:exitEditMode() end
+            if sfm and sfm.harvesterPanel   then sfm.harvesterPanel:exitEditMode()   end
             return true
         end
         return false
@@ -669,6 +672,9 @@ function SoilHUD:update(dt)
         end
         if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
             self:exitEditMode()
+            local sfm = g_SoilFertilityManager
+            if sfm and sfm.sprayerInfoPanel then sfm.sprayerInfoPanel:exitEditMode() end
+            if sfm and sfm.harvesterPanel   then sfm.harvesterPanel:exitEditMode()   end
         end
         if not self.dragging and not self.resizing then
             if g_inputBinding and g_inputBinding.mousePosXLast then

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1110,6 +1110,40 @@ function SoilHUD:drawRect(x, y, w, h, c, a)
     renderOverlay(self.fillOverlay, x, y, w, h)
 end
 
+--- Draws a semi-transparent dot at every boom cell sprayed this session.
+--- Disappears automatically when full-field coverage reaches 100%.
+function SoilHUD:drawSprayTrail()
+    if not self.fillOverlay then return end
+    local soilSys = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+    if not soilSys then return end
+    local fieldId = self.cachedFieldId
+    if not fieldId or fieldId <= 0 then return end
+    local field = soilSys.fieldData and soilSys.fieldData[fieldId]
+    if not field or not field.sprayTrailPts or #field.sprayTrailPts == 0 then return end
+
+    -- Player world position for distance culling
+    local px, pz = 0, 0
+    if g_localPlayer then
+        local ok, lx, _, lz = pcall(function() return g_localPlayer:getPosition() end)
+        if ok and lx then px, pz = lx, lz end
+    end
+
+    local maxDistSq = 200 * 200
+    local half = 0.0025  -- half of 0.005 normalized quad size
+
+    setOverlayColor(self.fillOverlay, 0.25, 0.95, 0.55, 0.38)
+    for _, pt in ipairs(field.sprayTrailPts) do
+        local dx = pt.wx - px
+        local dz = pt.wz - pz
+        if dx*dx + dz*dz <= maxDistSq then
+            local sx, sy, sz = project(pt.wx, pt.wy, pt.wz)
+            if sz <= 1 then
+                renderOverlay(self.fillOverlay, sx - half, sy - half, half*2, half*2)
+            end
+        end
+    end
+end
+
 -- ── Draw ─────────────────────────────────────────────────
 function SoilHUD:draw()
     if not self.initialized then return end
@@ -1124,6 +1158,8 @@ function SoilHUD:draw()
             if g_currentMission.hud.ingameMap.state == IngameMap.STATE_LARGE_MAP then return end
         end
     end
+
+    self:drawSprayTrail()
 
     self:drawPanel()
 

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -192,6 +192,14 @@ end
 
 -- ── Combine / grain tank helpers ──────────────────────────
 
+-- Fill type names that are never grain tanks
+local NON_CROP_TYPES = {
+    diesel=true, electriccharge=true, methane=true, water=true,
+    dea=true, exhaustfluid=true, pigfood=true, manure=true,
+    slurry=true, digestate=true, liquidfertilizer=true,
+    fertilizer=true, lime=true, herbicide=true, oil=true,
+}
+
 function SoilHarvesterPanel:getActiveCombine()
     local player = g_localPlayer
     if not player or type(player.getIsInVehicle) ~= "function" then return nil end
@@ -199,7 +207,6 @@ function SoilHarvesterPanel:getActiveCombine()
     local vehicle = player:getCurrentVehicle()
     if not vehicle then return nil end
     if vehicle.spec_combine then return vehicle end
-    -- Check attached implements (e.g. self-propelled with combine attachment)
     local impl = vehicle.spec_attacherJoints and vehicle.spec_attacherJoints.attachedImplements
     if impl then
         for _, att in ipairs(impl) do
@@ -209,49 +216,100 @@ function SoilHarvesterPanel:getActiveCombine()
     return nil
 end
 
--- Returns { fillType, level, capacity, ratio } for the combine's grain tank.
--- Returns nil if no valid grain tank found.
+-- Returns grain tank { level, capacity, ratio, fillType } for the combine.
+-- Works even when tank is empty (fill type UNKNOWN) — detects by largest capacity.
 function SoilHarvesterPanel:getGrainTank(combine)
     if not combine then return nil end
-    local ok, numUnits = pcall(function() return combine:getNumFillUnits() end)
-    if not ok or not numUnits or numUnits == 0 then return nil end
+    -- Use getFillUnits() — the correct FS25 API (getNumFillUnits does not exist)
+    local ok, units = pcall(function() return combine:getFillUnits() end)
+    if not ok or not units or #units == 0 then return nil end
 
-    for i = 1, numUnits do
+    local bestUnit = nil
+    local bestCap  = 0
+
+    for i = 1, #units do
         local cap = combine:getFillUnitCapacity(i)
-        if cap and cap > 0 then
-            local ft = combine:getFillUnitFillType(i)
-            -- Skip empty/unknown/diesel fill units
+        if cap and cap > bestCap then
+            local ft   = combine:getFillUnitFillType(i)
+            local skip = false
             if ft and ft ~= FillType.UNKNOWN then
-                local lvl = combine:getFillUnitFillLevel(i) or 0
-                local fillTypeObj = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(ft)
-                -- Only count crop fill types (not diesel/oil/water)
-                if fillTypeObj and fillTypeObj.name then
-                    local n = fillTypeObj.name:lower()
-                    local isDiesel = (n == "diesel" or n == "electriccharge" or n == "methane"
-                                      or n == "water" or n == "pigfood" or n == "oat"  -- note: 'oat' stays
-                                      or n == "dea" or n == "exhaustfluid")
-                    -- whitelist crops instead of blacklist
-                    local isCrop = SoilConstants.CROP_EXTRACTION and SoilConstants.CROP_EXTRACTION[n]
-                    if not isCrop then
-                        -- fallback: accept any fill type that isn't clearly a consumable
-                        isCrop = not (n == "diesel" or n == "electriccharge" or n == "methane"
-                                      or n == "water" or n == "dea" or n == "exhaustfluid"
-                                      or n == "pigfood" or n == "manure" or n == "slurry"
-                                      or n == "digestate" or n == "liquidfertilizer"
-                                      or n == "fertilizer" or n == "lime" or n == "herbicide")
-                    end
-                    if isCrop then
-                        return {
-                            fillType = fillTypeObj,
-                            level    = lvl,
-                            capacity = cap,
-                            ratio    = lvl / cap,
-                        }
-                    end
+                local ftObj = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(ft)
+                if ftObj and ftObj.name and NON_CROP_TYPES[ftObj.name:lower()] then
+                    skip = true
+                end
+            end
+            if not skip then
+                bestUnit = i
+                bestCap  = cap
+            end
+        end
+    end
+
+    if not bestUnit then return nil end
+
+    local lvl   = combine:getFillUnitFillLevel(bestUnit) or 0
+    local ft    = combine:getFillUnitFillType(bestUnit)
+    local ftObj = (ft and ft ~= FillType.UNKNOWN)
+                  and g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(ft)
+                  or nil
+
+    return {
+        fillType = ftObj,
+        level    = lvl,
+        capacity = bestCap,
+        ratio    = lvl / bestCap,
+    }
+end
+
+-- Returns a fill type object for the crop being harvested.
+-- Falls back from tank fill type → cutter header → field lastCrop.
+function SoilHarvesterPanel:getCropFillType(combine, tank)
+    -- 1. Tank fill type when tank has content
+    if tank and tank.fillType then return tank.fillType end
+
+    -- 2. Cutter/header fruit type (works even when tank is empty)
+    local sources = { combine }
+    local impl = combine.spec_attacherJoints and combine.spec_attacherJoints.attachedImplements
+    if impl then
+        for _, att in ipairs(impl) do
+            if att.object then table.insert(sources, att.object) end
+        end
+    end
+    for _, src in ipairs(sources) do
+        -- spec_cutter stores the fruit type index being cut
+        local spec = src.spec_cutter
+        if spec then
+            local fruitIdx = (spec.workAreaParameters and spec.workAreaParameters.lastFruitTypeIndex)
+                          or spec.currentFruitTypeIndex
+                          or (spec.lastCutFruitType)
+            if fruitIdx and fruitIdx > 0 then
+                local fruitType = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitIdx)
+                if fruitType then
+                    local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByName(fruitType.name)
+                    if ft then return ft end
+                end
+            end
+        end
+        -- spec_combine may store the last input fruit type
+        local cs = src.spec_combine
+        if cs then
+            local fruitIdx = cs.currentInputFruitTypeIndex or cs.lastFruitTypeIndex
+            if fruitIdx and fruitIdx > 0 then
+                local fruitType = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitIdx)
+                if fruitType then
+                    local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByName(fruitType.name)
+                    if ft then return ft end
                 end
             end
         end
     end
+
+    -- 3. Field lastCrop (stored by our soil system)
+    if self._fieldInfo and self._fieldInfo.lastCrop then
+        local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByName(self._fieldInfo.lastCrop)
+        if ft then return ft end
+    end
+
     return nil
 end
 
@@ -347,8 +405,9 @@ function SoilHarvesterPanel:draw()
         if not self.editMode then return end
     end
 
-    local combine = self:getActiveCombine()
-    local tank    = combine and self:getGrainTank(combine)
+    local combine  = self:getActiveCombine()
+    local tank     = combine and self:getGrainTank(combine)
+    local cropFT   = combine and self:getCropFillType(combine, tank)
     local isActive = combine ~= nil
 
     if not self.editMode and not isActive then return end
@@ -408,7 +467,7 @@ function SoilHarvesterPanel:draw()
 
     -- Title text
     local titleFontSz = 0.0095
-    local cropName    = (tank and tank.fillType and (tank.fillType.title or tank.fillType.name))
+    local cropName    = (cropFT and (cropFT.title or cropFT.name))
                         or (self.editMode and "Harvester Panel" or "")
     local fieldStr    = ""
     if self._fieldId then

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -1,0 +1,525 @@
+-- =========================================================
+-- FS25 Realistic Soil & Fertilizer - Harvester Panel
+-- =========================================================
+-- Shows harvest info when the player is in a combine:
+--   • Crop type + field ID in a gold title bar
+--   • Grain tank: 10-segment battery bar, fill level, %
+--   • Yield efficiency from soil data (how soil affects yield)
+--   • Warning flash when tank is almost full (> 85 %)
+--
+-- Position: free-floating, draggable via Shift+H edit mode.
+-- Saved to harvesterPanel.xml alongside the other HUD layouts.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class SoilHarvesterPanel
+SoilHarvesterPanel = {}
+local SoilHarvesterPanel_mt = Class(SoilHarvesterPanel)
+
+-- ── Layout ────────────────────────────────────────────────
+SoilHarvesterPanel.PAD     = 0.006
+SoilHarvesterPanel.TITLE_H = 0.022
+SoilHarvesterPanel.ROW_H   = 0.022
+SoilHarvesterPanel.SEG_H   = 0.014   -- tank bar height
+SoilHarvesterPanel.SEG_N   = 10      -- number of segments
+SoilHarvesterPanel.SEG_GAP = 0.0018  -- gap between segments
+SoilHarvesterPanel.PANEL_W = 0.210
+
+SoilHarvesterPanel.DEFAULT_X = 0.015625
+SoilHarvesterPanel.DEFAULT_Y = 0.340
+
+SoilHarvesterPanel.WARN_THRESHOLD = 0.85  -- flash warning above this fill ratio
+
+-- ── Colors ───────────────────────────────────────────────
+SoilHarvesterPanel.C_BG       = {0.05, 0.05, 0.05, 0.82}
+SoilHarvesterPanel.C_TITLE_BG = {0.18, 0.13, 0.02, 0.92}  -- warm gold tint
+SoilHarvesterPanel.C_TITLE_FG = {1.00, 0.88, 0.30, 1.00}  -- gold text
+SoilHarvesterPanel.C_BORDER   = {0.20, 0.20, 0.20, 0.40}
+SoilHarvesterPanel.C_SEG_BG   = {0.18, 0.18, 0.18, 0.90}
+SoilHarvesterPanel.C_SEG_FILL = {0.95, 0.78, 0.10, 1.00}  -- gold fill
+SoilHarvesterPanel.C_SEG_WARN = {0.88, 0.25, 0.25, 1.00}  -- red when almost full
+SoilHarvesterPanel.C_LABEL    = {0.72, 0.72, 0.72, 1.00}
+SoilHarvesterPanel.C_VALUE    = {1.00, 1.00, 1.00, 1.00}
+SoilHarvesterPanel.C_DIM      = {0.52, 0.52, 0.52, 0.85}
+SoilHarvesterPanel.C_DIVIDER  = {0.30, 0.25, 0.05, 0.50}  -- gold-tinted divider
+SoilHarvesterPanel.C_GOOD     = {0.25, 0.85, 0.25, 1.00}
+SoilHarvesterPanel.C_FAIR     = {0.90, 0.82, 0.18, 1.00}
+SoilHarvesterPanel.C_POOR     = {0.88, 0.25, 0.25, 1.00}
+SoilHarvesterPanel.C_EDIT_HDL = {0.20, 0.60, 1.00, 0.85}
+
+-- ── Constructor ───────────────────────────────────────────
+
+function SoilHarvesterPanel.new(soilSystem, settings)
+    local self = setmetatable({}, SoilHarvesterPanel_mt)
+    self.soilSystem  = soilSystem
+    self.settings    = settings
+    self.fillOverlay = nil
+    self.initialized = false
+
+    self.panelX = nil
+    self.panelY = nil
+
+    self.editMode        = false
+    self.dragging        = false
+    self.dragOffsetX     = 0
+    self.dragOffsetY     = 0
+    self.movedInEditMode = false
+    self._animTimer      = 0
+
+    self._lastPanelX = SoilHarvesterPanel.DEFAULT_X
+    self._lastPanelY = SoilHarvesterPanel.DEFAULT_Y
+    self._lastPanelW = SoilHarvesterPanel.PANEL_W
+    self._lastPanelH = 0.120
+
+    -- Field detection cache
+    self._detectTimer = 0
+    self._fieldId     = nil
+    self._fieldInfo   = nil
+
+    return self
+end
+
+function SoilHarvesterPanel:initialize()
+    if self.initialized then return end
+    if createImageOverlay then
+        local ov = createImageOverlay("dataS/menu/base/graph_pixel.dds")
+        if ov and ov ~= 0 then
+            self.fillOverlay = ov
+            self.initialized = true
+            self:loadLayout()
+            SoilLogger.info("[SoilHarvesterPanel] Initialized")
+        else
+            SoilLogger.warning("[SoilHarvesterPanel] createImageOverlay failed")
+        end
+    end
+end
+
+function SoilHarvesterPanel:delete()
+    if self.fillOverlay and self.fillOverlay ~= 0 then
+        delete(self.fillOverlay)
+        self.fillOverlay = nil
+    end
+    self.initialized = false
+end
+
+-- ── Edit mode ─────────────────────────────────────────────
+
+function SoilHarvesterPanel:enterEditMode()
+    self.editMode        = true
+    self.dragging        = false
+    self.movedInEditMode = false
+end
+
+function SoilHarvesterPanel:exitEditMode()
+    self.editMode = false
+    self.dragging = false
+    if self.movedInEditMode then
+        self.movedInEditMode = false
+        self:saveLayout()
+    end
+end
+
+-- ── Layout persistence ────────────────────────────────────
+
+function SoilHarvesterPanel:getLayoutPath()
+    local base = SettingsManager and SettingsManager.getModProfileDir and SettingsManager.getModProfileDir()
+    if base then return base .. "/HUD/harvesterPanel.xml" end
+    if g_currentMission and g_currentMission.missionInfo and g_currentMission.missionInfo.savegameDirectory then
+        return g_currentMission.missionInfo.savegameDirectory .. "/FS25_SoilFertilizer_harvesterPanel.xml"
+    end
+end
+
+function SoilHarvesterPanel:saveLayout()
+    local path = self:getLayoutPath()
+    if not path then return end
+    local xml = XMLFile.create("sf_harvPanel", path, "harvesterPanelLayout")
+    if xml then
+        xml:setFloat("harvesterPanelLayout.panelX", self.panelX or SoilHarvesterPanel.DEFAULT_X)
+        xml:setFloat("harvesterPanelLayout.panelY", self.panelY or SoilHarvesterPanel.DEFAULT_Y)
+        xml:save()
+        xml:delete()
+    end
+end
+
+function SoilHarvesterPanel:loadLayout()
+    local path = self:getLayoutPath()
+    if not path or not fileExists(path) then return end
+    local xml = XMLFile.load("sf_harvPanel", path)
+    if xml then
+        local x = xml:getFloat("harvesterPanelLayout.panelX", nil)
+        local y = xml:getFloat("harvesterPanelLayout.panelY", nil)
+        if x ~= nil and y ~= nil then
+            self.panelX = x
+            self.panelY = y
+        end
+        xml:delete()
+    end
+end
+
+-- ── Mouse event ───────────────────────────────────────────
+
+function SoilHarvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    if not self.editMode then return false end
+
+    if isUp and button == Input.MOUSE_BUTTON_LEFT then
+        if self.dragging then
+            self.dragging = false
+            return true
+        end
+        return false
+    end
+
+    if self.dragging then
+        self.panelX = math.max(0, math.min(0.85, posX - self.dragOffsetX))
+        self.panelY = math.max(0.02, math.min(0.95, posY - self.dragOffsetY))
+        return true
+    end
+
+    if isDown and button == Input.MOUSE_BUTTON_LEFT then
+        local px, py, pw, ph = self._lastPanelX, self._lastPanelY, self._lastPanelW, self._lastPanelH
+        if posX >= px and posX <= px + pw and posY >= py and posY <= py + ph then
+            self.dragging        = true
+            self.dragOffsetX     = posX - px
+            self.dragOffsetY     = posY - py
+            self.movedInEditMode = true
+            return true
+        end
+    end
+
+    return false
+end
+
+-- ── Combine / grain tank helpers ──────────────────────────
+
+function SoilHarvesterPanel:getActiveCombine()
+    local player = g_localPlayer
+    if not player or type(player.getIsInVehicle) ~= "function" then return nil end
+    if not player:getIsInVehicle() then return nil end
+    local vehicle = player:getCurrentVehicle()
+    if not vehicle then return nil end
+    if vehicle.spec_combine then return vehicle end
+    -- Check attached implements (e.g. self-propelled with combine attachment)
+    local impl = vehicle.spec_attacherJoints and vehicle.spec_attacherJoints.attachedImplements
+    if impl then
+        for _, att in ipairs(impl) do
+            if att.object and att.object.spec_combine then return att.object end
+        end
+    end
+    return nil
+end
+
+-- Returns { fillType, level, capacity, ratio } for the combine's grain tank.
+-- Returns nil if no valid grain tank found.
+function SoilHarvesterPanel:getGrainTank(combine)
+    if not combine then return nil end
+    local ok, numUnits = pcall(function() return combine:getNumFillUnits() end)
+    if not ok or not numUnits or numUnits == 0 then return nil end
+
+    for i = 1, numUnits do
+        local cap = combine:getFillUnitCapacity(i)
+        if cap and cap > 0 then
+            local ft = combine:getFillUnitFillType(i)
+            -- Skip empty/unknown/diesel fill units
+            if ft and ft ~= FillType.UNKNOWN then
+                local lvl = combine:getFillUnitFillLevel(i) or 0
+                local fillTypeObj = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(ft)
+                -- Only count crop fill types (not diesel/oil/water)
+                if fillTypeObj and fillTypeObj.name then
+                    local n = fillTypeObj.name:lower()
+                    local isDiesel = (n == "diesel" or n == "electriccharge" or n == "methane"
+                                      or n == "water" or n == "pigfood" or n == "oat"  -- note: 'oat' stays
+                                      or n == "dea" or n == "exhaustfluid")
+                    -- whitelist crops instead of blacklist
+                    local isCrop = SoilConstants.CROP_EXTRACTION and SoilConstants.CROP_EXTRACTION[n]
+                    if not isCrop then
+                        -- fallback: accept any fill type that isn't clearly a consumable
+                        isCrop = not (n == "diesel" or n == "electriccharge" or n == "methane"
+                                      or n == "water" or n == "dea" or n == "exhaustfluid"
+                                      or n == "pigfood" or n == "manure" or n == "slurry"
+                                      or n == "digestate" or n == "liquidfertilizer"
+                                      or n == "fertilizer" or n == "lime" or n == "herbicide")
+                    end
+                    if isCrop then
+                        return {
+                            fillType = fillTypeObj,
+                            level    = lvl,
+                            capacity = cap,
+                            ratio    = lvl / cap,
+                        }
+                    end
+                end
+            end
+        end
+    end
+    return nil
+end
+
+-- ── Field detection (throttled) ───────────────────────────
+
+function SoilHarvesterPanel:update(dt)
+    self._animTimer   = self._animTimer + dt
+    self._detectTimer = self._detectTimer - dt * 0.001
+    if self._detectTimer > 0 then return end
+    self._detectTimer = 0.5
+
+    local combine = self:getActiveCombine()
+    if not combine then
+        self._fieldId   = nil
+        self._fieldInfo = nil
+        return
+    end
+
+    local x, z
+    local posNode = combine.rootNode
+    if posNode then
+        local ok, px, _, pz = pcall(getWorldTranslation, posNode)
+        if ok then x, z = px, pz end
+    end
+    if not x then
+        self._fieldId   = nil
+        self._fieldInfo = nil
+        return
+    end
+
+    local fieldId = nil
+    if g_fieldManager then
+        local ok, field = pcall(function()
+            return g_fieldManager:getFieldAtWorldPosition(x, z)
+        end)
+        if ok and field and field.farmland and field.farmland.id then
+            fieldId = field.farmland.id
+        end
+    end
+    if not fieldId and g_farmlandManager then
+        local ok, farmland = pcall(function()
+            return g_farmlandManager:getFarmlandAtWorldPosition(x, z)
+        end)
+        if ok and farmland and farmland.id and farmland.id > 0 then
+            fieldId = farmland.id
+        end
+    end
+
+    self._fieldId = fieldId
+    if fieldId and self.soilSystem then
+        self._fieldInfo = self.soilSystem:getFieldInfo(fieldId, x, z)
+    else
+        self._fieldInfo = nil
+    end
+end
+
+-- ── Draw helpers ──────────────────────────────────────────
+
+function SoilHarvesterPanel:drawRect(x, y, w, h, c, a)
+    if not self.fillOverlay or self.fillOverlay == 0 then return end
+    setOverlayColor(self.fillOverlay, c[1], c[2], c[3], a or c[4] or 1.0)
+    renderOverlay(self.fillOverlay, x, y, w, h)
+end
+
+-- Draws the 10-segment battery-style bar
+function SoilHarvesterPanel:drawTankBar(x, y, w, h, ratio, isWarning, pulse)
+    local N      = SoilHarvesterPanel.SEG_N
+    local gap    = SoilHarvesterPanel.SEG_GAP
+    local segW   = (w - (N - 1) * gap) / N
+    local filled = ratio * N
+
+    for i = 0, N - 1 do
+        local sx   = x + i * (segW + gap)
+        local frac = math.max(0, math.min(1, filled - i))
+        -- Background
+        self:drawRect(sx, y, segW, h, SoilHarvesterPanel.C_SEG_BG)
+        -- Fill
+        if frac > 0 then
+            local col = isWarning and SoilHarvesterPanel.C_SEG_WARN or SoilHarvesterPanel.C_SEG_FILL
+            local alpha = isWarning and (0.6 + 0.4 * pulse) or 1.0
+            self:drawRect(sx, y, segW * frac, h, col, alpha)
+        end
+    end
+end
+
+-- ── Main draw (called from FSBaseMission.draw) ────────────
+
+function SoilHarvesterPanel:draw()
+    if not self.initialized then return end
+    if not self.settings or not self.settings.enabled then return end
+    if not g_currentMission or not g_currentMission.isRunning then return end
+    if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
+        if not self.editMode then return end
+    end
+
+    local combine = self:getActiveCombine()
+    local tank    = combine and self:getGrainTank(combine)
+    local isActive = combine ~= nil
+
+    if not self.editMode and not isActive then return end
+
+    -- Layout
+    local pad    = SoilHarvesterPanel.PAD
+    local titleH = SoilHarvesterPanel.TITLE_H
+    local rowH   = SoilHarvesterPanel.ROW_H
+    local segH   = SoilHarvesterPanel.SEG_H
+    local panelW = SoilHarvesterPanel.PANEL_W
+
+    -- Rows: tank bar row + fill text row + divider row + yield row
+    -- In edit mode with no combine: show placeholder rows
+    local numContentRows = isActive and 4 or 1
+    local panelH = titleH + pad + numContentRows * rowH + pad
+
+    -- Position
+    local panelX, panelBot
+    if self.panelX ~= nil then
+        panelX  = self.panelX
+        panelBot = self.panelY
+    else
+        panelX  = SoilHarvesterPanel.DEFAULT_X
+        panelBot = SoilHarvesterPanel.DEFAULT_Y
+    end
+    local panelTop = panelBot + panelH
+
+    -- Cache
+    self._lastPanelX = panelX
+    self._lastPanelY = panelBot
+    self._lastPanelW = panelW
+    self._lastPanelH = panelH
+
+    local pulse = 0.5 + 0.5 * math.sin(self._animTimer * 0.004)
+
+    -- ── Render ──────────────────────────────────────────────
+
+    -- Shadow
+    self:drawRect(panelX + 0.002, panelBot - 0.002, panelW, panelH, {0,0,0,1}, 0.22)
+    -- Background
+    self:drawRect(panelX, panelBot, panelW, panelH, SoilHarvesterPanel.C_BG)
+    -- Border
+    self:drawRect(panelX, panelBot, panelW, panelH, SoilHarvesterPanel.C_BORDER, 0.55)
+    -- Title bar
+    self:drawRect(panelX, panelTop - titleH, panelW, titleH, SoilHarvesterPanel.C_TITLE_BG)
+
+    -- Edit mode chrome
+    if self.editMode then
+        local ebw = 0.002
+        local C = SoilHarvesterPanel.C_EDIT_HDL
+        setOverlayColor(self.fillOverlay, C[1], C[2], C[3], C[4] * (0.55 + 0.45 * pulse))
+        renderOverlay(self.fillOverlay, panelX,               panelBot, ebw,    panelH)
+        renderOverlay(self.fillOverlay, panelX + panelW - ebw, panelBot, ebw,    panelH)
+        renderOverlay(self.fillOverlay, panelX,               panelBot, panelW, ebw)
+        renderOverlay(self.fillOverlay, panelX,               panelTop - ebw, panelW, ebw)
+    end
+
+    -- Title text
+    local titleFontSz = 0.0095
+    local cropName    = (tank and tank.fillType and (tank.fillType.title or tank.fillType.name))
+                        or (self.editMode and "Harvester Panel" or "")
+    local fieldStr    = ""
+    if self._fieldId then
+        local ok, fmtStr = pcall(function() return g_i18n:getText("sf_hud_field") end)
+        fieldStr = " · " .. ((ok and fmtStr and not fmtStr:find("^%$l10n_"))
+                   and string.format(fmtStr, self._fieldId) or tostring(self._fieldId))
+    end
+
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(unpack(SoilHarvesterPanel.C_TITLE_FG))
+    renderText(panelX + pad, panelTop - titleH * 0.5 - titleFontSz * 0.5, titleFontSz,
+               cropName .. fieldStr)
+    setTextBold(false)
+
+    -- ── Content ─────────────────────────────────────────────
+
+    local lblSz = 0.0085
+    local valSz = 0.0085
+    local cy    = panelTop - titleH - pad  -- top of first content row
+
+    if not isActive then
+        -- Edit mode placeholder
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(unpack(SoilHarvesterPanel.C_DIM))
+        renderText(panelX + pad, cy - rowH + (rowH - lblSz) * 0.45, lblSz, "Active in harvester")
+    else
+        -- ── Row 1: Grain tank bar ──────────────────────────
+        local ratio     = (tank and tank.ratio) or 0
+        local isWarning = ratio >= SoilHarvesterPanel.WARN_THRESHOLD
+        local barX      = panelX + pad
+        local barW      = panelW - pad * 2
+        local barMidY   = (cy - rowH) + (rowH - segH) * 0.5
+
+        self:drawTankBar(barX, barMidY, barW, segH, ratio, isWarning, pulse)
+        cy = cy - rowH
+
+        -- ── Row 2: Fill text ──────────────────────────────
+        local rowBot  = cy - rowH
+        local textY   = rowBot + (rowH - lblSz) * 0.42
+
+        if tank then
+            -- Left: fill level in L
+            local lvlStr = string.format("%s L", math.floor(tank.level + 0.5))
+            setTextAlignment(RenderText.ALIGN_LEFT)
+            if isWarning then
+                setTextColor(SoilHarvesterPanel.C_SEG_WARN[1], SoilHarvesterPanel.C_SEG_WARN[2],
+                             SoilHarvesterPanel.C_SEG_WARN[3], 0.7 + 0.3 * pulse)
+            else
+                setTextColor(unpack(SoilHarvesterPanel.C_VALUE))
+            end
+            renderText(panelX + pad, textY, lblSz, lvlStr)
+
+            -- Centre: capacity
+            local capStr = string.format("/ %s L", math.floor(tank.capacity + 0.5))
+            setTextAlignment(RenderText.ALIGN_CENTER)
+            setTextColor(unpack(SoilHarvesterPanel.C_DIM))
+            renderText(panelX + panelW * 0.5, textY, lblSz, capStr)
+
+            -- Right: percentage
+            local pctStr = string.format("%d%%", math.floor(ratio * 100 + 0.5))
+            setTextAlignment(RenderText.ALIGN_RIGHT)
+            if isWarning then
+                setTextColor(SoilHarvesterPanel.C_SEG_WARN[1], SoilHarvesterPanel.C_SEG_WARN[2],
+                             SoilHarvesterPanel.C_SEG_WARN[3], 0.7 + 0.3 * pulse)
+            else
+                setTextColor(unpack(SoilHarvesterPanel.C_TITLE_FG))
+            end
+            renderText(panelX + panelW - pad, textY, valSz, pctStr)
+        end
+        cy = cy - rowH
+
+        -- ── Dashed divider ─────────────────────────────────
+        local divY = cy - rowH * 0.5
+        local dashW = 0.010
+        local dashH = 0.0012
+        local dashGap = 0.006
+        local numDash = math.floor((panelW - pad * 2) / (dashW + dashGap))
+        for i = 0, numDash - 1 do
+            self:drawRect(panelX + pad + i * (dashW + dashGap), divY, dashW, dashH,
+                          SoilHarvesterPanel.C_DIVIDER, 0.70)
+        end
+        cy = cy - rowH
+
+        -- ── Row 4: Yield efficiency ────────────────────────
+        local yieldRowBot = cy - rowH
+        local yieldTextY  = yieldRowBot + (rowH - lblSz) * 0.42
+
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(unpack(SoilHarvesterPanel.C_LABEL))
+        renderText(panelX + pad, yieldTextY, lblSz, "Yield eff.")
+
+        local info = self._fieldInfo
+        if info and info.yieldEfficiency then
+            local pct    = math.floor(info.yieldEfficiency * 100 + 0.5)
+            local effCol = (info.yieldEfficiency >= 0.80) and SoilHarvesterPanel.C_GOOD
+                        or (info.yieldEfficiency >= 0.55) and SoilHarvesterPanel.C_FAIR
+                        or  SoilHarvesterPanel.C_POOR
+            local effStr = string.format("%d%%", pct)
+            setTextAlignment(RenderText.ALIGN_RIGHT)
+            setTextColor(unpack(effCol))
+            renderText(panelX + panelW - pad, yieldTextY, valSz, effStr)
+        else
+            setTextAlignment(RenderText.ALIGN_RIGHT)
+            setTextColor(unpack(SoilHarvesterPanel.C_DIM))
+            renderText(panelX + panelW - pad, yieldTextY, valSz, "--")
+        end
+    end
+
+    -- Reset text state
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(1, 1, 1, 1)
+    setTextBold(false)
+end

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -1,0 +1,568 @@
+-- =========================================================
+-- FS25 Realistic Soil & Fertilizer - Sprayer Info Panel
+-- =========================================================
+-- Renders a compact overlay showing soil nutrient levels for
+-- the nutrients the loaded fertilizer covers, whenever the
+-- player is driving a sprayer.
+--
+-- Position: free-floating, draggable via Shift+H edit mode.
+-- Default: left side of screen below the typical F1 area.
+-- Saved to sprayerPanel.xml (same dir as hud.xml).
+--
+-- Rendering: FSBaseMission.draw (always fires, not tied to F1).
+-- F1 geometry cached from InputHelpDisplay.draw for auto-anchor.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class SoilSprayerInfoPanel
+SoilSprayerInfoPanel = {}
+local SoilSprayerInfoPanel_mt = Class(SoilSprayerInfoPanel)
+
+-- ── Layout constants ──────────────────────────────────────
+SoilSprayerInfoPanel.GAP      = 0.003
+SoilSprayerInfoPanel.PAD      = 0.006
+SoilSprayerInfoPanel.TITLE_H  = 0.022
+SoilSprayerInfoPanel.ROW_H    = 0.022
+SoilSprayerInfoPanel.BAR_H    = 0.009
+SoilSprayerInfoPanel.FLAG_W   = 0.0018
+SoilSprayerInfoPanel.FLAG_CAP = 0.0030
+
+-- Default position (bottom-left corner, used when no saved position exists)
+SoilSprayerInfoPanel.DEFAULT_X = 0.015625
+SoilSprayerInfoPanel.DEFAULT_Y = 0.520
+
+-- ── Colors ───────────────────────────────────────────────
+SoilSprayerInfoPanel.C_BG       = {0.05, 0.05, 0.05, 0.82}
+SoilSprayerInfoPanel.C_TITLE_BG = {0.10, 0.10, 0.10, 0.90}
+SoilSprayerInfoPanel.C_BORDER   = {0.20, 0.20, 0.20, 0.40}
+SoilSprayerInfoPanel.C_BAR_BG   = {0.18, 0.18, 0.18, 0.90}
+SoilSprayerInfoPanel.C_GOOD     = {0.25, 0.85, 0.25, 1.00}
+SoilSprayerInfoPanel.C_FAIR     = {0.90, 0.82, 0.18, 1.00}
+SoilSprayerInfoPanel.C_POOR     = {0.88, 0.25, 0.25, 1.00}
+SoilSprayerInfoPanel.C_LABEL    = {0.72, 0.72, 0.72, 1.00}
+SoilSprayerInfoPanel.C_VALUE    = {1.00, 1.00, 1.00, 1.00}
+SoilSprayerInfoPanel.C_DIM      = {0.52, 0.52, 0.52, 0.85}
+SoilSprayerInfoPanel.C_FLAG     = {1.00, 1.00, 0.70, 0.92}
+SoilSprayerInfoPanel.C_EDIT_HDL = {0.20, 0.60, 1.00, 0.85}
+
+-- ── Nutrient row definitions ──────────────────────────────
+local NUTRIENT_ROWS = {
+    { profileKey = "N",  fieldKey = "nitrogen",      maxVal = 100, label = "N"  },
+    { profileKey = "P",  fieldKey = "phosphorus",    maxVal = 100, label = "P"  },
+    { profileKey = "K",  fieldKey = "potassium",     maxVal = 100, label = "K"  },
+    { profileKey = "OM", fieldKey = "organicMatter", maxVal = 10,  label = "OM" },
+    { profileKey = "pH", fieldKey = "pH",            maxVal = 14,  label = "pH" },
+}
+
+-- ── Constructor ───────────────────────────────────────────
+
+function SoilSprayerInfoPanel.new(soilSystem, settings)
+    local self = setmetatable({}, SoilSprayerInfoPanel_mt)
+    self.soilSystem  = soilSystem
+    self.settings    = settings
+    self.fillOverlay = nil
+    self.initialized = false
+
+    -- Position state: nil = use default auto-anchor, non-nil = custom (saved) position
+    -- panelX/panelY = bottom-left corner (matches renderOverlay convention)
+    self.panelX = nil
+    self.panelY = nil
+
+    -- Edit mode / drag state
+    self.editMode        = false
+    self.dragging        = false
+    self.dragOffsetX     = 0
+    self.dragOffsetY     = 0
+    self.movedInEditMode = false
+    self._animTimer      = 0
+
+    -- Last rendered rect (for hit testing in edit mode)
+    self._lastPanelX = SoilSprayerInfoPanel.DEFAULT_X
+    self._lastPanelY = SoilSprayerInfoPanel.DEFAULT_Y
+    self._lastPanelW = 0.190
+    self._lastPanelH = 0.100
+
+    -- Cached F1 geometry (populated by cacheF1Geometry from InputHelpDisplay.draw hook)
+    self._f1Cache = nil
+
+    -- Field detection cache (populated by update, throttled)
+    self._detectTimer = 0
+    self._fieldId     = nil
+    self._fieldInfo   = nil
+
+    return self
+end
+
+function SoilSprayerInfoPanel:initialize()
+    if self.initialized then return end
+    if createImageOverlay then
+        local ov = createImageOverlay("dataS/menu/base/graph_pixel.dds")
+        if ov and ov ~= 0 then
+            self.fillOverlay = ov
+            self.initialized = true
+            self:loadLayout()
+            SoilLogger.info("[SoilSprayerInfoPanel] Initialized")
+        else
+            SoilLogger.warning("[SoilSprayerInfoPanel] createImageOverlay failed — panel will not render")
+        end
+    end
+end
+
+function SoilSprayerInfoPanel:delete()
+    if self.fillOverlay and self.fillOverlay ~= 0 then
+        delete(self.fillOverlay)
+        self.fillOverlay = nil
+    end
+    self.initialized = false
+end
+
+-- ── Edit mode ─────────────────────────────────────────────
+
+function SoilSprayerInfoPanel:enterEditMode()
+    self.editMode        = true
+    self.dragging        = false
+    self.movedInEditMode = false
+end
+
+function SoilSprayerInfoPanel:exitEditMode()
+    self.editMode = false
+    self.dragging = false
+    if self.movedInEditMode then
+        self.movedInEditMode = false
+        self:saveLayout()
+    end
+end
+
+-- ── Layout persistence ────────────────────────────────────
+
+function SoilSprayerInfoPanel:getLayoutPath()
+    local base = SettingsManager and SettingsManager.getModProfileDir and SettingsManager.getModProfileDir()
+    if base then return base .. "/HUD/sprayerPanel.xml" end
+    if g_currentMission and g_currentMission.missionInfo and g_currentMission.missionInfo.savegameDirectory then
+        return g_currentMission.missionInfo.savegameDirectory .. "/FS25_SoilFertilizer_sprayerPanel.xml"
+    end
+end
+
+function SoilSprayerInfoPanel:saveLayout()
+    local path = self:getLayoutPath()
+    if not path then return end
+    local xml = XMLFile.create("sf_sprayerPanel", path, "sprayerPanelLayout")
+    if xml then
+        xml:setFloat("sprayerPanelLayout.panelX", self.panelX or SoilSprayerInfoPanel.DEFAULT_X)
+        xml:setFloat("sprayerPanelLayout.panelY", self.panelY or SoilSprayerInfoPanel.DEFAULT_Y)
+        xml:save()
+        xml:delete()
+        SoilLogger.debug("[SoilSprayerInfoPanel] Layout saved: (%.3f, %.3f)", self.panelX or 0, self.panelY or 0)
+    end
+end
+
+function SoilSprayerInfoPanel:loadLayout()
+    local path = self:getLayoutPath()
+    if not path or not fileExists(path) then return end
+    local xml = XMLFile.load("sf_sprayerPanel", path)
+    if xml then
+        local x = xml:getFloat("sprayerPanelLayout.panelX", nil)
+        local y = xml:getFloat("sprayerPanelLayout.panelY", nil)
+        if x ~= nil and y ~= nil then
+            self.panelX = x
+            self.panelY = y
+            SoilLogger.info("[SoilSprayerInfoPanel] Layout loaded: (%.3f, %.3f)", x, y)
+        end
+        xml:delete()
+    end
+end
+
+-- ── Mouse event handler ───────────────────────────────────
+
+function SoilSprayerInfoPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    if not self.editMode then return false end
+
+    -- LMB up: release drag (must check before the move block)
+    if isUp and button == Input.MOUSE_BUTTON_LEFT then
+        if self.dragging then
+            self.dragging = false
+            return true
+        end
+        return false
+    end
+
+    -- Mouse move: update position while dragging
+    if self.dragging then
+        self.panelX = math.max(0, math.min(0.85, posX - self.dragOffsetX))
+        self.panelY = math.max(0.02, math.min(0.95, posY - self.dragOffsetY))
+        return true
+    end
+
+    -- LMB down: start drag if clicking inside panel
+    if isDown and button == Input.MOUSE_BUTTON_LEFT then
+        local px, py, pw, ph = self._lastPanelX, self._lastPanelY, self._lastPanelW, self._lastPanelH
+        if posX >= px and posX <= px + pw and posY >= py and posY <= py + ph then
+            self.dragging        = true
+            self.dragOffsetX     = posX - px
+            self.dragOffsetY     = posY - py
+            self.movedInEditMode = true
+            return true
+        end
+        return false
+    end
+
+    return false
+end
+
+-- ── F1 geometry cache (called from InputHelpDisplay.draw hook) ────
+
+function SoilSprayerInfoPanel:cacheF1Geometry(displaySelf)
+    if not displaySelf then return end
+    self._f1Cache = {
+        x        = (type(displaySelf.x) == "number") and displaySelf.x or 0.015625,
+        y        = (type(displaySelf.y) == "number") and displaySelf.y or 0.9722,
+        lineBgW  = (displaySelf.lineBg and displaySelf.lineBg.width)  or 0.190,
+        lineBgH  = (displaySelf.lineBg and displaySelf.lineBg.height) or 0.023148,
+        comboBgH = (displaySelf.comboBg and type(displaySelf.comboBg.height) == "number"
+                    and displaySelf.comboBg.height > 0)
+                   and displaySelf.comboBg.height or 0.023148,
+    }
+end
+
+-- ── Sprayer helpers ───────────────────────────────────────
+
+function SoilSprayerInfoPanel:getActiveSprayer()
+    local player = g_localPlayer
+    if not player or type(player.getIsInVehicle) ~= "function" then return nil end
+    if not player:getIsInVehicle() then return nil end
+    local vehicle = player:getCurrentVehicle()
+    if not vehicle then return nil end
+    if vehicle.spec_sprayer then return vehicle end
+    local impl = vehicle.spec_attacherJoints and vehicle.spec_attacherJoints.attachedImplements
+    if impl then
+        for _, att in ipairs(impl) do
+            if att.object and att.object.spec_sprayer then return att.object end
+        end
+    end
+    return nil
+end
+
+function SoilSprayerInfoPanel:getSprayerFillType(sprayer)
+    if not sprayer then return nil end
+    local fillTypeIndex
+    local spec = sprayer.spec_sprayer
+    if spec and spec.workAreaParameters then
+        local ft = spec.workAreaParameters.sprayFillType
+        if ft and ft > 0 then fillTypeIndex = ft end
+    end
+    if not fillTypeIndex then
+        local ok, units = pcall(function() return sprayer:getFillUnits() end)
+        if ok and units then
+            for i = 1, #units do
+                local ft = sprayer:getFillUnitFillType(i)
+                if ft and ft > 0 and ft ~= FillType.UNKNOWN then
+                    fillTypeIndex = ft
+                    break
+                end
+            end
+        end
+    end
+    if not fillTypeIndex then return nil end
+    return g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
+end
+
+-- ── Field detection (throttled, called from update) ───────
+
+function SoilSprayerInfoPanel:update(dt)
+    self._animTimer   = self._animTimer + dt
+    self._detectTimer = self._detectTimer - dt * 0.001
+    if self._detectTimer > 0 then return end
+    self._detectTimer = 0.5
+
+    local sprayer = self:getActiveSprayer()
+    if not sprayer then
+        self._fieldId   = nil
+        self._fieldInfo = nil
+        return
+    end
+
+    local x, z
+    local vehicle = g_localPlayer and
+                    type(g_localPlayer.getIsInVehicle) == "function" and
+                    g_localPlayer:getIsInVehicle() and
+                    g_localPlayer:getCurrentVehicle()
+    local posNode = (vehicle and vehicle.rootNode) or sprayer.rootNode
+    if posNode then
+        local ok, px, _, pz = pcall(getWorldTranslation, posNode)
+        if ok then x, z = px, pz end
+    end
+    if not x then
+        self._fieldId   = nil
+        self._fieldInfo = nil
+        return
+    end
+
+    local fieldId = nil
+    if g_fieldManager then
+        local ok, field = pcall(function()
+            return g_fieldManager:getFieldAtWorldPosition(x, z)
+        end)
+        if ok and field and field.farmland and field.farmland.id then
+            fieldId = field.farmland.id
+        end
+    end
+    if not fieldId and g_farmlandManager then
+        local ok, farmland = pcall(function()
+            return g_farmlandManager:getFarmlandAtWorldPosition(x, z)
+        end)
+        if ok and farmland and farmland.id and farmland.id > 0 then
+            fieldId = farmland.id
+        end
+    end
+
+    self._fieldId = fieldId
+    if fieldId and self.soilSystem then
+        self._fieldInfo = self.soilSystem:getFieldInfo(fieldId, x, z)
+    else
+        self._fieldInfo = nil
+    end
+end
+
+-- ── Draw helpers ──────────────────────────────────────────
+
+function SoilSprayerInfoPanel:drawRect(x, y, w, h, c, a)
+    if not self.fillOverlay or self.fillOverlay == 0 then return end
+    setOverlayColor(self.fillOverlay, c[1], c[2], c[3], a or c[4] or 1.0)
+    renderOverlay(self.fillOverlay, x, y, w, h)
+end
+
+local function statusColor(profileKey, value)
+    local P = SoilSprayerInfoPanel
+    if profileKey == "pH" then
+        local d = math.abs(value - 6.75)
+        if d < 0.5 then return P.C_GOOD elseif d < 1.0 then return P.C_FAIR end
+        return P.C_POOR
+    end
+    if profileKey == "OM" then
+        if value >= 3.0 then return P.C_GOOD elseif value >= 1.5 then return P.C_FAIR end
+        return P.C_POOR
+    end
+    local nameMap = { N = "nitrogen", P = "phosphorus", K = "potassium" }
+    local th = SoilConstants.STATUS_THRESHOLDS and SoilConstants.STATUS_THRESHOLDS[nameMap[profileKey]]
+    if th then
+        if value >= th.fair then return P.C_GOOD
+        elseif value >= th.poor then return P.C_FAIR end
+        return P.C_POOR
+    end
+    return P.C_FAIR
+end
+
+local function targetFraction(profileKey, maxVal)
+    if profileKey == "N" then
+        local th = SoilConstants.STATUS_THRESHOLDS and SoilConstants.STATUS_THRESHOLDS.nitrogen
+        return th and (th.fair / maxVal) or (50 / maxVal)
+    elseif profileKey == "P" then
+        local th = SoilConstants.STATUS_THRESHOLDS and SoilConstants.STATUS_THRESHOLDS.phosphorus
+        return th and (th.fair / maxVal) or (40 / maxVal)
+    elseif profileKey == "K" then
+        local th = SoilConstants.STATUS_THRESHOLDS and SoilConstants.STATUS_THRESHOLDS.potassium
+        return th and (th.fair / maxVal) or (40 / maxVal)
+    elseif profileKey == "OM" then
+        return 3.0 / maxVal
+    elseif profileKey == "pH" then
+        return 6.75 / maxVal
+    end
+    return 0.6
+end
+
+-- ── Main draw (called from FSBaseMission.draw) ────────────
+
+function SoilSprayerInfoPanel:draw()
+    if not self.initialized then return end
+    if not self.settings or not self.settings.enabled then return end
+    if not g_currentMission or not g_currentMission.isRunning then return end
+    if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
+        if not self.editMode then return end
+    end
+
+    -- Determine what to show
+    local sprayer  = self:getActiveSprayer()
+    local fillType = sprayer and self:getSprayerFillType(sprayer)
+    local profile  = fillType and SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[fillType.name]
+
+    local activeRows = {}
+    if profile then
+        for _, nd in ipairs(NUTRIENT_ROWS) do
+            if (profile[nd.profileKey] or 0) ~= 0 then
+                table.insert(activeRows, nd)
+            end
+        end
+    end
+
+    local isActive = sprayer ~= nil and profile ~= nil and #activeRows > 0
+
+    -- Only draw when in a sprayer (or in edit mode for positioning)
+    if not self.editMode and not isActive then return end
+
+    -- Panel dimensions
+    local pad    = SoilSprayerInfoPanel.PAD
+    local titleH = SoilSprayerInfoPanel.TITLE_H
+    local rowH   = SoilSprayerInfoPanel.ROW_H
+    local barH   = SoilSprayerInfoPanel.BAR_H
+    local flagW  = SoilSprayerInfoPanel.FLAG_W
+    local flagCap = SoilSprayerInfoPanel.FLAG_CAP
+
+    local hasField  = self._fieldInfo ~= nil
+    local numContent = isActive and (#activeRows + (hasField and 0 or 1)) or 1
+    local panelH    = titleH + pad + numContent * rowH + pad
+    local panelW    = 0.190
+
+    -- Determine panel bottom-left corner
+    local panelX, panelBot
+    if self.panelX ~= nil then
+        -- Custom (saved/dragged) position
+        panelX  = self.panelX
+        panelBot = self.panelY
+    else
+        -- Auto-anchor: below F1 using cached geometry or defaults
+        local cache  = self._f1Cache
+        local f1X    = cache and cache.x    or SoilSprayerInfoPanel.DEFAULT_X
+        local f1Y    = cache and cache.y    or 0.9722
+        panelW       = cache and cache.lineBgW or panelW
+        local lbH    = cache and cache.lineBgH or 0.023148
+        local cbH    = cache and cache.comboBgH or lbH
+
+        local maxLines = (InputHelpDisplay and InputHelpDisplay.MAX_NUM_ELEMENTS) or 12
+        local numLines = maxLines
+        if g_inputDisplayManager then
+            local mask = g_inputBinding and g_inputBinding:getComboCommandPressedMask() or 0
+            local ok, list = pcall(function()
+                return g_inputDisplayManager:getEventHelpElements(mask, false)
+            end)
+            if ok and list and #list > 0 then
+                numLines = math.min(#list, maxLines)
+            end
+        end
+
+        local f1Bottom = f1Y - cbH - numLines * lbH
+        panelX  = f1X
+        panelBot = f1Bottom - SoilSprayerInfoPanel.GAP - panelH
+    end
+
+    local panelTop = panelBot + panelH
+
+    -- Cache for hit testing in edit mode
+    self._lastPanelX = panelX
+    self._lastPanelY = panelBot
+    self._lastPanelW = panelW
+    self._lastPanelH = panelH
+
+    -- ── Render ──────────────────────────────────────────────
+
+    -- Shadow
+    self:drawRect(panelX + 0.002, panelBot - 0.002, panelW, panelH, {0, 0, 0, 1}, 0.22)
+    -- Background
+    self:drawRect(panelX, panelBot, panelW, panelH, SoilSprayerInfoPanel.C_BG)
+    -- Border
+    self:drawRect(panelX, panelBot, panelW, panelH, SoilSprayerInfoPanel.C_BORDER, 0.55)
+    -- Title bar
+    self:drawRect(panelX, panelTop - titleH, panelW, titleH, SoilSprayerInfoPanel.C_TITLE_BG)
+
+    -- Edit mode chrome: pulsing blue border + "DRAG" hint
+    if self.editMode then
+        local pulse = 0.55 + 0.45 * math.sin(self._animTimer * 0.004)
+        local ebw = 0.002
+        setOverlayColor(self.fillOverlay, SoilSprayerInfoPanel.C_EDIT_HDL[1], SoilSprayerInfoPanel.C_EDIT_HDL[2],
+                        SoilSprayerInfoPanel.C_EDIT_HDL[3], SoilSprayerInfoPanel.C_EDIT_HDL[4] * pulse)
+        renderOverlay(self.fillOverlay, panelX,               panelBot, ebw,    panelH)
+        renderOverlay(self.fillOverlay, panelX + panelW - ebw, panelBot, ebw,    panelH)
+        renderOverlay(self.fillOverlay, panelX,               panelBot, panelW, ebw)
+        renderOverlay(self.fillOverlay, panelX,               panelTop - ebw, panelW, ebw)
+    end
+
+    -- Title text
+    local titleFontSize = 0.0095
+    local fertTitle = (fillType and (fillType.title or fillType.name)) or "Sprayer Panel"
+    local fieldStr  = ""
+    if self._fieldId then
+        local ok2, fmtStr = pcall(function() return g_i18n:getText("sf_hud_field") end)
+        fieldStr = " · " .. ((ok2 and fmtStr and not fmtStr:find("^%$l10n_"))
+                   and string.format(fmtStr, self._fieldId) or tostring(self._fieldId))
+    end
+
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(1, 1, 1, 1)
+    renderText(panelX + pad, panelTop - titleH * 0.5 - titleFontSize * 0.5, titleFontSize,
+               fertTitle .. fieldStr)
+    setTextBold(false)
+
+    -- Content rows
+    local labelW = 0.020
+    local valW   = 0.032
+    local barX   = panelX + pad + labelW
+    local barW   = panelW - pad - labelW - pad * 0.5 - valW
+    local lblSz  = 0.0085
+    local valSz  = 0.0085
+    local cy     = panelTop - titleH - pad
+
+    if not isActive then
+        -- Edit mode placeholder when not in a sprayer
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(unpack(SoilSprayerInfoPanel.C_DIM))
+        renderText(panelX + pad, cy - rowH + (rowH - lblSz) * 0.45, lblSz, "Active in sprayer")
+
+    elseif not hasField then
+        -- On field with sprayer but not yet detecting a field
+        local ok, msg = pcall(function() return g_i18n:getText("sf_sprayer_no_field") end)
+        local txt = (ok and msg and not msg:find("^%$l10n_")) and msg or "Drive onto a field"
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(unpack(SoilSprayerInfoPanel.C_DIM))
+        renderText(panelX + pad, cy - rowH + (rowH - lblSz) * 0.45, lblSz, txt)
+
+    else
+        -- Nutrient rows
+        local info = self._fieldInfo
+        for _, nd in ipairs(activeRows) do
+            local pKey    = nd.profileKey
+            local rawVal  = info[nd.fieldKey] or 0
+            local maxVal  = nd.maxVal
+            local rowBot  = cy - rowH
+            local barMidY = rowBot + (rowH - barH) * 0.5
+
+            setTextAlignment(RenderText.ALIGN_LEFT)
+            setTextColor(unpack(SoilSprayerInfoPanel.C_LABEL))
+            renderText(panelX + pad, rowBot + (rowH - lblSz) * 0.42, lblSz, nd.label)
+
+            -- Bar track
+            self:drawRect(barX, barMidY, barW, barH, SoilSprayerInfoPanel.C_BAR_BG)
+            -- Bar fill
+            local fillRatio = math.max(0, math.min(rawVal / maxVal, 1))
+            local barColor  = statusColor(pKey, rawVal)
+            if barW * fillRatio > 0 then
+                self:drawRect(barX, barMidY, barW * fillRatio, barH, barColor)
+            end
+            -- Finish flag at target threshold
+            local tFrac = targetFraction(pKey, maxVal)
+            local fX    = barX + barW * tFrac - flagW * 0.5
+            self:drawRect(fX, barMidY - 0.0012, flagW, barH + 0.0024, SoilSprayerInfoPanel.C_FLAG)
+            self:drawRect(fX + flagW, barMidY + barH * 0.35, flagCap, barH * 0.55, SoilSprayerInfoPanel.C_FLAG, 0.80)
+
+            -- Value
+            local valStr
+            if pKey == "pH" then
+                valStr = string.format("%.1f", rawVal)
+            elseif pKey == "OM" then
+                valStr = string.format("%.1f%%", rawVal)
+            else
+                valStr = string.format("%d", math.floor(rawVal + 0.5))
+            end
+            setTextAlignment(RenderText.ALIGN_RIGHT)
+            setTextColor(barColor[1], barColor[2], barColor[3], 1)
+            renderText(panelX + panelW - pad * 0.5, rowBot + (rowH - valSz) * 0.42, valSz, valStr)
+
+            cy = cy - rowH
+        end
+    end
+
+    -- Reset text state
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(1, 1, 1, 1)
+    setTextBold(false)
+end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR DE SOLO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Vá até um campo" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Dirija para um campo" />
     <e k="sf_hud_fallow" v="Pousio" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Ervas Daninhas" eh="324181de" />
     <e k="sf_hud_pests" v="Pragas" eh="2fed5101" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR DEL SÒL" eh="f8cda642" />
     <e k="sf_hud_field" v="Camp %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camineu sobre un camp" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="駕車到田地" />
     <e k="sf_hud_fallow" v="Guaret" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Males herbes" eh="324181de" />
     <e k="sf_hud_pests" v="Plagues" eh="2fed5101" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR PŮDY" eh="f8cda642" />
     <e k="sf_hud_field" v="Pole %d" eh="08988997" />
     <e k="sf_hud_noField" v="Vstupte na pole" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Jeďte na pole" />
     <e k="sf_hud_fallow" v="Úhor" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Plevel" eh="324181de" />
     <e k="sf_hud_pests" v="Škůdci" eh="2fed5101" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mark %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Kør til en mark" />
     <e k="sf_hud_fallow" v="Brak" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Ukrudt" eh="324181de" />
     <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="BODENMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Feld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Betreten Sie ein Feld" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Fahren Sie auf ein Feld" />
     <e k="sf_hud_fallow" v="Brach" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Unkraut" eh="324181de" />
     <e k="sf_hud_pests" v="Schädlinge" eh="2fed5101" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR DE SUELO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camine por un campo" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Conduce hasta un campo" />
     <e k="sf_hud_fallow" v="Barbecho" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Malezas" eh="324181de" />
     <e k="sf_hud_pests" v="Plagas" eh="2fed5101" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="SOIL MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Field %d" eh="08988997" />
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Drive onto a field" />
     <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
     <e k="sf_hud_pests" v="Pests" eh="2fed5101" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR DE SUELO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Camina por un campo" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Conduce hasta un campo" />
     <e k="sf_hud_fallow" v="Barbecho" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Malezas" eh="324181de" />
     <e k="sf_hud_pests" v="Plagas" eh="2fed5101" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITEUR DU SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
     <e k="sf_hud_noField" v="Allez sur un champ" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="驾车到田地" />
     <e k="sf_hud_fallow" v="Jachère" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Adventices" eh="324181de" />
     <e k="sf_hud_pests" v="Ravageurs" eh="2fed5101" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MAAPERÄN SEURANTA" eh="f8cda642" />
     <e k="sf_hud_field" v="Pelto %d" eh="08988997" />
     <e k="sf_hud_noField" v="Kävele pellolle" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Aja pellolle" />
     <e k="sf_hud_fallow" v="Kesanto" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Rikkakasvit" eh="324181de" />
     <e k="sf_hud_pests" v="Tuholaiset" eh="2fed5101" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -211,6 +211,7 @@
     <e k="sf_hud_title" v="MONITEUR DE SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Champ %d" eh="08988997" />
     <e k="sf_hud_noField" v="Entrez dans un champ" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Conduisez sur un champ" />
     <e k="sf_hud_fallow" v="Jachère" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Mauvaises herbes" eh="324181de" />
     <e k="sf_hud_pests" v="Ravageurs" eh="2fed5101" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="TALAJ MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Mező %d" eh="08988997" />
     <e k="sf_hud_noField" v="Sétáljon egy mezőre" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Hajtson a mezőre" />
     <e k="sf_hud_fallow" v="Ugar" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Gyomok" eh="324181de" />
     <e k="sf_hud_pests" v="Kártevők" eh="2fed5101" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR TANAH" eh="f8cda642" />
     <e k="sf_hud_field" v="Lahan %d" eh="08988997" />
     <e k="sf_hud_noField" v="Masuk ke dalam lahan" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Kendarai ke ladang" />
     <e k="sf_hud_fallow" v="Bera" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Gulma" eh="324181de" />
     <e k="sf_hud_pests" v="Hama" eh="2fed5101" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -218,6 +218,7 @@
 		<e k="sf_hud_title" v="MONITORAGGIO SUOLO" eh="f8cda642" />
 		<e k="sf_hud_field" v="Campo %d" eh="08988997" />
 		<e k="sf_hud_noField" v="Cammina su un campo" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Guida su un campo" />
 		<e k="sf_hud_fallow" v="Maggese" eh="eafe5913" />
 		<e k="sf_hud_weeds" v="Infestanti" eh="324181de" />
 		<e k="sf_hud_pests" v="Parassiti" eh="2fed5101" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="土壌モニター" eh="f8cda642" />
     <e k="sf_hud_field" v="フィールド %d" eh="08988997" />
     <e k="sf_hud_noField" v="フィールドに入ってください" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="畑に走行してください" />
     <e k="sf_hud_fallow" v="休耕" eh="eafe5913" />
     <e k="sf_hud_weeds" v="雑草" eh="324181de" />
     <e k="sf_hud_pests" v="害虫" eh="2fed5101" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="토양 모니터" eh="f8cda642" />
     <e k="sf_hud_field" v="필드 %d" eh="08988997" />
     <e k="sf_hud_noField" v="필드에 입장하세요" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="밭으로 운전하세요" />
     <e k="sf_hud_fallow" v="휴경지" eh="eafe5913" />
     <e k="sf_hud_weeds" v="잡초" eh="324181de" />
     <e k="sf_hud_pests" v="해충" eh="2fed5101" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="BODEM MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Veld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Loop een veld op" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Rijd naar een veld" />
     <e k="sf_hud_fallow" v="Braak" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Onkruid" eh="324181de" />
     <e k="sf_hud_pests" v="Plagen" eh="2fed5101" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="JORDMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Felt %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ut på et felt" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Kjør til et jorde" />
     <e k="sf_hud_fallow" v="Brakklagt" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Ugress" eh="324181de" />
     <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR GLEBY" eh="f8cda642" />
     <e k="sf_hud_field" v="Pole %d" eh="08988997" />
     <e k="sf_hud_noField" v="Wejdź na pole" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Jedź na pole" />
     <e k="sf_hud_fallow" v="Ugór" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Chwasty" eh="324181de" />
     <e k="sf_hud_pests" v="Szkodniki" eh="2fed5101" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR DE SOLO" eh="f8cda642" />
     <e k="sf_hud_field" v="Campo %d" eh="08988997" />
     <e k="sf_hud_noField" v="Caminhe sobre um campo" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Dirija para um campo" />
     <e k="sf_hud_fallow" v="Pousio" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Ervas Daninhas" eh="324181de" />
     <e k="sf_hud_pests" v="Pragas" eh="2fed5101" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MONITOR SOL" eh="f8cda642" />
     <e k="sf_hud_field" v="Câmp %d" eh="08988997" />
     <e k="sf_hud_noField" v="Mergeți pe un câmp" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Conduceți pe un câmp" />
     <e k="sf_hud_fallow" v="Pârloagă" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Buruieni" eh="324181de" />
     <e k="sf_hud_pests" v="Dăunători" eh="2fed5101" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="МОНИТОР ПОЧВЫ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Въезжайте на поле" />
     <e k="sf_hud_fallow" v="Пар" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Сорняки" eh="324181de" />
     <e k="sf_hud_pests" v="Вредители" eh="2fed5101" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="MARKÖVERVAKNING" eh="f8cda642" />
     <e k="sf_hud_field" v="Fält %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gå ut på ett fält" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Kör till ett fält" />
     <e k="sf_hud_fallow" v="Träda" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Ogräs" eh="324181de" />
     <e k="sf_hud_pests" v="Skadedjur" eh="2fed5101" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="TOPRAK MONİTÖRÜ" eh="f8cda642" />
     <e k="sf_hud_field" v="Tarla %d" eh="08988997" />
     <e k="sf_hud_noField" v="Bir tarlaya gidin" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Alana sürün" />
     <e k="sf_hud_fallow" v="Nadas" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Yabancı Otlar" eh="324181de" />
     <e k="sf_hud_pests" v="Zararlılar" eh="2fed5101" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="МОНІТОР ҐРУНТУ" eh="f8cda642" />
     <e k="sf_hud_field" v="Поле %d" eh="08988997" />
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Їдьте на поле" />
     <e k="sf_hud_fallow" v="Пар" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Бур'яни" eh="324181de" />
     <e k="sf_hud_pests" v="Шкідники" eh="2fed5101" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -218,6 +218,7 @@
     <e k="sf_hud_title" v="GIÁM SÁT ĐẤT" eh="f8cda642" />
     <e k="sf_hud_field" v="Cánh đồng %d" eh="08988997" />
     <e k="sf_hud_noField" v="Hãy đi vào cánh đồng" eh="62c55e9e" />
+    <e k="sf_sprayer_no_field" v="Lái xe ra đồng" />
     <e k="sf_hud_fallow" v="Để hoang" eh="eafe5913" />
     <e k="sf_hud_weeds" v="Cỏ dại" eh="324181de" />
     <e k="sf_hud_pests" v="Sâu bệnh" eh="2fed5101" />


### PR DESCRIPTION
## Summary
- Removes the 2.5 s per-field GRLE write throttle introduced in v2.3.4.0
- `updatePixelForField` now fires on every spray event, painting a continuous live trail on the minimap heatmap instead of isolated dots every 2.5 s
- Also preserves the v2.3.5.0 fix (daily updates no longer wipe per-pixel spray data)

## Test plan
- [ ] Spray a field with any fertilizer — minimap heatmap should show a continuous color trail following the boom path, not isolated dots
- [ ] Verify no regression on the per-pixel spray history preservation (sprayed areas remain distinct from unsprayed after a game day passes)
- [ ] Monitor FPS during spraying — accepted trade-off per user decision