### PR TITLE
hotfix: v2.3.6.0 — weed spikes, rate display, colorblind auto-detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 
 > [!WARNING]
 > To play the mod at its finest please download the following file.
-> https://modsfire.com/OwETnO2y0uo66g2
+> https://modsfire.com/X5v9Ytvq7No8flb
 > Instructions are inside the README
 
 > [!TIP]
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.5.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.6.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.5.0</version>
+    <version>2.3.6.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -680,6 +680,19 @@ function SoilFertilityManager:onMissionStarted()
     -- is available on fresh saves, so it falls back to defaults.
     self.settings:load()
 
+    -- Auto-detect game colorblind mode (issue #539): if the player has enabled
+    -- colorblind mode in game settings, mirror that into SF's colorblind setting.
+    -- Only activate — never force-disable if the user has explicitly turned it on.
+    if not self.settings.colorblindMode and g_gameSettings then
+        local ok, gameColorblind = pcall(function()
+            return g_gameSettings:getValue("useColorblindMode")
+        end)
+        if ok and gameColorblind then
+            self.settings.colorblindMode = true
+            SoilLogger.info("Colorblind mode auto-enabled from game settings")
+        end
+    end
+
     SoilLogger.info("Mission started — checking for Precision Farming compatibility...")
 
     local ok, err = pcall(function()

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2051,10 +2051,19 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
             local herbicideAppliedToday = self.herbicideDailyApplied and
                 self.herbicideDailyApplied[fieldId] and
                 self.herbicideDailyApplied[fieldId].day == currentDay
+            local target = math.max(0, math.min(100, gameWeedFactor * 100))
             if (field.herbicideDaysLeft or 0) > 0 or herbicideAppliedToday then
-                field.weedPressure = math.min(field.weedPressure or 0, math.max(0, gameWeedFactor * 100))
+                -- Under herbicide protection: only allow pressure to decrease
+                field.weedPressure = math.min(field.weedPressure or 0, target)
             else
-                field.weedPressure = math.max(0, math.min(100, gameWeedFactor * 100))
+                local current = field.weedPressure or 0
+                if target > current then
+                    -- Cap the daily increase to prevent reload/time-skip spikes (#536)
+                    local maxIncrease = SoilConstants.WEED_PRESSURE.MAX_DAILY_INCREASE or 20
+                    field.weedPressure = math.min(target, current + maxIncrease)
+                else
+                    field.weedPressure = target
+                end
             end
 
             -- Sync zone cells so overlay map matches field-level weed pressure.

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -792,6 +792,11 @@ SoilConstants.WEED_PRESSURE = {
     -- 0 = no weeds, 1-6 = living stages, 7-9 = withered (dying/brown visual)
     WEED_STATE_CLEAR     = 0,
     WEED_STATE_WITHERED  = 7,   -- small withered — visible brown weeds
+
+    -- Maximum weed pressure increase per daily update.
+    -- Prevents the snap-to-game-weedFactor spike on reload/time-skip (issue #536).
+    -- Decreases still happen immediately so herbicide/cultivation relief is instant.
+    MAX_DAILY_INCREASE   = 20,
 }
 
 -- ========================================

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3852,8 +3852,8 @@ function HookManager:installSprayerUsageHook()
                 local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillType)
                 if ft then ftName = ft.name end
                 SoilLogger.debug(
-                    "SprayUsage veh=%d type=%-12s  spd=%.1f km/h  w=%.1fm  lps=%.6f  scale=%.2f  usage/s=%.4f L/s  eff=%.1f L/ha",
-                    vehId, ftName, actualSpeedKmh, workWidth, lps, fillScale, usagePerSec, effectiveLpha)
+                    "SprayUsage veh=%d type=%-12s  spd=%.1f km/h  w=%.1fm  lps=%.6f  scale=%.2f  rate=%.2fx  usage/s=%.4f L/s  eff=%.1f L/ha",
+                    vehId, ftName, actualSpeedKmh, workWidth, lps, fillScale, mapMult, usagePerSec, effectiveLpha)
             end
 
             return usage

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -493,6 +493,19 @@ function SoilSprayerInfoPanel:draw()
                fertTitle .. fieldStr)
     setTextBold(false)
 
+    -- SF rate multiplier badge (top-right of title bar)
+    if sprayer and g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager then
+        local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(sprayer.id or 0)
+        local rateTxt = string.format("%.1fx", mult)
+        local rateColor = (math.abs(mult - 1.0) < 0.01)
+            and SoilSprayerInfoPanel.C_DIM
+            or  { 1.00, 0.88, 0.30, 1.00 }
+        setTextAlignment(RenderText.ALIGN_RIGHT)
+        setTextColor(unpack(rateColor))
+        renderText(panelX + panelW - pad, panelTop - titleH * 0.5 - titleFontSize * 0.5,
+                   titleFontSize, rateTxt)
+    end
+
     -- Content rows
     local labelW = 0.020
     local valW   = 0.032

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,13 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "v2.3.6.0",
+    "- Fixed: weed pressure no longer spikes on reload or time-skip;",
+    "  increases are now capped at 20 pts/day so pressure rises gradually",
+    "- Fixed: SF application rate multiplier now shown in sprayer panel",
+    "  title bar so you always know the active rate at a glance",
+    "- Fixed: colorblind mode now auto-enables when the game's own",
+    "  colorblind setting is turned on",
     "v2.3.5.0",
     "- Fixed: minimap heatmap spray trail — daily updates no longer wipe",
     "  per-pixel nutrient data, so sprayed areas now visually differ from",


### PR DESCRIPTION
## Summary

- **#536 fixed**: Weed pressure no longer spikes on save reload or time-skip. Daily increases are now capped at 20 pts so pressure rises gradually (decreases are still instant so herbicide/cultivation relief is unaffected).
- **#538 fixed**: SF application rate multiplier is now shown as a badge in the sprayer panel title bar (gold = non-default, dim = 1.0x). Also added `rate=` to the debug log so it can be verified in log.txt. Note: the vanilla game's top-right L/min display will never reflect SF's rate — it uses its own separate calculation. The SF rate DOES affect actual tank drain and field application.
- **#539 fixed**: Colorblind mode now auto-enables on mission start when the game's own `useColorblindMode` setting is on.

## Test plan

- [ ] Load a save with weedy fallow fields, sleep 5 days — pressure should rise max ~20 pts/day, not jump to 75%+ instantly
- [ ] Enter a sprayer, press [ / ] to change rate — confirm badge in panel title changes (e.g. "0.5x" in dim, "1.5x" in gold)
- [ ] Enable colorblind mode in game settings, reload — SF HUD and overlay should switch to Okabe-Ito palette automatically
- [ ] Check log.txt for `rate=X.XXx` in SprayUsage debug lines