### PR TITLE
fix: unwrap N/P/K table values in SoilSprayerInfoPanel nutrient bars

### DIFF
--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -534,7 +534,8 @@ function SoilSprayerInfoPanel:draw()
         local info = self._fieldInfo
         for _, nd in ipairs(activeRows) do
             local pKey    = nd.profileKey
-            local rawVal  = info[nd.fieldKey] or 0
+            local rawRet  = info[nd.fieldKey]
+            local rawVal  = (type(rawRet) == "table") and (rawRet.value or 0) or (rawRet or 0)
             local maxVal  = nd.maxVal
             local rowBot  = cy - rowH
             local barMidY = rowBot + (rowH - barH) * 0.5


### PR DESCRIPTION
## Summary
- `getFieldInfo` returns `nitrogen`, `phosphorus`, and `potassium` as `{ value, status }` tables, but `SoilSprayerInfoPanel` was indexing them as plain numbers
- This caused a `attempt to perform arithmetic (div) on table and number` crash at line 549 when attaching a modded sprayer
- Fix: unwrap `.value` when the field result is a table; OM and pH (plain numbers) are unaffected

## Test plan
- [ ] Attach a standard sprayer — nutrient bars render correctly
- [ ] Attach modded sprayer (e.g. UX5201Super) — no crash, bars render correctly
- [ ] Verify OM and pH bars still display correctly