### PR TITLE
fix: harvester/sprayer panel stats bar, resize handles, trace nutrient filter

### DIFF
--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -677,11 +677,8 @@ function SoilHarvesterPanel:draw()
         end
 
         -- Gather values
-        local fieldArea = (info and info.fieldArea) or 0
-        local sessCov   = (info and info.sessionCoverageFraction) or 0
-        local totCov    = (info and info.coverageFraction) or 0
-        local sessHa    = sessCov * fieldArea
-        local totHa     = fieldArea
+        local fieldArea     = (info and info.fieldArea) or 0
+        local daysSinceHarv = (info and info.daysSinceHarvest) or 0
 
         -- Yield estimate: yieldEfficiency * base crop yield (t/ha)
         local cropName  = info and info.lastCrop
@@ -716,36 +713,26 @@ function SoilHarvesterPanel:draw()
         setTextColor(unpack(C.C_VALUE))
         renderText(cell1X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, thaStr)
 
-        -- ── Cell 2: Coverage % + mini progress bar ─────────────
-        local cell2X = panelX + cellW
-        local covPct  = math.floor(sessCov * 100 + 0.5)
-        local covStr  = string.format("%d%%", covPct)
-        local covCol  = (sessCov >= 0.80) and C.C_GOOD
-                     or (sessCov >= 0.40) and C.C_FAIR
-                     or C.C_LABEL
-
-        -- Small mini-bar (3 segments) showing coverage
-        local mbW  = cellW * 0.72
-        local mbH  = 0.0045 * sc
-        local mbX  = cell2X + (cellW - mbW) * 0.5
-        local mbY  = sbY + sbH * 0.60
-        local mSeg = 4
-        local mGap = 0.0015 * sc
-        local mSW  = (mbW - (mSeg-1)*mGap) / mSeg
-        local mFill = sessCov * mSeg
-        for mi = 0, mSeg - 1 do
-            local msx = mbX + mi * (mSW + mGap)
-            self:drawRect(msx, mbY, mSW, mbH, C.C_SEG_BG)
-            local mfrac = math.max(0, math.min(1, mFill - mi))
-            if mfrac > 0 then
-                self:drawRect(msx, mbY, mSW * mfrac, mbH, covCol)
-            end
+        -- ── Cell 2: Grain bag icon + session grain (L) ──────────
+        local cell2X  = panelX + cellW
+        local sessL   = self._sessGrainL or 0
+        local grainStr
+        if sessL >= 1000 then
+            grainStr = string.format("%.1f kL", sessL / 1000)
+        else
+            grainStr = string.format("%d L", math.floor(sessL + 0.5))
         end
+        -- Grain bag icon (bag body + neck + tie knot)
+        local gb_sz = isz
+        local gb_x  = cell2X + (cellW - gb_sz * 0.75) * 0.5
+        local gb_y  = sbY + sbH * 0.42
+        self:drawRect(gb_x,               gb_y,              gb_sz * 0.75, gb_sz * 0.58, C.C_TITLE_FG, 0.85)
+        self:drawRect(gb_x + gb_sz*0.20,  gb_y + gb_sz*0.58, gb_sz * 0.35, gb_sz * 0.20, C.C_TITLE_FG, 0.72)
+        self:drawRect(gb_x + gb_sz*0.27,  gb_y + gb_sz*0.76, gb_sz * 0.21, gb_sz * 0.12, C.C_TITLE_FG, 0.60)
 
-        -- Coverage % text
         setTextAlignment(RenderText.ALIGN_CENTER)
-        setTextColor(covCol[1], covCol[2], covCol[3], covCol[4] or 1)
-        renderText(cell2X + cellW * 0.5, sbY + (sbH * 0.30 - 0.0075*sc) * 0.5 + mbH + 0.003*sc, 0.0080*sc, covStr)
+        setTextColor(unpack(C.C_VALUE))
+        renderText(cell2X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, grainStr)
 
         -- ── Cell 3: Field icon + session area (ha) ─────────────
         local cell3X = panelX + cellW * 2
@@ -763,30 +750,26 @@ function SoilHarvesterPanel:draw()
         self:drawRect(ic3lx + ib, ic3by + ic3sz*0.5 - icm*0.5, ic3sz-ib*2, icm, C.C_LABEL, 0.40)
         self:drawRect(ic3lx + ic3sz*0.5 - icm*0.5, ic3by + ib, icm, ic3sz-ib*2, C.C_LABEL, 0.40)
 
-        local sessHaStr = string.format("%.1f ha", sessHa)
+        local areaStr = string.format("%.1f ha", fieldArea)
         setTextAlignment(RenderText.ALIGN_CENTER)
         setTextColor(unpack(C.C_VALUE))
-        renderText(cell3X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, sessHaStr)
+        renderText(cell3X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, areaStr)
 
-        -- ── Cell 4: Sigma field icon + total field area (ha) ───
+        -- ── Cell 4: Calendar icon + days since last harvest ────
         local cell4X = panelX + cellW * 3
         local ic4sz  = isz
-        local ic4lx  = cell4X + (cellW - ic4sz) * 0.5 + ic4sz * 0.15
+        local ic4lx  = cell4X + (cellW - ic4sz) * 0.5
         local ic4by  = sbY + sbH * 0.45
-        -- Same field icon (slightly right to leave room for Σ)
-        self:drawRect(ic4lx,               ic4by,               ic4sz * 0.85, ib,              C.C_DIM, 0.80)
-        self:drawRect(ic4lx,               ic4by + ic4sz - ib,  ic4sz * 0.85, ib,              C.C_DIM, 0.80)
-        self:drawRect(ic4lx,               ic4by,               ib,           ic4sz,            C.C_DIM, 0.80)
-        self:drawRect(ic4lx + ic4sz*0.85 - ib, ic4by,           ib,           ic4sz,            C.C_DIM, 0.80)
-        -- Σ prefix (tiny, left of icon)
-        setTextAlignment(RenderText.ALIGN_RIGHT)
-        setTextColor(C.C_DIM[1], C.C_DIM[2], C.C_DIM[3], 0.90)
-        renderText(ic4lx - 0.001, ic4by + ic4sz * 0.25, ic4sz * 0.55, "S")
+        -- Calendar icon: box body + header bar + two ring notches
+        self:drawRect(ic4lx,               ic4by,               ic4sz, ic4sz * 0.85, C.C_DIM, 0.40)
+        self:drawRect(ic4lx,               ic4by + ic4sz * 0.72, ic4sz, ic4sz * 0.13, C.C_DIM, 0.90)
+        self:drawRect(ic4lx + ic4sz*0.22,  ic4by + ic4sz * 0.79, ic4sz * 0.16, ic4sz * 0.22, C.C_TITLE_BG, 1.0)
+        self:drawRect(ic4lx + ic4sz*0.62,  ic4by + ic4sz * 0.79, ic4sz * 0.16, ic4sz * 0.22, C.C_TITLE_BG, 1.0)
 
-        local totHaStr = string.format("%.1f ha", totHa)
+        local dayStr = (daysSinceHarv > 0) and string.format("%dd", math.floor(daysSinceHarv)) or "--"
         setTextAlignment(RenderText.ALIGN_CENTER)
         setTextColor(C.C_DIM[1], C.C_DIM[2], C.C_DIM[3], 0.90)
-        renderText(cell4X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, totHaStr)
+        renderText(cell4X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, dayStr)
     end
 
     -- Reset text state

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -27,6 +27,7 @@ SoilSprayerInfoPanel.ROW_H    = 0.022
 SoilSprayerInfoPanel.BAR_H    = 0.009
 SoilSprayerInfoPanel.FLAG_W   = 0.0018
 SoilSprayerInfoPanel.FLAG_CAP = 0.0030
+SoilSprayerInfoPanel.STAT_H   = 0.036
 
 -- Default position (bottom-left corner, used when no saved position exists)
 SoilSprayerInfoPanel.DEFAULT_X = 0.015625
@@ -423,8 +424,18 @@ function SoilSprayerInfoPanel:draw()
 
     local activeRows = {}
     if profile then
+        -- Find the largest nutrient value in this fertilizer's profile so we can
+        -- filter out trace nutrients (< 8% of the primary). This prevents e.g.
+        -- MAP (N=11, P=411) from showing an N bar alongside the P bar.
+        local maxProfileVal = 0
         for _, nd in ipairs(NUTRIENT_ROWS) do
-            if (profile[nd.profileKey] or 0) ~= 0 then
+            local v = profile[nd.profileKey] or 0
+            if v > maxProfileVal then maxProfileVal = v end
+        end
+        local threshold = maxProfileVal * 0.08
+        for _, nd in ipairs(NUTRIENT_ROWS) do
+            local v = profile[nd.profileKey] or 0
+            if v > 0 and v >= threshold then
                 table.insert(activeRows, nd)
             end
         end
@@ -446,7 +457,8 @@ function SoilSprayerInfoPanel:draw()
 
     local hasField   = self._fieldInfo ~= nil
     local numContent = isActive and (#activeRows + (hasField and 0 or 1)) or 1
-    local panelH     = titleH + pad + numContent * rowH + pad
+    local statH      = (isActive and hasField) and (SoilSprayerInfoPanel.STAT_H * sc) or 0
+    local panelH     = titleH + pad + numContent * rowH + statH + pad
     local panelW     = 0.190 * sc
 
     -- Determine panel bottom-left corner
@@ -612,6 +624,97 @@ function SoilSprayerInfoPanel:draw()
 
             cy = cy - rowH
         end
+    end
+
+    -- ── Stats bar (coverage, session ha, field area, days since harvest) ──
+    if isActive and hasField and statH > 0 then
+        local info          = self._fieldInfo
+        local sessCov       = (info and info.sessionCoverageFraction) or 0
+        local fieldArea     = (info and info.fieldArea) or 0
+        local sessHa        = sessCov * fieldArea
+        local daysSinceHarv = (info and info.daysSinceHarvest) or 0
+
+        local sbY   = panelBot
+        local sbH   = statH
+        local cellW = panelW / 4
+        local statSz = sbH * 0.38
+        local statFs = 0.0075 * sc
+
+        -- Separator line
+        self:drawRect(panelX, sbY + sbH - 0.0015*sc, panelW, 0.0015*sc,
+                      SoilSprayerInfoPanel.C_BORDER, 0.80)
+        -- Cell dividers
+        for i = 1, 3 do
+            self:drawRect(panelX + cellW * i - 0.0008*sc, sbY + pad,
+                          0.0008*sc, sbH - pad * 2,
+                          SoilSprayerInfoPanel.C_BORDER, 0.60)
+        end
+
+        -- ── Cell 1: Coverage % + mini bar ────────────────────────
+        local covPct = math.floor(sessCov * 100 + 0.5)
+        local covStr = string.format("%d%%", covPct)
+        local covCol = (sessCov >= 0.80) and SoilSprayerInfoPanel.C_GOOD
+                    or (sessCov >= 0.40) and SoilSprayerInfoPanel.C_FAIR
+                    or SoilSprayerInfoPanel.C_LABEL
+        local mbW  = cellW * 0.72
+        local mbH  = 0.0045 * sc
+        local mbX  = panelX + (cellW - mbW) * 0.5
+        local mbY  = sbY + sbH * 0.62
+        local mSeg = 4
+        local mGap = 0.0015 * sc
+        local mSW  = (mbW - (mSeg-1)*mGap) / mSeg
+        local mFill = sessCov * mSeg
+        for mi = 0, mSeg - 1 do
+            local msx = mbX + mi * (mSW + mGap)
+            self:drawRect(msx, mbY, mSW, mbH, SoilSprayerInfoPanel.C_BAR_BG)
+            local mfrac = math.max(0, math.min(1, mFill - mi))
+            if mfrac > 0 then
+                self:drawRect(msx, mbY, mSW * mfrac, mbH, covCol)
+            end
+        end
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(covCol[1], covCol[2], covCol[3], covCol[4] or 1)
+        renderText(panelX + cellW * 0.5,
+                   sbY + (sbH * 0.30 - statFs) * 0.5 + mbH + 0.003*sc, statFs, covStr)
+
+        -- ── Cell 2: Session ha sprayed ────────────────────────────
+        local cell2X    = panelX + cellW
+        local sessHaStr = string.format("%.2f ha", sessHa)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(unpack(SoilSprayerInfoPanel.C_VALUE))
+        renderText(cell2X + cellW * 0.5, sbY + (sbH * 0.35 - statFs) * 0.5, statFs, sessHaStr)
+
+        -- ── Cell 3: Field icon + total field area ─────────────────
+        local cell3X = panelX + cellW * 2
+        local ic3sz  = statSz
+        local ic3lx  = cell3X + (cellW - ic3sz) * 0.5
+        local ic3by  = sbY + sbH * 0.45
+        local ib3    = ic3sz * 0.11
+        local icm3   = ib3 * 0.70
+        self:drawRect(ic3lx,                ic3by,                ic3sz,       ib3,   SoilSprayerInfoPanel.C_LABEL, 0.80)
+        self:drawRect(ic3lx,                ic3by + ic3sz - ib3,  ic3sz,       ib3,   SoilSprayerInfoPanel.C_LABEL, 0.80)
+        self:drawRect(ic3lx,                ic3by,                ib3,         ic3sz, SoilSprayerInfoPanel.C_LABEL, 0.80)
+        self:drawRect(ic3lx + ic3sz - ib3,  ic3by,                ib3,         ic3sz, SoilSprayerInfoPanel.C_LABEL, 0.80)
+        self:drawRect(ic3lx + ib3,          ic3by + ic3sz*0.5 - icm3*0.5, ic3sz-ib3*2, icm3, SoilSprayerInfoPanel.C_LABEL, 0.40)
+        self:drawRect(ic3lx + ic3sz*0.5 - icm3*0.5, ic3by + ib3, icm3, ic3sz-ib3*2, SoilSprayerInfoPanel.C_LABEL, 0.40)
+        local areaStr = string.format("%.1f ha", fieldArea)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(unpack(SoilSprayerInfoPanel.C_VALUE))
+        renderText(cell3X + cellW * 0.5, sbY + (sbH * 0.35 - statFs) * 0.5, statFs, areaStr)
+
+        -- ── Cell 4: Calendar icon + days since last harvest ───────
+        local cell4X = panelX + cellW * 3
+        local ic4sz  = statSz
+        local ic4lx  = cell4X + (cellW - ic4sz) * 0.5
+        local ic4by  = sbY + sbH * 0.45
+        self:drawRect(ic4lx,               ic4by,               ic4sz,       ic4sz * 0.85, SoilSprayerInfoPanel.C_DIM, 0.40)
+        self:drawRect(ic4lx,               ic4by + ic4sz * 0.72, ic4sz,      ic4sz * 0.13, SoilSprayerInfoPanel.C_DIM, 0.90)
+        self:drawRect(ic4lx + ic4sz*0.22,  ic4by + ic4sz * 0.79, ic4sz*0.16, ic4sz * 0.22, SoilSprayerInfoPanel.C_BG, 1.0)
+        self:drawRect(ic4lx + ic4sz*0.62,  ic4by + ic4sz * 0.79, ic4sz*0.16, ic4sz * 0.22, SoilSprayerInfoPanel.C_BG, 1.0)
+        local dayStr = (daysSinceHarv > 0) and string.format("%dd", math.floor(daysSinceHarv)) or "--"
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(SoilSprayerInfoPanel.C_DIM[1], SoilSprayerInfoPanel.C_DIM[2], SoilSprayerInfoPanel.C_DIM[3], 0.90)
+        renderText(cell4X + cellW * 0.5, sbY + (sbH * 0.35 - statFs) * 0.5, statFs, dayStr)
     end
 
     -- Reset text state


### PR DESCRIPTION
## Summary

- **fix:** Harvester panel stats bar now shows real harvest data — session grain (L/kL), field area (ha), and days since last harvest. Was incorrectly showing spray coverage metrics that always read 0 during harvesting.
- **fix:** Sprayer info panel now has a matching stats bar at the bottom — spray coverage % with mini-bar, session ha sprayed, field area, and days since last harvest (visible when active and on a field).
- **fix:** Trace nutrient filter — nutrients contributing less than 8% of a fertilizer's primary nutrient are suppressed from the bar list. Fixes MAP/DAP showing a spurious N bar alongside the P bar (closes #544 adjacent).
- **fix:** Both new panels (Harvester + Sprayer Info) now have a resize handle in edit mode — blue corner square, drag to scale 0.5×–2.5×, persisted in layout XML (closes #544).
- **fix:** Unwrap N/P/K table values in Sprayer Info Panel nutrient bars.
- **l10n:** Sync French translation — 2 missing keys, 2 new disease-moisture keys.
- **feat:** Harvest trail overlay — in-world dots + minimap pixels.
- **feat:** Harvester panel stats bar with 4 harvest indicators.
- **fix:** Various hotfixes — weed spike detection, rate display, colorblind auto-detect, grain tank detection API.

## Notes
- No save migration needed
- Version: 2.3.6.0