### PR TITLE
fix: rate multiplier now affects L/min display and physical consumption (#538)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.6.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.3.7.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.3.6.0</version>
+    <version>2.3.7.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -65,6 +65,13 @@ SettingsSchema.definitions = {
         localOnly = true,
     },
     {
+        id = "showWorkTrail",
+        type = "boolean",
+        default = true,
+        uiId = "sf_show_work_trail",
+        localOnly = true,
+    },
+    {
         id = "miniReportX",
         type = "number",
         default = 0.18,

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -186,6 +186,12 @@ function HookManager:installAll(soilSystem)
         self:propagateExternalFillHookToLiveVehicles()
     end
 
+    -- Rate multiplier → wap.usage + wap.usagePerMin (event listener, reliable class-table dispatch).
+    -- Must run before installSprayerUsageHook so the chain is: vanilla sets wap.usage → this hook
+    -- scales it → onEndWorkAreaProcessing reads the already-scaled value.
+    local sprayStartOk = self:installSprayerStartHook()
+    if sprayStartOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
     -- Speed-based area-normalized consumption (tank-drain path).
     -- Replaces vanilla getSprayerUsage's speedLimit with actual lastSpeed so product
     -- consumption scales correctly with area covered at the vehicle's real speed.
@@ -2190,10 +2196,13 @@ function HookManager:installSprayerAreaHook()
                     return
                 end
 
-                -- Apply rate multiplier
+                -- Rate multiplier is applied to wap.usage by installSprayerStartHook before
+                -- onEndWorkAreaProcessing runs. liters (= wap.usage) already reflects the
+                -- multiplier; do NOT multiply again or nutrient gain would be multiplier².
+                -- Keep rateMultiplier lookup for burn-threshold check only.
                 local rm = g_SoilFertilityManager.sprayerRateManager
                 local rateMultiplier = (rm ~= nil) and rm:getMultiplier(self.id) or 1.0
-                local effectiveLiters = liters * rateMultiplier
+                local effectiveLiters = liters
 
                 -- Section Control double-penalty fix (Issue #345):
                 -- wap.usage already reflects section shutoff (VariableWorkWidth.getIsWorkAreaActive
@@ -3744,6 +3753,52 @@ function HookManager:installExternalFillHook()
 end
 
 -- =========================================================
+-- HOOK 9a-pre: Rate multiplier applied to wap.usage / wap.usagePerMin
+-- =========================================================
+-- onStartWorkAreaProcessing is registered as an EVENT LISTENER (not registerFunction),
+-- so class-table patches via Utils.appendedFunction reach ALL vehicles reliably without
+-- any 3-layer instance-table patching. This is the correct place to apply the rate
+-- multiplier to the values that control:
+--   • tank drain rate (wap.usage read in onEndWorkAreaProcessing)
+--   • L/min HUD display (wap.usagePerMin read by getVariableWorkWidthUsage)
+-- Applying mapMult inside getSprayerUsage (Hook 9a) was unreliable because
+-- copyTypeFunctionsInto copies getSprayerUsage directly into vehicle instance tables,
+-- and Layer-3 live patching missed vehicles in some FS25 versions (issue #538).
+---@return boolean success
+function HookManager:installSprayerStartHook()
+    if not Sprayer or type(Sprayer.onStartWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("SprayerStart hook: Sprayer.onStartWorkAreaProcessing not available — skipping")
+        return false
+    end
+
+    local original = Sprayer.onStartWorkAreaProcessing
+    Sprayer.onStartWorkAreaProcessing = Utils.appendedFunction(
+        original,
+        function(self, dt)
+            if not self.isServer then return end
+            local spec = self.spec_sprayer
+            if not spec or not spec.workAreaParameters then return end
+            if not g_SoilFertilityManager or not g_SoilFertilityManager.sprayerRateManager then return end
+
+            local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(self.id or 0)
+            if mult == 1.0 then return end
+
+            local wap = spec.workAreaParameters
+            if wap.usage and wap.usage ~= 0 then
+                wap.usage = wap.usage * mult
+            end
+            if wap.usagePerMin and wap.usagePerMin ~= 0 then
+                wap.usagePerMin = wap.usagePerMin * mult
+            end
+        end
+    )
+
+    self:register(Sprayer, "onStartWorkAreaProcessing", original, "Sprayer.onStartWorkAreaProcessing (rate multiplier)")
+    SoilLogger.info("[OK] SprayerStart hook installed — rate multiplier applied to wap.usage/usagePerMin")
+    return true
+end
+
+-- =========================================================
 -- HOOK 9a: Speed-based area-normalized sprayer consumption
 -- =========================================================
 -- Vanilla Sprayer:getSprayerUsage multiplies by self.speedLimit (configured max speed,
@@ -3759,6 +3814,7 @@ end
 --
 -- Three-layer patch required: SpecializationUtil.registerFunction (line 91 of Sprayer.lua)
 -- + copyTypeFunctionsInto means class-table patches never reach live vehicle instances.
+-- Rate multiplier is no longer applied here; see installSprayerStartHook above.
 ---@return boolean success
 function HookManager:installSprayerUsageHook()
     if not Sprayer or type(Sprayer.getSprayerUsage) ~= "function" then
@@ -3838,12 +3894,13 @@ function HookManager:installSprayerUsageHook()
                 if okW and w and w > 0 then workWidth = w end
             end
 
-            local mapMult = 1.0
-            if g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager then
-                mapMult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(sprayerSelf.id or 0)
-            end
-
-            local usage = fillScale * mapMult * lps * actualSpeedKmh * workWidth * dt * 0.001
+            -- Rate multiplier is NOT applied here. It is applied via installSprayerStartHook
+            -- (appended to Sprayer.onStartWorkAreaProcessing, an event listener with reliable
+            -- class-table dispatch) which multiplies wap.usage and wap.usagePerMin after vanilla
+            -- sets them. Applying it here via the 3-layer instance-table patch was unreliable:
+            -- copyTypeFunctionsInto copies getSprayerUsage into vehicle instances at load time,
+            -- and Layer 3 instance patching missed vehicles in some FS25 versions (issue #538).
+            local usage = fillScale * lps * actualSpeedKmh * workWidth * dt * 0.001
 
             -- Throttled diagnostic: log once per 4 s per vehicle (debug mode only).
             -- Shows speed / width / lps / usage-per-second / effective L/ha so you can
@@ -3861,8 +3918,8 @@ function HookManager:installSprayerUsageHook()
                 local ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillType)
                 if ft then ftName = ft.name end
                 SoilLogger.debug(
-                    "SprayUsage veh=%d type=%-12s  spd=%.1f km/h  w=%.1fm  lps=%.6f  scale=%.2f  rate=%.2fx  usage/s=%.4f L/s  eff=%.1f L/ha",
-                    vehId, ftName, actualSpeedKmh, workWidth, lps, fillScale, mapMult, usagePerSec, effectiveLpha)
+                    "SprayUsage veh=%d type=%-12s  spd=%.1f km/h  w=%.1fm  lps=%.6f  scale=%.2f  usage/s=%.4f L/s  eff=%.1f L/ha",
+                    vehId, ftName, actualSpeedKmh, workWidth, lps, fillScale, usagePerSec, effectiveLpha)
             end
 
             return usage

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1198,8 +1198,10 @@ function SoilHUD:draw()
         end
     end
 
-    self:drawSprayTrail()
-    self:drawHarvestTrail()
+    if self.settings.showWorkTrail then
+        self:drawSprayTrail()
+        self:drawHarvestTrail()
+    end
 
     self:drawPanel()
 

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -381,7 +381,9 @@ function SoilMinimapLayer:draw(mapSelf)
         setOverlayUVs(ov, unpack(Overlay.DEFAULT_UVS))
     end
 
-    self:drawHarvestTrailDots(mapSelf)
+    if not self.settings or self.settings.showWorkTrail ~= false then
+        self:drawHarvestTrailDots(mapSelf)
+    end
 end
 
 --- Draws amber pixel dots on the minimap for each harvested cell in the current session.

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -130,7 +130,7 @@ local CATEGORIES = {
         sections = {
             {
                 headerKey = "sf_panel_hdr_visibility",
-                items     = { "showHUD", "showMiniReport", "showFieldInfoBox", "useImperialUnits", "colorblindMode" }
+                items     = { "showHUD", "showMiniReport", "showWorkTrail", "showFieldInfoBox", "useImperialUnits", "colorblindMode" }
             },
             {
                 headerKey = "sf_panel_hdr_hud_style",
@@ -197,6 +197,7 @@ local SETTING_DESCS = {
     compactionEnabled = "sf_desc_compactionEnabled",
     showHUD           = "sf_desc_showHUD",
     showMiniReport    = "sf_desc_showMiniReport",
+    showWorkTrail     = "sf_desc_showWorkTrail",
     useImperialUnits  = "sf_desc_useImperialUnits",
     hudColorTheme     = "sf_desc_hudColorTheme",
     hudFontSize       = "sf_desc_hudFontSize",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,8 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- New: work trail toggle in HUD & Display settings — show/hide",
+    "  spray and harvest trail dots (in-world and on minimap)",
     "- New: harvest trail overlay — amber dots show combine pass in the",
     "  game world and on the minimap; clears when full field is covered",
     "- New: harvester panel stats bar — 4 cells showing estimated t/ha,",

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar sobreposição HUD de info de solo (F8 para alternar temporariamente)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Mostrar Relatório de Célula" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mostrar/ocultar a sobreposição do relatório de célula do minimapa" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posição HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Escolha onde o HUD de info de solo aparece na tela" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Canto superior direito" eh="5f9f6784" />
@@ -652,6 +654,7 @@
     <e k="sf_desc_showNotifications" v="Notificações de status do solo no jogo" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Mostrar a sobreposição do HUD de solo" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mostrar a sobreposição do relatório de célula do minimapa" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Posição de ancoragem predefinida do HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta de cores para elementos do HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Tamanho do texto do HUD" eh="48a6fc15" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Mostra/amaga la superposició de l'HUD d'informació del sòl (F8 per alternar temporalment)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Mostrar informe de cel·la" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mostra/amaga la superposició de l'informe de cel·la del minimapa" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posició de l'HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Trieu on apareix l'HUD d'informació del sòl a la pantalla" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="A dalt a la dreta" eh="5f9f6784" />
@@ -651,6 +653,7 @@
     <e k="sf_desc_showNotifications" v="Notificacions de l'estat del sòl al joc" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Mostra la superposició de l'HUD del sòl" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mostra la superposició de l'informe de cel·la del minimapa" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Posició d'ancoratge predeterminada de l'HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta de colors per als elements de l'HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Mida del text de l'HUD" eh="48a6fc15" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Zobrazit/skrýt HUD s informacemi o půdě (F8 pro dočasné přepnutí)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Zobrazit zprávu o buňce" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Zobrazit/skrýt překryv zprávy o buňce na minimapě" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Pozice HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Vyberte, kde se na obrazovce zobrazí HUD s informacemi o půdě" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Vpravo nahoře" eh="5f9f6784" />
@@ -651,6 +653,7 @@
     <e k="sf_desc_showNotifications" v="Herní upozornění na stav půdy" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Zobrazit překryv HUD půdy" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Zobrazit překryv zprávy o buňce na minimapě" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Přednastavená kotevní pozice HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Barevná paleta pro prvky HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Velikost textu HUD" eh="48a6fc15" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Vis/skjul jord-HUD-overlejringen (F8 for midlertidigt skift)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Vis cellerapport" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Vis/skjul cellerapport-overlejringen på minikortet" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD-position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Vælg hvor jord-HUD'et vises på skærmen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Øverst til højre" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Notifikationer om jordstatus i spillet" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Vis jord-HUD-overlejringen" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Vis celle-overlejringen på minikortet" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD-position" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Farvetema for HUD-elementer" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD-tekststørrelse" eh="48a6fc15" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Boden-Info-HUD ein-/ausblenden (F8 zum temporären Umschalten)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Cellerapport anzeigen" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Minimap-Zellenbericht-Overlay ein-/ausblenden" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD-Position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Wählen Sie, wo das Boden-Info-HUD auf dem Bildschirm erscheint" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Oben rechts" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="In-Game-Benachrichtigungen zum Bodenstatus" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Boden-HUD-Overlay anzeigen" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Minimap-Zellenbericht-Overlay anzeigen" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD-Voreinstellungs-Ankerpunkt" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Farbpalette für HUD-Elemente" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD-Textgröße" eh="48a6fc15" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar la superposición HUD de información del suelo (F8 para alternar temporalmente)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Mostrar Informe de Celda" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mostrar/ocultar la superposición del informe de celda del minimapa" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posición del HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Elegir dónde aparece el HUD de información del suelo en pantalla" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Arriba Derecha" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Notificaciones de estado en el juego" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Mostrar monitor de suelo en pantalla" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mostrar informe de celda en el minimapa" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Anclaje de posición del HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta de colores del HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Tamaño del texto del HUD" eh="48a6fc15" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Show/hide the soil info HUD overlay (F8 to toggle temporarily)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Show Cell Report" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Show/hide the minimap cell report overlay" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD Position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Choose where the soil info HUD appears on screen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Top Right" eh="5f9f6784" />
@@ -654,6 +656,7 @@
     <e k="sf_desc_showNotifications" v="In-game soil status notifications" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Show the soil HUD overlay" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Show the minimap cell report overlay" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD preset anchor position" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Color palette for HUD elements" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD text size" eh="48a6fc15" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar la superposición HUD de información del suelo (F8 para alternar temporalmente)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Mostrar informe celda" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mostrar/ocultar la superposición del informe de celda del minimapa" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posición del HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Elegir dónde aparece el HUD de información del suelo en pantalla" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Arriba derecha" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Notificaciones de estado en el juego" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Mostrar monitor de suelo en pantalla" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mostrar informe de celda en el minimapa" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Anclaje de posición del HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta de colores del HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Tamaño del texto del HUD" eh="48a6fc15" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Afficher/masquer l'incrustation HUD d'info sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Afficher le rapport de cellule" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Afficher/masquer l'incrustation du rapport de cellule de la minimap" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Position du HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Choisir où le HUD d'info sol apparaît à l'écran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Haut droite" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Notifications de statut en jeu" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Afficher le HUD sol" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Afficher le rapport de cellule minimap" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Ancrage prédéfini du HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Palette de couleurs du HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Taille du texte du HUD" eh="48a6fc15" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Näytä/piilota maaperätietojen HUD (F8 tilapäiseen vaihtoon)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Näytä soluraportti" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Näytä/piilota minimapin soluraportti" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUDin sijainti" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Valitse missä maaperätietojen HUD näkyy näytöllä" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Yläoikea" eh="5f9f6784" />
@@ -614,6 +616,7 @@
     <e k="sf_desc_showNotifications" v="Maaperän tilasta kertovat ilmoitukset" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Näytä maaperän HUD-näyttö" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Näytä minimapin solunäkymä" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD-näytön kiinnityskohta" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="HUDin väripaletti" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUDin tekstin koko" eh="48a6fc15" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -43,6 +43,8 @@
     <e k="sf_show_hud_long" v="Afficher/masquer le HUD d'information du sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Afficher le rapport de cellule" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Afficher/masquer le rapport de cellule sur la mini-carte" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Position du HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Choisir où afficher le HUD du sol à l'écran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Haut droite" eh="5f9f6784" />
@@ -644,6 +646,7 @@
     <e k="sf_desc_showNotifications" v="Notifications de statut du sol en jeu" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Afficher le HUD du sol" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Afficher la superposition du rapport de cellule sur la mini-carte" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Position d’ancrage prédéfinie du HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Palette de couleurs du HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Taille du texte du HUD" eh="48a6fc15" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Talajinformáció HUD átfedés megjelenítése/elrejtése (F8 az ideiglenes váltáshoz)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Cella jelentés mutatása" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Minimap cella jelentés átfedés megjelenítése/elrejtése" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD pozíció" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Válassza ki, hol jelenjen meg a talajinformáció HUD a képernyőn" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Jobb felső" eh="5f9f6784" />
@@ -632,6 +634,7 @@
     <e k="sf_desc_showNotifications" v="Talajállapot értesítések játék közben" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Talaj HUD átfedés megjelenítése" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Minimap cella jelentés átfedés megjelenítése" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD rögzítési pozíciója" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Színpaletta a HUD elemekhez" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD szövegméret" eh="48a6fc15" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Tampilkan/sembunyikan overlay HUD info tanah (F8 untuk beralih sementara)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Tampilkan Laporan Sel" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Tampilkan/sembunyikan overlay laporan sel minimap" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posisi HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Pilih di mana HUD info tanah muncul di layar" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Kanan Atas" eh="5f9f6784" />
@@ -651,6 +653,7 @@
     <e k="sf_desc_showNotifications" v="Notifikasi status tanah dalam game" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Tampilkan overlay HUD tanah" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Tampilkan overlay laporan sel minimap" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Posisi jangkar preset HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Palet warna untuk elemen HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Ukuran teks HUD" eh="48a6fc15" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Mostra/nascondi overlay HUD info suolo (F8 per alternare temporaneamente)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Mostra rapporto cella" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mostra/nascondi overlay rapporto cella sulla minimappa" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posizione HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Scegli dove appare l'HUD info suolo sullo schermo" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="In alto a destra" eh="5f9f6784" />
@@ -651,6 +653,7 @@
     <e k="sf_desc_showNotifications" v="Notifiche di gioco sullo stato del suolo" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Mostra l'overlay dell'HUD del suolo" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mostra l'overlay del rapporto cella sulla minimappa" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Posizione di ancoraggio predefinita dell'HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Tavolozza colori per gli elementi dell'HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Dimensione del testo dell'HUD" eh="48a6fc15" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="土壌情報HUDオーバーレイを表示/非表示にします（F8で一時的に切替）" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="セルレポートを表示" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="ミニマップのセルレポートオーバーレイを表示/非表示にします" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUDの位置" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="土壌情報HUDを画面のどこに表示するか選択します" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="右上" eh="5f9f6784" />
@@ -637,6 +639,7 @@
     <e k="sf_desc_showNotifications" v="ゲーム内での土壌ステータス通知" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="土壌 HUD オーバーレイを表示します" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="ミニマップのセルレポートオーバーレイを表示します" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD のプリセット固定位置" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="HUD エレメントの配色パレット" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD のテキストサイズ" eh="48a6fc15" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="토양 정보 HUD 오버레이 표시/숨기기 (F8 키로 일시 전환 가능)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="셀 보고서 표시" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="미니맵 셀 보고서 오버레이 표시/숨기기" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD 위치" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="화면에 토양 정보 HUD가 표시될 위치 선택" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="우측 상단" eh="5f9f6784" />
@@ -638,6 +640,7 @@
     <e k="sf_desc_showNotifications" v="게임 내 토양 상태 알림 표시" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="토양 HUD 오버레이 표시" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="미니맵 셀 보고서 오버레이 표시" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD 고정 위치 설정" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="HUD 요소의 색상 구성" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD 텍스트 크기" eh="48a6fc15" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="De bodem-info HUD-overlay tonen/verbergen (F8 om tijdelijk te wisselen)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Toon celrapport" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Toon/verberg de minimap celrapport-overlay" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD-positie" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Kies waar de bodem-info HUD op het scherm verschijnt" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Rechtsboven" eh="5f9f6784" />
@@ -639,6 +641,7 @@
     <e k="sf_desc_showNotifications" v="In-game bodemstatusmeldingen" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="De bodem HUD-overlay tonen" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="De minimap celrapport-overlay tonen" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD-voorinstelling ankerpositie" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Kleurenpalet voor HUD-elementen" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD-tekstgrootte" eh="48a6fc15" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Vis/skjul HUD-overlegget for jordinfo (F8 for å veksle midlertidig)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Vis cellerapport" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Vis/skjul overlegget for cellerapport på minimappet" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD-posisjon" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Velg hvor HUD for jordinfo skal vises på skjermen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Øverst til høyre" eh="5f9f6784" />
@@ -639,6 +641,7 @@
     <e k="sf_desc_showNotifications" v="Varslinger om jordstatus i spillet" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Vis HUD-overlegget for jord" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Vis overlegget for cellerapport på minimappet" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Forhåndsinnstilt ankerposisjon for HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Fargepalett for HUD-elementer" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD-tekststørrelse" eh="48a6fc15" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Pokaż/ukryj nakładkę HUD z informacjami o glebie (F8, aby przełączyć tymczasowo)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Pokaż raport komórki" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Pokaż/ukryj nakładkę raportu komórki na minimapie" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Pozycja HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Wybierz miejsce wyświetlania HUDu z informacjami o glebie" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Góra prawa" eh="5f9f6784" />
@@ -639,6 +641,7 @@
     <e k="sf_desc_showNotifications" v="Powiadomienia o statusie gleby w grze" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Pokaż nakładkę HUD gleby" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Pokaż nakładkę raportu komórki na minimapie" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Predefiniowana pozycja zakotwiczenia HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta kolorów dla elementów HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Rozmiar tekstu HUD" eh="48a6fc15" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar a sobreposição do HUD de informações do solo (F8 para alternar temporariamente)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Mostrar Relatório de Célula" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mostrar/ocultar a sobreposição do relatório de células do minimapa" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Posição do HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Escolha onde o HUD de informações do solo aparece no ecrã" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Canto Superior Direito" eh="5f9f6784" />
@@ -652,6 +654,7 @@
     <e k="sf_desc_showNotifications" v="Notificações de estado do solo no jogo" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Mostrar a sobreposição do HUD do solo" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mostrar a sobreposição do relatório de células do minimapa" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Posição de ancoragem do HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta de cores para elementos do HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Tamanho do texto do HUD" eh="48a6fc15" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Afișează/ascunde HUD-ul cu informații despre sol (F8 pentru comutare temporară)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Afișare Raport Celulă" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Afișează/ascunde raportul de celulă de pe minimapă" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Poziție HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Alege unde apare HUD-ul cu informații despre sol pe ecran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Sus Dreapta" eh="5f9f6784" />
@@ -652,6 +654,7 @@
     <e k="sf_desc_showNotifications" v="Notificări de stare a solului în joc" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Afișează suprapunerea HUD a solului" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Afișează suprapunerea raportului de celulă de pe minimapă" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Poziția de ancorare presetată a HUD-ului" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Paleta de culori pentru elementele HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Dimensiunea textului HUD-ului" eh="48a6fc15" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Показать/скрыть накладку HUD с информацией о грунте (F8 для временного переключения)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Показать отчет по ячейке" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Показать/скрыть наложение отчета по ячейке на миникарте" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Позиция HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Выберите, где на экране отображается HUD с информацией о грунте" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Справа вверху" eh="5f9f6784" />
@@ -607,6 +609,7 @@
     <e k="sf_desc_showNotifications" v="Уведомления о статусе почвы" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Показать HUD почвы" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Отчет по ячейке на миникарте" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Позиция привязки HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Цветовая палитра HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Размер текста HUD" eh="48a6fc15" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Visa/dölj HUD-överlagring för markinfo (F8 för att växla tillfälligt)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Visa cellrapport" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Visa/dölj cellrapport för minimap" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD-position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Välj var markinfo-HUD ska visas på skärmen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Uppe till höger" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Statusaviseringar för marken i spelet" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Visa HUD-överlagringen för marken" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Visa cellrapporten för minimap" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Förankringsposition för HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Färgpalett för HUD-element" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Textstorlek i HUD" eh="48a6fc15" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Toprak bilgisi HUD katmanını göster/gizle (Geçici olarak değiştirmek için F8)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Hücre Raporunu Göster" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Mini harita hücre raporu katmanını göster/gizle" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="HUD Konumu" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Toprak bilgisi HUD'ının ekranda nerede görüneceğini seçin" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Sağ Üst" eh="5f9f6784" />
@@ -614,6 +616,7 @@
     <e k="sf_desc_showNotifications" v="Oyun içi toprak durumu bildirimleri" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Toprak HUD katmanını göster" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Mini harita hücre raporu katmanını göster" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="HUD ön ayarlı çıpa konumu" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="HUD öğeleri için renk paleti" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD metin boyutu" eh="48a6fc15" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Показати/сховати HUD інформації про ґрунт (F8 для тимчасового перемикання)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Звіт комірки" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Показати/сховати звіт комірки на міні-карті" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Позиція HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Виберіть, де на екрані відображатиметься HUD ґрунту" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Верхній правий" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Сповіщення про стан ґрунту в грі" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Показувати HUD оверлей ґрунту" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Показувати звіт комірки на міні-карті" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Фіксована позиція HUD" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Колірна палітра елементів HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Розмір тексту HUD" eh="48a6fc15" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -41,6 +41,8 @@
     <e k="sf_show_hud_long" v="Hiện/ẩn lớp phủ HUD thông tin đất (F8 để chuyển đổi tạm thời)" eh="4e2e11b6" />
     <e k="sf_show_mini_report_short" v="Hiện báo cáo ô" eh="6b14e786" />
     <e k="sf_show_mini_report_long" v="Hiện/ẩn lớp phủ báo cáo ô trên bản đồ nhỏ" eh="9f57fb65" />
+    <e k="sf_show_work_trail_short" v="Work Trail" />
+    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
     <e k="sf_hud_position_short" v="Vị trí HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Chọn nơi HUD thông tin đất xuất hiện trên màn hình" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Trên bên phải" eh="5f9f6784" />
@@ -613,6 +615,7 @@
     <e k="sf_desc_showNotifications" v="Thông báo trạng thái đất trong game" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Hiển thị lớp phủ HUD đất" eh="fa8b9224" />
     <e k="sf_desc_showMiniReport" v="Hiển thị lớp phủ báo cáo ô trên bản đồ nhỏ" eh="b847f98c" />
+    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
     <e k="sf_desc_hudPosition" v="Vị trí neo HUD được thiết lập sẵn" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Bảng màu cho các thành phần HUD" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="Kích thước văn bản HUD" eh="48a6fc15" />


### PR DESCRIPTION
## Summary

- **Root cause**: `getSprayerUsage` requires 3-layer instance-table patching because `copyTypeFunctionsInto` copies function refs into vehicle instances at load time. Layer-3 live patching was unreliable in some FS25 versions — rate multiplier changes had no visible effect on the L/min HUD display or actual tank drain.
- **Fix**: Moved rate multiplier application to `Sprayer.onStartWorkAreaProcessing`, which is registered as an **event listener** (not `registerFunction`). Class-table patches via `Utils.appendedFunction` reach all vehicles reliably for event listeners — no 3-layer patching required.
- **Also fixes double-application bug**: `effectiveLiters` in `onEndWorkAreaProcessing` was `liters * rateMultiplier`, but `liters` (= `wap.usage`) already included the multiplier on vehicles where the old patch worked → nutrient gain was `multiplier²`. Now `effectiveLiters = liters` directly.

## Changes

- `installSprayerStartHook()` — new function, appended to `Sprayer.onStartWorkAreaProcessing`, multiplies `wap.usage` and `wap.usagePerMin` by the current rate multiplier after vanilla sets them
- `installSprayerUsageHook()` — removed `mapMult` from usage formula (keeps actual-speed fix)
- `installSprayerAreaHook()` — `effectiveLiters = liters` (no longer re-applies rate multiplier; keeps `rateMultiplier` for burn-threshold check)
- `installAll()` — calls `installSprayerStartHook()` in the hook sequence

## Test plan

- [ ] Set rate to 2.0×, spray a field → L/min HUD display should double vs 1.0×
- [ ] Same product, same speed — tank should drain approximately twice as fast at 2.0× vs 1.0×
- [ ] Nutrient gain at 2.0× should be 2× base, not 4× (no double-application)
- [ ] Burn effects still trigger at rates above threshold
- [ ] AI spraying (Courseplay) correctly uses actual speed, not speedLimit