### PR TITLE
feat: tillage work trail (plow/cultivate) on HUD and minimap

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3807,3 +3807,52 @@ function SoilFertilitySystem:recordHarvestTrailPoint(fieldId, wx, wz)
         field.harvestSessionDay = nil
     end
 end
+
+---@param fieldId number
+---@param wx      number  World X (implement rootNode)
+---@param wz      number  World Z (implement rootNode)
+---@param isPlow  boolean true = plow (dark brown), false = cultivate (tan)
+function SoilFertilitySystem:recordTillageTrailPoint(fieldId, wx, wz, isPlow)
+    local field = self.fieldData and self.fieldData[fieldId]
+    if not field then return end
+
+    local zone = SoilConstants.ZONE
+    if not zone then return end
+
+    local currentDay = (g_currentMission and g_currentMission.environment and
+                        g_currentMission.environment.currentDay) or 0
+
+    if field.tillageSessionDay ~= currentDay then
+        field.tillageSessionDay = currentDay
+        field.tillageTrailPts   = nil
+        field.tillageCells      = nil
+    end
+
+    local cx = math.floor(wx / zone.CELL_SIZE)
+    local cz = math.floor(wz / zone.CELL_SIZE)
+    local cellKey = tostring(cx * 10000 + cz)
+
+    if not field.tillageCells then field.tillageCells = {} end
+    if field.tillageCells[cellKey] then return end
+    field.tillageCells[cellKey] = true
+
+    if not field.tillageTrailPts then field.tillageTrailPts = {} end
+    local twx = (cx + 0.5) * zone.CELL_SIZE
+    local twz = (cz + 0.5) * zone.CELL_SIZE
+    local twy = 0.3
+    if g_terrainNode then
+        local ok, h = pcall(getTerrainHeightAtWorldPos, g_terrainNode, twx, 0, twz)
+        if ok and h then twy = h + 0.3 end
+    end
+    table.insert(field.tillageTrailPts, {wx = twx, wy = twy, wz = twz, isPlow = isPlow})
+
+    local cellArea = zone.CELL_AREA_HA
+    local areaHa   = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
+    local count    = 0
+    for _ in pairs(field.tillageCells) do count = count + 1 end
+    if count * cellArea >= areaHa then
+        field.tillageTrailPts   = nil
+        field.tillageCells      = nil
+        field.tillageSessionDay = nil
+    end
+end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2619,10 +2619,12 @@ function HookManager:installPlowingHook()
                         g_SoilFertilityManager.soilSystem._lastTillageX = x
                         g_SoilFertilityManager.soilSystem._lastTillageZ = z
                         g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa)
+                        g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
                     else
                         g_SoilFertilityManager.soilSystem._lastTillageX = x
                         g_SoilFertilityManager.soilSystem._lastTillageZ = z
                         g_SoilFertilityManager.soilSystem:onCultivation(farmlandId, areaHa)
+                        g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, false)
                     end
 
                     -- Compaction: check if subsoiler or heavy vehicle
@@ -2715,6 +2717,7 @@ function HookManager:installDedicatedPlowHook()
                     g_SoilFertilityManager.soilSystem._lastTillageX = x
                     g_SoilFertilityManager.soilSystem._lastTillageZ = z
                     g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa)
+                    g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
 
                     -- Dedicated plows are always heavy equipment
                     if g_SoilFertilityManager.settings.compactionEnabled then

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1183,6 +1183,43 @@ function SoilHUD:drawSprayTrail()
     end
 end
 
+--- Draws earth-brown (plow) or tan (cultivate) dots for each cell tilled today.
+--- Disappears automatically when full-field coverage is reached.
+function SoilHUD:drawTillageTrail()
+    if not self.fillOverlay then return end
+    local soilSys = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+    if not soilSys then return end
+    local fieldId = self.cachedFieldId
+    if not fieldId or fieldId <= 0 then return end
+    local field = soilSys.fieldData and soilSys.fieldData[fieldId]
+    if not field or not field.tillageTrailPts or #field.tillageTrailPts == 0 then return end
+
+    local px, pz = 0, 0
+    if g_localPlayer then
+        local ok, lx, _, lz = pcall(function() return g_localPlayer:getPosition() end)
+        if ok and lx then px, pz = lx, lz end
+    end
+
+    local maxDistSq = 200 * 200
+    local half = 0.0030
+
+    for _, pt in ipairs(field.tillageTrailPts) do
+        local dx = pt.wx - px
+        local dz = pt.wz - pz
+        if dx*dx + dz*dz <= maxDistSq then
+            local sx, sy, sz = project(pt.wx, pt.wy, pt.wz)
+            if sz <= 1 then
+                if pt.isPlow then
+                    setOverlayColor(self.fillOverlay, 0.55, 0.28, 0.05, 0.50)
+                else
+                    setOverlayColor(self.fillOverlay, 0.72, 0.52, 0.22, 0.45)
+                end
+                renderOverlay(self.fillOverlay, sx - half, sy - half, half*2, half*2)
+            end
+        end
+    end
+end
+
 -- ── Draw ─────────────────────────────────────────────────
 function SoilHUD:draw()
     if not self.initialized then return end
@@ -1201,6 +1238,7 @@ function SoilHUD:draw()
     if self.settings.showWorkTrail then
         self:drawSprayTrail()
         self:drawHarvestTrail()
+        self:drawTillageTrail()
     end
 
     self:drawPanel()

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -848,7 +848,7 @@ function SoilHUD:updateFieldInfoBox()
     if     info.potassium.status  == "Poor" then table.insert(needs, "K!")
     elseif info.potassium.status  == "Fair" then table.insert(needs, "K")  end
     if info.pH and (info.pH < phGoodLow or info.pH > phGoodHigh) then table.insert(needs, "pH") end
-    if weedPct    >= weedMed    then table.insert(needs, g_i18n:getText("sf_hud_weeds")   or "Weeds")   end
+    if weedPct    >= weedMed    then table.insert(needs, g_i18n:getText("sf_hud_weeds")   or "Weed Risk")   end
     if pestPct    >= pestMed    then table.insert(needs, g_i18n:getText("sf_hud_pests")   or "Pests")   end
     if diseasePct >= diseaseMed then table.insert(needs, g_i18n:getText("sf_hud_disease") or "Disease") end
     if compPct    > 10          then table.insert(needs, g_i18n:getText("sf_hud_compaction") or "Compaction") end
@@ -873,7 +873,7 @@ function SoilHUD:updateFieldInfoBox()
     box:addLine("K (ppm)", fmtNutrient(info.potassium.value,  "K", ppm.K))
     box:addLine("pH",      string.format("%.1f", info.pH))
     box:addLine("OM",      string.format("%.1f%%", info.organicMatter))
-    if weedPct    > 0 then box:addLine(g_i18n:getText("sf_hud_weeds")      or "Weeds",      pressureLine(weedPct,    info.herbicideActive))  end
+    if weedPct    > 0 then box:addLine(g_i18n:getText("sf_hud_weeds")      or "Weed Risk",  pressureLine(weedPct,    info.herbicideActive))  end
     if pestPct    > 0 then box:addLine(g_i18n:getText("sf_hud_pests")      or "Pests",      pressureLine(pestPct,    info.insecticideActive)) end
     if diseasePct > 0 then box:addLine(g_i18n:getText("sf_hud_disease")    or "Disease",    pressureLine(diseasePct, info.fungicideActive))   end
     if compPct    > 0 then

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -374,6 +374,52 @@ function SoilMinimapLayer:draw(mapSelf)
 
     if not self.settings or self.settings.showWorkTrail ~= false then
         self:drawHarvestTrailDots(mapSelf)
+        self:drawTillageTrailDots(mapSelf)
+    end
+end
+
+--- Draws earth-brown/tan pixel dots on the minimap for each tilled cell today.
+--- Dark brown = plow pass, tan = cultivate pass.
+function SoilMinimapLayer:drawTillageTrailDots(mapSelf)
+    local dotOv = self._dotOverlay
+    if not dotOv or dotOv == 0 then return end
+
+    local soilSys = self.soilSystem
+    if not soilSys or not soilSys.fieldData then return end
+
+    local layout = mapSelf and (mapSelf.fullScreenLayout or mapSelf.layout)
+    if not layout or not layout.getMapObjectPosition then return end
+
+    local worldSizeX = mapSelf.worldSizeX or (g_currentMission and g_currentMission.terrainSize) or 2048
+    local worldSizeZ = mapSelf.worldSizeZ or (g_currentMission and g_currentMission.terrainSize) or 2048
+    if worldSizeX == 0 or worldSizeZ == 0 then return end
+
+    local extX = mapSelf.mapExtensionOffsetX    or 0
+    local extZ = mapSelf.mapExtensionOffsetZ    or 0
+    local scl  = mapSelf.mapExtensionScaleFactor or 1
+    local offX = mapSelf.worldCenterOffsetX     or 0
+    local offZ = mapSelf.worldCenterOffsetZ     or 0
+
+    local dotSz = 0.0038
+    local half  = dotSz * 0.5
+
+    for _, field in pairs(soilSys.fieldData) do
+        local pts = field.tillageTrailPts
+        if pts then
+            for _, pt in ipairs(pts) do
+                if pt.isPlow then
+                    setOverlayColor(dotOv, 0.55, 0.28, 0.05, 0.65)
+                else
+                    setOverlayColor(dotOv, 0.72, 0.52, 0.22, 0.60)
+                end
+                local objX = ((pt.wx + offX) / worldSizeX) * scl + extX
+                local objZ = ((pt.wz + offZ) / worldSizeZ) * scl + extZ
+                local sx, sy = layout:getMapObjectPosition(objX, objZ, 0, 0)
+                if sx and sy then
+                    renderOverlay(dotOv, sx - half, sy - half, dotSz, dotSz)
+                end
+            end
+        end
     end
 end
 

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -45,8 +45,6 @@ function SoilMinimapLayer.new(soilSystem, settings)
     self._usingDensityLayers = false
     self._dirty          = true    -- force first build on init
     self._lastLayerIdx   = -1      -- detect layer-switch → force rebuild
-    self._prevMW         = nil     -- animation-skip: previous frame's terrain width
-    self._prevMH         = nil     -- animation-skip: previous frame's terrain height
     self._farmlandMap    = nil
     self._farmlandNumCh  = nil
     self._nextRebuildMs  = 0
@@ -136,8 +134,6 @@ function SoilMinimapLayer:update(dt, soilMapOverlay)
         self._lastLayerIdx  = layerIdx
         self._dirty         = true
         self._buildInFlight = false  -- cancel any in-flight build from the previous layer
-        self._prevMW        = nil    -- reset animation baseline for the new layer
-        self._prevMH        = nil
     end
 
     -- Only rebuild when dirty and the previous build has finished
@@ -328,39 +324,34 @@ function SoilMinimapLayer:draw(mapSelf)
     local my = y + h * extZ
     local mw = w * scl
     local mh = h * scl
-    local rx = (px + x) - mx
-    local ry = (py + y) - my
+    -- Rotation pivot: absolute screen coordinates of the map centre.
+    -- px/py are already in screen space from layout:getMapPivot() (or widget centre).
+    local rx = px
+    local ry = py
 
-    -- Skip rendering while the minimap layout is animating between states.
-    local prevMW = self._prevMW
-    local prevMH = self._prevMH
-    self._prevMW = mw
-    self._prevMH = mh
-    if prevMW ~= nil and (math.abs(mw - prevMW) > 0.003 or math.abs(mh - prevMH) > 0.003) then
-        return
-    end
+    -- Always clip the overlay to the minimap widget bounds.
+    -- mapSelf.clipX1 is passed as a draw-call parameter, not stored as a property, so it
+    -- is nil here. Fall back to the widget rect from layout so that on large maps (16x etc.)
+    -- where mapExtensionScaleFactor > 1 and the terrain rect extends beyond the widget,
+    -- we still extract the correct UV slice and don't render an oversized off-screen rect.
+    local cx1 = mapSelf.clipX1 or x
+    local cy1 = mapSelf.clipY1 or y
+    local cx2 = mapSelf.clipX2 or (x + w)
+    local cy2 = mapSelf.clipY2 or (y + h)
 
-    setOverlayUVs(ov, 0, 0, 0, 1, 1, 0, 1, 1)
+    local x1, y1 = mx, my
+    local x2, y2 = mx + mw, my + mh
+    if x1 == x2 or y1 == y2 then return end
 
-    local didClip = false
-    local uL, vT, uR, vB = 0, 0, 1, 1
-    if mapSelf.clipX1 ~= nil then
-        local x1, y1 = mx, my
-        local x2, y2 = mx + mw, my + mh
-        local cx1, cy1 = mapSelf.clipX1, mapSelf.clipY1
-        local cx2, cy2 = mapSelf.clipX2, mapSelf.clipY2
-        local rx1 = math.max(x1, cx1); local ry1 = math.max(y1, cy1)
-        local rx2 = math.min(x2, cx2); local ry2 = math.min(y2, cy2)
-        if (rx2 - rx1) <= 0 or (ry2 - ry1) <= 0 then return end
-        uL = (rx1 - x1) / (x2 - x1); vT = (ry1 - y1) / (y2 - y1)
-        uR = (rx2 - x1) / (x2 - x1); vB = (ry2 - y1) / (y2 - y1)
-        mx, my, mw, mh = rx1, ry1, rx2 - rx1, ry2 - ry1
-        didClip = true
-    end
+    local rx1 = math.max(x1, cx1); local ry1 = math.max(y1, cy1)
+    local rx2 = math.min(x2, cx2); local ry2 = math.min(y2, cy2)
+    if (rx2 - rx1) <= 0 or (ry2 - ry1) <= 0 then return end
 
-    if didClip then
-        setOverlayUVs(ov, uL, vT, uL, vB, uR, vT, uR, vB)
-    end
+    local uL = (rx1 - x1) / (x2 - x1); local vT = (ry1 - y1) / (y2 - y1)
+    local uR = (rx2 - x1) / (x2 - x1); local vB = (ry2 - y1) / (y2 - y1)
+    mx, my, mw, mh = rx1, ry1, rx2 - rx1, ry2 - ry1
+
+    setOverlayUVs(ov, uL, vT, uL, vB, uR, vT, uR, vB)
 
     if layout.getMapRotation then
         local rot = layout:getMapRotation()
@@ -377,7 +368,7 @@ function SoilMinimapLayer:draw(mapSelf)
     setOverlayColor(ov, 1, 1, 1, alpha)
     renderOverlay(ov, mx, my, mw, mh)
 
-    if didClip and Overlay ~= nil and Overlay.DEFAULT_UVS ~= nil then
+    if Overlay ~= nil and Overlay.DEFAULT_UVS ~= nil then
         setOverlayUVs(ov, unpack(Overlay.DEFAULT_UVS))
     end
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,8 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: 'Weeds' bar renamed to 'Weed Risk' — it shows growth",
+    "  pressure/risk, not current weed presence",
     "- New: work trail toggle in HUD & Display settings — show/hide",
     "  spray and harvest trail dots (in-world and on minimap)",
     "- New: harvest trail overlay — amber dots show combine pass in the",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -30,12 +30,6 @@ SoilVersionDialog.CHANGELOG = {
     "  game world and on the minimap; clears when full field is covered",
     "- New: harvester panel stats bar — 4 cells showing estimated t/ha,",
     "  field coverage %, session area harvested, and total field area",
-    "- Fixed: weed pressure no longer spikes on reload or time-skip;",
-    "  increases are now capped at 20 pts/day so pressure rises gradually",
-    "- Fixed: SF application rate multiplier now shown in sprayer panel",
-    "  title bar so you always know the active rate at a glance",
-    "- Fixed: colorblind mode now auto-enables when the game's own",
-    "  colorblind setting is turned on",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Vá até um campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Dirija para um campo" />
     <e k="sf_hud_fallow" v="Pousio" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Ervas Daninhas" eh="324181de" />
+    <e k="sf_hud_weeds" v="Ervas Daninhas Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Pragas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Doença" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protegido)" eh="8273211e" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Camineu sobre un camp" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="駕車到田地" />
     <e k="sf_hud_fallow" v="Guaret" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Males herbes" eh="324181de" />
+    <e k="sf_hud_weeds" v="Males herbes Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Plagues" eh="2fed5101" />
     <e k="sf_hud_disease" v="Malaltia" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protegit)" eh="8273211e" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Vstupte na pole" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Jeďte na pole" />
     <e k="sf_hud_fallow" v="Úhor" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Plevel" eh="324181de" />
+    <e k="sf_hud_weeds" v="Plevel Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Škůdci" eh="2fed5101" />
     <e k="sf_hud_disease" v="Choroby" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(chráněno)" eh="8273211e" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Kør til en mark" />
     <e k="sf_hud_fallow" v="Brak" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Ukrudt" eh="324181de" />
+    <e k="sf_hud_weeds" v="Ukrudt Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />
     <e k="sf_hud_disease" v="Sygdom" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(beskyttet)" eh="8273211e" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Betreten Sie ein Feld" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Fahren Sie auf ein Feld" />
     <e k="sf_hud_fallow" v="Brach" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Unkraut" eh="324181de" />
+    <e k="sf_hud_weeds" v="Unkraut Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Schädlinge" eh="2fed5101" />
     <e k="sf_hud_disease" v="Krankheit" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(geschützt)" eh="8273211e" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Camine por un campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Conduce hasta un campo" />
     <e k="sf_hud_fallow" v="Barbecho" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Malezas" eh="324181de" />
+    <e k="sf_hud_weeds" v="Malezas Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Plagas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Enfermedad" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protegido)" eh="8273211e" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Drive onto a field" />
     <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Weeds" eh="324181de" />
+    <e k="sf_hud_weeds" v="Weed Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
     <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protected)" eh="8273211e" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Camina por un campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Conduce hasta un campo" />
     <e k="sf_hud_fallow" v="Barbecho" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Malezas" eh="324181de" />
+    <e k="sf_hud_weeds" v="Malezas Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Plagas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Enfermedad" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protegido)" eh="8273211e" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Allez sur un champ" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="驾车到田地" />
     <e k="sf_hud_fallow" v="Jachère" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Adventices" eh="324181de" />
+    <e k="sf_hud_weeds" v="Adventices Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Ravageurs" eh="2fed5101" />
     <e k="sf_hud_disease" v="Maladies" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protégé)" eh="8273211e" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Kävele pellolle" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Aja pellolle" />
     <e k="sf_hud_fallow" v="Kesanto" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Rikkakasvit" eh="324181de" />
+    <e k="sf_hud_weeds" v="Rikkakasvit Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Tuholaiset" eh="2fed5101" />
     <e k="sf_hud_disease" v="Taudit" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(suojattu)" eh="8273211e" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -224,7 +224,7 @@
     <e k="sf_hud_noField" v="Entrez dans un champ" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Conduisez sur un champ" />
     <e k="sf_hud_fallow" v="Jachère" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Mauvaises herbes" eh="324181de" />
+    <e k="sf_hud_weeds" v="Mauvaises herbes Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Ravageurs" eh="2fed5101" />
     <e k="sf_hud_disease" v="Maladie" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protégé)" eh="8273211e" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Sétáljon egy mezőre" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Hajtson a mezőre" />
     <e k="sf_hud_fallow" v="Ugar" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Gyomok" eh="324181de" />
+    <e k="sf_hud_weeds" v="Gyomok Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Kártevők" eh="2fed5101" />
     <e k="sf_hud_disease" v="Betegség" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(védett)" eh="8273211e" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Masuk ke dalam lahan" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Kendarai ke ladang" />
     <e k="sf_hud_fallow" v="Bera" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Gulma" eh="324181de" />
+    <e k="sf_hud_weeds" v="Gulma Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Hama" eh="2fed5101" />
     <e k="sf_hud_disease" v="Penyakit" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(terlindungi)" eh="8273211e" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -222,7 +222,7 @@
 		<e k="sf_hud_noField" v="Cammina su un campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Guida su un campo" />
 		<e k="sf_hud_fallow" v="Maggese" eh="eafe5913" />
-		<e k="sf_hud_weeds" v="Infestanti" eh="324181de" />
+		<e k="sf_hud_weeds" v="Infestanti Risk" eh="324181de" />
 		<e k="sf_hud_pests" v="Parassiti" eh="2fed5101" />
 		<e k="sf_hud_disease" v="Malattie" eh="e7067a8c" />
 		<e k="sf_hud_protected" v="(protetto)" eh="8273211e" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="フィールドに入ってください" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="畑に走行してください" />
     <e k="sf_hud_fallow" v="休耕" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="雑草" eh="324181de" />
+    <e k="sf_hud_weeds" v="雑草 Risk" eh="324181de" />
     <e k="sf_hud_pests" v="害虫" eh="2fed5101" />
     <e k="sf_hud_disease" v="病害" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(保護済み)" eh="8273211e" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="필드에 입장하세요" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="밭으로 운전하세요" />
     <e k="sf_hud_fallow" v="휴경지" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="잡초" eh="324181de" />
+    <e k="sf_hud_weeds" v="잡초 Risk" eh="324181de" />
     <e k="sf_hud_pests" v="해충" eh="2fed5101" />
     <e k="sf_hud_disease" v="병해" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(보호됨)" eh="8273211e" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Loop een veld op" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Rijd naar een veld" />
     <e k="sf_hud_fallow" v="Braak" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Onkruid" eh="324181de" />
+    <e k="sf_hud_weeds" v="Onkruid Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Plagen" eh="2fed5101" />
     <e k="sf_hud_disease" v="Ziekte" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(beschermd)" eh="8273211e" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Gå ut på et felt" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Kjør til et jorde" />
     <e k="sf_hud_fallow" v="Brakklagt" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Ugress" eh="324181de" />
+    <e k="sf_hud_weeds" v="Ugress Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />
     <e k="sf_hud_disease" v="Sykdom" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(beskyttet)" eh="8273211e" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Wejdź na pole" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Jedź na pole" />
     <e k="sf_hud_fallow" v="Ugór" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Chwasty" eh="324181de" />
+    <e k="sf_hud_weeds" v="Chwasty Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Szkodniki" eh="2fed5101" />
     <e k="sf_hud_disease" v="Choroby" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(chronione)" eh="8273211e" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Caminhe sobre um campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Dirija para um campo" />
     <e k="sf_hud_fallow" v="Pousio" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Ervas Daninhas" eh="324181de" />
+    <e k="sf_hud_weeds" v="Ervas Daninhas Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Pragas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Doenças" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protegido)" eh="8273211e" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Mergeți pe un câmp" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Conduceți pe un câmp" />
     <e k="sf_hud_fallow" v="Pârloagă" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Buruieni" eh="324181de" />
+    <e k="sf_hud_weeds" v="Buruieni Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Dăunători" eh="2fed5101" />
     <e k="sf_hud_disease" v="Boli" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(protejat)" eh="8273211e" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Въезжайте на поле" />
     <e k="sf_hud_fallow" v="Пар" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Сорняки" eh="324181de" />
+    <e k="sf_hud_weeds" v="Сорняки Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Вредители" eh="2fed5101" />
     <e k="sf_hud_disease" v="Болезни" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(защищено)" eh="8273211e" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Gå ut på ett fält" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Kör till ett fält" />
     <e k="sf_hud_fallow" v="Träda" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Ogräs" eh="324181de" />
+    <e k="sf_hud_weeds" v="Ogräs Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Skadedjur" eh="2fed5101" />
     <e k="sf_hud_disease" v="Sjukdomar" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(skyddat)" eh="8273211e" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Bir tarlaya gidin" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Alana sürün" />
     <e k="sf_hud_fallow" v="Nadas" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Yabancı Otlar" eh="324181de" />
+    <e k="sf_hud_weeds" v="Yabancı Otlar Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Zararlılar" eh="2fed5101" />
     <e k="sf_hud_disease" v="Hastalık" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(korumalı)" eh="8273211e" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Їдьте на поле" />
     <e k="sf_hud_fallow" v="Пар" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Бур'яни" eh="324181de" />
+    <e k="sf_hud_weeds" v="Бур'яни Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Шкідники" eh="2fed5101" />
     <e k="sf_hud_disease" v="Хвороби" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(захищено)" eh="8273211e" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -222,7 +222,7 @@
     <e k="sf_hud_noField" v="Hãy đi vào cánh đồng" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Lái xe ra đồng" />
     <e k="sf_hud_fallow" v="Để hoang" eh="eafe5913" />
-    <e k="sf_hud_weeds" v="Cỏ dại" eh="324181de" />
+    <e k="sf_hud_weeds" v="Cỏ dại Risk" eh="324181de" />
     <e k="sf_hud_pests" v="Sâu bệnh" eh="2fed5101" />
     <e k="sf_hud_disease" v="Bệnh hại" eh="e7067a8c" />
     <e k="sf_hud_protected" v="(được bảo vệ)" eh="8273211e" />


### PR DESCRIPTION
## Summary
- Adds `recordTillageTrailPoint()` to `SoilFertilitySystem` — same cell-dedup, per-day-reset, and auto-clear-on-full-coverage pattern as the harvest trail
- Both Cultivator and dedicated Plow hooks now call the new trail recorder after `onPlowing`/`onCultivation`, passing `isPlow=true/false` to distinguish the two
- `SoilHUD:drawTillageTrail()` renders dark brown dots for plow passes and tan dots for cultivate passes in the in-world 3D overlay (gated by `showWorkTrail` setting)
- `SoilMinimapLayer:drawTillageTrailDots()` renders the same color-coded dots on the minimap alongside the existing amber harvest trail dots

## Test plan
- [ ] Drive a cultivator across a field — tan dots appear on HUD and minimap
- [ ] Drive a plow across a field — dark brown dots appear on HUD and minimap
- [ ] Confirm dots auto-clear when full field coverage is reached
- [ ] Confirm dots reset on new game day
- [ ] Confirm `showWorkTrail = false` hides all trail types (spray, harvest, tillage)
- [ ] Confirm harvest amber dots still render correctly alongside tillage dots