### PR TITLE
development → main: v2.4.0.0 + post-release fixes and code review pass

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -702,7 +702,8 @@ function SoilFertilityManager:onMissionStarted()
             if self.hasPrecisionFarming then
                 SoilLogger.warning("Precision Farming detected! Soil & Fertilizer mod is NOT compatible and will be disabled.")
                 self.settings.enabled = false
-                
+                self._disabledByPF = true  -- track that WE disabled it, not the player
+
                 -- Queue incompatibility dialog with a delay to ensure GUI is stable
                 if not self.disableGUI then
                     SoilLogger.info("Incompatibility dialog queued (3.5s delay)")
@@ -711,14 +712,12 @@ function SoilFertilityManager:onMissionStarted()
                 end
                 return
             else
-                -- PF is absent. If the mod was previously disabled solely by the PF incompatibility 
-                -- gate, we should re-enable it. 
-                -- We track this via the fact that `self.settings.enabled` is currently false 
-                -- but PF is gone.
-                if not self.settings.enabled then
+                -- PF is absent. Re-enable only if we were the ones who disabled it
+                -- (i.e. the player didn't manually turn the mod off themselves).
+                if self._disabledByPF then
                     SoilLogger.info("Precision Farming not detected — re-enabling Soil & Fertilizer")
                     self.settings.enabled = true
-                    -- Save the re-enabled state
+                    self._disabledByPF = false
                     self.settings:save()
                 end
             end
@@ -885,7 +884,9 @@ function SoilFertilityManager:onToggleAutoInput()
     local rm = self.sprayerRateManager
     if rm then
         local newState = rm:toggleAutoMode(vehicle.id)
-        SoilNetworkEvents_SendSprayerAutoMode(vehicle, newState)
+        if SoilNetworkEvents_SendSprayerAutoMode then
+            SoilNetworkEvents_SendSprayerAutoMode(vehicle, newState)
+        end
     end
 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3,7 +3,7 @@
 -- =========================================================
 -- Per-field N/P/K/pH/OM tracking: depletion on harvest,
 -- restoration on fertilizer, rain leaching, seasonal effects,
--- fallow recovery, seasonal effects.
+-- and fallow recovery.
 -- =========================================================
 -- Author: TisonK
 -- =========================================================

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -4683,6 +4683,20 @@ function HookManager:installSprayerVisualEffectHook()
                 g_soundManager:playSamples(st.samples and st.samples.spray or {})
             end
         end
+        -- Start VWW wing-section effects (these are separate from spec.effects and
+        -- are never started by the vanilla system for custom fill types, causing only
+        -- the center to show mist while wing booms appear dry).
+        local vww = vehicle.spec_variableWorkWidth
+        if vww and vww.sections then
+            local suppressed = vehicle._sfOverlapSuppressedSections or {}
+            for i, section in ipairs(vww.sections) do
+                if section.isActive and not suppressed[i] and
+                   section.effects and #section.effects > 0 then
+                    g_effectManager:setEffectTypeInfo(section.effects, vanillaFillType)
+                    g_effectManager:startEffects(section.effects)
+                end
+            end
+        end
     end
 
     local function stopSprayerEffects(vehicle)
@@ -4693,6 +4707,15 @@ function HookManager:installSprayerVisualEffectHook()
             g_effectManager:stopEffects(st.effects)
             g_animationManager:stopAnimations(st.animationNodes)
             g_soundManager:stopSamples(st.samples and st.samples.spray or {})
+        end
+        -- Stop VWW wing-section effects.
+        local vww = vehicle.spec_variableWorkWidth
+        if vww and vww.sections then
+            for _, section in ipairs(vww.sections) do
+                if section.effects and #section.effects > 0 then
+                    g_effectManager:stopEffects(section.effects)
+                end
+            end
         end
     end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -267,7 +267,6 @@ function HookManager:installAll(soilSystem)
 
     -- Smart Soil Sensor: per-section spray suppression based on SF soil data.
     -- Appended AFTER installDensityMapSprayHook so cleanup unwinds correctly.
-    -- No-ops when PF compat mode is on (PF owns section control in that mode).
     self:installSectionControlHook()
 
     -- System 2: See & Spray — per-cell spot-spray suppression (appended after Smart Sensor).
@@ -992,8 +991,6 @@ end
 -- (pest=0, disease=0, K≥target, or P≥target) the section is temporarily set
 -- to isActive=false. VWW resets it on the next tick — no persistent corruption.
 --
--- Guard: entire hook is a no-op when PF compat mode is on, because PF owns
--- section control in that mode and we must not fight its density-map logic.
 function HookManager:installSectionControlHook()
     if not Sprayer or type(Sprayer.onStartWorkAreaProcessing) ~= "function" then
         SoilLogger.warning("[SectionSensor] Sprayer.onStartWorkAreaProcessing not found — skipping")
@@ -1066,10 +1063,7 @@ function HookManager:installSectionControlHook()
                 end
             end
 
-            -- Gate 2: skip entirely in PF compat mode — PF manages section control
-
-
-            -- Gate 2b: skip if admin has disabled Smart Sensor globally
+            -- Gate 2: skip if admin has disabled Smart Sensor globally
             if sfm.settings and sfm.settings.smartSensorEnabled == false then return end
 
             local sensorMgr = sfm.sensorManager
@@ -1161,7 +1155,6 @@ end
 -- exact soil cell under each boom section.  Sections are suppressed when the
 -- cell's pest/disease/weed pressure is below the configured threshold.
 -- Falls back to field average when no cell entry exists (unvisited cell).
--- No-ops when PF compat mode is on or when admin has disabled See & Spray.
 function HookManager:installSeeAndSprayHook()
     if not Sprayer or type(Sprayer.onStartWorkAreaProcessing) ~= "function" then
         SoilLogger.warning("[SeeAndSpray] Sprayer.onStartWorkAreaProcessing not found — skipping")

--- a/src/maps/SoilBundledMaps.lua
+++ b/src/maps/SoilBundledMaps.lua
@@ -52,8 +52,7 @@ local NUM_CHANNELS  = 2    -- 2-bit channel (4 values: 0-3)
 local PH_CHANNEL    = 0    -- zero-based channel index
 
 -- pH zone lookup: raw value 0-3 → semantic pH
--- !! Confirm with Seb what his 4 zones represent !!
--- Current assumption: 0=neutral descending toward acidic
+-- Zone 0 = neutral/alkaline, descending to zone 3 = acidic (verified from grleConverter output)
 local PH_ZONE_MAP = {
     [0] = 7.0,   -- zone 0: neutral/alkaline
     [1] = 6.5,   -- zone 1: slightly acidic

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -61,9 +61,13 @@ function SoilSettingChangeEvent:run(connection)
     -- SERVER ONLY: Validate and apply setting change
     if g_server == nil then return end
 
-    -- Local-only settings should never be routed through the server; reject silently
+    -- Reject unknown settings and local-only settings — never apply to server state
     local def = SettingsSchema and SettingsSchema.byId and SettingsSchema.byId[self.settingName]
-    if def and def.localOnly then return end
+    if not def then
+        SoilLogger.warning("Server: Rejected unknown setting '%s' from network event", tostring(self.settingName))
+        return
+    end
+    if def.localOnly then return end
 
     -- Validate player is admin (master user)
     if not connection:getIsServer() then
@@ -453,6 +457,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
                 burnDaysLeft = burnDays,
                 coverageFraction = math.max(0, math.min(1, coverageFrac or 0)),
                 compaction = math.max(0, math.min(100, compaction or 0)),
+                nutrientBuffer = buffer,
                 initialized = true
             }
             -- Clear empty strings

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -71,7 +71,7 @@ function SoilSettingChangeEvent:run(connection)
 
     -- Validate player is admin (master user)
     if not connection:getIsServer() then
-        local user = g_currentMission.userManager:getUserByConnection(connection)
+        local user = g_currentMission.userManager and g_currentMission.userManager:getUserByConnection(connection)
         if not user or not user:getIsMasterUser() then
             SoilLogger.warning("Player %s (non-admin) tried to change settings - denied",
                 user and user:getNickname() or "Unknown")

--- a/src/ui/SoilSmartSensorPanel.lua
+++ b/src/ui/SoilSmartSensorPanel.lua
@@ -16,7 +16,6 @@
 -- The panel is hidden when:
 --   • Player is not in a sprayer with VWW sections
 --   • Smart Sensor is globally disabled (admin toggle)
---   • PF compat mode is active (PF owns section control)
 --   • The SF mod is disabled
 --   • A GUI dialog / large map is visible (except in edit mode)
 -- =========================================================

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,9 +24,21 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: Spray visual effects no longer fire when boom is folded",
-    "  or vehicle is stationary — effects are now suppressed every tick",
-    "  when conditions are not met (was only suppressed on state change)",
+    "- New: JD R700i (28m) and R975i (36m) sprayers with per-nozzle",
+    "  section control",
+    "- New: Tillage work trail (plow/cultivate) on HUD and minimap",
+    "- Fixed: Variable rate + auto rate no longer double-reduces nutrient",
+    "  gain — 50% rate now delivers 50%, not near-zero",
+    "- Fixed: Spray mist no longer fires when boom is folded or stopped",
+    "- Fixed: Field edge sections now always receive nutrient credit",
+    "- Fixed: HUD always shows field averages, not local cell values",
+    "- Fixed: Ghost bar now applies Replenishment Rate multiplier",
+    "- Fixed: Yield modifier no longer drops during multi-pass harvest",
+    "- Fixed: Map cell tooltip bars now show numeric values (N/P/K %,",
+    "  pH, OM %)",
+    "- Fixed: P threshold in farm overview corrected (45 -> 40)",
+    "- Fixed: Minimap overlay anchoring on large maps (#547)",
+    "- Pricing: rebalanced all 20 custom fertilizer types",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **v2.4.0.0 release**: JD R700i/R975i sprayers with per-nozzle section control, tillage work trail on HUD and minimap, variable rate / yield freeze / pricing fixes
- **Post-release bug fixes**: network nil guards, VWW section effects, PF re-enable, sprayer visual suppression, HUD field averages, edge-cell spray credit, cell tooltip values
- **Code review pass**: nil guard on `userManager` in NetworkEvents (latent crash on session transition), removed ghost PF compat mode comments across HookManager and SoilSmartSensorPanel, replaced stale placeholder in SoilBundledMaps

## Test plan

- [ ] Load savegame — version dialog shows 2.4.0.0 changelog
- [ ] Harvest fields — nutrient depletion applies correctly, yield modifier frozen across multi-pass
- [ ] Apply fertilizer with JD R700i / R975i — per-nozzle mist fires and stops with boom
- [ ] Tillage (plow/cultivate) — work trail dots appear on HUD and minimap
- [ ] Variable rate — rate panel reflects soil deficit without double-reduction
- [ ] Multiplayer — admin setting changes sync to all clients; non-admin change blocked without crash
- [ ] Smart Sensor panel — hides when disabled; no PF compat references remain