### PR TITLE
fix: minimap heatmap blank on dedicated server clients

### DIFF
--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -818,6 +818,24 @@ function SoilFieldBatchSyncEvent:run(connection)
             g_SoilFertilityManager.soilMapOverlay:requestRefresh()
         end
 
+        -- Seed GRLE layers from the just-received fieldData so the DMV minimap
+        -- heatmap is correct on join. On pure dedi-server clients the startup seed
+        -- in SoilFertilityManager ran before fieldData arrived, so the GRLE was
+        -- blank. Skipped on listen-server hosts where the sprayer hook owns GRLE.
+        if g_server == nil then
+            local layerSys = soilSystem.layerSystem
+            if layerSys and layerSys.available then
+                for fieldId, field in pairs(soilSystem.fieldData) do
+                    local fsField = g_fieldManager and g_fieldManager.fields
+                                 and g_fieldManager.fields[fieldId]
+                    layerSys:writeFieldToLayers(fieldId, field, fsField)
+                end
+                local sfm = g_SoilFertilityManager
+                if sfm and sfm.soilMinimapLayer then sfm.soilMinimapLayer:markDirty() end
+                SoilLogger.info("Client: GRLE layers seeded from batch sync (%d fields)", total)
+            end
+        end
+
         -- Refresh any open UI panels
         if g_SoilFertilityManager.settingsUI then
             g_SoilFertilityManager.settingsUI:refreshUI()
@@ -1033,6 +1051,22 @@ function SoilFieldUpdateEvent:run(connection)
         end
 
         soilSys.fieldData[self.fieldId] = newField
+
+        -- On pure dedi-server clients the sprayer hook never runs locally, so the
+        -- GRLE layers (which power the DMV minimap heatmap) are never written.
+        -- Write the updated field now so the minimap stays in sync with the HUD.
+        -- Skipped on listen-server hosts (g_server ~= nil) where the hook writes
+        -- per-pixel data directly and writeFieldToLayers would smear the average.
+        if g_server == nil then
+            local layerSys = soilSys.layerSystem
+            if layerSys and layerSys.available then
+                local fsField = g_fieldManager and g_fieldManager.fields
+                             and g_fieldManager.fields[self.fieldId]
+                layerSys:writeFieldToLayers(self.fieldId, newField, fsField)
+                local sfm = g_SoilFertilityManager
+                if sfm and sfm.soilMinimapLayer then sfm.soilMinimapLayer:markDirty() end
+            end
+        end
 
         -- Refresh overlay so the map tile updates on the client without waiting for the timer
         local overlay = g_SoilFertilityManager.soilMapOverlay


### PR DESCRIPTION
## Summary

- **Root cause**: On dedicated server clients, the DMV minimap heatmap reads from GRLE density-map layers, but those layers were never written on the client — only the server writes them via spray/harvest hooks. `fieldData` was correct (HUD worked fine) but the GRLE stayed at blank/default terrain values from initialization.
- **Fix 1** (`SoilFieldBatchSyncEvent:run`): After the last field batch lands on join, seed all GRLE layers from the received `fieldData` — mirroring the startup seed that ran before `fieldData` arrived.
- **Fix 2** (`SoilFieldUpdateEvent:run`): Write the updated field into GRLE on every server broadcast so the minimap stays current during active gameplay.
- Both paths guard with `g_server == nil` to skip listen-server hosts where the sprayer hook writes per-pixel GRLE data directly (avoiding smearing the average over pixel-precise data).

## Reported by

Discord user on Pinchoniere Valley dedicated server — minimap showed no heatmap while HUD showed correct nutrient values.

## Test plan

- [ ] Join a dedicated server — minimap heatmap shows correct nutrient colors on join
- [ ] Watch another player apply fertilizer — minimap updates within the next DMV rebuild cycle (≤3s)
- [ ] Singleplayer: minimap still shows per-pixel spray precision (not smeared averages)
- [ ] Listen server host: minimap unaffected