### PR TITLE
v2.3.1 → v2.4.0 + post-release fixes: SFNozzleEffects, spray trails, minimap/DMV overhaul, network hardening

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -929,7 +929,6 @@ local function showSensorMsg(name, on)
 end
 
 function SoilFertilityManager:onSensorPestInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:togglePest(vehicle.id)
@@ -938,7 +937,6 @@ function SoilFertilityManager:onSensorPestInput()
 end
 
 function SoilFertilityManager:onSensorDiseaseInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:toggleDisease(vehicle.id)
@@ -947,7 +945,6 @@ function SoilFertilityManager:onSensorDiseaseInput()
 end
 
 function SoilFertilityManager:onSensorNutrientInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:toggleNutrient(vehicle.id)
@@ -958,7 +955,6 @@ end
 -- ── System 2: See & Spray input callbacks ─────────────────
 
 function SoilFertilityManager:onSeeSprayPestInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:toggleSeeSprayPest(vehicle.id)
@@ -967,7 +963,6 @@ function SoilFertilityManager:onSeeSprayPestInput()
 end
 
 function SoilFertilityManager:onSeeSprayDiseaseInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:toggleSeeSprayDisease(vehicle.id)
@@ -976,7 +971,6 @@ function SoilFertilityManager:onSeeSprayDiseaseInput()
 end
 
 function SoilFertilityManager:onSeeSprayWeedInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:toggleSeeSprayWeed(vehicle.id)
@@ -987,7 +981,6 @@ end
 -- ── System 3: Variable Rate input callback ─────────────────
 
 function SoilFertilityManager:onVariableRateInput()
-
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
     local newState = self.sensorManager:toggleVariableRate(vehicle.id)
@@ -1620,6 +1613,15 @@ function SoilFertilityManager:delete()
         self.vehicleSettingsPanelEventId = nil
     end
 
+    if self.minimapZoomEventId and g_inputBinding then
+        g_inputBinding:removeActionEvent(self.minimapZoomEventId)
+        self.minimapZoomEventId = nil
+    end
+
+    if self.vehicleMinimapZoomEventId and g_inputBinding then
+        g_inputBinding:removeActionEvent(self.vehicleMinimapZoomEventId)
+        self.vehicleMinimapZoomEventId = nil
+    end
 
     if self.soilReportDialog then
         if g_gui then g_gui:closeDialogByName("SoilReportDialog") end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -336,12 +336,11 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField._farmlandAreaConfirmed  = nil  -- re-confirm on next session's first spray (#507)
         harvestField.sprayTrailPts           = nil
 
-        -- Clear frozen yield modifier when a NEW crop type is harvested. This indicates
-        -- the start of a new crop cycle; the old snapshot is stale (#556).
-        if harvestField.frozenYieldFruitType and harvestField.frozenYieldFruitType ~= fruitTypeIndex then
-            harvestField.frozenYieldModifier  = nil
-            harvestField.frozenYieldFruitType = nil
-        end
+        -- Clear the frozen yield modifier now that the harvest session is complete.
+        -- The freeze exists to prevent mid-pass modifier drops (#556); once onHarvest
+        -- fires the session is over and the snapshot must not carry into the next season.
+        harvestField.frozenYieldModifier  = nil
+        harvestField.frozenYieldFruitType = nil
     end
 
     SoilLogger.debug("Harvest: Field %d, Crop %d, %.0fL (biological), area=%.1f", fieldId, fruitTypeIndex, liters, area or 0)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2360,14 +2360,16 @@ function HookManager:installSprayerAreaHook()
 
             -- Guard: folded implement must not record nutrient application.
             -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
-            -- turnOnFoldDirection==0 means no fold restriction; fall back to animation-only guard.
+            -- turnOnFoldDirection is always 1 or -1 after Foldable init; nil falls back to
+            -- animation-only detection (0 < fa < 1).
             if self.spec_foldable then
                 local foldSpec = self.spec_foldable
                 local fa  = foldSpec.foldAnimTime
-                local dir = foldSpec.turnOnFoldDirection or 0
+                local dir = foldSpec.turnOnFoldDirection
                 if fa ~= nil then
-                    local notWorking = (dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1) or (dir == 0 and fa > 0 and fa < 1)
-                    if notWorking then return end
+                    local folded = dir ~= nil and ((dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1))
+                                or (dir == nil and fa > 0 and fa < 1)
+                    if folded then return end
                 end
             end
 
@@ -4773,13 +4775,30 @@ function HookManager:installSprayerVisualEffectHook()
                 spec._soilEffectsActive   = nil
             end
 
+            -- Fold detection — computed once, applied to both vanilla and custom paths below.
+            -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
+            -- turnOnFoldDirection defaults to 1 or -1 (never 0 after Foldable init); if somehow
+            -- nil, fall back to animation-only detection (0 < fa < 1).
+            local isFolded = false
+            if sprayerSelf.spec_foldable then
+                local foldSpec = sprayerSelf.spec_foldable
+                local fa  = foldSpec.foldAnimTime
+                local dir = foldSpec.turnOnFoldDirection
+                if fa ~= nil then
+                    if dir ~= nil then
+                        isFolded = (dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1)
+                    else
+                        isFolded = fa > 0 and fa < 1
+                    end
+                end
+            end
+
             if not vanillaFillType then
-                -- Vanilla fill type (e.g. HERBICIDE): stop effects every tick when stationary.
-                -- We run AFTER the vanilla onUpdateTick (appendedFunction), so vanilla may restart
-                -- effects each tick. State-change guards don't work here — must suppress every tick.
-                -- g_effectManager:stopEffects is a no-op when effects are already stopped.
+                -- Vanilla fill type (e.g. HERBICIDE): stop effects when stationary OR folded.
+                -- We run AFTER vanilla onUpdateTick (appendedFunction), so we must suppress
+                -- every tick — state-change guards don't work here.
                 local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
-                if speed < 0.5 then
+                if speed < 0.5 or isFolded then
                     stopSprayerEffects(sprayerSelf)
                 end
                 return
@@ -4789,18 +4808,7 @@ function HookManager:installSprayerVisualEffectHook()
             local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
             local effectsVisible = sprayerSelf:getAreEffectsVisible() and speed >= 0.5
 
-            -- Suppress effects while animating or folded.
-            -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
-            -- turnOnFoldDirection==0 means no fold restriction; suppress only mid-animation then.
-            if sprayerSelf.spec_foldable then
-                local foldSpec = sprayerSelf.spec_foldable
-                local fa  = foldSpec.foldAnimTime
-                local dir = foldSpec.turnOnFoldDirection or 0
-                if fa ~= nil then
-                    local notWorking = (dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1) or (dir == 0 and fa > 0 and fa < 1)
-                    if notWorking then effectsVisible = false end
-                end
-            end
+            if isFolded then effectsVisible = false end
 
             -- Stop path: suppress every tick (no state-change guard).
             -- vanilla onUpdateTick runs before us (appendedFunction) and can

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -4695,9 +4695,20 @@ function HookManager:installSprayerVisualEffectHook()
                 g_soundManager:playSamples(st.samples and st.samples.spray or {})
             end
         end
-        -- VWW wing-section effects are managed per-tick in onUpdateTick so that
-        -- suppression from Smart Sensor / boundary enforcement / overlap prevention
-        -- can be applied every frame, matching PF's per-nozzle effect behavior.
+        -- Start VWW wing-section effects for sections that are active and not suppressed.
+        -- (The per-tick loop in onUpdateTick will stop suppressed sections dynamically.)
+        local vww = vehicle.spec_variableWorkWidth
+        if vww and vww.sections then
+            local sfSuppressed      = vehicle._sfSuppressedSections       or {}
+            local overlapSuppressed = vehicle._sfOverlapSuppressedSections or {}
+            for i, section in ipairs(vww.sections) do
+                if section.isActive and not sfSuppressed[i] and not overlapSuppressed[i] and
+                   section.effects and #section.effects > 0 then
+                    g_effectManager:setEffectTypeInfo(section.effects, vanillaFillType)
+                    g_effectManager:startEffects(section.effects)
+                end
+            end
+        end
     end
 
     local function stopSprayerEffects(vehicle)
@@ -4784,10 +4795,12 @@ function HookManager:installSprayerVisualEffectHook()
                 return
             end
 
-            -- Per-tick VWW section effect management.
-            -- Runs every tick when effectsVisible=true so suppression state from Smart Sensor,
-            -- boundary enforcement, and overlap prevention is reflected in nozzle animations,
-            -- matching PF's per-nozzle updateSprayerEffectState() behavior.
+            -- Per-tick VWW section effect correction.
+            -- startSprayerEffects handles the initial start (state change). This loop handles
+            -- dynamic suppression changes: stops effects on sections suppressed by Smart Sensor,
+            -- boundary enforcement, or overlap prevention; restarts them when un-suppressed.
+            -- Does NOT stop sections that VWW set to isActive=false for its own reasons
+            -- (overlap prevention, width control, "no width" mode) — those are VWW's concern.
             do
                 local vwwS = sprayerSelf.spec_variableWorkWidth
                 if vwwS and vwwS.sections then
@@ -4795,12 +4808,15 @@ function HookManager:installSprayerVisualEffectHook()
                     local overlapSuppressed = sprayerSelf._sfOverlapSuppressedSections or {}
                     for i, section in ipairs(vwwS.sections) do
                         if section.effects and #section.effects > 0 then
-                            if section.isActive and not sfSuppressed[i] and not overlapSuppressed[i] then
+                            if sfSuppressed[i] or overlapSuppressed[i] then
+                                -- Positively suppressed by our system: stop nozzle animation
+                                g_effectManager:stopEffects(section.effects)
+                            elseif section.isActive then
+                                -- Active and not suppressed: ensure running (handles un-suppress)
                                 g_effectManager:setEffectTypeInfo(section.effects, vanillaFillType)
                                 g_effectManager:startEffects(section.effects)
-                            else
-                                g_effectManager:stopEffects(section.effects)
                             end
+                            -- isActive=false + not suppressed: VWW-managed, do not interfere
                         end
                     end
                 end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2359,15 +2359,15 @@ function HookManager:installSprayerAreaHook()
             if self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then return end
 
             -- Guard: folded implement must not record nutrient application.
-            -- Use turnOnFoldMinLimit/turnOnFoldMaxLimit (vanilla's own gate) so both
-            -- deploy orientations work — foldAnimTime=0-deployed and foldAnimTime=1-deployed.
+            -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
+            -- turnOnFoldDirection==0 means no fold restriction; fall back to animation-only guard.
             if self.spec_foldable then
                 local foldSpec = self.spec_foldable
-                local fa = foldSpec.foldAnimTime
-                if fa ~= nil and foldSpec.turnOnFoldMinLimit ~= nil then
-                    if fa < foldSpec.turnOnFoldMinLimit or fa > (foldSpec.turnOnFoldMaxLimit or 1) then
-                        return
-                    end
+                local fa  = foldSpec.foldAnimTime
+                local dir = foldSpec.turnOnFoldDirection or 0
+                if fa ~= nil then
+                    local notWorking = (dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1) or (dir == 0 and fa > 0 and fa < 1)
+                    if notWorking then return end
                 end
             end
 
@@ -4789,21 +4789,16 @@ function HookManager:installSprayerVisualEffectHook()
             local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
             local effectsVisible = sprayerSelf:getAreEffectsVisible() and speed >= 0.5
 
-            -- Suppress effects while animating OR when fully folded.
-            -- foldAnimTime=0 and foldAnimTime=1 are both valid stable end-states (which one is
-            -- "deployed" depends on the vehicle), so we can't gate on a raw value alone.
-            -- turnOnFoldMinLimit/turnOnFoldMaxLimit are vanilla's own working-range limits —
-            -- if fa is outside them the implement is folded regardless of deploy orientation.
+            -- Suppress effects while animating or folded.
+            -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
+            -- turnOnFoldDirection==0 means no fold restriction; suppress only mid-animation then.
             if sprayerSelf.spec_foldable then
                 local foldSpec = sprayerSelf.spec_foldable
-                local fa = foldSpec.foldAnimTime
+                local fa  = foldSpec.foldAnimTime
+                local dir = foldSpec.turnOnFoldDirection or 0
                 if fa ~= nil then
-                    local animating    = fa > 0 and fa < 1
-                    local minL         = foldSpec.turnOnFoldMinLimit
-                    local outOfRange   = minL ~= nil and (fa < minL or fa > (foldSpec.turnOnFoldMaxLimit or 1))
-                    if animating or outOfRange then
-                        effectsVisible = false
-                    end
+                    local notWorking = (dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1) or (dir == 0 and fa > 0 and fa < 1)
+                    if notWorking then effectsVisible = false end
                 end
             end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2358,6 +2358,19 @@ function HookManager:installSprayerAreaHook()
 
             if self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then return end
 
+            -- Guard: folded implement must not record nutrient application.
+            -- Use turnOnFoldMinLimit/turnOnFoldMaxLimit (vanilla's own gate) so both
+            -- deploy orientations work — foldAnimTime=0-deployed and foldAnimTime=1-deployed.
+            if self.spec_foldable then
+                local foldSpec = self.spec_foldable
+                local fa = foldSpec.foldAnimTime
+                if fa ~= nil and foldSpec.turnOnFoldMinLimit ~= nil then
+                    if fa < foldSpec.turnOnFoldMinLimit or fa > (foldSpec.turnOnFoldMaxLimit or 1) then
+                        return
+                    end
+                end
+            end
+
             if not fillTypeIndex or fillTypeIndex <= 0 then return end
 
             -- Track the active custom fill type BEFORE the liters/sprayFillLevel guards.
@@ -4776,16 +4789,21 @@ function HookManager:installSprayerVisualEffectHook()
             local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
             local effectsVisible = sprayerSelf:getAreEffectsVisible() and speed >= 0.5
 
-            -- Suppress effects while the fold animation is actively running mid-travel.
-            -- Courseplay folds the implement before filling completes, leaving effects stuck on.
-            -- In FS25, foldAnimTime=0 and foldAnimTime=1 are both stable end-states (fully folded
-            -- or fully deployed depending on the vehicle). Suppressing at any value below 0.9 breaks
-            -- all sprayers whose deployed/working state is foldAnimTime=0 (the default base state).
-            -- Only suppress when strictly between 0 and 1 (actively animating).
+            -- Suppress effects while animating OR when fully folded.
+            -- foldAnimTime=0 and foldAnimTime=1 are both valid stable end-states (which one is
+            -- "deployed" depends on the vehicle), so we can't gate on a raw value alone.
+            -- turnOnFoldMinLimit/turnOnFoldMaxLimit are vanilla's own working-range limits —
+            -- if fa is outside them the implement is folded regardless of deploy orientation.
             if sprayerSelf.spec_foldable then
-                local fa = sprayerSelf.spec_foldable.foldAnimTime
-                if fa ~= nil and fa > 0 and fa < 1 then
-                    effectsVisible = false
+                local foldSpec = sprayerSelf.spec_foldable
+                local fa = foldSpec.foldAnimTime
+                if fa ~= nil then
+                    local animating    = fa > 0 and fa < 1
+                    local minL         = foldSpec.turnOnFoldMinLimit
+                    local outOfRange   = minL ~= nil and (fa < minL or fa > (foldSpec.turnOnFoldMaxLimit or 1))
+                    if animating or outOfRange then
+                        effectsVisible = false
+                    end
                 end
             end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1058,6 +1058,8 @@ function HookManager:installSectionControlHook()
                                 if not fid or fid <= 0 or
                                    (vehicleFieldId and vehicleFieldId > 0 and fid ~= vehicleFieldId) then
                                     section.isActive = false
+                                    if not sprayerSelf._sfSuppressedSections then sprayerSelf._sfSuppressedSections = {} end
+                                    sprayerSelf._sfSuppressedSections[i] = true
                                 end
                             end
                         end
@@ -1141,6 +1143,8 @@ function HookManager:installSectionControlHook()
                             end
                             if skip then
                                 section.isActive = false
+                                if not sprayerSelf._sfSuppressedSections then sprayerSelf._sfSuppressedSections = {} end
+                                sprayerSelf._sfSuppressedSections[i] = true
                             end
                         end
                     end
@@ -1299,7 +1303,11 @@ function HookManager:installSeeAndSprayHook()
                                 end
                                 skip = skip or weedsGone
                             end
-                            if skip then section.isActive = false end
+                            if skip then
+                                section.isActive = false
+                                if not sprayerSelf._sfSuppressedSections then sprayerSelf._sfSuppressedSections = {} end
+                                sprayerSelf._sfSuppressedSections[i] = true
+                            end
                         end
                     end
                 end
@@ -1753,6 +1761,17 @@ function HookManager:installSectionStatePreserver()
             local vww = sprayerSelf.spec_variableWorkWidth
             if not vww or not vww.sections or #vww.sections == 0 then return end
 
+            -- Clear suppression tracking from the previous work-area pass.
+            -- Each appended hook writes to _sfSuppressedSections directly when it
+            -- suppresses a section. Clearing here (before the original + our hooks run)
+            -- ensures only THIS tick's suppression is visible to the visual effects hook.
+            -- Do NOT infer suppression by comparing before/after states — that would
+            -- falsely capture VWW's own section management as "suppressed by us".
+            local sfSup = sprayerSelf._sfSuppressedSections
+            if sfSup then
+                for k in pairs(sfSup) do sfSup[k] = nil end
+            end
+
             -- Reuse existing table to avoid per-tick allocation
             local saved = sprayerSelf._sfSavedSectionStates
             if not saved then
@@ -1810,21 +1829,8 @@ function HookManager:installSectionStatePreserver()
                 if not saved then return end
                 local vww = sprayerSelf.spec_variableWorkWidth
                 if vww and vww.sections then
-                    -- Capture which sections were suppressed by our hooks (was active → became inactive).
-                    -- The visual effects hook reads _sfSuppressedSections every tick to stop nozzle
-                    -- animations on those sections, matching PF's per-nozzle effect behavior.
-                    local suppressed = sprayerSelf._sfSuppressedSections
-                    if not suppressed then
-                        suppressed = {}
-                        sprayerSelf._sfSuppressedSections = suppressed
-                    else
-                        for k in pairs(suppressed) do suppressed[k] = nil end
-                    end
                     for i, section in ipairs(vww.sections) do
                         if saved[i] ~= nil then
-                            if saved[i] and not section.isActive then
-                                suppressed[i] = true
-                            end
                             section.isActive = saved[i]
                         end
                     end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1808,8 +1808,21 @@ function HookManager:installSectionStatePreserver()
                 if not saved then return end
                 local vww = sprayerSelf.spec_variableWorkWidth
                 if vww and vww.sections then
+                    -- Capture which sections were suppressed by our hooks (was active → became inactive).
+                    -- The visual effects hook reads _sfSuppressedSections every tick to stop nozzle
+                    -- animations on those sections, matching PF's per-nozzle effect behavior.
+                    local suppressed = sprayerSelf._sfSuppressedSections
+                    if not suppressed then
+                        suppressed = {}
+                        sprayerSelf._sfSuppressedSections = suppressed
+                    else
+                        for k in pairs(suppressed) do suppressed[k] = nil end
+                    end
                     for i, section in ipairs(vww.sections) do
                         if saved[i] ~= nil then
+                            if saved[i] and not section.isActive then
+                                suppressed[i] = true
+                            end
                             section.isActive = saved[i]
                         end
                     end
@@ -4682,20 +4695,9 @@ function HookManager:installSprayerVisualEffectHook()
                 g_soundManager:playSamples(st.samples and st.samples.spray or {})
             end
         end
-        -- Start VWW wing-section effects (these are separate from spec.effects and
-        -- are never started by the vanilla system for custom fill types, causing only
-        -- the center to show mist while wing booms appear dry).
-        local vww = vehicle.spec_variableWorkWidth
-        if vww and vww.sections then
-            local suppressed = vehicle._sfOverlapSuppressedSections or {}
-            for i, section in ipairs(vww.sections) do
-                if section.isActive and not suppressed[i] and
-                   section.effects and #section.effects > 0 then
-                    g_effectManager:setEffectTypeInfo(section.effects, vanillaFillType)
-                    g_effectManager:startEffects(section.effects)
-                end
-            end
-        end
+        -- VWW wing-section effects are managed per-tick in onUpdateTick so that
+        -- suppression from Smart Sensor / boundary enforcement / overlap prevention
+        -- can be applied every frame, matching PF's per-nozzle effect behavior.
     end
 
     local function stopSprayerEffects(vehicle)
@@ -4780,6 +4782,28 @@ function HookManager:installSprayerVisualEffectHook()
                     SoilLogger.debug("SprayerVisual: stopped effects (fillType=%d)", fillType)
                 end
                 return
+            end
+
+            -- Per-tick VWW section effect management.
+            -- Runs every tick when effectsVisible=true so suppression state from Smart Sensor,
+            -- boundary enforcement, and overlap prevention is reflected in nozzle animations,
+            -- matching PF's per-nozzle updateSprayerEffectState() behavior.
+            do
+                local vwwS = sprayerSelf.spec_variableWorkWidth
+                if vwwS and vwwS.sections then
+                    local sfSuppressed      = sprayerSelf._sfSuppressedSections       or {}
+                    local overlapSuppressed = sprayerSelf._sfOverlapSuppressedSections or {}
+                    for i, section in ipairs(vwwS.sections) do
+                        if section.effects and #section.effects > 0 then
+                            if section.isActive and not sfSuppressed[i] and not overlapSuppressed[i] then
+                                g_effectManager:setEffectTypeInfo(section.effects, vanillaFillType)
+                                g_effectManager:startEffects(section.effects)
+                            else
+                                g_effectManager:stopEffects(section.effects)
+                            end
+                        end
+                    end
+                end
             end
 
             -- Start path: only act on state change to avoid per-tick overhead

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -4737,7 +4737,11 @@ function HookManager:installSprayerVisualEffectHook()
     local function stopSprayerEffects(vehicle)
         local spec = vehicle.spec_sprayer
         if not spec then return end
+        -- Mirror vanilla Sprayer updateSprayerEffects off-path exactly:
+        -- spec.effects, spec.animationNodes, spec.samples.spray, then all sprayTypes.
         g_effectManager:stopEffects(spec.effects)
+        g_animationManager:stopAnimations(spec.animationNodes)
+        g_soundManager:stopSamples(spec.samples and spec.samples.spray or {})
         for _, st in ipairs(spec.sprayTypes or {}) do
             g_effectManager:stopEffects(st.effects)
             g_animationManager:stopAnimations(st.animationNodes)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1003,6 +1003,7 @@ function HookManager:installSectionControlHook()
     local diseaseFillTypes = {}   -- ftName → true  (fungicides)
     local kOnlyFillTypes   = {}   -- ftName → true  (K dominant, P=0)
     local pDomFillTypes    = {}   -- ftName → true  (P dominant, K=0)
+    local nDomFillTypes    = {}   -- ftName → true  (N only, P=0 K=0)
 
     local pp = SoilConstants.PEST_PRESSURE
     if pp and pp.INSECTICIDE_TYPES then
@@ -1020,6 +1021,7 @@ function HookManager:installSectionControlHook()
             local k = prof.K or 0
             if k > 0 and p == 0 then kOnlyFillTypes[name] = true end
             if p > 0 and k == 0 then pDomFillTypes[name]  = true end
+            if n > 0 and p == 0 and k == 0 then nDomFillTypes[name] = true end
         end
     end
 
@@ -1090,13 +1092,14 @@ function HookManager:installSectionControlHook()
             local isDisease = diseaseFillTypes[ft.name] == true
             local isKOnly   = kOnlyFillTypes[ft.name]   == true
             local isPDom    = pDomFillTypes[ft.name]    == true
+            local isNDom    = nDomFillTypes[ft.name]    == true
 
-            if not isPest and not isDisease and not isKOnly and not isPDom then return end
+            if not isPest and not isDisease and not isKOnly and not isPDom and not isNDom then return end
 
             -- Check which sensors are active for this vehicle
-            local pestOn    = isPest                and sensorMgr:isPestEnabled(vehicleId)
-            local diseaseOn = isDisease             and sensorMgr:isDiseaseEnabled(vehicleId)
-            local nutrientOn = (isKOnly or isPDom)  and sensorMgr:isNutrientEnabled(vehicleId)
+            local pestOn     = isPest                          and sensorMgr:isPestEnabled(vehicleId)
+            local diseaseOn  = isDisease                       and sensorMgr:isDiseaseEnabled(vehicleId)
+            local nutrientOn = (isKOnly or isPDom or isNDom)  and sensorMgr:isNutrientEnabled(vehicleId)
 
             if not pestOn and not diseaseOn and not nutrientOn then return end
 
@@ -1125,6 +1128,9 @@ function HookManager:installSectionControlHook()
                             local skip = false
                             if pestOn    then skip = skip or ((fd.pestPressure    or 0) <= 0) end
                             if diseaseOn then skip = skip or ((fd.diseasePressure or 0) <= 0) end
+                            if nutrientOn and isNDom then
+                                skip = skip or ((fd.nitrogen   or 0) >= NUTRIENT_TARGET)
+                            end
                             if nutrientOn and isKOnly then
                                 skip = skip or ((fd.potassium  or 0) >= NUTRIENT_TARGET)
                             end
@@ -1144,7 +1150,7 @@ function HookManager:installSectionControlHook()
     self:register(Sprayer, "onStartWorkAreaProcessing", origStart,
         "Sprayer.onStartWorkAreaProcessing (SF section sensor)")
 
-    SoilLogger.info("[OK] SF Smart Sensor hook installed — pest/disease/nutrient K+P section control active")
+    SoilLogger.info("[OK] SF Smart Sensor hook installed — pest/disease/nutrient N+K+P section control active")
     return true
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1112,11 +1112,13 @@ function HookManager:installSectionControlHook()
             local tips = sprayerSelf._sfSectionTip
 
             for i, section in ipairs(vww.sections) do
-                -- Only suppress sections VWW has activated. isCenter sections are never
-                -- added to sectionsLeft/Right so VWW never touches them — leave them alone.
-                -- installSectionStatePreserver() restores isActive after work areas process.
-                if section.isActive and not section.isCenter then
-                    -- Midpoint between root and section outer edge (from preserver cache)
+                -- Center sections CAN be suppressed: getIsWorkAreaActive() checks workArea.sectionIndex
+                -- → section.isActive for all sections including center. Center has no tip node, so its
+                -- position check falls back to rootX/rootZ (vehicle center = center strip position).
+                -- installSectionStatePreserver() restores isActive for all sections after work areas process.
+                if section.isActive then
+                    -- Midpoint between root and section outer edge (from preserver cache).
+                    -- Center section has no tip node → tips[i] = nil → falls back to rootX/rootZ.
                     local tip = tips and tips[i]
                     local sx = tip and ((rootX + tip[1]) * 0.5) or rootX
                     local sz = tip and ((rootZ + tip[2]) * 0.5) or rootZ

--- a/src/main.lua
+++ b/src/main.lua
@@ -183,7 +183,7 @@ local function loadedMission(mission, node)
             if tmpl then
                 -- Our 11 solid fill types that need ground-tipping support.
                 local solidTypes = {
-                    "UREA", "AN", "AMS", "MAP", "DAP", "POTASH",
+                    "UREA", "AN", "AMS", "MAP", "DAP", "POTASH", "POLIFOSKA",
                     "GYPSUM", "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE",
                 }
                 local registered = 0

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -95,6 +95,11 @@ function SoilHarvesterPanel.new(soilSystem, settings)
     self._fieldId     = nil
     self._fieldInfo   = nil
 
+    -- Per-frame draw cache (set by update, consumed by draw to avoid per-frame API calls)
+    self._cachedCombine = nil
+    self._cachedTank    = nil
+    self._cachedCropFT  = nil
+
     -- Session grain tracking for t/ha estimate
     self._sessGrainL   = 0
     self._lastTankLvl  = nil
@@ -379,8 +384,11 @@ function SoilHarvesterPanel:update(dt)
 
     local combine = self:getActiveCombine()
     if not combine then
-        self._fieldId   = nil
-        self._fieldInfo = nil
+        self._fieldId      = nil
+        self._fieldInfo    = nil
+        self._cachedCombine = nil
+        self._cachedTank    = nil
+        self._cachedCropFT  = nil
         return
     end
 
@@ -391,21 +399,16 @@ function SoilHarvesterPanel:update(dt)
         if ok then x, z = px, pz end
     end
     if not x then
-        self._fieldId   = nil
-        self._fieldInfo = nil
+        self._fieldId      = nil
+        self._fieldInfo    = nil
+        self._cachedCombine = nil
+        self._cachedTank    = nil
+        self._cachedCropFT  = nil
         return
     end
 
     local fieldId = nil
-    if g_fieldManager then
-        local ok, field = pcall(function()
-            return g_fieldManager:getFieldAtWorldPosition(x, z)
-        end)
-        if ok and field and field.farmland and field.farmland.id then
-            fieldId = field.farmland.id
-        end
-    end
-    if not fieldId and g_farmlandManager then
+    if g_farmlandManager then
         local ok, farmland = pcall(function()
             return g_farmlandManager:getFarmlandAtWorldPosition(x, z)
         end)
@@ -442,6 +445,11 @@ function SoilHarvesterPanel:update(dt)
     else
         self._lastTankLvl = nil
     end
+
+    -- Cache for draw() so it doesn't repeat these API calls every rendered frame
+    self._cachedCombine = combine
+    self._cachedTank    = tank
+    self._cachedCropFT  = combine and self:getCropFillType(combine, tank) or nil
 end
 
 -- ── Draw helpers ──────────────────────────────────────────
@@ -483,9 +491,9 @@ function SoilHarvesterPanel:draw()
         if not self.editMode then return end
     end
 
-    local combine  = self:getActiveCombine()
-    local tank     = combine and self:getGrainTank(combine)
-    local cropFT   = combine and self:getCropFillType(combine, tank)
+    local combine  = self._cachedCombine
+    local tank     = self._cachedTank
+    local cropFT   = self._cachedCropFT
     local isActive = combine ~= nil
 
     if not self.editMode and not isActive then return end
@@ -644,9 +652,9 @@ function SoilHarvesterPanel:draw()
 
         local info = self._fieldInfo
         if info and info.yieldEfficiency then
-            local pct    = math.floor(info.yieldEfficiency * 100 + 0.5)
-            local effCol = (info.yieldEfficiency >= 0.80) and SoilHarvesterPanel.C_GOOD
-                        or (info.yieldEfficiency >= 0.55) and SoilHarvesterPanel.C_FAIR
+            local pct    = info.yieldEfficiency  -- already 0-100 integer from getFieldInfo()
+            local effCol = (info.yieldEfficiency >= 80) and SoilHarvesterPanel.C_GOOD
+                        or (info.yieldEfficiency >= 55) and SoilHarvesterPanel.C_FAIR
                         or  SoilHarvesterPanel.C_POOR
             local effStr = string.format("%d%%", pct)
             setTextAlignment(RenderText.ALIGN_RIGHT)

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -93,9 +93,11 @@ function SoilSprayerInfoPanel.new(soilSystem, settings)
     self._f1Cache = nil
 
     -- Field detection cache (populated by update, throttled)
-    self._detectTimer = 0
-    self._fieldId     = nil
-    self._fieldInfo   = nil
+    self._detectTimer   = 0
+    self._fieldId       = nil
+    self._fieldInfo     = nil
+    -- Smoothed display values: interpolated toward _fieldInfo every frame (~400ms time constant)
+    self._smoothValues  = {}
 
     -- Per-frame draw cache (set by update, consumed by draw to avoid per-frame API calls)
     self._cachedSprayer = nil
@@ -311,6 +313,23 @@ end
 function SoilSprayerInfoPanel:update(dt)
     self._animTimer   = self._animTimer + dt
     self._detectTimer = self._detectTimer - dt * 0.001
+
+    -- Smooth nutrient display values toward field data every frame (~400ms time constant).
+    -- This eases field-boundary transitions instead of snapping, matching PF's UsageBuffer approach.
+    local sv    = self._smoothValues
+    local info  = self._fieldInfo
+    local alpha = 1.0 - math.exp(-dt * 0.0025)
+    for _, nd in ipairs(NUTRIENT_ROWS) do
+        if info then
+            local raw = info[nd.fieldKey]
+            local tgt = (type(raw) == "table") and (raw.value or 0) or (raw or 0)
+            local cur = sv[nd.fieldKey]
+            sv[nd.fieldKey] = (cur == nil) and tgt or (cur + (tgt - cur) * alpha)
+        else
+            sv[nd.fieldKey] = nil
+        end
+    end
+
     if self._detectTimer > 0 then return end
     self._detectTimer = 0.5
 
@@ -581,8 +600,7 @@ function SoilSprayerInfoPanel:draw()
         local info = self._fieldInfo
         for _, nd in ipairs(activeRows) do
             local pKey    = nd.profileKey
-            local rawRet  = info[nd.fieldKey]
-            local rawVal  = (type(rawRet) == "table") and (rawRet.value or 0) or (rawRet or 0)
+            local rawVal  = self._smoothValues[nd.fieldKey] or 0
             local maxVal  = nd.maxVal
             local rowBot  = cy - rowH
             local barMidY = rowBot + (rowH - barH) * 0.5

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -97,6 +97,9 @@ function SoilSprayerInfoPanel.new(soilSystem, settings)
     self._fieldId     = nil
     self._fieldInfo   = nil
 
+    -- Per-frame draw cache (set by update, consumed by draw to avoid per-frame API calls)
+    self._cachedSprayer = nil
+
     return self
 end
 
@@ -312,6 +315,7 @@ function SoilSprayerInfoPanel:update(dt)
     self._detectTimer = 0.5
 
     local sprayer = self:getActiveSprayer()
+    self._cachedSprayer = sprayer
     if not sprayer then
         self._fieldId   = nil
         self._fieldInfo = nil
@@ -335,15 +339,7 @@ function SoilSprayerInfoPanel:update(dt)
     end
 
     local fieldId = nil
-    if g_fieldManager then
-        local ok, field = pcall(function()
-            return g_fieldManager:getFieldAtWorldPosition(x, z)
-        end)
-        if ok and field and field.farmland and field.farmland.id then
-            fieldId = field.farmland.id
-        end
-    end
-    if not fieldId and g_farmlandManager then
+    if g_farmlandManager then
         local ok, farmland = pcall(function()
             return g_farmlandManager:getFarmlandAtWorldPosition(x, z)
         end)
@@ -417,8 +413,8 @@ function SoilSprayerInfoPanel:draw()
         if not self.editMode then return end
     end
 
-    -- Determine what to show
-    local sprayer  = self:getActiveSprayer()
+    -- Determine what to show (sprayer cached by update() to avoid per-frame API calls)
+    local sprayer  = self._cachedSprayer
     local fillType = sprayer and self:getSprayerFillType(sprayer)
     local profile  = fillType and SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[fillType.name]
 


### PR DESCRIPTION
## Summary

86 commits since v2.3.0.0 — covers five minor releases (2.3.1–2.3.10) plus v2.4.0.0 and a batch of post-release bug fixes. Work spans two major new systems (SFNozzleEffects + live overlay trails), a full minimap/DMV/GRLE rebuild, and extensive hardening across network, HUD, and sprayer logic.

---

## New Systems

### SFNozzleEffects Specialization + JD Sprayer Vehicles
- New `SFNozzleEffects` vehicle specialization: per-nozzle particle effects tied to individual boom sections
- Bundled John Deere R700i (28 m) and R975i (36 m) sprayer vehicles with full textures, sounds, and See & Spray support
- Per-section mist on/off driven by VWW (Variable Width Work) section state in real time

### Live Spray Trail Overlay
- In-world coloured dots rendered at actual spray position as the boom crosses the field
- Minimap pixels updated live — no daily-rebuild delay
- Per-pixel GRLE history preserved across daily updates and multiplayer syncs (including dedi-server clients)
- Removed 2.5 s throttle that was silently dropping GRLE writes

### Harvest Trail Overlay
- In-world dots + minimap pixels tracking harvester path
- Stats bar with 4 harvest indicators (speed, tank %, yield, moisture) in the harvester panel

### Tillage Work Trail (plow/cultivate)
- HUD and minimap overlay showing tillage work coverage
- Toggle in HUD & Display settings

### Draggable Panels + Resize Handles
- Sprayer info panel and harvester panel are now freely draggable
- Per-panel user-scale + resize handle; positions persist across sessions

---

## Bug Fixes — Sprayer / SFNozzleEffects

| Fix | Detail |
|-----|--------|
| Spray mist persists after stop | `stopSprayerEffects` was not passing `spec.animationNodes` — effects never cleared |
| Folded sprayer still showed effects | Fold detection was reading the wrong node state |
| Folded sprayer mist | Fold check was only applied on the custom-fill-type code path, not the standard path |
| VWW section effects for custom fill types | `start/stopSprayerEffects` not wired through the VWW per-section loop |
| `_sfSuppressedSections` captured VWW sections | Section suppression set was incorrectly including VWW-owned sections, causing double-suppression |
| Wing nozzle effects stopped early | Per-tick loop stopped wing effects one tick before the section was actually off (regression from smoothing pass) |
| Effects on stationary / folded sprayer | Tick loop now re-suppresses every frame when folded or not moving |
| Overlap prevention | Transition-based suppression replaces old flag-flip approach, preventing flicker during boom fold/unfold |

---

## Bug Fixes — Smart Sensor

| Fix | Detail |
|-----|--------|
| Center boom section not suppressed | Center section was missing from the suppression set; Smart Sensor skipped it entirely |
| N-dominant fertilizers not gated | Nutrient gate only blocked zero-N products; extended to block any product above the N threshold (e.g. UAN, liquid N) |

---

## Bug Fixes — Minimap / DMV / GRLE

| Fix | Detail |
|-----|--------|
| DMV state colors engine crash | Clamped colors to 16 states (engine max); was sending up to 256 |
| `setDensityMapVisualizationOverlayStateColor` arg order | `maskMapId` and `firstChannel` were swapped |
| `layerSystem.hasData` guard always skipped DMV | Guard referenced a field that does not exist on the object |
| Minimap overlay broken after 2.3.1 | Restored polygon tile rendering in PDA; fixed GRLE wire-up to all UI systems |
| DMV heatmap flicker | Moved rebuild off the render tick into a throttled background job |
| 8-handle engine limit | Split into one DMV overlay per layer to stay within the engine ceiling |
| AABB rectangle painted to GRLE | Switched to polygon shape paint so the heatmap follows field boundaries exactly |
| DMV heatmap blank on startup | Seeds all GRLE layers from `fieldData` on load |
| GRLE writes on unowned farmland | Restricted writes to player-owned fields |
| Large-map minimap anchor drift | Fixed overlay anchoring and flicker on maps with non-standard extents |
| Dedi-server client missing GRLE | Full sync now includes GRLE layer seed so clients joining a dedicated server get the heatmap |

---

## Bug Fixes — Network

| Fix | Detail |
|-----|--------|
| Unknown setting injection | Server accepted settings keys not in schema — now validated against `SettingsSchema` |
| `nutrientBuffer` dropped in legacy sync | Legacy full-sync path was not serialising `nutrientBuffer`; clients received zeros |
| `userManager` nil crash | Nil guard added for servers where `userManager` initialises after the mod |
| PF re-enable on reconnect | Precision Farming bridge was not re-registered after a client reconnect |

---

## Bug Fixes — HUD / UI

| Fix | Detail |
|-----|--------|
| HUD field averages wrong | Cell aggregation was averaging across all cells including unsprayed ones |
| Edge cell spray credit | Cells at field boundary were not receiving spray credit |
| Cell tooltip values stale | Tooltip was reading from the pre-update snapshot |
| P threshold mismatch | Phosphorus status threshold was inconsistent between HUD and settings |
| Sprayer stats bar | Stats bar was wired to stale cached values instead of live sensor data |
| Trace nutrient filter | Filter was suppressing valid trace readings as zero |
| N/P/K table unwrap in SprayerInfoPanel | `fillTypeData` returned a nested table; panel was rendering the table address string |
| Grain tank detection | Harvester panel used incorrect FS25 API for tank capacity query |
| Weed label renamed | Weeds renamed to Weed Risk to clarify the value is pressure/risk, not current presence |
| Protected at 0% | See & Spray panel now shows Protected status when weed pressure reaches exactly 0% |

---

## Bug Fixes — Simulation / Balance

| Fix | Detail |
|-----|--------|
| Variable rate double-reduction | Rate multiplier was applied in both `getSprayerUsage` and `onStartWorkAreaProcessing` — halved effective rate |
| Yield freeze | Under certain crop rotation sequences yield calculation entered a degenerate state |
| Pricing rebalance | Fertilizer purchase prices recalibrated against in-game economy |
| P status threshold | Aligned with N/K thresholds for consistent difficulty scaling |
| Fallow auto-rate | Auto-recovery rate on fallow fields was using a stale daily-tick divisor |
| Cell report % denominator stale | Report pass-percentage was dividing by the wrong snapshot count |
| Compost OM rate | Compost organic-matter contribution was 10x lower than intended |

---

## Bug Fixes — POLIFOSKA / Fill Types

| Fix | Detail |
|-----|--------|
| POLIFOSKA tipping | Liquid POLIFOSKA was registering as solid in the drain-rate table, causing incorrect application |
| Sensor callback polish | Sensor update callback was firing on every frame during idle; now debounced |
| Minimap zoom event leak | Zoom event listener was not removed on cleanup, accumulating handlers across reloads |

---

## Performance

- Fixed FPS drops during spraying with wide boom sprayers (tick-cost profiling pass on spray hooks)
- Removed 2.5 s GRLE write throttle that caused spray trail pixels to drop silently

---

## Localization

- French translation sync (contributed by Seb): 2 missing keys added, 2 new disease/moisture metric keys

---

## Test plan

- [ ] Deploy and start a new save — confirm no Lua errors in log.txt
- [ ] Attach R700i or R975i, spray a field — confirm per-section mist starts/stops with boom sections
- [ ] Fold the boom mid-spray — confirm mist stops immediately on fold
- [ ] Unfold and resume — confirm mist returns without leftover particles
- [ ] Use Smart Sensor — confirm center boom section is suppressed when not needed
- [ ] Apply POLIFOSKA liquid — confirm correct drain rate and nutrient credit
- [ ] Open minimap during spray pass — confirm live GRLE pixels appear
- [ ] Rejoin a dedicated server mid-session — confirm minimap heatmap populated on join
- [ ] Check HUD field averages before and after a spray pass — confirm values update correctly
- [ ] Verify French locale in-game shows no untranslated keys
