### PR TITLE
  fix: SoilHarvesterPanel respects HUD visibility toggle

### DIFF
--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -487,6 +487,7 @@ function SoilHarvesterPanel:draw()
     if not self.initialized then return end
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
+    local sfm = g_SoilFertilityManager; if sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
         if not self.editMode then return end
     end


### PR DESCRIPTION
  ## Summary
  - `SoilHarvesterPanel:draw()` did not check `soilHUD.visible`, causing
    the harvester panel to remain visible after toggling with SF_TOGGLE_HUD (numpad /).
  - Added an early return when `soilHUD.visible` is false.

  ## Steps to reproduce
  1. Enter a harvester with SoilFertilizer active.
  2. Press numpad / to hide the HUD.
  3. The main SoilFertilizer HUD disappears, but the harvester panel stays visible.

  ## Fix
  Added guard in `SoilHarvesterPanel:draw()`:
  ```lua
  local sfm = g_SoilFertilityManager
  if sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end

  Version tested: v2.4.1.0
