### PR TITLE
fix: v2.4.1.1 — spray visuals, overlap prevention, HUD toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.1
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.1.0</version>
+    <version>2.4.1.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -686,9 +686,11 @@ function HookManager:installSprayTypeEffectsHook()
     -- Solid custom types visually match FERTILIZER spreading
     local solidNames  = { "UREA", "AMS", "AN", "MAP", "DAP", "POTASH", "POLIFOSKA",
                           "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }
-    -- Liquid custom types visually match LIQUIDFERTILIZER spraying
-    -- HERBICIDE is included so it gets added to LIQUIDFERTILIZER slots (full-boom spray),
-    -- but it is a vanilla fill type and must NOT be stripped from HERBICIDE-only slots in Pass 2.
+    -- Liquid custom types visually match LIQUIDFERTILIZER spraying.
+    -- HERBICIDE, INSECTICIDE, FUNGICIDE are included so they get injected into LIQUIDFERTILIZER
+    -- slots (Pass 1), giving full-boom coverage on fertilizer sprayers. They are preserved in
+    -- vanillaNames so Pass 2 does NOT strip them from their dedicated crop-protection slots.
+    -- Their visual effects are managed by vanilla updateSprayerEffects (not our custom path).
     -- NOTE: LIQUIDMANURE / MANURE / DIGESTATE are intentionally absent here. They spread via
     -- the game's native slurry/manure systems, not the sprayer effect path — registerCustomSprayTypes
     -- only calibrates their drain rate (issue #311). Do not add them to this effects list.
@@ -703,9 +705,10 @@ function HookManager:installSprayTypeEffectsHook()
     for _, n in ipairs(solidNames)  do solidNameSet[string.upper(n)]  = true end
 
     -- Pass 2 must NOT strip vanilla fill type names from their native slots.
-    -- HERBICIDE is a vanilla type that lives in HERBICIDE-only slots — removing it would
-    -- break herbicide application. Only strip our own custom types.
-    local vanillaNames = { HERBICIDE = true }  -- extend if more vanilla types added to liquidNames
+    -- HERBICIDE is a vanilla spray type; INSECTICIDE/FUNGICIDE have dedicated vehicle
+    -- slots with their own effects. Stripping them empties the slot → getActiveSprayType()
+    -- returns nil → vanilla starts no slot effects → no spray visual.
+    local vanillaNames = { HERBICIDE = true, INSECTICIDE = true, FUNGICIDE = true }
 
     -- Shared helper: walk a vehicle's sprayType entries and inject our names.
     --
@@ -4712,8 +4715,11 @@ function HookManager:installSprayerVisualEffectHook()
         end
     end
     if liqFertIdx then
+        -- INSECTICIDE/FUNGICIDE are intentionally excluded here — they have dedicated vehicle
+        -- slots (preserved by vanillaNames in installSprayTypeEffectsHook) and vanilla manages
+        -- their effects cleanly. Including them in the visual remap bypasses the slot lookup
+        -- and causes effects to never start on sprayers without a LIQUIDFERTILIZER slot.
         for _, name in ipairs({ "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
-                                 "INSECTICIDE", "FUNGICIDE",
                                  "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }) do
             local idx = fm:getFillTypeIndexByName(name)
             if idx then remap[idx] = liqFertIdx end
@@ -4793,12 +4799,16 @@ function HookManager:installSprayerVisualEffectHook()
             local fillType = sprayerSelf:getFillUnitFillType(fillUnitIndex)
             local vanillaFillType = fillType and remap[fillType]
 
-            -- If fill type changed away from custom, stop our managed effects and reset
+            -- If fill type changed away from custom, stop our managed effects and reset.
+            -- Also reset lastEffectsState so vanilla re-evaluates its state machine next
+            -- tick — without this, vanilla thinks effects are still running after our stop
+            -- and won't restart them when switching to a vanilla fill type (HERBICIDE etc.).
             local lastFT = spec._soilManagedFillType
             if lastFT and lastFT ~= fillType then
                 stopSprayerEffects(sprayerSelf)
                 spec._soilManagedFillType = nil
                 spec._soilEffectsActive   = nil
+                spec.lastEffectsState     = nil
             end
 
             -- Fold detection — computed once, applied to both vanilla and custom paths below.
@@ -4820,13 +4830,11 @@ function HookManager:installSprayerVisualEffectHook()
             end
 
             if not vanillaFillType then
-                -- Vanilla fill type (e.g. HERBICIDE): stop effects when stationary OR folded.
-                -- We run AFTER vanilla onUpdateTick (appendedFunction), so we must suppress
-                -- every tick — state-change guards don't work here.
-                local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
-                if speed < 0.5 or isFolded then
-                    stopSprayerEffects(sprayerSelf)
-                end
+                -- Vanilla fill type (HERBICIDE, INSECTICIDE, FUNGICIDE): let vanilla manage
+                -- effects entirely via getAreEffectsVisible() / updateSprayerEffects().
+                -- Calling stopSprayerEffects here desyncs vanilla's lastEffectsState,
+                -- causing effects to stay dark after any pause — vanilla sees no state
+                -- change on recovery and never restarts them.
                 return
             end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1854,8 +1854,11 @@ function HookManager:installSectionStatePreserver()
                 if not saved then return end
                 local vww = sprayerSelf.spec_variableWorkWidth
                 if vww and vww.sections then
+                    -- Don't restore sections suppressed by overlap prevention —
+                    -- they must stay isActive=false so SFNozzleEffects fades them out.
+                    local overlapSup = sprayerSelf._sfOverlapSuppressedSections
                     for i, section in ipairs(vww.sections) do
-                        if saved[i] ~= nil then
+                        if saved[i] ~= nil and (not overlapSup or not overlapSup[i]) then
                             section.isActive = saved[i]
                         end
                     end
@@ -4705,21 +4708,19 @@ function HookManager:installSprayerVisualEffectHook()
     local fertIdx    = fm:getFillTypeIndexByName("FERTILIZER")
     local liqFertIdx = fm:getFillTypeIndexByName("LIQUIDFERTILIZER")
 
-    -- Build remap: custom fill type index → vanilla fill type index (cosmetic only)
+    -- Build remap: custom fill type index → vanilla fill type index (cosmetic only).
+    -- LIQUID types only — solid types are intentionally EXCLUDED.
+    -- Solid types (UREA, AMS, MAP, DAP, etc.) use the vanilla path (remap returns nil →
+    -- just return), which lets vanilla's onEndWorkAreaProcessing/updateSprayerEffects manage
+    -- effects. This matches how AN works (AN is absent from this remap and works correctly).
+    -- The custom path (Sprayer.onUpdateTick appended) fires BEFORE WorkArea.onUpdateTick,
+    -- so getAreEffectsVisible() is false when our code runs — the stop-path kills effects
+    -- every tick for solid types. The vanilla path fires from onEndWorkAreaProcessing, which
+    -- runs AFTER processSprayerArea sets lastSprayTime → effectsVisible = true → effects start.
     local remap = {}
-    if fertIdx then
-        for _, name in ipairs({ "UREA", "AMS", "MAP", "DAP", "POTASH", "POLIFOSKA",
-                                 "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM" }) do
-            local idx = fm:getFillTypeIndexByName(name)
-            if idx then remap[idx] = fertIdx end
-        end
-    end
     if liqFertIdx then
-        -- INSECTICIDE/FUNGICIDE are intentionally excluded here — they have dedicated vehicle
-        -- slots (preserved by vanillaNames in installSprayTypeEffectsHook) and vanilla manages
-        -- their effects cleanly. Including them in the visual remap bypasses the slot lookup
-        -- and causes effects to never start on sprayers without a LIQUIDFERTILIZER slot.
         for _, name in ipairs({ "UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME",
+                                 "HERBICIDE", "INSECTICIDE", "FUNGICIDE",
                                  "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH" }) do
             local idx = fm:getFillTypeIndexByName(name)
             if idx then remap[idx] = liqFertIdx end
@@ -4830,17 +4831,13 @@ function HookManager:installSprayerVisualEffectHook()
             end
 
             if not vanillaFillType then
-                -- Vanilla fill type (HERBICIDE, INSECTICIDE, FUNGICIDE): let vanilla manage
-                -- effects entirely via getAreEffectsVisible() / updateSprayerEffects().
-                -- Calling stopSprayerEffects here desyncs vanilla's lastEffectsState,
-                -- causing effects to stay dark after any pause — vanilla sees no state
-                -- change on recovery and never restarts them.
                 return
             end
 
-            -- Gate on speed: no visual spray when standing still (matches our nutrient hook guard)
-            local speed = (sprayerSelf.getLastSpeed and sprayerSelf:getLastSpeed()) or 0
-            local effectsVisible = sprayerSelf:getAreEffectsVisible() and speed >= 0.5
+            -- getAreEffectsVisible() uses a 100ms window on lastSprayTime; if processSprayerArea
+            -- isn't running (vehicle stopped or empty) that window expires naturally — no speed
+            -- check needed. The speed check broke trailed spreaders whose getLastSpeed() returns 0.
+            local effectsVisible = sprayerSelf:getAreEffectsVisible()
 
             if isFolded then effectsVisible = false end
 

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -428,6 +428,7 @@ function SoilSprayerInfoPanel:draw()
     if not self.initialized then return end
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
+    local sfm = g_SoilFertilityManager; if sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
         if not self.editMode then return end
     end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,14 +24,6 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: Custom fertilizer piles load without texture warnings",
-    "- Fixed: Soil data tracked live per-nozzle during application",
-    "- Fixed: Field edge nozzle sections no longer lose coverage credit",
-    "- Fixed: See & Spray is now a vehicle shop config on JD R700i / R975i",
-    "  (no longer a runtime toggle key)",
-    "- Changed: Field Report dialog removed — detail is in PDA > Farm Overview",
-    "",
-    "v2.4.1.1 — Hotfix",
     "- Fixed: Dry spreader types (UREA, AMS, MAP, DAP, POTASH, etc.) now show",
     "  spreading visual correctly (was invisible before)",
     "- Fixed: HERBICIDE, INSECTICIDE, FUNGICIDE sprayer visuals restored",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -30,6 +30,14 @@ SoilVersionDialog.CHANGELOG = {
     "- Fixed: See & Spray is now a vehicle shop config on JD R700i / R975i",
     "  (no longer a runtime toggle key)",
     "- Changed: Field Report dialog removed — detail is in PDA > Farm Overview",
+    "",
+    "v2.4.1.1 — Hotfix",
+    "- Fixed: Dry spreader types (UREA, AMS, MAP, DAP, POTASH, etc.) now show",
+    "  spreading visual correctly (was invisible before)",
+    "- Fixed: HERBICIDE, INSECTICIDE, FUNGICIDE sprayer visuals restored",
+    "- Fixed: Overlap prevention — outer boom nozzles now correctly fade out",
+    "  when their tip passes over already-sprayed ground on the final swath",
+    "- Fixed: Harvester panel and sprayer info panel now respect HUD toggle (/ key)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixed dry spreader types (UREA, AMS, MAP, DAP, POTASH, etc.) showing no spreading visual — solid types now use the vanilla effects path which fires from `onEndWorkAreaProcessing` after `lastSprayTime` is set
- Fixed HERBICIDE, INSECTICIDE, FUNGICIDE spray visuals not showing — restored to liquid remap so `startSprayerEffects` is called explicitly with `LIQUIDFERTILIZER` index
- Removed `speed >= 0.5` guard from visual effect check — broke trailed spreader implements whose `getLastSpeed()` returns 0
- Fixed overlap prevention not fading out outer boom nozzles over already-sprayed ground — state preserver was blindly restoring all `section.isActive` states, undoing overlap suppression before `SFNozzleEffects:onUpdate()` could read them; preserver now skips sections in `_sfOverlapSuppressedSections`
- Fixed harvester panel and sprayer info panel remaining visible after HUD toggle (numpad /) — merged community PR #572 (Kynuska) and applied the same guard to `SoilSprayerInfoPanel`

## Test plan

- [ ] Solid fertilizer spreader (UREA, AMS, DAP) — verify spreading visual appears
- [ ] Apply HERBICIDE / INSECTICIDE / FUNGICIDE — verify spray mist appears
- [ ] Final field swath — outer boom sections should fade out when tip hits already-sprayed ground
- [ ] Toggle HUD off (numpad /) in harvester and sprayer — both panels should hide