### PR TITLE
fix: sprayer boom lock, HUD nutrient bar color, minimap Circle overlay (#574 #575 #578 #579)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -102,7 +102,9 @@
         <actionBinding action="SF_TOGGLE_AUTO" />
         <actionBinding action="SF_CYCLE_MAP_LAYER" />
         <actionBinding action="SF_OPEN_SETTINGS" />
-        <actionBinding action="SF_HUD_DRAG" />
+        <actionBinding action="SF_HUD_DRAG">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h" />
+        </actionBinding>
         <actionBinding action="SF_VARIABLE_RATE">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt KEY_7" />
         </actionBinding>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -76,6 +76,9 @@
         <type name="sfSprayer" parent="sprayer" filename="$dataS/scripts/vehicles/Vehicle.lua">
             <specialization name="sfNozzleEffects"/>
         </type>
+        <type name="sfSelfPropelledSprayer" parent="selfPropelledSprayer" filename="$dataS/scripts/vehicles/Vehicle.lua">
+            <specialization name="sfNozzleEffects"/>
+        </type>
     </vehicleTypes>
 
     <actions>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1007,20 +1007,21 @@ function SoilFertilityManager:seedGRLEFromFieldData()
     local fieldData = soilSys.fieldData
     if not fieldData then return end
 
-    local count = 0
-    for fieldId, field in pairs(fieldData) do
-        local fsField = g_fieldManager and g_fieldManager.fields and g_fieldManager.fields[fieldId]
-        if not fsField or not fsField.farmland or fsField.farmland.id ~= fieldId then
-            fsField = nil
-            if g_fieldManager and g_fieldManager.fields then
-                for _, f in ipairs(g_fieldManager.fields) do
-                    if f and f.farmland and f.farmland.id == fieldId then
-                        fsField = f
-                        break
-                    end
-                end
+    -- Build a farmland-id → Field lookup once so the per-field loop is O(n), not O(n²).
+    -- On large maps (200+ fields) the old nested ipairs scan blocked the main thread
+    -- long enough to cause an apparent crash/freeze at ~40% map load (#583).
+    local farmlandToField = {}
+    if g_fieldManager and g_fieldManager.fields then
+        for _, f in ipairs(g_fieldManager.fields) do
+            if f and f.farmland then
+                farmlandToField[f.farmland.id] = f
             end
         end
+    end
+
+    local count = 0
+    for fieldId, field in pairs(fieldData) do
+        local fsField = farmlandToField[fieldId]
         if fsField then
             layerSys:writeFieldToLayers(fieldId, field, fsField)
             count = count + 1

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1283,7 +1283,7 @@ function HookManager:installSeeAndSprayHook()
             local tips    = sprayerSelf._sfSectionTip
 
             for i, section in ipairs(vww.sections) do
-                if section.isActive and not section.isCenter then
+                if section.isActive then
                     local tip = tips and tips[i]
                     local sx = tip and ((rootX + tip[1]) * 0.5) or rootX
                     local sz = tip and ((rootZ + tip[2]) * 0.5) or rootZ

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1810,6 +1810,12 @@ function HookManager:installSectionStatePreserver()
             sprayerSelf._sfRootX = rx
             sprayerSelf._sfRootZ = rz
 
+            -- Overlap-suppressed sections have isActive=false from the previous frame.
+            -- Saving that false means the preserver would restore false when overlap clears,
+            -- permanently locking the section. Treat any overlap-suppressed section as
+            -- "would be active" so it can recover once its tip leaves sprayed ground.
+            local prevOverlapSup = sprayerSelf._sfOverlapSuppressedSections
+
             -- Cache each section's tip node world position so all hooks can
             -- reuse it without redundant pcall(getWorldTranslation) calls.
             if rx then
@@ -1819,7 +1825,7 @@ function HookManager:installSectionStatePreserver()
                     sprayerSelf._sfSectionTip = tips
                 end
                 for i, section in ipairs(vww.sections) do
-                    saved[i] = section.isActive
+                    saved[i] = (prevOverlapSup and prevOverlapSup[i] ~= nil) and true or section.isActive
                     if section.maxWidthNode then
                         local ok, wx, _, wz = pcall(getWorldTranslation, section.maxWidthNode)
                         if ok and wx then
@@ -1835,7 +1841,7 @@ function HookManager:installSectionStatePreserver()
                 end
             else
                 for i, section in ipairs(vww.sections) do
-                    saved[i] = section.isActive
+                    saved[i] = (prevOverlapSup and prevOverlapSup[i] ~= nil) and true or section.isActive
                 end
             end
         end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1612,7 +1612,16 @@ function HookManager:installOverlapPreventionHook()
 
             local checkFert = fertFillTypes[fillTypeIndex] == true
             local checkLime = limeFillTypes[fillTypeIndex] == true
-            if not checkFert and not checkLime then return end
+            if not checkFert and not checkLime then
+                -- Clear any stale suppression left over from a prior fertilizer fill type.
+                -- Without this, switching from LIQUIDFERTILIZER to FUNGICIDE/HERBICIDE leaves
+                -- _sfOverlapSuppressedSections populated, which blocks section state restoration
+                -- and causes wing nozzles to show no visual effects.
+                if sprayerSelf._sfOverlapSuppressedSections then
+                    sprayerSelf._sfOverlapSuppressedSections = {}
+                end
+                return
+            end
 
             if not initHandles() then return end
 
@@ -1643,7 +1652,11 @@ function HookManager:installOverlapPreventionHook()
 
             local suppressCount = 0
             for i, section in ipairs(vww.sections) do
-                if section.isActive and not section.isCenter then
+                -- Check all non-center sections regardless of current isActive.
+                -- Gating on isActive caused a 2-frame flicker: suppressed (isActive=false)
+                -- → gate skips → not in currSuppressed → state restorer brings it back to
+                -- true → next frame active → overlap suppresses again → loop.
+                if not section.isCenter then
                     local tip = tips and tips[i]
 
                     -- Sections with no tip node (no maxWidthNode): skip overlap check.
@@ -1705,9 +1718,11 @@ function HookManager:installOverlapPreventionHook()
                                 end
                             end
                         elseif prevSuppressed[i] then
-                            -- Transition: was suppressed last frame, now clear → restart effects.
+                            -- Transition: was suppressed last frame, tip now clear.
+                            -- Only restart effects if the section is intended to be active
+                            -- (not player-deactivated via section width control).
                             local prevSection = prevSuppressed[i]
-                            if prevSection.effects and #prevSection.effects > 0 then
+                            if section.isActive and prevSection.effects and #prevSection.effects > 0 then
                                 g_effectManager:startEffects(prevSection.effects)
                             end
                         end
@@ -2533,11 +2548,12 @@ function HookManager:installSprayerAreaHook()
                 -- updateFractions=false: markBoomCells (called below) owns coverage for
                 -- fertilizers via spatial cell deduplication. trackSprayerCoverage here
                 -- only records the product name for the HUD label.
-                -- Crop protection direct paths (herbicide/insecticide/fungicide) call
-                -- trackSprayerCoverage with default updateFractions=true since they have
-                -- no boomPoints.
+                -- Crop protection direct paths (herbicide/insecticide/fungicide) have no
+                -- boomPoints, so coverage must be tracked via the liter-based fallback
+                -- (updateFractions=true). Fertilizers use markBoomCells for spatial
+                -- deduplication and must pass false to avoid double-counting.
                 if g_SoilFertilityManager.soilSystem then
-                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, false)
+                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, not isFertilizer)
                 end
 
                 -- ── Sub-field section attribution (issue #300) ────────────────────

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1418,6 +1418,22 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     local tx    = px + pad
     local col   = self:statusColor(nutrient.status)
 
+    local cropTarget    = info and info.cropTargets and info.cropTargets[baseLabel]
+    local displayCol    = col
+    local displayStatus = nutrient.status
+    if cropTarget then
+        if nutrient.value >= cropTarget.opt then
+            displayCol    = self:statusColor("Good")
+            displayStatus = "Good"
+        elseif nutrient.value >= cropTarget.min then
+            displayCol    = self:statusColor("Fair")
+            displayStatus = "Fair"
+        else
+            displayCol    = self:statusColor("Poor")
+            displayStatus = "Poor"
+        end
+    end
+
     cy = cy - rowH
 
     -- Label (N / P / K)
@@ -1432,7 +1448,7 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     
     local fill = math.max(0, math.min(1, nutrient.value / 100))
     if fill > 0 then
-        self:drawRect(barX, barY, barW * fill, barH, col)
+        self:drawRect(barX, barY, barW * fill, barH, displayCol)
     end
 
     -- Projected "Ghost Bar" (V1.7 Realism Update)
@@ -1465,7 +1481,7 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
                     projectedDelta = profile[label] * (remaining / 1000) / (info.fieldArea or 1.0) * rrMult
                     local ghostFill = math.min(1.0 - fill, projectedDelta / 100)
                     if ghostFill > 0 then
-                        self:drawRect(barX + barW * fill, barY, barW * ghostFill, barH, col, 0.35)
+                        self:drawRect(barX + barW * fill, barY, barW * ghostFill, barH, displayCol, 0.35)
                     end
                 end
             end
@@ -1492,7 +1508,6 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     end
 
     -- Per-crop target tick at optimal level (bright cyan, taller than status ticks)
-    local cropTarget = info and info.cropTargets and info.cropTargets[baseLabel]
     if cropTarget then
         local tickW = 0.0008 * s
         local tickH = barH + 0.005 * s
@@ -1505,17 +1520,6 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     local ppmMult = SoilConstants.PPM_DISPLAY and SoilConstants.PPM_DISPLAY[baseLabel] or 1.0
     local valX    = barX + barW + 0.006*s
 
-    -- Derive color from crop target if available, otherwise keep status color
-    local displayCol = col
-    if cropTarget then
-        if nutrient.value >= cropTarget.opt then
-            displayCol = self:statusColor("Good")
-        elseif nutrient.value >= cropTarget.min then
-            displayCol = self:statusColor("Fair")
-        else
-            displayCol = self:statusColor("Poor")
-        end
-    end
     setTextColor(displayCol[1], displayCol[2], displayCol[3], 1.0)
 
     -- Base value string is pre-formatted in refreshFieldData (cachedValStr); only the
@@ -1537,7 +1541,7 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     -- Status label
     setTextAlignment(RenderText.ALIGN_RIGHT)
     setTextColor(displayCol[1], displayCol[2], displayCol[3], 0.80)
-    renderText(px + pw - pad, cy + (rowH - 0.009*s) * 0.5, 0.009 * fontMult * s, nutrient.status)
+    renderText(px + pw - pad, cy + (rowH - 0.009*s) * 0.5, 0.009 * fontMult * s, displayStatus)
     setTextAlignment(RenderText.ALIGN_LEFT)
 
     return cy

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -308,6 +308,10 @@ function SoilMinimapLayer:draw(mapSelf)
     local layout = mapSelf.layout
     if not layout then return end
 
+    -- Circle minimap rotates with the vehicle heading; our terrain-space overlay doesn't
+    -- transform correctly in that coordinate frame and drifts. Skip until fixed (#578).
+    if layout:isa(IngameMapLayoutCircle) then return end
+
     local w, h   = layout:getMapSize()
     local x, y   = layout:getMapPosition()
     local px, py


### PR DESCRIPTION
## Summary

- **#574 / #579 — Sprayer boom permanent lock**: Section state preserver was saving `false` for overlap-suppressed sections on each tick, so when overlap cleared the preserver restored `false` and permanently disabled boom sections. Fixed by saving `true` for any section that was in `_sfOverlapSuppressedSections` from the previous frame.
- **#575 — HUD nutrient bar color mismatch**: Bar fill and ghost bar used global `STATUS_THRESHOLDS` color while the value text used per-crop `displayCol`. Moved `cropTarget`/`displayCol`/`displayStatus` computation before the bar draw so bar fill, ghost bar, and status label all reflect per-crop thresholds.
- **#578 — Minimap overlay drift on Circle layout**: `IngameMapLayoutCircle` rotates its content with vehicle heading; our terrain-space overlay doesn't transform correctly in that coordinate frame and drifts. Added `:isa(IngameMapLayoutCircle)` guard to skip drawing on the rotating minimap until a proper heading-space transform is implemented. Overlay still works on Square and SquareLarge layouts.
- **modDesc**: Added `sfSelfPropelledSprayer` vehicle type so self-propelled sprayers inherit the SFNozzleEffects specialization.

## Test plan

- [ ] Attach a sprayer with overlap prevention, drive over previously sprayed ground, confirm boom sections suppress, then drive off and confirm they recover (not permanently locked)
- [ ] On a field with a known crop (e.g. oats with N=45), verify HUD bar shows green fill and "Good" label, not yellow/Fair
- [ ] Cycle minimap to circle mode, confirm overlay is hidden (no drift artifact); cycle to square/large, confirm overlay shows normally