### PR TITLE
fix: sprayer crash + nozzle visual persist + nutrient status threshold (v2.4.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.1
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.2
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.1.1</version>
+    <version>2.4.1.2</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3237,11 +3237,21 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     local thresholds = SoilConstants.STATUS_THRESHOLDS
     local fertThresholds = SoilConstants.FERTILIZATION_THRESHOLDS
 
-    local function nutrientStatus(value, nutrient)
+    local function nutrientStatus(value, nutrient, ct)
         local t = thresholds[nutrient]
         if not t then return "Unknown" end
-        if value < t.poor then return "Poor"
-        elseif value < t.fair then return "Fair"
+        if value < t.poor then return "Poor" end
+        -- When a crop is growing, treat its opt target as the Good threshold if lower
+        -- than the global threshold — so reaching the crop's blue tick always shows Good.
+        local goodAt = t.fair
+        if ct then
+            local nutKey = nutrient == "nitrogen" and "N"
+                        or nutrient == "phosphorus" and "P"
+                        or "K"
+            local entry = ct[nutKey]
+            if entry and entry.opt and entry.opt < goodAt then goodAt = entry.opt end
+        end
+        if value < goodAt then return "Fair"
         else return "Good" end
     end
 
@@ -3364,9 +3374,9 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     return {
         fieldId = fieldId,
         fieldArea = field.fieldArea or 1.0,
-        nitrogen = { value = math.floor(n), status = nutrientStatus(n, "nitrogen") },
-        phosphorus = { value = math.floor(p), status = nutrientStatus(p, "phosphorus") },
-        potassium = { value = math.floor(k), status = nutrientStatus(k, "potassium") },
+        nitrogen = { value = math.floor(n), status = nutrientStatus(n, "nitrogen", cropTargets) },
+        phosphorus = { value = math.floor(p), status = nutrientStatus(p, "phosphorus", cropTargets) },
+        potassium = { value = math.floor(k), status = nutrientStatus(k, "potassium", cropTargets) },
         cropTargets = cropTargets,
         organicMatter = om,
         pH = ph,

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2452,7 +2452,8 @@ function HookManager:installSprayerAreaHook()
             -- Require minimum forward speed (matches WeedSpotSpray.onEndWorkAreaProcessing).
             -- A stationary sprayer drains the tank and consumes liters but covers no ground —
             -- without this guard coverage climbs to 100% without moving.
-            if (self.getLastSpeed and self:getLastSpeed() or 0) < 0.5 then return end
+            local _spd = tonumber(self.getLastSpeed and self:getLastSpeed()) or 0
+            if _spd < 0.5 then return end
 
             local success, errorMsg = pcall(function()
                 local fillType = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -329,7 +329,7 @@ function SFNozzleEffects:onUpdate(dt, isActiveForInput, isActiveForInputIgnoreSe
 
     -- Update per-nozzle active state (also triggers fade direction transitions).
     local isTurnedOn = self:getIsTurnedOn()
-    local lastSpeed  = (self.getLastSpeed and self:getLastSpeed()) or 0
+    local lastSpeed  = tonumber(self.getLastSpeed and self:getLastSpeed()) or 0
     self:updateExtendedSprayerNozzleEffectsState(spec.sprayerEffects, dt, isTurnedOn, lastSpeed)
 
     -- Animate shader fade transitions for any nozzle with an effect node.

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,12 +24,12 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: Dry spreader types (UREA, AMS, MAP, DAP, POTASH, etc.) now show",
-    "  spreading visual correctly (was invisible before)",
-    "- Fixed: HERBICIDE, INSECTICIDE, FUNGICIDE sprayer visuals restored",
-    "- Fixed: Overlap prevention — outer boom nozzles now correctly fade out",
-    "  when their tip passes over already-sprayed ground on the final swath",
-    "- Fixed: Harvester panel and sprayer info panel now respect HUD toggle (/ key)",
+    "- Fixed: Crash when turning on a sprayer — attempt to compare boolean < number",
+    "  (getLastSpeed returned non-numeric value on some vehicles)",
+    "- Fixed: Spray nozzle visuals no longer persist after sprayer stops",
+    "  (same root cause as the crash above)",
+    "- Fixed: Nutrient status 'Good' now aligns with the crop's blue-tick optimum",
+    "  (reaching the crop target no longer shows 'Fair')",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#591 / #587 — Sprayer crash + nozzle visuals persist**: `getLastSpeed()` returns a boolean on some modded vehicles, causing `attempt to compare boolean < number`. Wrapped both call sites in `tonumber()` — `SFNozzleEffects.lua` and `HookManager.lua`. The same crash also prevented the effect-clearing code from running, so spray nozzle visuals persisted after stopping. One root cause, two symptoms, one fix.
- **#575 — Field stays 'Fair' at crop blue-tick optimum**: `nutrientStatus()` used fixed global thresholds (nitrogen.fair=50) but some crops have lower optima (oats N.opt=45). Passing `cropTargets` to `nutrientStatus()` now uses `min(globalThreshold, cropOpt)` as the Good boundary, so reaching the crop's own target immediately shows Good.

## Test plan

- [ ] Load a savegame with a custom/modded sprayer — confirm no crash on sprayer activation
- [ ] Spray and stop — confirm nozzle visuals stop immediately
- [ ] Check a field planted with oats/barley/rye at N≈45 — confirm HUD shows Good, not Fair