### PR TITLE
fix: v2.4.1.3 — outer boom visuals, overlay blank, imperial units, herbicide guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.2
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.3
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.1.2</version>
+    <version>2.4.1.3</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1404,6 +1404,10 @@ function SoilFertilitySystem:scanFields()
                 if self.layerSystem and self.layerSystem.available and farmlandObj then
                     self.layerSystem:readFieldFromLayers(farmlandId, self.fieldData[farmlandId], farmlandObj)
                 end
+                local farmlandOwner2 = g_farmlandManager:getFarmlandOwner(farmlandId)
+                if farmlandOwner2 and farmlandOwner2 > 0 then
+                    self:_addToActiveSet(farmlandId)
+                end
                 fieldCount = fieldCount + 1
                 SoilLogger.debug("Secondary scan caught missed farmland %d (%.2f ha)", farmlandId, flArea)
             end
@@ -2076,9 +2080,13 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
             -- 1-2 days — reading it would overwrite the pressure reduction from onHerbicideApplied.
             -- Under protection, or when herbicide was applied today (even partial coverage), only
             -- allow pressure to decrease — never let the daily weedFactor read undo a reduction.
-            local herbicideAppliedToday = self.herbicideDailyApplied and
-                self.herbicideDailyApplied[fieldId] and
-                self.herbicideDailyApplied[fieldId].day == currentDay
+            -- herbicideAppliedDay is set by onHerbicideApplied (FERTILIZER_PROFILES path);
+            -- herbicideDailyApplied is set by the direct-application path — check both.
+            local herbicideAppliedToday =
+                (self.herbicideDailyApplied and
+                 self.herbicideDailyApplied[fieldId] and
+                 self.herbicideDailyApplied[fieldId].day == currentDay)
+                or (self.herbicideAppliedDay[fieldId] == currentDay)
             local target = math.max(0, math.min(100, gameWeedFactor * 100))
             if (field.herbicideDaysLeft or 0) > 0 or herbicideAppliedToday then
                 -- Under herbicide protection: only allow pressure to decrease

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -398,6 +398,12 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
 
     local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
 
+    -- Passes 1-3 and See & Spray threshold checks only apply when at least one See & Spray
+    -- feature is purchased.  Without it every active VWW section sprays normally, matching
+    -- vanilla behaviour (all nozzles on regardless of field-boundary or nutrient state).
+    local hasAny = spec.seeSprayWeed or spec.seeSprayPest or spec.seeSprayDisease
+    if not hasAny then return isTurnedOn, 1 end
+
     -- Resolve fill type once — shared by Pass 3 nutrient check and See & Spray below.
     local sprayerSpec = self.spec_sprayer
     local wap = sprayerSpec and sprayerSpec.workAreaParameters
@@ -406,6 +412,8 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
     if fillTypeIndex and fillTypeIndex ~= 0 then
         ft = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
     end
+
+    if not ft then return isTurnedOn, 1 end
 
     -- Probe nozzle world position once — reused for all three passes below.
     local probeX, probeZ
@@ -436,11 +444,11 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
         end
 
         -- Pass 3: nutrient adequacy — suppress visual when this cell already has enough
-        -- of every nutrient the current fill type contributes. No vehicle config needed.
+        -- of every nutrient the current fill type contributes.
         -- Suppresses only when ALL contributing criteria are met: a DAP nozzle over a
         -- high-N/low-P cell keeps spraying for the P benefit even if N is already full.
         local sfm = g_SoilFertilityManager
-        local prof = ft and SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[ft.name]
+        local prof = SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[ft.name]
         if sfm and sfm.soilSystem and prof then
             local fieldId = spec._sfFieldId
             local fd = fieldId and sfm.soilSystem.fieldData[fieldId]
@@ -467,12 +475,6 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
             end
         end
     end
-
-    -- See & Spray: only active when the vehicle was purchased with that capability.
-    local hasAny = spec.seeSprayWeed or spec.seeSprayPest or spec.seeSprayDisease
-    if not hasAny then return isTurnedOn, 1 end
-
-    if not ft then return isTurnedOn, 1 end
 
     local ssCfg = SoilConstants.SEE_AND_SPRAY
     local isPest    = spec.seeSprayPest    and SoilConstants.PEST_PRESSURE.INSECTICIDE_TYPES[ft.name]

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -143,14 +143,31 @@ local function _rateString(profileKey, nutrientKey, deficit, rrMult, fieldArea)
     local baseRate = SoilConstants.SPRAYER_RATE.BASE_RATES[profileKey]
     if not profile or not profile[nutrientKey] or profile[nutrientKey] == 0 then return nil end
 
-    local coeff    = profile[nutrientKey]
+    local coeff     = profile[nutrientKey]
     local ratePerHa = deficit * 1000 / (coeff * rrMult)
     local total     = ratePerHa * fieldArea
-    local unit      = (baseRate and baseRate.unit == "dry") and "kg/ha" or "L/ha"
+    local isDry     = baseRate and baseRate.unit == "dry"
+    local useImp    = g_SoilFertilityManager and g_SoilFertilityManager.settings
+                        and g_SoilFertilityManager.settings.useImperialUnits
 
-    return string.format("%s %d %s (%d %s)",
-        profileKey, math.ceil(ratePerHa), unit,
-        math.ceil(total), (unit == "kg/ha") and "kg" or "L")
+    local displayRate, displayTotal, unit, totalUnit
+    if useImp then
+        if isDry then
+            displayRate  = math.ceil(ratePerHa * SoilConstants.KG_PER_HA_TO_LB_PER_AC)
+            displayTotal = math.ceil(total * 2.20462)
+            unit, totalUnit = "lb/ac", "lb"
+        else
+            displayRate  = math.ceil(ratePerHa * SoilConstants.L_PER_HA_TO_GAL_PER_AC)
+            displayTotal = math.ceil(total * 0.26417)
+            unit, totalUnit = "gal/ac", "gal"
+        end
+    else
+        displayRate  = math.ceil(ratePerHa)
+        displayTotal = math.ceil(total)
+        unit, totalUnit = isDry and "kg/ha" or "L/ha", isDry and "kg" or "L"
+    end
+
+    return string.format("%s %d %s (%d %s)", profileKey, displayRate, unit, displayTotal, totalUnit)
 end
 
 -- Builds a two-product action string for a nutrient, e.g.:

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -30,6 +30,13 @@ SoilVersionDialog.CHANGELOG = {
     "  (same root cause as the crash above)",
     "- Fixed: Nutrient status 'Good' now aligns with the crop's blue-tick optimum",
     "  (reaching the crop target no longer shows 'Fair')",
+    "- Fixed: Outer boom sections now show spray visuals when See & Spray is not purchased",
+    "  (field-boundary check was incorrectly suppressing nozzles over field edges)",
+    "- Fixed: Soil overlay blank on large/custom maps (Evergreen Coast etc.)",
+    "  (secondary field scan now adds owned farmlands to the active set)",
+    "- Fixed: Treatment dialog now shows lb/ac and gal/ac when imperial units is enabled",
+    "- Fixed: Herbicide applied via the FERTILIZER_PROFILES path now correctly",
+    "  prevents the daily weed-pressure update from overwriting the reduction",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Outer boom sections now spray visually when See & Spray is not purchased** — the field-boundary and nutrient-adequacy checks (Passes 1–3) were running before the `hasAny` guard, suppressing outer nozzles on the R975i/R700i whenever they extended past the field edge. Moved the early-exit for non-See&Spray vehicles to before those passes.
- **Soil overlay blank on large/custom maps fixed** — the secondary field scan (catch-all for non-sequential farmland indices on maps like Evergreen Coast) was calling `getOrCreateField` but never calling `_addToActiveSet`, so those fields had data but were excluded from overlay rendering. Fixed with the same ownership check used in the primary scan.
- **Treatment dialog now honours the imperial units setting** — `_rateString` was hardcoded to kg/ha and L/ha. Now converts to lb/ac + lb or gal/ac + gal when `settings.useImperialUnits` is true.
- **Herbicide daily guard now covers both code paths** — `onHerbicideApplied` (FERTILIZER_PROFILES / vanilla HERBICIDE fill types) wrote to `herbicideAppliedDay` while the daily weed-pressure update only checked `herbicideDailyApplied`, so the guard had no effect for those products. Extended the guard condition to check both dicts.

## Test plan

- [ ] R975i/R700i spraying fertilizer without See & Spray purchased: all boom sections show spray visuals
- [ ] R975i/R700i with See & Spray purchased: outer sections suppress correctly when off-field or below pressure threshold
- [ ] Load a save on Evergreen Coast (or any large 64x map): soil overlay renders correctly for all owned fields
- [ ] Toggle imperial units in settings: treatment dialog rates switch between metric and imperial
- [ ] Apply vanilla HERBICIDE to a field: weed pressure reduction survives the next daily update tick