### PR TITLE
v2.4.1.6 — Grass pest exemption + compaction fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.5
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.6
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.1.5</version>
+    <version>2.4.1.6</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1125,8 +1125,33 @@ function SoilFertilityManager:update(dt)
         self.tuningPanel:update()
     end
 
+    -- Compaction: periodic check for local player's heavy vehicle driving over fields
+    if g_currentMission and g_currentMission.isServer then
+        self._compactionTimer = (self._compactionTimer or 0) + dt
+        if self._compactionTimer >= 30000 then
+            self._compactionTimer = 0
+            self:_checkVehicleCompaction()
+        end
+    end
+
     -- Auto-rate control: adjust sprayer rate based on current field soil data
     self:updateAutoRates(dt)
+end
+
+function SoilFertilityManager:_checkVehicleCompaction()
+    if not (self.settings.compactionEnabled and SoilConstants.COMPACTION) then return end
+    if not (self.soilSystem and self.soilSystem.hookManager) then return end
+    local cp      = SoilConstants.COMPACTION
+    local vehicle = self:getCurrentVehicle()
+    if not vehicle or not vehicle.rootNode then return end
+    local okM, totalMass = pcall(function() return vehicle:getTotalMass(false) end)
+    if not (okM and totalMass and totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T) then return end
+    local ok, x, _, z = pcall(getWorldTranslation, vehicle.rootNode)
+    if not (ok and x) then return end
+    local farmlandId = self.soilSystem.hookManager:getFieldIdAtWorldPosition(x, z, false)
+    if farmlandId and farmlandId > 0 then
+        pcall(function() self.soilSystem:onCompaction(farmlandId, x, z) end)
+    end
 end
 
 --- Auto-rate control update — throttled, client-side only.

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -264,8 +264,8 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         end
     end
 
-    -- Pest pressure modifier
-    if self.settings.pestPressure and SoilConstants.PEST_PRESSURE then
+    -- Pest pressure modifier (skip for grassland / non-crop fields, same as weed pressure)
+    if self.settings.pestPressure and SoilConstants.PEST_PRESSURE and not isGrass then
         local pp       = SoilConstants.PEST_PRESSURE
         local pressure = field.pestPressure or 0
         local penalty
@@ -2123,7 +2123,11 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     end
 
     -- ── Pest pressure daily growth ───────────────────────────────────────────
-    if self.settings.pestPressure and SoilConstants.PEST_PRESSURE then
+    -- Skip pest growth for grassland / non-crop fields (grass, drygrass, clover, etc.)
+    local _ys           = SoilConstants.YIELD_SENSITIVITY
+    local _isGrassField = _ys and _ys.NON_CROP_NAMES and
+        _ys.NON_CROP_NAMES[string.lower(field.lastCrop or "")]
+    if self.settings.pestPressure and SoilConstants.PEST_PRESSURE and not _isGrassField then
         local pp = SoilConstants.PEST_PRESSURE
 
         if (field.insecticideDaysLeft or 0) > 0 then

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2083,6 +2083,22 @@ function HookManager:installHarvestHook()
                 end)
             end
 
+            -- Compaction: heavy harvesters compact the soil on each harvest pass
+            if detectedFieldId and detectedX and
+               g_SoilFertilityManager.settings.compactionEnabled and
+               SoilConstants.COMPACTION then
+                local cp = SoilConstants.COMPACTION
+                local rootVeh = combineSelf.rootVehicle or combineSelf
+                local okM, totalMass = pcall(function()
+                    return rootVeh:getTotalMass(false)
+                end)
+                if okM and totalMass and totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T then
+                    pcall(function()
+                        g_SoilFertilityManager.soilSystem:onCompaction(detectedFieldId, detectedX, detectedZ)
+                    end)
+                end
+            end
+
             -- Forward original return values so Cutter.lua gets appliedDelta intact
             return r1, r2, r3, r4, r5
         end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: Pest pressure no longer builds up on grass / forage fields",
+    "  (grass, drygrass, clover, luzerne fields now skip pest growth and yield penalty)",
+    "- Fixed: Soil compaction now accumulates during harvest and heavy vehicle driving",
+    "  (compaction hook extended to harvest passes; periodic check added for driving)",
     "- Fixed: Crash when turning on a sprayer — attempt to compare boolean < number",
     "  (getLastSpeed returned non-numeric value on some vehicles)",
     "- Fixed: Spray nozzle visuals no longer persist after sprayer stops",


### PR DESCRIPTION
## Summary

- **Fixed #590:** Pest pressure no longer builds on grass/forage fields (grass, drygrass, clover, luzerne). These fields now skip both daily pest growth and the pest yield penalty, matching the existing weed pressure exemption.
- **Fixed #589:** Soil compaction now accumulates correctly. Extended the compaction hook to fire on every harvest pass (combines are always heavy), and added a 30-second periodic check in the update loop for heavy vehicles (>= 8t) driving over fields.

## Test plan
- [ ] Drive a heavy harvester over a field 3+ times — check compaction value rises via `SoilFieldInfo`
- [ ] Drive a heavy tractor over a field without implements — compaction should rise after ~30 seconds
- [ ] Mow a grass field — pest pressure should stay at 0 (never grow)
- [ ] Apply insecticide to a grass field — should have no effect (no pest growth to suppress)
- [ ] Verify non-grass crop fields still accumulate pest pressure normally