### PR TITLE
fix: LIME/GYPSUM fill unit gaps; Treatment Dialog crash; spray visuals; restore Smart Sensor panel

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -335,12 +335,9 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField.sessionLastProduct      = nil
         harvestField._farmlandAreaConfirmed  = nil  -- re-confirm on next session's first spray (#507)
         harvestField.sprayTrailPts           = nil
-
-        -- Clear the frozen yield modifier now that the harvest session is complete.
-        -- The freeze exists to prevent mid-pass modifier drops (#556); once onHarvest
-        -- fires the session is over and the snapshot must not carry into the next season.
-        harvestField.frozenYieldModifier  = nil
-        harvestField.frozenYieldFruitType = nil
+        -- frozenYieldModifier is NOT cleared here (#598): onHarvest fires per-cut, so
+        -- clearing here defeats the freeze and causes yield to drop with each combine pass.
+        -- The freeze is cleared once per game day in _processOneDailyField instead.
     end
 
     SoilLogger.debug("Harvest: Field %d, Crop %d, %.0fL (biological), area=%.1f", fieldId, fruitTypeIndex, liters, area or 0)
@@ -1940,6 +1937,12 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     field._covLastX               = nil
     field._covLastZ               = nil
     field._farmlandAreaConfirmed  = nil
+
+    -- Clear the yield-modifier freeze from the previous harvest session (#598).
+    -- Frozen on the first cut of a harvest pass and held until the next game day so
+    -- that per-cut nutrient depletion does not cause yield to drop mid-harvest (#556).
+    field.frozenYieldModifier  = nil
+    field.frozenYieldFruitType = nil
 
     -- ── Compaction natural decay ─────────────────────────────────────────────
     if self.settings.compactionEnabled and SoilConstants.COMPACTION then

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3309,11 +3309,13 @@ function HookManager:installFillUnitHookEarly()
     end
 
     local solidNames         = {"UREA", "AN", "AMS", "MAP", "DAP", "POTASH", "POLIFOSKA",
-                                 "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM"}
+                                 "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM", "LIME"}
     local liquidNames        = {"UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "INSECTICIDE", "FUNGICIDE",
                                 "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH"}
     -- Organic dry types also work in manure spreaders (MANURE fill-unit base)
     local manureCompatNames  = {"COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE"}
+    -- GYPSUM is physically applied the same way as lime; inject it into dedicated lime spreaders
+    local limeCompatNames    = {"GYPSUM"}
 
     local original = FillUnit.onPostLoad
     FillUnit.onPostLoad = Utils.prependedFunction(original, function(vehicleSelf)
@@ -3322,6 +3324,7 @@ function HookManager:installFillUnitHookEarly()
         local fertIdx    = fm:getFillTypeIndexByName("FERTILIZER")
         local liqFertIdx = fm:getFillTypeIndexByName("LIQUIDFERTILIZER")
         local manureIdx  = fm:getFillTypeIndexByName("MANURE")
+        local limeIdx    = fm:getFillTypeIndexByName("LIME")
         local spec = vehicleSelf.spec_fillUnit
         if not spec or not spec.fillUnits then return end
         for _, fu in pairs(spec.fillUnits) do
@@ -3329,6 +3332,7 @@ function HookManager:installFillUnitHookEarly()
                 local addSolid  = fertIdx    and fu.supportedFillTypes[fertIdx]
                 local addLiquid = liqFertIdx and fu.supportedFillTypes[liqFertIdx]
                 local addManure = manureIdx  and fu.supportedFillTypes[manureIdx]
+                local addLime   = limeIdx    and fu.supportedFillTypes[limeIdx]
                 if addSolid then
                     for _, name in ipairs(solidNames) do
                         local idx = fm:getFillTypeIndexByName(name)
@@ -3343,6 +3347,12 @@ function HookManager:installFillUnitHookEarly()
                 end
                 if addManure then
                     for _, name in ipairs(manureCompatNames) do
+                        local idx = fm:getFillTypeIndexByName(name)
+                        if idx then fu.supportedFillTypes[idx] = true end
+                    end
+                end
+                if addLime then
+                    for _, name in ipairs(limeCompatNames) do
                         local idx = fm:getFillTypeIndexByName(name)
                         if idx then fu.supportedFillTypes[idx] = true end
                     end
@@ -3423,25 +3433,31 @@ function HookManager:installFillUnitHook()
     -- CHICKEN_MANURE (organic dry products) were accepted by trailers (which
     -- support both) but rejected by dedicated spreaders (MANURE-only fill unit).
     local manureIndex = fm:getFillTypeIndexByName("MANURE")
+    local limeIndex   = fm:getFillTypeIndexByName("LIME")
 
     local solidNames  = {"UREA", "AN", "AMS", "MAP", "DAP", "POTASH", "POLIFOSKA",
-                          "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM"}
+                          "COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE", "GYPSUM", "LIME"}
     local liquidNames = {"UAN32", "UAN28", "ANHYDROUS", "STARTER", "LIQUIDLIME", "INSECTICIDE", "FUNGICIDE",
                          "LIQUID_UREA", "LIQUID_AMS", "LIQUID_MAP", "LIQUID_DAP", "LIQUID_POTASH"}
     -- Organic dry types also work in manure spreaders (MANURE fill-unit base).
     local manureCompatNames = {"COMPOST", "BIOSOLIDS", "CHICKEN_MANURE", "PELLETIZED_MANURE"}
+    -- GYPSUM is physically applied the same way as lime; inject into dedicated lime spreaders.
+    local limeCompatNames   = {"GYPSUM"}
     -- Store for deferred re-patch (dedi server timing fix)
     self._fuSolidNames  = solidNames
     self._fuLiquidNames = liquidNames
     self._fuManureCompatNames = manureCompatNames
+    self._fuLimeCompatNames   = limeCompatNames
     self._fuFertIndex    = fertIndex
     self._fuLiqFertIndex = liqFertIndex
     self._fuManureIndex  = manureIndex
+    self._fuLimeIndex    = limeIndex
     self._fuFm           = fm
 
-    local solidIndices       = {}
-    local liquidIndices      = {}
+    local solidIndices        = {}
+    local liquidIndices       = {}
     local manureCompatIndices = {}
+    local limeCompatIndices   = {}
     for _, name in ipairs(solidNames) do
         local idx = fm:getFillTypeIndexByName(name)
         if idx then table.insert(solidIndices, idx) end
@@ -3453,6 +3469,10 @@ function HookManager:installFillUnitHook()
     for _, name in ipairs(manureCompatNames) do
         local idx = fm:getFillTypeIndexByName(name)
         if idx then table.insert(manureCompatIndices, idx) end
+    end
+    for _, name in ipairs(limeCompatNames) do
+        local idx = fm:getFillTypeIndexByName(name)
+        if idx then table.insert(limeCompatIndices, idx) end
     end
 
     -- Category-based indices: safety net for fill types in our fillTypes.xml not yet in solidNames
@@ -3485,6 +3505,8 @@ function HookManager:installFillUnitHook()
                 local addLiquid = liqFertIndex and fillUnit.supportedFillTypes[liqFertIndex]
                 -- Manure spreaders support MANURE; enable organic dry types for them too
                 local addManure = manureIndex  and fillUnit.supportedFillTypes[manureIndex]
+                -- Dedicated lime spreaders support LIME; enable GYPSUM for them too
+                local addLime   = limeIndex    and fillUnit.supportedFillTypes[limeIndex]
                 if addSolid then
                     for _, idx in ipairs(solidIndices) do
                         fillUnit.supportedFillTypes[idx] = true
@@ -3497,6 +3519,11 @@ function HookManager:installFillUnitHook()
                 end
                 if addManure then
                     for _, idx in ipairs(manureCompatIndices) do
+                        fillUnit.supportedFillTypes[idx] = true
+                    end
+                end
+                if addLime then
+                    for _, idx in ipairs(limeCompatIndices) do
                         fillUnit.supportedFillTypes[idx] = true
                     end
                 end
@@ -3536,8 +3563,9 @@ function HookManager:installFillUnitHook()
 
     -- Build customToBase: custom fill type index → vanilla base type index.
     -- Used by getFillUnitSupportsFillType hook below.
-    local customToBase  = {}
+    local customToBase   = {}
     local customToManure = {}  -- organic dry types that also fit in MANURE-based fill units
+    local customToLime   = {}  -- lime-compatible types (GYPSUM) that fit in LIME-based fill units
     if fertIndex then
         for _, idx in ipairs(solidIndices) do
             customToBase[idx] = fertIndex
@@ -3553,6 +3581,11 @@ function HookManager:installFillUnitHook()
             customToManure[idx] = manureIndex
         end
     end
+    if limeIndex then
+        for _, idx in ipairs(limeCompatIndices) do
+            customToLime[idx] = limeIndex
+        end
+    end
 
     -- Hook getFillUnitSupportsFillType so Dischargeable:dischargeToObject (vehicle-to-vehicle
     -- auger wagon → spreader, tanker → sprayer, etc.) passes the fill type check for our
@@ -3561,7 +3594,7 @@ function HookManager:installFillUnitHook()
     -- table. Wrapping the method directly is the belt-and-suspenders fix.
     --
     -- Logic: if the vehicle supports the corresponding vanilla base type (FERTILIZER or
-    -- LIQUIDFERTILIZER or MANURE), it also supports the matching custom type.
+    -- LIQUIDFERTILIZER or MANURE or LIME), it also supports the matching custom type.
     if FillUnit.getFillUnitSupportsFillType then
         local origGetSupports = FillUnit.getFillUnitSupportsFillType
         FillUnit.getFillUnitSupportsFillType = function(vehicleSelf, fillUnitIndex, fillType)
@@ -3577,6 +3610,11 @@ function HookManager:installFillUnitHook()
             -- Organic dry types (BIOSOLIDS, CHICKEN_MANURE) also fit MANURE-based fill units.
             local manureBase = customToManure[fillType]
             if manureBase and origGetSupports(vehicleSelf, fillUnitIndex, manureBase) then
+                return true
+            end
+            -- GYPSUM fits LIME-based fill units (dedicated lime spreaders).
+            local limeBase = customToLime[fillType]
+            if limeBase and origGetSupports(vehicleSelf, fillUnitIndex, limeBase) then
                 return true
             end
             -- Category-based fallback: support any fill type in the "fertilizer" /
@@ -3638,8 +3676,9 @@ function HookManager:reapplyFillUnitPatch()
     local fertIdx    = self._fuFertIndex    or fm:getFillTypeIndexByName("FERTILIZER")
     local liqFertIdx = self._fuLiqFertIndex or fm:getFillTypeIndexByName("LIQUIDFERTILIZER")
     local manureIdx  = self._fuManureIndex  or fm:getFillTypeIndexByName("MANURE")
+    local limeIdx    = self._fuLimeIndex    or fm:getFillTypeIndexByName("LIME")
 
-    local solidIdxs, liquidIdxs, manureIdxs = {}, {}, {}
+    local solidIdxs, liquidIdxs, manureIdxs, limeIdxs = {}, {}, {}, {}
     local found, missing = 0, 0
     for _, name in ipairs(self._fuSolidNames or {}) do
         local idx = fm:getFillTypeIndexByName(name)
@@ -3653,6 +3692,10 @@ function HookManager:reapplyFillUnitPatch()
     for _, name in ipairs(self._fuManureCompatNames or {}) do
         local idx = fm:getFillTypeIndexByName(name)
         if idx then table.insert(manureIdxs, idx) end
+    end
+    for _, name in ipairs(self._fuLimeCompatNames or {}) do
+        local idx = fm:getFillTypeIndexByName(name)
+        if idx then table.insert(limeIdxs, idx) end
     end
 
     if found == 0 then return false end  -- still not available
@@ -3669,9 +3712,11 @@ function HookManager:reapplyFillUnitPatch()
                     local addSolid  = fertIdx    and fillUnit.supportedFillTypes[fertIdx]
                     local addLiquid = liqFertIdx and fillUnit.supportedFillTypes[liqFertIdx]
                     local addManure = manureIdx  and fillUnit.supportedFillTypes[manureIdx]
+                    local addLime   = limeIdx    and fillUnit.supportedFillTypes[limeIdx]
                     if addSolid  then for _, idx in ipairs(solidIdxs)  do fillUnit.supportedFillTypes[idx] = true end end
                     if addLiquid then for _, idx in ipairs(liquidIdxs) do fillUnit.supportedFillTypes[idx] = true end end
                     if addManure then for _, idx in ipairs(manureIdxs) do fillUnit.supportedFillTypes[idx] = true end end
+                    if addLime   then for _, idx in ipairs(limeIdxs)   do fillUnit.supportedFillTypes[idx] = true end end
                 end
             end
         end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1678,12 +1678,19 @@ function HookManager:installOverlapPreventionHook()
                             if checkFert then
                                 lvlModifier:setParallelogramWorldCoords(
                                     px, pz, px + 0.1, pz, px, pz + 0.1, DensityCoordType.POINT_POINT_POINT)
-                                local lvl = lvlModifier:executeGet(lvlFilter, nil)
+                                -- Check how many pixels in this area are AT max spray level.
+                                -- executeGet returns (sumPixels, numMatchingPixels, total) — use
+                                -- numMatchingPixels (2nd return) with an EQUAL filter so that
+                                -- multi-pixel areas on high-res maps (16x etc.) don't produce false
+                                -- positives via a sumPixels > 0 test (#600).  Only suppress when
+                                -- the area is FULLY fertilized (at lvlMax), not merely touched.
+                                lvlFilter:setValueCompareParams(DensityValueCompareType.EQUAL, lvlMax)
+                                local _, numAtMax, _ = lvlModifier:executeGet(lvlFilter, nil)
                                 if doLog and i <= 4 then
-                                    SoilLogger.debug("[OverlapPrev]   sec%d px=%.1f pz=%.1f lvl=%s lvlMax=%s",
-                                        i, px, pz, tostring(lvl), tostring(lvlMax))
+                                    SoilLogger.debug("[OverlapPrev]   sec%d px=%.1f pz=%.1f numAtMax=%s lvlMax=%s",
+                                        i, px, pz, tostring(numAtMax), tostring(lvlMax))
                                 end
-                                return lvl ~= nil and lvl > 0
+                                return numAtMax ~= nil and numAtMax > 0
                             elseif checkLime then
                                 stModifier:setParallelogramWorldCoords(
                                     px, pz, px + 0.1, pz, px, pz + 0.1, DensityCoordType.POINT_POINT_POINT)

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -458,6 +458,12 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
         if ok and nx then probeX, probeZ = nx, nz end
     end
 
+    -- Farmland ID resolved from the nozzle probe position (filled by Pass 2).
+    -- Used for the threshold check so the tractor body being on the headland or a road
+    -- does not suppress nozzles that are still over the crop (spec._sfFieldId is cached
+    -- from the vehicle root and can be nil during headland turns).
+    local nozzleFarmId = nil
+
     if probeX then
         -- Passes 1+2: field-boundary checks — See & Spray chemicals only.
         -- Fertiliser outer boom sections crossing the headland must not be gated here.
@@ -472,12 +478,15 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
             end
 
             -- Pass 2: farmland ID — crossing onto an adjacent parcel → suppress.
+            -- Save the validated farmland ID so the threshold check can use the nozzle
+            -- probe position instead of the vehicle-root cache (spec._sfFieldId).
             if g_farmlandManager then
                 local nFarmId = g_farmlandManager:getFarmlandIdAtWorldPosition(probeX, probeZ)
                 local vFarmId = spec._sfFieldId
                 if nFarmId == 0 or (vFarmId and vFarmId > 0 and nFarmId ~= vFarmId) then
                     return false, 1
                 end
+                if nFarmId > 0 then nozzleFarmId = nFarmId end
             end
         end
 
@@ -487,7 +496,7 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
         local sfm3 = g_SoilFertilityManager
         local prof  = SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[ft.name]
         if sfm3 and sfm3.soilSystem and prof then
-            local fieldId3 = spec._sfFieldId
+            local fieldId3 = nozzleFarmId or spec._sfFieldId
             local fd3 = fieldId3 and sfm3.soilSystem.fieldData[fieldId3]
             if fd3 then
                 local cellKey = tostring(math.floor(probeX / CELL_SIZE) * 10000 + math.floor(probeZ / CELL_SIZE))
@@ -518,7 +527,9 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
     local sfm = g_SoilFertilityManager
     if not sfm then return false, 1 end
 
-    local fieldId = spec._sfFieldId
+    -- Prefer the farmland ID resolved from the nozzle probe position (Pass 2).
+    -- Fall back to the vehicle-root cache only when the probe position was unavailable.
+    local fieldId = nozzleFarmId or spec._sfFieldId
     if not fieldId then return false, 1 end
 
     local fd = sfm.soilSystem and sfm.soilSystem.fieldData[fieldId]

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -514,18 +514,19 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
     if not isPest and not isDisease and not isWeed then return isTurnedOn, 1 end
 
     -- See & Spray threshold checks (per-cell using probeNode 1m ahead).
+    -- Fail-closed: suppress the nozzle until a target is positively confirmed.
     local sfm = g_SoilFertilityManager
-    if not sfm then return isTurnedOn, 1 end
+    if not sfm then return false, 1 end
 
     local fieldId = spec._sfFieldId
-    if not fieldId then return true, 1 end
+    if not fieldId then return false, 1 end
 
     local fd = sfm.soilSystem and sfm.soilSystem.fieldData[fieldId]
-    if not fd then return true, 1 end
+    if not fd then return false, 1 end
 
-    if not effectData.probeNode then return true, 1 end
+    if not effectData.probeNode then return false, 1 end
     local pok, px, _, pz = pcall(localToWorld, effectData.probeNode, 0, 0, 1)
-    if not pok then return true, 1 end
+    if not pok then return false, 1 end
 
     local cellKey = tostring(math.floor(px / CELL_SIZE) * 10000 + math.floor(pz / CELL_SIZE))
     local cell    = fd.zoneData and fd.zoneData[cellKey]
@@ -546,18 +547,23 @@ end
 
 -- Field-level See & Spray check for non-custom-nozzle vehicles (hasCustomEffects=false).
 -- Returns true → spray normally; false → suppress (no target pressure in this field).
+-- Fail-closed for See & Spray chemicals: suppress until a target is positively confirmed.
+-- Non-See&Spray fill types (fertilisers) are classified first and always return true.
 local function sfCheckFieldSeeSpraysTarget(spec, ft)
-    local sfm = g_SoilFertilityManager
-    if not sfm then return true end
-    local fieldId = spec._sfFieldId
-    if not fieldId then return true end
-    local fd = sfm.soilSystem and sfm.soilSystem.fieldData[fieldId]
-    if not fd or not ft then return true end
-    local ssCfg = SoilConstants.SEE_AND_SPRAY
+    if not ft then return true end
+    local ssCfg     = SoilConstants.SEE_AND_SPRAY
     local isPest    = spec.seeSprayPest    and SoilConstants.PEST_PRESSURE.INSECTICIDE_TYPES[ft.name]
     local isDisease = spec.seeSprayDisease and SoilConstants.DISEASE_PRESSURE.FUNGICIDE_TYPES[ft.name]
     local isWeed    = spec.seeSprayWeed    and SoilConstants.WEED_PRESSURE.HERBICIDE_TYPES[ft.name]
+    -- Not a See & Spray chemical (e.g. fertiliser) → always spray regardless of field state.
     if not isPest and not isDisease and not isWeed then return true end
+    -- It IS a See & Spray chemical — require a positive confirmation before allowing fluid.
+    local sfm = g_SoilFertilityManager
+    if not sfm then return false end
+    local fieldId = spec._sfFieldId
+    if not fieldId then return false end
+    local fd = sfm.soilSystem and sfm.soilSystem.fieldData[fieldId]
+    if not fd then return false end
     if isPest    and (fd.pestPressure    or 0) >= ssCfg.PEST_THRESHOLD    then return true end
     if isDisease and (fd.diseasePressure or 0) >= ssCfg.DISEASE_THRESHOLD then return true end
     if isWeed    and (fd.weedPressure    or 0) >= ssCfg.WEED_THRESHOLD

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -296,8 +296,8 @@ function SFNozzleEffects:onUpdate(dt, isActiveForInput, isActiveForInputIgnoreSe
     local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
     if not spec.hasCustomEffects then
         -- Non-custom-nozzle vehicles (e.g. Condor) still need the field ID cache when
-        -- See & Spray is purchased so that getAreEffectsVisible / getSprayerUsage can
-        -- suppress effects and consumption when there is no target pressure.
+        -- See & Spray is purchased so that getSprayerUsage can gate consumption
+        -- when there is no target pressure.
         local hasAny = spec.seeSprayWeed or spec.seeSprayPest or spec.seeSprayDisease
         if hasAny then
             spec._sfFieldTimer = spec._sfFieldTimer + dt
@@ -413,6 +413,8 @@ end
 -- Per-nozzle decision: returns (isActive, amountScale).
 -- Checks in order: sprayer state → section active → field boundary → See & Spray threshold.
 function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, isTurnedOn, lastSpeed)
+    local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
+
     if not isTurnedOn                                      then return false, 1 end
     if (lastSpeed or 0) < 0.25                             then return false, 1 end
     if self.movingDirection and self.movingDirection < 0   then return false, 1 end
@@ -422,8 +424,6 @@ function SFNozzleEffects:updateExtendedSprayerNozzleEffectState(effectData, dt, 
         local section = spec_vww.sections[effectData.sectionIndex]
         if section and not section.isActive then return false, 1 end
     end
-
-    local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
 
     -- Passes 1-3 and See & Spray threshold checks only apply when at least one See & Spray
     -- feature is purchased.  Without it every active VWW section sprays normally, matching
@@ -583,19 +583,10 @@ local function sfCheckFieldSeeSpraysTarget(spec, ft)
 end
 
 -- Suppress vanilla spray particle effects — our shader planes handle the visual.
--- For non-custom-nozzle vehicles with See & Spray purchased, suppress when no target.
+-- Non-custom vehicles always delegate to vanilla; usage gating is in getSprayerUsage.
 function SFNozzleEffects:getAreEffectsVisible(superFunc)
     local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
     if spec.hasCustomEffects then return false end
-    local hasAny = spec.seeSprayWeed or spec.seeSprayPest or spec.seeSprayDisease
-    if hasAny then
-        local sprayerSpec = self.spec_sprayer
-        local wap = sprayerSpec and sprayerSpec.workAreaParameters
-        local fillTypeIndex = wap and wap.sprayFillType
-        local ft = (fillTypeIndex and fillTypeIndex ~= 0)
-            and g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
-        if not sfCheckFieldSeeSpraysTarget(spec, ft) then return false end
-    end
     return superFunc(self)
 end
 
@@ -619,7 +610,7 @@ function SFNozzleEffects:getSprayerUsage(superFunc, fillType, dt)
     local spec  = self[SFNozzleEffects.SPEC_TABLE_NAME]
     local hasAny = spec.seeSprayWeed or spec.seeSprayPest or spec.seeSprayDisease
     if spec.hasCustomEffects and hasAny then
-        local _, alpha = self:getNumExtendedSprayerNozzleEffectsActive()
+        local numActive, alpha = self:getNumExtendedSprayerNozzleEffectsActive()
         usage = usage * alpha
         if (self.getIsAIActive ~= nil and self:getIsAIActive()) and usage == 0 then
             usage = 0.0001

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -153,11 +153,11 @@ local function _rateString(profileKey, nutrientKey, deficit, rrMult, fieldArea)
     local displayRate, displayTotal, unit, totalUnit
     if useImp then
         if isDry then
-            displayRate  = math.ceil(ratePerHa * SoilConstants.KG_PER_HA_TO_LB_PER_AC)
+            displayRate  = math.ceil(ratePerHa * SoilConstants.SPRAYER_RATE.KG_PER_HA_TO_LB_PER_AC)
             displayTotal = math.ceil(total * 2.20462)
             unit, totalUnit = "lb/ac", "lb"
         else
-            displayRate  = math.ceil(ratePerHa * SoilConstants.L_PER_HA_TO_GAL_PER_AC)
+            displayRate  = math.ceil(ratePerHa * SoilConstants.SPRAYER_RATE.L_PER_HA_TO_GAL_PER_AC)
             displayTotal = math.ceil(total * 0.26417)
             unit, totalUnit = "gal/ac", "gal"
         end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,8 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: See & Spray no longer drains tank when no target pressure is detected",
+    "  (insecticide/herbicide/fungicide now fail-closed: suppressed until target confirmed)",
     "- Fixed: Pest pressure no longer builds up on grass / forage fields",
     "  (grass, drygrass, clover, luzerne fields now skip pest growth and yield penalty)",
     "- Fixed: Soil compaction now accumulates during harvest and heavy vehicle driving",


### PR DESCRIPTION
Fixes two fill unit hook gaps, a Treatment Dialog crash, invisible spray visuals, and restores the Smart Sensor panel. Bumps to 2.4.1.7.

**#601** - LIME was missing from the solid fill type list so granular spreaders never got it via the hook. Also added a lime spreader gate (same pattern as manure spreaders) so dedicated lime spreaders now accept GYPSUM, including the vehicle-to-vehicle transfer path.

**#595** - Treatment Dialog was reading KG_PER_HA_TO_LB_PER_AC and L_PER_HA_TO_GAL_PER_AC off the top level of SoilConstants but they live under SoilConstants.SPRAYER_RATE. Caused a crash on any mouse event in the dialog when imperial units were enabled.

**Spray visuals** - Vehicles with SFNozzleEffects but no custom shader planes (e.g. Condor_Endurance_II_Edit) had their vanilla spray particles suppressed when See & Spray threshold wasn't met. Since those vehicles have no shader planes to replace them, the result was no visual at all. Fixed so non-custom-nozzle vehicles always let vanilla decide the visuals. See & Spray still gates usage consumption via getSprayerUsage so no product drains when there is no target.

**Smart Sensor panel** - The panel was removed in the See & Spray refactor. Restored and updated to show per-vehicle See & Spray purchase status (weed/pest/disease) from the SFNozzleEffects spec instead of the old toggle states. Live pressure readings show for all three regardless of purchase status. Collapse, drag, and layout persistence work.

## Test plan

- [ ] Granular spreader (FERTILIZER fill unit): LIME shows as a fill option
- [ ] Dedicated lime spreader: GYPSUM shows as a fill option
- [ ] GYPSUM can be transferred into a lime spreader from an auger wagon
- [ ] Treatment Dialog with imperial units on: no crash on hover or click
- [ ] Treatment Dialog with metric units: rates still display correctly
- [ ] Condor (or any non-custom-nozzle sprayer with SFNozzleEffects): spray cloud visible while working
- [ ] Tank still only drains when See & Spray target pressure is met
- [ ] Smart Sensor panel appears in HUD when in a sprayer
- [ ] Panel shows green dot for purchased See & Spray features, grey for not purchased
- [ ] Pressure % shows next to each row when field has pressure > 0