### PR TITLE
fix: restore Smart Sensor panel + bump to 2.4.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.6
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.1.7
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.1.6</version>
+    <version>2.4.1.7</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -154,6 +154,11 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             self.variableRatePanel = SoilVariableRatePanel.new(self.soilSystem, self.settings)
             SoilLogger.info("Variable Rate panel created")
         end
+        -- Smart Sensor panel (See & Spray status)
+        if SoilSmartSensorPanel then
+            self.smartSensorPanel = SoilSmartSensorPanel.new(self.soilSystem, self.settings)
+            SoilLogger.info("Smart Sensor panel created")
+        end
         -- Sprayer Info panel (gap view)
         if SoilSprayerInfoPanel then
             self.sprayerInfoPanel = SoilSprayerInfoPanel.new(self.soilSystem, self.settings)
@@ -550,6 +555,9 @@ function SoilFertilityManager:onMissionLoaded()
 
         if self.variableRatePanel then
             self.variableRatePanel:initialize()
+        end
+        if self.smartSensorPanel then
+            self.smartSensorPanel:initialize()
         end
         if self.sprayerInfoPanel then
             self.sprayerInfoPanel:initialize()
@@ -1376,6 +1384,10 @@ function SoilFertilityManager:delete()
     if self.variableRatePanel then
         self.variableRatePanel:delete()
         self.variableRatePanel = nil
+    end
+    if self.smartSensorPanel then
+        self.smartSensorPanel:delete()
+        self.smartSensorPanel = nil
     end
     if self.sprayerInfoPanel then
         self.sprayerInfoPanel:delete()

--- a/src/main.lua
+++ b/src/main.lua
@@ -58,6 +58,7 @@ source(modDirectory .. "src/utils/UIHelper.lua")
 source(modDirectory .. "src/settings/SoilSettingsUI.lua")
 source(modDirectory .. "src/ui/SoilHUD.lua")
 source(modDirectory .. "src/ui/SoilVariableRatePanel.lua")
+source(modDirectory .. "src/ui/SoilSmartSensorPanel.lua")
 source(modDirectory .. "src/ui/SoilSprayerInfoPanel.lua")
 source(modDirectory .. "src/ui/SoilHarvesterPanel.lua")
 source(modDirectory .. "src/ui/SoilMapOverlay.lua")
@@ -509,6 +510,9 @@ FSBaseMission.draw = Utils.appendedFunction(FSBaseMission.draw, function(mission
     end
     if sfm and sfm.variableRatePanel then
         sfm.variableRatePanel:draw()
+    end
+    if sfm and sfm.smartSensorPanel then
+        sfm.smartSensorPanel:draw()
     end
     if sfm and sfm.sprayerInfoPanel then
         sfm.sprayerInfoPanel:draw()

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -80,13 +80,13 @@ function SoilHUD.new(soilSystem, settings)
     self.animTimer        = 0
 
     -- Sub-panel free positioning (independent mode)
-    self.freePos        = { varRate = {} }
+    self.freePos        = { varRate = {}, smartSensor = {} }
     self.draggingSubKey = nil   -- key into freePos while dragging a sub-panel
     self.subDragOffX    = 0
     self.subDragOffY    = 0
 
     -- Loaded-from-disk collapsed states applied on first panel draw
-    self.savedCollapsed = { varRate = false }
+    self.savedCollapsed = { varRate = false, smartSensor = false }
 
     -- Camera freeze (NPCFavor pattern)
     self.savedCamRotX = nil
@@ -283,11 +283,21 @@ function SoilHUD:saveLayout()
                 xml:setFloat("hudLayout.freePosY_varRate", fp.y)
             end
         end
+        do
+            local fp = self.freePos["smartSensor"]
+            if fp and fp.x ~= nil then
+                xml:setFloat("hudLayout.freePosX_smartSensor", fp.x)
+                xml:setFloat("hudLayout.freePosY_smartSensor", fp.y)
+            end
+        end
 
         -- Sub-panel collapsed states
         local sfm = g_SoilFertilityManager
         if sfm and sfm.variableRatePanel then
             xml:setBool("hudLayout.collapsed_varRate", sfm.variableRatePanel.collapsed)
+        end
+        if sfm and sfm.smartSensorPanel then
+            xml:setBool("hudLayout.collapsed_smartSensor", sfm.smartSensorPanel.collapsed)
         end
 
         xml:save()
@@ -311,10 +321,16 @@ function SoilHUD:loadLayout()
             local y = xml:getFloat("hudLayout.freePosY_varRate", nil)
             if x ~= nil and y ~= nil then self.freePos["varRate"] = { x = x, y = y } end
         end
+        do
+            local x = xml:getFloat("hudLayout.freePosX_smartSensor", nil)
+            local y = xml:getFloat("hudLayout.freePosY_smartSensor", nil)
+            if x ~= nil and y ~= nil then self.freePos["smartSensor"] = { x = x, y = y } end
+        end
 
         -- Sub-panel collapsed states (applied on first draw since panels may not exist yet)
         self.savedCollapsed = {
-            varRate = xml:getBool("hudLayout.collapsed_varRate", false),
+            varRate     = xml:getBool("hudLayout.collapsed_varRate",     false),
+            smartSensor = xml:getBool("hudLayout.collapsed_smartSensor", false),
         }
 
         xml:delete()
@@ -472,6 +488,7 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
         if sfm then
             local subPanels = {
                 { panel = sfm.variableRatePanel, key = "varRate" },
+                { panel = sfm.smartSensorPanel,  key = "smartSensor" },
             }
             for _, sp in ipairs(subPanels) do
                 local p = sp.panel

--- a/src/ui/SoilSmartSensorPanel.lua
+++ b/src/ui/SoilSmartSensorPanel.lua
@@ -199,7 +199,6 @@ function SoilSmartSensorPanel:draw()
 end
 
 function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
-    local sensorMgr  = sfm.sensorManager
     local indMode    = sfm.settings and sfm.settings.independentPanels
 
     local hud = sfm.soilHUD
@@ -319,44 +318,28 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
 
     -- Field data for status readout
     local _, fd = self:getFieldData(sprayer)
-    local vehicleId = sprayer.id
 
-    -- Key hints — empty fallback since SF_SENSOR_* actions are not registered
-    local keyPest    = getActionKey("SF_SENSOR_PEST",    "")
-    local keyDisease = getActionKey("SF_SENSOR_DISEASE", "")
-    local keyNut     = getActionKey("SF_SENSOR_NUTRIENT","")
+    -- See & Spray purchase state from SFNozzleEffects vehicle spec
+    local sfSpec    = SFNozzleEffects and sprayer[SFNozzleEffects.SPEC_TABLE_NAME]
+    local pestOn    = sfSpec and sfSpec.seeSprayPest    or false
+    local diseaseOn = sfSpec and sfSpec.seeSprayDisease or false
+    local weedOn    = sfSpec and sfSpec.seeSprayWeed    or false
 
-    local pestOn    = sensorMgr:isPestEnabled(vehicleId)
-    local diseaseOn = sensorMgr:isDiseaseEnabled(vehicleId)
-    local nutrientOn = sensorMgr:isNutrientEnabled(vehicleId)
-
-    -- Build value strings (fd is a getFieldInfo table, not raw fieldData)
-    local pestVal, diseaseVal, nutVal = "", "", ""
+    -- Pressure readings (shown whenever pressure > 0, regardless of purchased state)
+    local pestVal, diseaseVal, weedVal = "", "", ""
     if fd then
         local pest = fd.pestPressure    or 0
         local dis  = fd.diseasePressure or 0
-        local k    = fd.potassium  and fd.potassium.value  or 0
-        local p    = fd.phosphorus and fd.phosphorus.value or 0
-        local ppm  = SoilConstants.PPM_DISPLAY or { P = 1, K = 1 }
-        if pest <= 0 then
-            pestVal = g_i18n:getText("sf_sensor_no_pressure") or "No pressure"
-        else
-            pestVal = string.format("%.0f%%", pest)
-        end
-        if dis <= 0 then
-            diseaseVal = g_i18n:getText("sf_sensor_no_pressure") or "No pressure"
-        else
-            diseaseVal = string.format("%.0f%%", dis)
-        end
-        nutVal = string.format("K=%d  P=%d",
-            math.floor(k * (ppm.K or 1) + 0.5),
-            math.floor(p * (ppm.P or 1) + 0.5))
+        local weed = fd.weedPressure    or 0
+        pestVal    = pest > 0 and string.format("%.0f%%", pest) or ""
+        diseaseVal = dis  > 0 and string.format("%.0f%%", dis)  or ""
+        weedVal    = weed > 0 and string.format("%.0f%%", weed) or ""
     end
 
     local rows = {
-        { label = g_i18n:getText("sf_sensor_pest"),     on = pestOn,    key = keyPest,    val = pestVal    },
-        { label = g_i18n:getText("sf_sensor_disease"),  on = diseaseOn, key = keyDisease, val = diseaseVal },
-        { label = g_i18n:getText("sf_sensor_nutrient"), on = nutrientOn,key = keyNut,     val = nutVal     },
+        { label = g_i18n:getText("sf_sensor_pest"),    on = pestOn,    val = pestVal    },
+        { label = g_i18n:getText("sf_sensor_disease"), on = diseaseOn, val = diseaseVal },
+        { label = g_i18n:getText("sf_pda_weed_label"), on = weedOn,    val = weedVal    },
     }
 
     local fs     = 0.0075 * s
@@ -385,17 +368,8 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
         setTextColor(labelC[1], labelC[2], labelC[3], labelC[4] or 1.0)
         renderText(tx + 0.010*s, midY - fs * 0.45, fs, row.label)
 
-        -- Key hint (right-aligned, dim) — only shown when a binding exists
-        if row.key and row.key ~= "" then
-            setTextAlignment(RenderText.ALIGN_RIGHT)
-            setTextColor(SoilSmartSensorPanel.C_DIM[1], SoilSmartSensorPanel.C_DIM[2],
-                SoilSmartSensorPanel.C_DIM[3], 0.70)
-            renderText(valX, midY - fsDim * 0.45, fsDim, "[" .. row.key .. "]")
-            setTextAlignment(RenderText.ALIGN_LEFT)
-        end
-
-        -- Value readout when sensor is on
-        if row.on and row.val ~= "" then
+        -- Pressure readout (always shown when > 0)
+        if row.val ~= "" then
             setTextColor(SoilSmartSensorPanel.C_LABEL[1], SoilSmartSensorPanel.C_LABEL[2],
                 SoilSmartSensorPanel.C_LABEL[3], 1.0)
             renderText(tx + 0.010*s, midY - fsDim * 0.45 - fsDim * 1.1, fsDim, row.val)

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -47,6 +47,10 @@ SoilVersionDialog.CHANGELOG = {
     "  (effects and fluid usage now suppressed correctly when no target pressure in field)",
     "- Fixed: JD sprayer outer boom sections now spray fertilizer across the full width",
     "  (field-boundary check was incorrectly suppressing outer sections for fertilizers)",
+    "- Fixed: Spray visuals now show on Condor and other non-custom-nozzle sprayers",
+    "  (vanilla particles were incorrectly suppressed when See & Spray threshold not met)",
+    "- Restored: Smart Sensor panel back on the HUD",
+    "  (shows See & Spray purchase status + live weed/pest/disease pressure per field)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
Restores the Smart Sensor panel to the HUD. Bumps to 2.4.1.7.

The panel was removed in the See & Spray refactor. It's back now, updated to show See & Spray purchase status (weed/pest/disease) from the SFNozzleEffects vehicle spec. Green dot = purchased, grey = not purchased. Live pressure % shows next to each row whenever the field has any pressure. Collapse, drag, and layout persistence are all working.

## Test plan

- [ ] Smart Sensor panel appears in HUD when controlling a sprayer
- [ ] Green dot for purchased See & Spray features, grey for not purchased
- [ ] Pressure % shows next to each row when field has pressure > 0
- [ ] Panel collapses and remembers state
- [ ] Panel drags correctly in independent mode (Shift+H)