### PR TITLE
fix: minimap key in vehicle, pass% reload, layer indicator, panel visibility toggles

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -318,6 +318,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     "rateUpEventId",     "rateDownEventId",
                     "toggleAutoEventId", "vehicleSettingsPanelEventId",
                     "vehicleHudDragEventId", "vehicleMinimapZoomEventId",
+                    "vehicleCycleMapLayerEventId",
                     "sensorPestEventId", "sensorDiseaseEventId", "sensorNutrientEventId",
                     "seeSprayPestEventId", "seeSprayDiseaseEventId", "seeSprayWeedEventId",
                     "variableRateEventId",
@@ -425,6 +426,20 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                         g_SoilFertilityManager.vehicleMinimapZoomEventId = vZoomId
                         binding:setActionEventTextVisibility(vZoomId, false)
                         SoilLogger.debug("Minimap zoom registered in VEHICLE context")
+                    end
+                end
+
+                -- Map layer cycle — VEHICLE context (#609: minimap layers visible while driving)
+                if g_SoilFertilityManager.soilMapOverlay then
+                    local vMapOk, vMapId = binding:registerActionEvent(
+                        InputAction.SF_CYCLE_MAP_LAYER, g_SoilFertilityManager,
+                        g_SoilFertilityManager.onCycleMapLayerInput,
+                        false, true, false, true
+                    )
+                    if vMapOk and vMapId then
+                        g_SoilFertilityManager.vehicleCycleMapLayerEventId = vMapId
+                        binding:setActionEventTextVisibility(vMapId, false)
+                        SoilLogger.debug("Map layer cycle registered in VEHICLE context")
                     end
                 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3598,13 +3598,26 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             initialized = true,
             nutrientBuffer = {},
             zoneData = {},
-            coveredAreaHa = 0,
+            coveredAreaHa = 0,        -- restored below from coverageFraction × fieldArea
             dailyCoverageCells = {},
-            sessionCoverageHa = 0,
+            sessionCoverageHa = 0,    -- restored below
             sessionCoverageFraction = 0,
             sessionCoverageCells = {},
             sessionLastProduct = nil,
         }
+
+        -- Restore coverage tracking so pass% persists across reloads (#608).
+        -- sessionCoverageCells is intentionally left empty (timestamps are session-local),
+        -- but the ha/fraction values are seeded from the saved cumulative coverage so the
+        -- sprayer panel displays the correct % immediately on reload and markBoomCells
+        -- continues accumulating from the right baseline instead of resetting to 0.
+        do
+            local f    = self.fieldData[fieldId]
+            local ha   = f.coverageFraction * f.fieldArea
+            f.coveredAreaHa           = ha
+            f.sessionCoverageHa       = ha
+            f.sessionCoverageFraction = f.coverageFraction
+        end
 
         -- Load daily application throttles
         self.herbicideAppliedDay[fieldId] = getXMLInt(xmlFile, fieldKey .. "#herbicideAppliedDay") or 0

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -615,8 +615,8 @@ SoilConstants.ZONE = {
     CELL_SIZE        = 10,    -- meters per cell side
     CELL_AREA_HA     = 0.01,  -- hectares per cell (10×10 m = 0.01 ha)
     -- A cell stamped less than this many ms ago won't trigger overlap suppression.
-    -- At 3 km/h a sprayer spends ~12 s in one cell; 20 s gives headroom for very slow passes.
-    OVERLAP_GRACE_MS = 20000,
+    -- At 6 km/h a sprayer crosses a 10m cell in ~6 s; 10 s gives safe headroom.
+    OVERLAP_GRACE_MS = 10000,
 }
 
 -- ========================================

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -65,6 +65,20 @@ SettingsSchema.definitions = {
         localOnly = true,
     },
     {
+        id = "showSprayerInfoPanel",
+        type = "boolean",
+        default = true,
+        uiId = "sf_show_sprayer_panel",
+        localOnly = true,
+    },
+    {
+        id = "showHarvesterPanel",
+        type = "boolean",
+        default = true,
+        uiId = "sf_show_harvester_panel",
+        localOnly = true,
+    },
+    {
         id = "hudPosition",
         type = "number",
         default = 1,  -- 1=Top Right, 2=Top Left, 3=Bottom Right, 4=Bottom Left, 5=Center Right, 6=Custom

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1694,68 +1694,61 @@ function HookManager:installOverlapPreventionHook()
             local prevSuppressed = sprayerSelf._sfOverlapSuppressedSections or {}
             local currSuppressed = {}
 
+            -- At >=99% field coverage every section is guaranteed to be on
+            -- already-sprayed ground — suppress everything without a grace period.
+            -- This handles the centre section whose coverage cells are always stamped
+            -- fresh (it's under the vehicle) and never age past graceMs on the current pass.
+            local coverage = fieldEntry and fieldEntry.sessionCoverageFraction or 0
+            local coverageComplete = coverage >= 0.99
+
             local suppressCount = 0
             for i, section in ipairs(vww.sections) do
-                -- Check all non-center sections regardless of current isActive.
-                -- Gating on isActive caused a 2-frame flicker: suppressed (isActive=false)
-                -- → gate skips → not in currSuppressed → state restorer brings it back to
-                -- true → next frame active → overlap suppresses again → loop.
-                if not section.isCenter then
-                    local tip = tips and tips[i]
+                local tip = tips and tips[i]
+                local alreadySprayed = coverageComplete  -- global gate at 99%+
 
-                    -- Sections with no tip node (no maxWidthNode): skip overlap check.
-                    -- Falling back to the root/hitch point causes false positives — on any
-                    -- second pass, the tractor track is already sprayed and all tip-less
-                    -- wing sections would be suppressed, leaving only the center spraying.
-                    if tip then
-                        -- Check ONLY the TIP cell (outermost edge of this section's coverage).
-                        -- If the outer edge's cell was stamped by us this session and the stamp
-                        -- is older than graceMs, the section is fully covered → suppress.
-                        local tx = tip[1]
-                        local tz = tip[2]
+                if not alreadySprayed and tip then
+                    -- Tip-based cell check for partial-overlap suppression (wings).
+                    -- Centre-section cells are stamped fresh (right under the vehicle),
+                    -- so they never age past graceMs on the current pass — skip them here;
+                    -- the coverageComplete gate above catches them at 99%+.
+                    local tx = tip[1]
+                    local tz = tip[2]
+                    local cx = math.floor(tx / zoneCell)
+                    local cz = math.floor(tz / zoneCell)
+                    local cellKey = tostring(cx * 10000 + cz)
+                    local stampMs = coveredCells[cellKey]
+                    alreadySprayed = stampMs ~= nil and (nowMs - stampMs) > graceMs
 
-                        local cx = math.floor(tx / zoneCell)
-                        local cz = math.floor(tz / zoneCell)
-                        local cellKey = tostring(cx * 10000 + cz)
-                        local stampMs = coveredCells[cellKey]
-                        local alreadySprayed = stampMs ~= nil and (nowMs - stampMs) > graceMs
+                    if doLog and i <= 4 then
+                        SoilLogger.debug("[OverlapPrev]   sec%d tip=%.1f,%.1f stampMs=%s graceOk=%s",
+                            i, tx, tz, tostring(stampMs), tostring(alreadySprayed))
+                    end
+                end
 
-                        if doLog and i <= 4 then
-                            SoilLogger.debug("[OverlapPrev]   sec%d tx=%.1f tz=%.1f stampMs=%s graceOk=%s",
-                                i, tx, tz, tostring(stampMs), tostring(alreadySprayed))
-                        end
+                if alreadySprayed then
+                    section.isActive = false
+                    suppressCount = suppressCount + 1
+                    currSuppressed[i] = section
 
-                        if alreadySprayed then
-                            section.isActive = false
-                            suppressCount = suppressCount + 1
-                            currSuppressed[i] = section
+                    if section.effects and #section.effects > 0 then
+                        g_effectManager:stopEffects(section.effects)
+                    end
 
-                            -- Stop section effects (idempotent if already stopped).
-                            if section.effects and #section.effects > 0 then
-                                g_effectManager:stopEffects(section.effects)
-                            end
-
-                            -- ESE per-nozzle shader: force fadeProgress to off {1,-1}.
-                            local eseSpec = sprayerSelf.spec_extendedSprayerEffects
-                            if eseSpec and eseSpec.sprayerEffectsBySection then
-                                local sectionEffects = eseSpec.sprayerEffectsBySection[i]
-                                if sectionEffects then
-                                    for _, ed in ipairs(sectionEffects) do
-                                        if ed.effectNode and ed.fadeCur then
-                                            setShaderParameter(ed.effectNode, "fadeProgress", 1, -1, 0, 0, false)
-                                        end
-                                    end
+                    local eseSpec = sprayerSelf.spec_extendedSprayerEffects
+                    if eseSpec and eseSpec.sprayerEffectsBySection then
+                        local sectionEffects = eseSpec.sprayerEffectsBySection[i]
+                        if sectionEffects then
+                            for _, ed in ipairs(sectionEffects) do
+                                if ed.effectNode and ed.fadeCur then
+                                    setShaderParameter(ed.effectNode, "fadeProgress", 1, -1, 0, 0, false)
                                 end
                             end
-                        elseif prevSuppressed[i] then
-                            -- Transition: was suppressed last frame, tip now clear.
-                            -- Only restart effects if the section is intended to be active
-                            -- (not player-deactivated via section width control).
-                            local prevSection = prevSuppressed[i]
-                            if section.isActive and prevSection.effects and #prevSection.effects > 0 then
-                                g_effectManager:startEffects(prevSection.effects)
-                            end
                         end
+                    end
+                elseif prevSuppressed[i] then
+                    local prevSection = prevSuppressed[i]
+                    if section.isActive and prevSection.effects and #prevSection.effects > 0 then
+                        g_effectManager:startEffects(prevSection.effects)
                     end
                 end
             end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1115,7 +1115,7 @@ function SoilHUD:drawSprayTrail()
     end
 
     local maxDistSq = 200 * 200
-    local half = 0.0025  -- half of 0.005 normalized quad size
+    local half = 0.004  -- slightly larger than original 0.0025
 
     setOverlayColor(self.fillOverlay, 0.25, 0.95, 0.55, 0.38)
     for _, pt in ipairs(field.sprayTrailPts) do

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -487,6 +487,9 @@ function SoilHarvesterPanel:draw()
     if not self.initialized then return end
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
+    local _sfm = g_SoilFertilityManager
+    if _sfm and _sfm.soilHUD and not _sfm.soilHUD.visible then return end
+    if _sfm and _sfm.settings and _sfm.settings.showHarvesterPanel == false then return end
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
         if not self.editMode then return end
     end

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -295,32 +295,32 @@ function SoilMinimapLayer:draw(mapSelf)
         end
         -- Still show the layer indicator in the polygon fallback path
         if layerIdx > 0 then
-            local layout = mapSelf.layout
-            if layout and layout.getMapSize and layout.getMapPosition then
-                local iw, ih = layout:getMapSize()
-                local ix, iy = layout:getMapPosition()
-                self:drawLayerIndicator(ix, iy, iw, ih, layerIdx)
-            end
+            self:drawLayerIndicator(mapSelf:getPosition(), mapSelf:getWidth(), mapSelf:getHeight(), layerIdx)
         end
         return
     end
 
     if layerIdx <= 0 then return end
 
-    local ovEntry = self._overlays[layerIdx]
-    if not ovEntry or not ovEntry.hasShown then return end
-
-    local ov = ovEntry.ov
-    if not ov then return end
-
     -- Map terrain-space → screen rect using the same math the game uses for
     -- its built-in BMP overlay layers (proven in v2.2.5).
     local layout = mapSelf.layout
     if not layout then return end
 
+    -- Draw the layer indicator before any overlay-readiness or layout-type guards
+    -- that might return early. mapSelf inherits HUDElement — getPosition/getWidth/
+    -- getHeight return the minimap widget's screen-space bounds.
+    self:drawLayerIndicator(mapSelf:getPosition(), mapSelf:getWidth(), mapSelf:getHeight(), layerIdx)
+
     -- Circle minimap rotates with the vehicle heading; our terrain-space overlay doesn't
     -- transform correctly in that coordinate frame and drifts. Skip until fixed (#578).
     if layout:isa(IngameMapLayoutCircle) then return end
+
+    local ovEntry = self._overlays[layerIdx]
+    if not ovEntry or not ovEntry.hasShown then return end
+
+    local ov = ovEntry.ov
+    if not ov then return end
 
     local w, h   = layout:getMapSize()
     local x, y   = layout:getMapPosition()
@@ -390,12 +390,6 @@ function SoilMinimapLayer:draw(mapSelf)
         self:drawHarvestTrailDots(mapSelf)
         self:drawTillageTrailDots(mapSelf)
     end
-
-    -- Use the raw widget rect (not the clipped terrain rect) so the label always
-    -- lands in the top-left corner of the minimap widget regardless of zoom/offset.
-    local indW, indH = layout:getMapSize()
-    local indX, indY = layout:getMapPosition()
-    self:drawLayerIndicator(indX, indY, indW, indH, layerIdx)
 end
 
 -- Short labels for each layer index (displayed in minimap corner).

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -285,16 +285,26 @@ function SoilMinimapLayer:draw(mapSelf)
     if mapSelf.isFullscreen then return end
     if g_gui ~= nil and g_gui:getIsGuiVisible() then return end
 
+    local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
+
     if not self._usingDensityLayers then
         -- No GRLE density-map layers on this terrain — hand off to polygon centroid dots.
         local sfm = g_SoilFertilityManager
         if sfm and sfm.soilMapOverlay then
             sfm.soilMapOverlay:onDrawMinimap(mapSelf)
         end
+        -- Still show the layer indicator in the polygon fallback path
+        if layerIdx > 0 then
+            local layout = mapSelf.layout
+            if layout and layout.getMapSize and layout.getMapPosition then
+                local iw, ih = layout:getMapSize()
+                local ix, iy = layout:getMapPosition()
+                self:drawLayerIndicator(ix, iy, iw, ih, layerIdx)
+            end
+        end
         return
     end
 
-    local layerIdx = self.settings and (self.settings.activeMapLayer or 0) or 0
     if layerIdx <= 0 then return end
 
     local ovEntry = self._overlays[layerIdx]
@@ -381,7 +391,11 @@ function SoilMinimapLayer:draw(mapSelf)
         self:drawTillageTrailDots(mapSelf)
     end
 
-    self:drawLayerIndicator(mx, my, mw, mh, layerIdx)
+    -- Use the raw widget rect (not the clipped terrain rect) so the label always
+    -- lands in the top-left corner of the minimap widget regardless of zoom/offset.
+    local indW, indH = layout:getMapSize()
+    local indX, indY = layout:getMapPosition()
+    self:drawLayerIndicator(indX, indY, indW, indH, layerIdx)
 end
 
 -- Short labels for each layer index (displayed in minimap corner).
@@ -400,28 +414,36 @@ local LAYER_LABEL_COLOR = {
     [9]  = {0.80, 0.10, 0.80},  [10] = {0.55, 0.30, 0.10},
 }
 
--- Draws a small "N", "pH", etc. tag in the bottom-left corner of the minimap.
+-- Draws a small "N", "pH", etc. tag in the top-left corner of the minimap widget.
+-- mx/my = bottom-left of the (clipped) minimap rect; mw/mh = size.
 function SoilMinimapLayer:drawLayerIndicator(mx, my, mw, mh, layerIdx)
     local label = LAYER_LABEL[layerIdx]
     if not label then return end
 
     local col = LAYER_LABEL_COLOR[layerIdx] or {1, 1, 1}
-    local sz  = 0.010
-    local pad = 0.004
-    local tx  = mx + pad
-    local ty  = my + pad
+    local sz  = 0.014   -- larger for readability
+    local pad = 0.005
 
-    -- Shadow for legibility
+    -- Top-left corner: y goes up from bottom, so top = my + mh
+    local tx = mx + pad
+    local ty = my + mh - sz - pad
+
+    -- Dark semi-transparent pill background
+    if self._dotOverlay and self._dotOverlay ~= 0 then
+        local bgW = sz * (#label * 0.62 + 0.4)
+        local bgH = sz * 1.35
+        setOverlayColor(self._dotOverlay, 0, 0, 0, 0.52)
+        renderOverlay(self._dotOverlay, tx - pad * 0.5, ty - pad * 0.3, bgW, bgH)
+    end
+
+    -- Text with shadow
     setTextBold(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
-    setTextColor(0, 0, 0, 0.65)
-    renderText(tx + 0.001, ty - 0.001, sz, label)
-
-    -- Coloured label
-    setTextColor(col[1], col[2], col[3], 0.92)
+    setTextColor(0, 0, 0, 0.70)
+    renderText(tx + 0.0008, ty - 0.0008, sz, label)
+    setTextColor(col[1], col[2], col[3], 0.95)
     renderText(tx, ty, sz, label)
 
-    -- Reset
     setTextBold(false)
     setTextColor(1, 1, 1, 1)
     setTextAlignment(RenderText.ALIGN_LEFT)

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -380,6 +380,51 @@ function SoilMinimapLayer:draw(mapSelf)
         self:drawHarvestTrailDots(mapSelf)
         self:drawTillageTrailDots(mapSelf)
     end
+
+    self:drawLayerIndicator(mx, my, mw, mh, layerIdx)
+end
+
+-- Short labels for each layer index (displayed in minimap corner).
+local LAYER_LABEL = {
+    [1]  = "N",        [2]  = "P",      [3]  = "K",
+    [4]  = "pH",       [5]  = "OM",     [6]  = "!",
+    [7]  = "Weed",     [8]  = "Pest",   [9]  = "Disease",
+    [10] = "Compact",
+}
+-- Matching accent colours (same palette as SoilMapOverlay.LAYER_COLORS).
+local LAYER_LABEL_COLOR = {
+    [1]  = {0.40, 0.90, 0.40},  [2]  = {0.40, 0.70, 1.00},
+    [3]  = {0.90, 0.70, 0.25},  [4]  = {0.80, 0.40, 1.00},
+    [5]  = {0.60, 0.35, 0.10},  [6]  = {0.95, 0.25, 0.25},
+    [7]  = {0.20, 0.70, 0.20},  [8]  = {0.85, 0.75, 0.10},
+    [9]  = {0.80, 0.10, 0.80},  [10] = {0.55, 0.30, 0.10},
+}
+
+-- Draws a small "N", "pH", etc. tag in the bottom-left corner of the minimap.
+function SoilMinimapLayer:drawLayerIndicator(mx, my, mw, mh, layerIdx)
+    local label = LAYER_LABEL[layerIdx]
+    if not label then return end
+
+    local col = LAYER_LABEL_COLOR[layerIdx] or {1, 1, 1}
+    local sz  = 0.010
+    local pad = 0.004
+    local tx  = mx + pad
+    local ty  = my + pad
+
+    -- Shadow for legibility
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(0, 0, 0, 0.65)
+    renderText(tx + 0.001, ty - 0.001, sz, label)
+
+    -- Coloured label
+    setTextColor(col[1], col[2], col[3], 0.92)
+    renderText(tx, ty, sz, label)
+
+    -- Reset
+    setTextBold(false)
+    setTextColor(1, 1, 1, 1)
+    setTextAlignment(RenderText.ALIGN_LEFT)
 end
 
 --- Draws earth-brown/tan pixel dots on the minimap for each tilled cell today.

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -130,7 +130,7 @@ local CATEGORIES = {
         sections = {
             {
                 headerKey = "sf_panel_hdr_visibility",
-                items     = { "showHUD", "showWorkTrail", "showFieldInfoBox", "useImperialUnits", "colorblindMode" }
+                items     = { "showHUD", "showWorkTrail", "showSprayerInfoPanel", "showHarvesterPanel", "showFieldInfoBox", "useImperialUnits", "colorblindMode" }
             },
             {
                 headerKey = "sf_panel_hdr_hud_style",
@@ -195,8 +195,10 @@ local SETTING_DESCS = {
     diseasePressure   = "sf_desc_diseasePressure",
     diseaseMoisture   = "sf_desc_diseaseMoisture",
     compactionEnabled = "sf_desc_compactionEnabled",
-    showHUD           = "sf_desc_showHUD",
-    showWorkTrail     = "sf_desc_showWorkTrail",
+    showHUD                = "sf_desc_showHUD",
+    showWorkTrail          = "sf_desc_showWorkTrail",
+    showSprayerInfoPanel   = "sf_desc_showSprayerInfoPanel",
+    showHarvesterPanel     = "sf_desc_showHarvesterPanel",
     useImperialUnits  = "sf_desc_useImperialUnits",
     hudColorTheme     = "sf_desc_hudColorTheme",
     hudFontSize       = "sf_desc_hudFontSize",

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -429,6 +429,7 @@ function SoilSprayerInfoPanel:draw()
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
     local sfm = g_SoilFertilityManager; if sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end
+    if sfm and sfm.settings and sfm.settings.showSprayerInfoPanel == false then return end
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
         if not self.editMode then return end
     end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Solo &amp; Fertilizante" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar sobreposição HUD de info de solo (F8 para alternar temporariamente)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posição HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Escolha onde o HUD de info de solo aparece na tela" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Canto superior direito" eh="5f9f6784" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Sòl i fertilitzants" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Mostra/amaga la superposició de l'HUD d'informació del sòl (F8 per alternar temporalment)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posició de l'HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Trieu on apareix l'HUD d'informació del sòl a la pantalla" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="A dalt a la dreta" eh="5f9f6784" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Půda &amp; Hnojivo" eh="f31197fb" />
@@ -43,6 +43,10 @@
     <e k="sf_show_mini_report_long" v="Zobrazit/skrýt překryv zprávy o buňce na minimapě" eh="9f57fb65" />
     <e k="sf_show_work_trail_short" v="Stopa práce" />
     <e k="sf_show_work_trail_long" v="Zobrazit/skrýt tečky stopy postřiku a sklizně ve světě a na minimapě" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Pozice HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Vyberte, kde se na obrazovce zobrazí HUD s informacemi o půdě" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Vpravo nahoře" eh="5f9f6784" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Jord &amp; Gødning" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Vis/skjul jord-HUD-overlejringen (F8 for midlertidigt skift)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD-position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Vælg hvor jord-HUD'et vises på skærmen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Øverst til højre" eh="5f9f6784" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Boden &amp; Dünger" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Boden-Info-HUD ein-/ausblenden (F8 zum temporären Umschalten)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD-Position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Wählen Sie, wo das Boden-Info-HUD auf dem Bildschirm erscheint" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Oben rechts" eh="5f9f6784" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suelo y Fertilizante" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar la superposición HUD de información del suelo (F8 para alternar temporalmente)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posición del HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Elegir dónde aparece el HUD de información del suelo en pantalla" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Arriba Derecha" eh="5f9f6784" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Show/hide the soil info HUD overlay (F8 to toggle temporarily)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD Position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Choose where the soil info HUD appears on screen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Top Right" eh="5f9f6784" />
@@ -604,6 +608,8 @@
     <e k="sf_desc_showNotifications" v="In-game soil status notifications" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="Show the soil HUD overlay" eh="fa8b9224" />
     <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
+    <e k="sf_desc_showSprayerInfoPanel" v="Show the sprayer nutrient panel when driving a sprayer" />
+    <e k="sf_desc_showHarvesterPanel" v="Show the harvester grain tank status panel when harvesting" />
     <e k="sf_desc_hudPosition" v="HUD preset anchor position" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Color palette for HUD elements" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD text size" eh="48a6fc15" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suelo y fertilizante" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar la superposición HUD de información del suelo (F8 para alternar temporalmente)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posición del HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Elegir dónde aparece el HUD de información del suelo en pantalla" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Arriba derecha" eh="5f9f6784" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Sol et engrais" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Afficher/masquer l'incrustation HUD d'info sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Position du HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Choisir où le HUD d'info sol apparaît à l'écran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Haut droite" eh="5f9f6784" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Maaperä ja lannoitus" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Näytä/piilota maaperätietojen HUD (F8 tilapäiseen vaihtoon)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUDin sijainti" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Valitse missä maaperätietojen HUD näkyy näytöllä" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Yläoikea" eh="5f9f6784" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Sol &amp; Engrais" eh="f31197fb" />
@@ -41,6 +41,10 @@
     <e k="sf_show_hud_long" v="Afficher/masquer le HUD d'information du sol (F8 pour basculer temporairement)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Position du HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Choisir où afficher le HUD du sol à l'écran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Haut droite" eh="5f9f6784" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Talaj &amp; Műtrágya" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Talajinformáció HUD átfedés megjelenítése/elrejtése (F8 az ideiglenes váltáshoz)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD pozíció" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Válassza ki, hol jelenjen meg a talajinformáció HUD a képernyőn" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Jobb felső" eh="5f9f6784" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Tanah &amp; Pupuk" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Tampilkan/sembunyikan overlay HUD info tanah (F8 untuk beralih sementara)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posisi HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Pilih di mana HUD info tanah muncul di layar" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Kanan Atas" eh="5f9f6784" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Suolo &amp; Fertilizzazione" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Mostra/nascondi overlay HUD info suolo (F8 per alternare temporaneamente)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posizione HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Scegli dove appare l'HUD info suolo sullo schermo" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="In alto a destra" eh="5f9f6784" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="土壌と肥料" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="土壌情報HUDオーバーレイを表示/非表示にします（F8で一時的に切替）" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUDの位置" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="土壌情報HUDを画面のどこに表示するか選択します" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="右上" eh="5f9f6784" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="토양 및 비료" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="토양 정보 HUD 오버레이 표시/숨기기 (F8 키로 일시 전환 가능)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD 위치" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="화면에 토양 정보 HUD가 표시될 위치 선택" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="우측 상단" eh="5f9f6784" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Bodem &amp; Meststoffen" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="De bodem-info HUD-overlay tonen/verbergen (F8 om tijdelijk te wisselen)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD-positie" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Kies waar de bodem-info HUD op het scherm verschijnt" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Rechtsboven" eh="5f9f6784" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Jord og Gjødsel" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Vis/skjul HUD-overlegget for jordinfo (F8 for å veksle midlertidig)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD-posisjon" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Velg hvor HUD for jordinfo skal vises på skjermen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Øverst til høyre" eh="5f9f6784" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Gleba i Nawóz" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Pokaż/ukryj nakładkę HUD z informacjami o glebie (F8, aby przełączyć tymczasowo)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Pozycja HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Wybierz miejsce wyświetlania HUDu z informacjami o glebie" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Góra prawa" eh="5f9f6784" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Solo e Fertilizante" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Mostrar/ocultar a sobreposição do HUD de informações do solo (F8 para alternar temporariamente)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Posição do HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Escolha onde o HUD de informações do solo aparece no ecrã" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Canto Superior Direito" eh="5f9f6784" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Sol și Îngrășământ" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Afișează/ascunde HUD-ul cu informații despre sol (F8 pentru comutare temporară)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Poziție HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Alege unde apare HUD-ul cu informații despre sol pe ecran" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Sus Dreapta" eh="5f9f6784" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Почва и удобрения" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Показать/скрыть накладку HUD с информацией о грунте (F8 для временного переключения)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Позиция HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Выберите, где на экране отображается HUD с информацией о грунте" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Справа вверху" eh="5f9f6784" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Mark &amp; Gödsel" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Visa/dölj HUD-överlagring för markinfo (F8 för att växla tillfälligt)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD-position" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Välj var markinfo-HUD ska visas på skärmen" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Uppe till höger" eh="5f9f6784" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Toprak &amp; Gübre" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Toprak bilgisi HUD katmanını göster/gizle (Geçici olarak değiştirmek için F8)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="HUD Konumu" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Toprak bilgisi HUD'ının ekranda nerede görüneceğini seçin" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Sağ Üst" eh="5f9f6784" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Ґрунт та Добриво" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Показати/сховати HUD інформації про ґрунт (F8 для тимчасового перемикання)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Позиція HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Виберіть, де на екрані відображатиметься HUD ґрунту" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Верхній правий" eh="5f9f6784" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Đất &amp; Phân bón" eh="f31197fb" />
@@ -39,6 +39,10 @@
     <e k="sf_show_hud_long" v="Hiện/ẩn lớp phủ HUD thông tin đất (F8 để chuyển đổi tạm thời)" eh="4e2e11b6" />
     <e k="sf_show_work_trail_short" v="Work Trail" />
     <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
+    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
+    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
+    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
+    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
     <e k="sf_hud_position_short" v="Vị trí HUD" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Chọn nơi HUD thông tin đất xuất hiện trên màn hình" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Trên bên phải" eh="5f9f6784" />


### PR DESCRIPTION
## Summary

- **#608** — Pass% shown in the sprayer panel no longer resets to 0 when reloading a save; `coveredAreaHa`, `sessionCoverageHa`, and `sessionCoverageFraction` are now seeded from the saved `coverageFraction` on load
- **#609** — `SF_CYCLE_MAP_LAYER` (minimap layer cycle key) is now registered in the VEHICLE input context so it works while seated in any vehicle, not just on foot
- **#610** — Coloured bold label (N, P, K, pH, OM, Weed, etc.) now appears in the bottom-left corner of the minimap whenever an SF layer is active
- Panel visibility: added `showSprayerInfoPanel` and `showHarvesterPanel` settings (Settings › Display › Visibility) so players can individually hide each panel; `SoilHarvesterPanel` also now respects the J-key HUD toggle

## Test plan

- [ ] Load a save with a partially-sprayed field — verify sprayer panel shows correct pass% without needing to re-spray
- [ ] Enter any vehicle, activate a minimap SF layer, confirm the cycle key changes layers while driving
- [ ] Confirm the layer label (e.g. "N", "pH") appears in the minimap corner when a layer is active and disappears when layer is set to Off
- [ ] Toggle Sprayer Panel and Harvester Panel off in Settings › Display — confirm panels hide without affecting anything else
- [ ] Press J to hide HUD — confirm harvester panel also hides (was broken before)