### PR TITLE
Compaction layer fixes (2.4.2.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.2.3
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.2.4
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.2.3</version>
+    <version>2.4.2.4</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1150,9 +1150,12 @@ function SoilFertilityManager:update(dt)
 
     -- Compaction: periodic check for local player's heavy vehicle driving over fields.
     -- getIsServer() is the documented API; the .isServer field is not guaranteed on FSBaseMission.
+    -- Sampled on a short interval (CHECK_INTERVAL_MS) so the wheels lay a continuous
+    -- compaction trail along the driven path, not one cell every 30 seconds.
     if g_currentMission and g_currentMission:getIsServer() then
         self._compactionTimer = (self._compactionTimer or 0) + dt
-        if self._compactionTimer >= 30000 then
+        local interval = (SoilConstants.COMPACTION and SoilConstants.COMPACTION.CHECK_INTERVAL_MS) or 1000
+        if self._compactionTimer >= interval then
             self._compactionTimer = 0
             self:_checkVehicleCompaction()
         end
@@ -1166,15 +1169,52 @@ function SoilFertilityManager:_checkVehicleCompaction()
     if not (self.settings.compactionEnabled and SoilConstants.COMPACTION) then return end
     if not (self.soilSystem and self.soilSystem.hookManager) then return end
     local cp      = SoilConstants.COMPACTION
-    local vehicle = self:getCurrentVehicle()
+    local vehicle = getPlayerVehicle()
     if not vehicle or not vehicle.rootNode then return end
     local okM, totalMass = pcall(function() return vehicle:getTotalMass(false) end)
     if not (okM and totalMass and totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T) then return end
     local ok, x, _, z = pcall(getWorldTranslation, vehicle.rootNode)
     if not (ok and x) then return end
-    local farmlandId = self.soilSystem.hookManager:getFieldIdAtWorldPosition(x, z, false)
-    if farmlandId and farmlandId > 0 then
-        pcall(function() self.soilSystem:onCompaction(farmlandId, x, z) end)
+
+    -- Compact a single world point if it sits on a field (onCompaction throttles
+    -- each cell to once/day, so repeated calls on the same cell are cheap no-ops).
+    local function compactAt(px, pz)
+        local fid = self.soilSystem.hookManager:getFieldIdAtWorldPosition(px, pz, false)
+        if fid and fid > 0 then
+            pcall(function() self.soilSystem:onCompaction(fid, px, pz) end)
+        end
+    end
+
+    local lx, lz = self._lastCompactionX, self._lastCompactionZ
+    self._lastCompactionX, self._lastCompactionZ = x, z
+
+    -- First sample (or after a discontinuity): just compact the current cell.
+    if not (lx and lz) then
+        compactAt(x, z)
+        return
+    end
+
+    local dx, dz = x - lx, z - lz
+    local dist   = math.sqrt(dx * dx + dz * dz)
+
+    -- Parked / barely moved: nothing new to lay this tick.
+    if dist < (cp.MIN_MOVE_DISTANCE_M or 2.0) then return end
+
+    -- Discontinuity (teleport / fast-travel / re-entered a vehicle far away):
+    -- don't draw a compaction line across the gap — just compact where we are.
+    if dist > (cp.MAX_SEGMENT_M or 30.0) then
+        compactAt(x, z)
+        return
+    end
+
+    -- Walk the driven segment in ~half-cell steps so no cell is skipped at speed.
+    -- This is what keeps the trail continuous whether crawling or driving fast.
+    local cellSize = (SoilConstants.ZONE and SoilConstants.ZONE.CELL_SIZE) or 10.0
+    local step     = cellSize * 0.5
+    local steps    = math.max(1, math.ceil(dist / step))
+    for i = 1, steps do
+        local t = i / steps
+        compactAt(lx + dx * t, lz + dz * t)
     end
 end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3834,6 +3834,11 @@ function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ)
 
     -- 3. Write per-pixel to compaction density map layer
     if self.layerSystem and self.layerSystem.available then
+        -- Mark the minimap heatmap dirty so it regenerates and shows the new
+        -- compaction immediately. Without this the GRLE fills silently while
+        -- driving and only appears on the next spray/harvest/daily refresh.
+        local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
+        if minimapLayer then minimapLayer:markDirty() end
         self.layerSystem:updatePixelForField("compaction", worldX, worldZ, newVal, zone.CELL_SIZE * 0.5)
     end
 
@@ -3879,6 +3884,8 @@ function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ)
 
     -- Write per-pixel to compaction density map layer
     if self.layerSystem and self.layerSystem.available then
+        local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
+        if minimapLayer then minimapLayer:markDirty() end
         self.layerSystem:updatePixelForField("compaction", worldX, worldZ, newVal, zone.CELL_SIZE * 0.5)
     end
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -962,11 +962,21 @@ SoilConstants.MAP_OVERLAY = {
 -- ========================================
 SoilConstants.COMPACTION = {
     HEAVY_VEHICLE_THRESHOLD_T = 8.0,   -- tonnes (Vehicle:getTotalMass returns tonnes)
-    COMPACTION_PER_PASS       = 2.0,   -- points added per heavy-vehicle work pass (once/day/field)
+    COMPACTION_PER_PASS       = 8.0,   -- points added per heavy-vehicle pass over a cell (once/day/cell).
+                                       -- Sized to clear the minimap heatmap's lowest visible bucket
+                                       -- (top-4-bit DMV → first colour at ~6.3%) so a single pass shows.
     NATURAL_DECAY_PER_DAY     = 0.5,   -- points removed per game day (natural recovery)
     SUBSOILER_REDUCTION       = 15.0,  -- points removed per subsoiler pass
     MAX_COMPACTION            = 100.0,
     NUTRIENT_PENALTY_MAX      = 0.20,  -- max 20% extra nutrient extraction at max compaction
+    -- Driving-based compaction: any heavy vehicle moving across a field compacts the
+    -- cell under it, whether or not it is working (spraying/harvesting/tilling have
+    -- their own hooks too). Sampled on a short timer so the wheels lay a continuous
+    -- trail instead of one tile every 30 s.
+    CHECK_INTERVAL_MS         = 1000,  -- how often the driving check samples vehicle position
+    MIN_MOVE_DISTANCE_M       = 2.0,   -- must move at least this far between samples (skip when parked)
+    MAX_SEGMENT_M             = 30.0,  -- if the vehicle jumped more than this between samples assume a
+                                       -- teleport/fast-travel and don't paint a compaction line across the gap
 }
 
 -- ========================================

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -88,7 +88,9 @@ local LAYER_DEFS = {
         perPixel    = true,
     },
     -- ── Biotic / physical pressure ───────────────────────────
-    -- perPixel=false (default): no spray hooks; daily update paints field AABB.
+    -- pest/disease: perPixel=false — field-level pressures, daily update paints
+    -- the field AABB uniformly. compaction: perPixel=true — written per-cell by
+    -- heavy-vehicle passes, so the daily write must skip it (see its entry below).
     {
         name        = "soilPest",
         field       = "pestPressure",
@@ -112,6 +114,11 @@ local LAYER_DEFS = {
         maxVal      = 100,
         numBits     = 8,
         numChannels = 8,
+        -- perPixel: compaction is written per-pixel by onCompaction/onSubsoil
+        -- (updatePixelForField). Mark it so the daily skipPerPixel write does NOT
+        -- repaint the whole field with the near-zero field average, which would
+        -- erase the per-cell compaction the vehicle just created (invisible layer).
+        perPixel    = true,
     },
     -- Note: weed is NOT in LAYER_DEFS — it is read from the game's
     -- native WeedSystem foliage density map (see weed* fields below).

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -72,6 +72,10 @@ local function layerValueToT(layerIdx, val)
     elseif layerIdx == 4 then                                                    -- pH  5.0-7.5, bell around 6.75
         return math.max(0, math.min(1, 1 - math.abs(val - 6.75) / 1.75))
     elseif layerIdx == 5 then return math.max(0, math.min(1, val / 4.0))        -- OM  0-10, green at 4+
+    elseif layerIdx == 10 then                                                   -- Compaction: steep ramp so a
+        -- single heavy pass (~8%) already reads as a warning tint, not "good" green.
+        -- 0% = green, ~40%+ = full red (rather than the gentle 0-100 ramp below).
+        return math.max(0, math.min(1, 1 - val / 40))
     else   return math.max(0, math.min(1, 1 - val / 100)) end                   -- pressure/urgency layers: inverted
 end
 

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,15 +24,14 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Fixed: Centre boom section now suppressed at 100% field coverage",
-    "  (session-coverage >= 99% gate bypasses the grace period that kept centre cells fresh)",
-    "- Fixed: Overlap prevention grace period reduced to 10 s (was 20 s)",
-    "- Fixed: Minimap soil layer indicator now shows on all minimap sizes",
-    "  (used HUDElement screen-space coords; layout UV coords placed label off-screen)",
-    "- Fixed: Minimap pass% resets on save/reload (issue #608)",
-    "- Fixed: Minimap layer key now works inside vehicles (issue #609)",
-    "- Fixed: Overlap prevention no longer fires on pre-fertilized / previously-sprayed fields",
-    "  (density-map replaced with session-cell tracking — only current-session spray triggers)",
+    "- Fixed: Soil compaction layer never appeared on the map",
+    "  (heavy vehicles now compact every cell they drive over, spraying or not)",
+    "- Fixed: Compaction trail now paints continuously at any speed",
+    "  (driving faster no longer skips cells — the whole wheel path is sampled)",
+    "- Fixed: Compaction heatmap refreshes live while driving (no longer needs a spray to show)",
+    "- Fixed: Daily soil update no longer wipes the per-cell compaction trail",
+    "- Fixed: Removed 'getCurrentVehicle' error spam from the compaction check",
+    "- Changed: A single heavy pass is now clearly visible (stronger effect + steeper colour ramp)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────


### PR DESCRIPTION
## What this does

Fixes the soil compaction layer, which never showed anything on the map even when driving a heavy vehicle across a field.

### Fixes
- **Crash:** the periodic compaction check called `getCurrentVehicle` on the manager (a Player method), spamming `attempt to call missing method` every 30s. Now uses the existing `getPlayerVehicle` helper.
- **Daily wipe:** the compaction layer is now flagged `perPixel`, so the daily soil update no longer repaints the field average over the per-cell compaction trail.
- **Detection:** any heavy vehicle (>= 8t) now compacts every cell it drives over, whether or not it is working (spraying, harvesting and tillage already had their own hooks).
- **Speed:** the check now walks the full driven segment between samples, so driving faster no longer skips cells. The trail stays continuous at any speed.
- **Live refresh:** `onCompaction` now marks the minimap heatmap dirty, so the trail appears while driving instead of only after the next spray/harvest.
- **Visibility:** bigger per-pass effect and a steeper colour ramp so a single heavy pass is clearly visible.

### Housekeeping
- Version bumped to 2.4.2.4
- Updated the What's new dialog and README version

Tested in-game: heavy vehicle now leaves a visible compaction trail at both crawl and driving speed.