### PR TITLE
l10n: complete Dutch (nl) translation

### DIFF
--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -37,12 +37,12 @@
     <e k="sf_notifications_long" v="Bodem- en meststoffenmeldingen in-/uitschakelen" eh="9a872f8f" />
     <e k="sf_show_hud_short" v="HUD tonen" eh="c94fd4d7" />
     <e k="sf_show_hud_long" v="De bodem-info HUD-overlay tonen/verbergen (F8 om tijdelijk te wisselen)" eh="4e2e11b6" />
-    <e k="sf_show_work_trail_short" v="Work Trail" />
-    <e k="sf_show_work_trail_long" v="Show/hide spray and harvest trail dots in-world and on the minimap" />
-    <e k="sf_show_sprayer_panel_short" v="Sprayer Panel" />
-    <e k="sf_show_sprayer_panel_long" v="Show/hide the sprayer nutrient info panel when driving a sprayer" />
-    <e k="sf_show_harvester_panel_short" v="Harvester Panel" />
-    <e k="sf_show_harvester_panel_long" v="Show/hide the harvester grain tank status panel when harvesting" />
+    <e k="sf_show_work_trail_short" v="Werkspoor" />
+    <e k="sf_show_work_trail_long" v="Spray- en oogstspoorpunten in de wereld en op de minikaart tonen/verbergen" />
+    <e k="sf_show_sprayer_panel_short" v="Sproeipaneel" />
+    <e k="sf_show_sprayer_panel_long" v="Het voedingsstofinfopaneel van de sproeier tonen/verbergen tijdens het rijden met een sproeier" />
+    <e k="sf_show_harvester_panel_short" v="Oogstmachinepaneel" />
+    <e k="sf_show_harvester_panel_long" v="Het graantankstatuspaneel van de oogstmachine tonen/verbergen tijdens het oogsten" />
     <e k="sf_hud_position_short" v="HUD-positie" eh="5ac371f2" />
     <e k="sf_hud_position_long" v="Kies waar de bodem-info HUD op het scherm verschijnt" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Rechtsboven" eh="5f9f6784" />
@@ -61,12 +61,12 @@
     <e k="sf_diff_long" v="Moeilijkheidsgraad bodembeheer" eh="d6f4560c" />
     <e k="sf_rr_short" v="Aanvullingssnelheid" eh="b363b336" />
     <e k="sf_rr_long" v="Hoe snel meststof de veldvoedingsstoffen herstelt (0,25x Zeer langzaam tot 2,0x Zeer snel)" eh="afe78a6d" />
-    <e k="sf_dm_short" v="[EN] Disease Climate" />
-    <e k="sf_dm_long" v="[EN] Climate moisture level — controls how quickly fungal diseases build up and how long fungicide protection lasts" />
-    <e k="sf_dm_1" v="[EN] Arid" />
-    <e k="sf_dm_2" v="[EN] Temperate" />
-    <e k="sf_dm_3" v="[EN] Humid" />
-    <e k="sf_dm_4" v="[EN] Wet" />
+    <e k="sf_dm_short" v="Ziekteklimaat" />
+    <e k="sf_dm_long" v="Klimaatvochtigheidsniveau — bepaalt hoe snel schimmelziekten zich opbouwen en hoe lang fungicidebescherming duurt" />
+    <e k="sf_dm_1" v="Droog" />
+    <e k="sf_dm_2" v="Gematigd" />
+    <e k="sf_dm_3" v="Vochtig" />
+    <e k="sf_dm_4" v="Nat" />
     <e k="sf_auto_rate_short" v="Automatische snelheidscontrole" eh="6f99137d" />
     <e k="sf_auto_rate_long" v="Past automatisch de bemestingssnelheid aan op basis van veldbehoeften" eh="a9ca9f6b" />
     <e k="sf_hud_theme_1" v="Groen" eh="d382816a" />
@@ -91,10 +91,10 @@
     <e k="sf_active_map_layer_long" v="Voedingsstoffenlaag getoond als overlay op de PDA-kaart" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kaartdetail" eh="a525859a" />
     <e k="sf_overlay_density_long" v="Steekproefpunten voor de PDA-bodemoverlay. Laag = betere FPS, Hoog = volledigere dekking op grote kaarten." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="[EN] Colorblind Mode" />
-    <e k="sf_colorblind_mode_long" v="[EN] Replaces red/green status colors with orange/blue (Okabe-Ito palette) for deuteranopia and protanopia accessibility." />
-    <e k="sf_show_field_info_box_short" v="[EN] Field Info Box" />
-    <e k="sf_show_field_info_box_long" v="[EN] Show soil nutrients in the native Field Info panel when standing on a field." />
+    <e k="sf_colorblind_mode_short" v="Kleurenblindmodus" />
+    <e k="sf_colorblind_mode_long" v="Vervangt rood/groen statuskleuren door oranje/blauw (Okabe-Ito palet) voor deuteranopie- en protanopietoegankelijkheid." />
+    <e k="sf_show_field_info_box_short" v="Veldinfovenster" />
+    <e k="sf_show_field_info_box_long" v="Bodemvoedingsstoffen tonen in het standaard veldinfovenster wanneer je op een veld staat." />
     <e k="input_SF_OPEN_SETTINGS" v="Bodeminstellingen openen" eh="2e31c0dd" />
     <e k="sf_reset" v="Bodeminstellingen herstellen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="Bodem HUD in-/uitschakelen" eh="f0224a10" />
@@ -106,14 +106,14 @@
     <e k="input_SF_TOGGLE_AUTO" v="Auto-modus wisselen" eh="a8642cf0" />
     <e k="input_SF_CYCLE_MAP_LAYER" v="Bodemkaartlaag wisselen" eh="8e4a716c" />
     <e k="input_SF_SOIL_PDA" v="Bodem-PDA openen" eh="7d70f7b4" />
-    <e k="input_SF_SENSOR_PEST"       v="Toggle Pest Sensor" />
-    <e k="input_SF_SENSOR_DISEASE"    v="Toggle Disease Sensor" />
-    <e k="input_SF_SENSOR_NUTRIENT"   v="Toggle Nutrient Sensor" />
-    <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Pest" />
-    <e k="input_SF_SEE_SPRAY_DISEASE" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
-    <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Weed" />
-    <e k="input_SF_VARIABLE_RATE"     v="Toggle Variable Rate" />
-    <e k="input_SF_MINIMAP_ZOOM"      v="Cycle Minimap Zoom" />
+    <e k="input_SF_SENSOR_PEST"       v="Plagsensor omschakelen" />
+    <e k="input_SF_SENSOR_DISEASE"    v="Ziektesensor omschakelen" />
+    <e k="input_SF_SENSOR_NUTRIENT"   v="Voedingsstoffensensor omschakelen" />
+    <e k="input_SF_SEE_SPRAY_PEST"    v="Zie &amp; Sproei: Plaag" />
+    <e k="input_SF_SEE_SPRAY_DISEASE" v="Zie &amp; Sproei: Ziekte" eh="a5e476a8" />
+    <e k="input_SF_SEE_SPRAY_WEED"    v="Zie &amp; Sproei: Onkruid" />
+    <e k="input_SF_VARIABLE_RATE"     v="Variabele dosering omschakelen" />
+    <e k="input_SF_MINIMAP_ZOOM"      v="Minikaart zoomniveau wisselen" />
     <e k="sf_uan32_title" v="UAN 32 Meststof (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="UAN 28 Meststof (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Watervrij Ammoniak (N)" eh="3fc85c02" />
@@ -124,7 +124,7 @@
     <e k="sf_map_title" v="MAP Meststof 11-52-0 (P)" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP Meststof 18-46-0 (P)" eh="5030a80a" />
     <e k="sf_potash_title" v="Kali 0-0-60 (K)" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="[EN] Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
+    <e k="sf_polifoska_title" v="Polifoska 6-20-30 (NPK)" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Vloeibare Ureum (N)" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Vloeibare Ammoniumsulfaat (N)" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="Vloeibare MAP (P)" eh="3ce7c8c9" />
@@ -133,57 +133,57 @@
     <e k="sf_insecticide_title" v="Insecticide" eh="5650eeef" />
     <e k="sf_fungicide_title" v="Fungicide" eh="e8512698" />
     <e k="sf_bigBag_uan32_name" v="IBC UAN 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="[EN] Nitrogen Fertilizer (liquid) — +44N ppm/ha @ 60.8 L/ha" eh="db7dfc87" />
+    <e k="sf_bigBag_uan32_function" v="Stikstofmeststof (vloeibaar) — +44N ppm/ha @ 60,8 L/ha" eh="db7dfc87" />
     <e k="sf_bigBag_uan28_name" v="IBC UAN 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="[EN] Nitrogen Fertilizer (liquid) — +38N ppm/ha @ 60.8 L/ha" eh="ceca3b39" />
+    <e k="sf_bigBag_uan28_function" v="Stikstofmeststof (vloeibaar) — +38N ppm/ha @ 60,8 L/ha" eh="ceca3b39" />
     <e k="sf_bigBag_anhydrous_name" v="IBC Watervrij Ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="[EN] Nitrogen Fertilizer (liquid) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
+    <e k="sf_bigBag_anhydrous_function" v="Stikstofmeststof (vloeibaar) — +67N ppm/ha @ 28 L/ha" eh="d8eec5de" />
     <e k="sf_bigBag_urea_name" v="Big Bag Ureum 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="[EN] Nitrogen Fertilizer (dry) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
+    <e k="sf_bigBag_urea_function" v="Stikstofmeststof (droog) — +78N ppm/ha @ 168 kg/ha" eh="a2d905dc" />
     <e k="sf_bigBag_an_name" v="Big Bag AN 34.5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="[EN] Nitrogen Fertilizer (dry) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
+    <e k="sf_bigBag_an_function" v="Stikstofmeststof (droog) — +68N ppm/ha @ 200 kg/ha" eh="7ac87840" />
     <e k="sf_bigBag_ams_name" v="Big Bag AMS 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="[EN] Nitrogen Fertilizer (dry) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
+    <e k="sf_bigBag_ams_function" v="Stikstofmeststof (droog) — +33N ppm/ha @ 168 kg/ha" eh="52cbe4bc" />
     <e k="sf_bigBag_map_name" v="Big Bag MAP 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="[EN] Phosphorus Fertilizer (dry) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
+    <e k="sf_bigBag_map_function" v="Fosformeststof (droog) — +8N +56P ppm/ha @ 225 kg/ha" eh="a8c90d06" />
     <e k="sf_bigBag_dap_name" v="Big Bag DAP 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="[EN] Phosphorus Fertilizer (dry) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
+    <e k="sf_bigBag_dap_function" v="Fosformeststof (droog) — +11N +44P ppm/ha @ 225 kg/ha" eh="92bb6ecd" />
     <e k="sf_bigBag_potash_name" v="Big Bag Kali 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="[EN] Potassium Fertilizer (dry) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
-    <e k="sf_bigBag_polifoska_name" v="[EN] Big Bag Polifoska 6-20-30" eh="33366162" />
-    <e k="sf_bigBag_polifoska_function" v="[EN] NPK Fertilizer (dry) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
+    <e k="sf_bigBag_potash_function" v="Kaliummeststof (droog) — +90K ppm/ha @ 225 kg/ha" eh="40e845e0" />
+    <e k="sf_bigBag_polifoska_name" v="Big Bag Polifoska 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="NPK-meststof (droog) — +4N +21P +50K ppm/ha @ 250 kg/ha" eh="d6a84718" />
     <e k="sf_bigBag_liquid_urea_name" v="IBC Vloeibare Ureum" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="[EN] Nitrogen Fertilizer (liquid) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
+    <e k="sf_bigBag_liquid_urea_function" v="Stikstofmeststof (vloeibaar) — +78N ppm/ha @ 168 L/ha" eh="2cb4eeeb" />
     <e k="sf_bigBag_liquid_ams_name" v="IBC Vloeibare AMS" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="[EN] Nitrogen Fertilizer (liquid) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
+    <e k="sf_bigBag_liquid_ams_function" v="Stikstofmeststof (vloeibaar) — +33N ppm/ha @ 168 L/ha" eh="73a75155" />
     <e k="sf_bigBag_liquid_map_name" v="IBC Vloeibare MAP" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="[EN] Phosphorus Fertilizer (liquid) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
+    <e k="sf_bigBag_liquid_map_function" v="Fosformeststof (vloeibaar) — +8N +56P ppm/ha @ 225 L/ha" eh="de3da62c" />
     <e k="sf_bigBag_liquid_dap_name" v="IBC Vloeibare DAP" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="[EN] Phosphorus Fertilizer (liquid) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
+    <e k="sf_bigBag_liquid_dap_function" v="Fosformeststof (vloeibaar) — +11N +44P ppm/ha @ 225 L/ha" eh="217bf779" />
     <e k="sf_bigBag_liquid_potash_name" v="IBC Vloeibare Kali" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="[EN] Potassium Fertilizer (liquid) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
+    <e k="sf_bigBag_liquid_potash_function" v="Kaliummeststof (vloeibaar) — +90K ppm/ha @ 225 L/ha" eh="b58cc13c" />
     <e k="sf_bigBag_starter_name" v="IBC Starter 10-34-0" eh="62b13bd1" />
     <e k="sf_bigBag_insecticide_name" v="IBC Insecticide" eh="c8f0aabb" />
     <e k="sf_bigBag_insecticide_function" v="Insecticide (vloeibaar)" eh="09580f6b" />
     <e k="sf_bigBag_fungicide_name" v="IBC Fungicide" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Fungicide (vloeibaar)" eh="745c34cb" />
-    <e k="sf_bigBag_starter_function" v="[EN] Starter Fertilizer (liquid) — +9N +17P ppm/ha @ 46.8 L/ha" eh="ab9c08be" />
+    <e k="sf_bigBag_starter_function" v="Startmeststof (vloeibaar) — +9N +17P ppm/ha @ 46,8 L/ha" eh="ab9c08be" />
     <e k="sf_bigBag_gypsum_name" v="Big Bag Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="[EN] Soil Amendment (dry) — pH -0.15/pass @ 1500 kg/ha" eh="61a7adbd" />
+    <e k="sf_bigBag_gypsum_function" v="Bodemverbeteraar (droog) — pH -0,15/beurt @ 1500 kg/ha" eh="61a7adbd" />
     <e k="sf_bigBag_compost_name" v="Big Bag Compost" eh="14322c5d" />
-    <e k="sf_bigBag_compost_10k_name" v="[EN] Big Bag Compost 10000L" eh="760ccc30" />
-    <e k="sf_bigBag_compost_function" v="[EN] Organic Soil Amendment (dry) — +11N +2P +11K ppm, +3.0% OM @ 5t/ha" eh="3d7d5d60" />
+    <e k="sf_bigBag_compost_10k_name" v="Big Bag Compost 10000L" eh="760ccc30" />
+    <e k="sf_bigBag_compost_function" v="Organische bodemverbeteraar (droog) — +11N +2P +11K ppm, +3,0% OS @ 5 t/ha" eh="3d7d5d60" />
     <e k="sf_bigBag_biosolids_name" v="Big Bag Biogrondstoffen" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="[EN] Big Bag Biosolids (10,000L)" />
-    <e k="sf_bigBag_biosolids_function" v="[EN] Organic Fertilizer (dry) — +28N +3P +22K ppm, +2.0% OM @ 4.5t/ha" eh="97cb385e" />
+    <e k="sf_bigBag_biosolids_10k_name" v="Big Bag Biogrondstoffen (10.000L)" />
+    <e k="sf_bigBag_biosolids_function" v="Organische meststof (droog) — +28N +3P +22K ppm, +2,0% OS @ 4,5 t/ha" eh="97cb385e" />
     <e k="sf_bigBag_chicken_manure_name" v="Big Bag Kippenmest" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="[EN] Big Bag Chicken Manure (10,000L)" />
-    <e k="sf_bigBag_chicken_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +3P +22K ppm, +1.1% OM @ 2t/ha" eh="c85fd5c1" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="Big Bag Kippenmest (10.000L)" />
+    <e k="sf_bigBag_chicken_manure_function" v="Organische meststof (droog) — +22N +3P +22K ppm, +1,1% OS @ 2 t/ha" eh="c85fd5c1" />
     <e k="sf_bigBag_pelletized_manure_name" v="Big Bag Gekorrelde mest" eh="064be7fa" />
-    <e k="sf_bigBag_pelletized_manure_10k_name" v="[EN] Big Bag Pelletized Manure (10,000L)" />
-    <e k="sf_bigBag_pelletized_manure_function" v="[EN] Organic Fertilizer (dry) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
+    <e k="sf_bigBag_pelletized_manure_10k_name" v="Big Bag Gekorrelde mest (10.000L)" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Organische meststof (droog) — +22N +2P +33K ppm @ 450 kg/ha" eh="522ccf1e" />
     <e k="sf_bigBag_liquidlime_name" v="Vloeibare kalktank" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="[EN] pH Raising Agent (liquid) — pH +0.40/pass @ 374 L/ha" eh="23f18783" />
+    <e k="sf_bigBag_liquidlime_function" v="pH-verhogend middel (vloeibaar) — pH +0,40/beurt @ 374 L/ha" eh="23f18783" />
     <e k="sf_hud_title" v="BODEM MONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Veld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Loop een veld op" eh="62c55e9e" />
@@ -199,8 +199,8 @@
     <e k="sf_hud_post_harvest" v="Na de oogst · Bemesten" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Sleep: verplaats   Hoek: formaat   RMB/Shift+H: klaar" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: verplaats/formaat" eh="f1d565b1" />
-    <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
-    <e k="sf_incompatibility_pf_text" v="[EN] Soil &amp; Fertilizer Mod has been disabled because Precision Farming was detected. These two mods are not compatible and cannot be used together." eh="8c645296" />
+    <e k="sf_incompatibility_pf_title" v="Incompatibiliteit gedetecteerd" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="Bodem &amp; Meststoffen Mod is uitgeschakeld omdat Precision Farming is gedetecteerd. Deze twee mods zijn niet compatibel en kunnen niet tegelijk worden gebruikt." eh="8c645296" />
 
     <!-- ======================================================
          HELP LINES (ESC > Help > Realistic Soil & Fertilizer)
@@ -414,7 +414,7 @@
     <e k="sf_pda_map_unavailable" v="Kaartvoorbeeld niet beschikbaar" eh="43983f81" />
     <e k="sf_map_health_overall" v="Gemiddelde bodemgezondheid" eh="5533cbe3" />
     <e k="sf_map_btn_report" v="Open boerderijoverzicht" eh="6f0800e8" />
-    <e k="sf_map_btn_help" v="[EN] Help" eh="6a26f548" />
+    <e k="sf_map_btn_help" v="Help" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Laag wisselen" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandelplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay uitschakelen" eh="8e75dec5" />
@@ -498,15 +498,15 @@
     <e k="sf_treat_action_n_poor" v="Gebruik UAN32, UREUM of WATERVRIJ AMMONIAK." eh="ebc225b0" />
     <e k="sf_treat_action_n_fair" v="Gebruik AMS of STARTER meststof." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="Gebruik MAP of DAP (Fosfor)." eh="ec2d9afa" />
-    <e k="sf_treat_action_p_fair" v="[EN] Top-up with Liquid MAP, Liquid DAP, or DAP (P)." eh="0c99c3e8" />
+    <e k="sf_treat_action_p_fair" v="Bijvullen met Vloeibare MAP, Vloeibare DAP of DAP (P)." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Gebruik POTASH (Kalium)." eh="bb2960f3" />
-    <e k="sf_treat_action_k_fair" v="[EN] Top-up with Liquid Potash or Potash (K)." eh="1e12fc32" />
+    <e k="sf_treat_action_k_fair" v="Bijvullen met Vloeibare Kali of Kali (K)." eh="1e12fc32" />
     <e k="sf_treat_action_weed" v="Onmiddellijk HERBICIDE toepassen." eh="625551c5" />
     <e k="sf_treat_action_pest" v="Onmiddellijk INSECTICIDE toepassen." eh="f4db9a03" />
     <e k="sf_treat_action_disease" v="Onmiddellijk FUNGICIDE toepassen." eh="9228323a" />
     <e k="sf_detail_rotation_ok" v="OK" eh="e0aa021e" />
-    <e k="sf_detail_yield_eff_label" v="[EN] Yield eff." eh="2aa6bf08" />
-    <e k="sf_detail_yield_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_detail_yield_eff_label" v="Opbr. effic." eh="2aa6bf08" />
+    <e k="sf_detail_yield_optimal" v="Optimaal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Leguminosen Bonus (+N)" eh="8ab86f6a" />
     <e k="sf_detail_rotation_fatigue" v="Bodemmoeheid (x1,15 uitputting)" eh="522a6d93" />
     <e k="sf_detail_no_field" v="Geen gegevens beschikbaar." eh="c6d95d5e" />
@@ -517,9 +517,9 @@
     <e k="sf_hud_label_om" v="OS" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dekking: %d%% / %d%%" eh="d407bb6d" />
-    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_coverage" v="Beurt: %d%% (%s)" eh="531a10ef" />
     <e k="sf_hud_compaction" v="Verdichting: %d%%" eh="bef3a4f5" />
-    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
+    <e k="sf_hud_yield_eff" v="Opbrengst: %d%%" eh="7b49cf24" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DOSERING ( AUTO: AAN )" eh="099b5dac" />
@@ -531,7 +531,7 @@
     <!-- Notifications -->
     <e k="sf_notify_welcome" v="Bodem &amp; Meststoffen Mod Actief | Shift+O voor instellingen | Typ 'soilfertility' voor commando's" eh="d97e4139" />
     <e k="sf_startup_dialog_version" v="Nieuw in deze versie:" eh="0b25f5c2" />
-    <e k="sf_startup_dialog_footer" v="Bedankt voor het gebruiken van mijn mod, het betekent veel voor me <3" eh="0f08d735" />
+    <e k="sf_startup_dialog_footer" v="Bedankt voor het gebruiken van mijn mod, het betekent veel voor me &lt;3" eh="0f08d735" />
     <e k="sf_startup_dialog_footer2" v="Bug gevonden? Meld het op GitHub!" eh="728e2cf3" />
     <e k="sf_startup_dialog_footer3" v="Veel plezier met boeren en vergeet niet:" eh="aa38e511" />
     <e k="sf_startup_dialog_footer4" v="Je bodem onthoudt alles..." eh="1a3e5c35" />
@@ -544,10 +544,10 @@
     <e k="sf_notify_burn_title" v="Meststofverbranding" eh="ad8ed599" />
     <e k="sf_notify_burn_body" v="Veld %d: schade door overdosering (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Bodem Mod: Datasynchronisatieprobleem gedetecteerd. Meld dit als het aanhoudt." eh="1a307946" />
-		<e k="sf_notify_lime_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
-		<e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop — yield -80%% at harvest!" eh="75217c5a" />
-		<e k="sf_notify_om_crop_title" v="[EN] Amendment Warning" eh="33228c86" />
-		<e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop — yield -20%% at harvest." eh="5f47bb88" />
+    <e k="sf_notify_lime_crop_title" v="Verbeteraarswaarschuwing" eh="33228c86" />
+    <e k="sf_notify_lime_crop_body" v="Veld %d: Kalk op groeiend gewas — opbrengst -80%% bij de oogst!" eh="75217c5a" />
+    <e k="sf_notify_om_crop_title" v="Verbeteraarswaarschuwing" eh="33228c86" />
+    <e k="sf_notify_om_crop_body" v="Veld %d: Organische stof op groeiend gewas — opbrengst -20%% bij de oogst." eh="5f47bb88" />
 
     <!-- Settings Panel -->
     <e k="sf_panel_cat_sim" v="Simulatie" eh="4f502b57" />
@@ -568,9 +568,9 @@
     <e k="sf_panel_hdr_mod_ctrl" v="Mod-beheer &amp; Moeilijkheid" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Systemen" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Acties &amp; Veldtools" eh="f64ba1c9" />
-		<e k="sf_panel_hdr_hud_layout" v="[EN] HUD Layout" eh="54e1930b" />
-		<e k="sf_hud_enter_drag_label" v="[EN] Move &amp; Resize Panels" eh="be34d24d" />
-		<e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" eh="13230ef7" />
+    <e k="sf_panel_hdr_hud_layout" v="HUD-indeling" eh="54e1930b" />
+    <e k="sf_hud_enter_drag_label" v="Panelen verplaatsen &amp; vergroten/verkleinen" eh="be34d24d" />
+    <e k="sf_hud_enter_drag_desc" v="Sleep HUD om te verplaatsen — sleep hoek om formaat aan te passen — RMB of Esc om te voltooien" eh="13230ef7" />
 
     <!-- Settings Panel Chrome -->
     <e k="sf_panel_admin_yes" v="Admin: JA" eh="4628842a" />
@@ -592,7 +592,7 @@
     <e k="sf_desc_fertilizerCosts" v="Echte in-game kosten voor meststoffen" eh="1c197c9f" />
     <e k="sf_desc_showNotifications" v="In-game bodemstatusmeldingen" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="De bodem HUD-overlay tonen" eh="fa8b9224" />
-    <e k="sf_desc_showWorkTrail" v="Show spray and harvest pass trail overlays" />
+    <e k="sf_desc_showWorkTrail" v="Spray- en oogstspooroverlay's tonen" />
     <e k="sf_desc_hudPosition" v="HUD-voorinstelling ankerpositie" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Kleurenpalet voor HUD-elementen" eh="97271907" />
     <e k="sf_desc_hudFontSize" v="HUD-tekstgrootte" eh="48a6fc15" />
@@ -604,7 +604,7 @@
     <e k="sf_desc_weedPressure" v="Onkruidverspreiding bijhouden en bestraffen" eh="df20c38d" />
     <e k="sf_desc_pestPressure" v="Insectenplagen bijhouden" eh="12b3412e" />
     <e k="sf_desc_diseasePressure" v="Schimmelziekten bijhouden" eh="0858395f" />
-    <e k="sf_desc_diseaseMoisture" v="[EN] Climate moisture level affecting disease spread and fungicide duration" />
+    <e k="sf_desc_diseaseMoisture" v="Klimaatvochtigheidsniveau dat ziekteverspreiding en fungicideduur beïnvloedt" />
     <e k="sf_desc_compactionEnabled" v="Bodemverdichting door zware voertuigen" eh="a7d3a795" />
     <e k="sf_desc_difficulty" v="Intensiteitsniveau van nutriëntenafvoer" eh="54a7902e" />
     <e k="sf_desc_replenishmentRate" v="Snelheid van nutriëntenherstel door meststof" eh="858d2b23" />
@@ -613,8 +613,8 @@
     <e k="sf_desc_cropRotation" v="Rotatievoordelen en -straffen" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Voedingsstoffenlaag getoond in PDA-kaart" eh="3c01c599" />
     <e k="sf_desc_overlayDensity" v="Steekproefpuntenbudget (Laag=8k, Gem=20k, Hoog=40k)" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="[EN] Use orange/blue palette instead of red/green" />
-    <e k="sf_desc_showFieldInfoBox" v="[EN] Show soil data in the Field Info panel" />
+    <e k="sf_desc_colorblindMode" v="Gebruik oranje/blauw palet in plaats van rood/groen" />
+    <e k="sf_desc_showFieldInfoBox" v="Bodemgegevens tonen in het veldinfovenster" />
 
     <!-- Multi-option values -->
     <e k="sf_rr_1" v="Zeer langzaam (0,25x)" eh="b681a1b4" />
@@ -681,314 +681,316 @@
     <e k="sf_cell_report" v="Celrapport" eh="2a403943" />
     <e k="sf_cell_no_data_title" v="Geen celgegevens gevonden" eh="dc41c753" />
     <e k="sf_cell_no_data" v="Geen bodemgegevens op deze locatie" eh="5dfa58aa" />
-    <e k="sf_field_avg" v="[EN] Field avg" eh="e01500f8" />
+    <e k="sf_field_avg" v="Veldgemiddelde" eh="e01500f8" />
     <e k="sf_cell" v="Cel" eh="1a66ab62" />
     <e k="sf_cell_dialog_title" v="Bodemcel-inspectie" eh="7ce7fc03" />
     <e k="sf_cell_sidebar_header" v="Celdetails" eh="6fc5243e" />
     <e k="sf_cell_coord" v="Coördinaten" eh="99171d3a" />
     <e k="sf_cell_click_hint" v="Klik op de kaart om een bodemcel te inspecteren" eh="fc9d240b" />
     <!-- SMART SYSTEMS (admin panel section) -->
-    <e k="sf_panel_hdr_smart_systems"    v="Smart Systems" />
-    <e k="sf_smart_sensor_short"         v="Smart Sensor" />
-    <e k="sf_smart_sensor_long"          v="Enable or disable the Smart Spray Sensor system" />
-    <e k="sf_desc_smartSensorEnabled"    v="Allow players to use Smart Sensor boom-section control based on live soil data" />
+    <e k="sf_panel_hdr_smart_systems"    v="Slimme systemen" />
+    <e k="sf_smart_sensor_short"         v="Slimme sensor" />
+    <e k="sf_smart_sensor_long"          v="Het slimme sproeisensorsysteem in- of uitschakelen" />
+    <e k="sf_desc_smartSensorEnabled"    v="Spelers toestaan de slimme sensor voor boomregeling te gebruiken op basis van live bodemgegevens" />
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_panel_title" v="[EN] SMART SENSORS" eh="33809906" />
-    <e k="sf_sensor_pest"        v="Pest Sensor" />
-    <e k="sf_sensor_disease"     v="Disease Sensor" />
-    <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
-    <e k="sf_sensor_state_on"    v="ON" />
-    <e k="sf_sensor_state_off"   v="OFF" />
-    <e k="action_SF_SENSOR_PEST"     v="SF: Toggle Pest Sensor" />
-    <e k="action_SF_SENSOR_DISEASE"  v="SF: Toggle Disease Sensor" />
-        <!-- SMART SYSTEMS -->
-    <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
-    <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
-    <e k="sf_nav_smart_systems_desc"       v="Configure Smart Sensor, See &amp; Spray and Variable Rate systems" />
-    <e k="sf_nav_tuning_label"            v="Constants Tuning Editor" />
-    <e k="sf_nav_tuning_desc"             v="Fine-tune simulation constants: depletion rates, stress growth, starting soil values" />
-    <e k="sf_panel_hdr_smart_sensor_sys"   v="Smart Sensor System" />
-    <e k="sf_panel_hdr_see_spray_sys"      v="See &amp; Spray System" />
-    <e k="sf_panel_hdr_var_rate_sys"       v="Variable Rate System" />
-    <e k="sf_smart_sensor_short"           v="Smart Sensor" />
-    <e k="sf_smart_sensor_long"            v="Enable or disable the Smart Spray Sensor system" />
-    <e k="sf_see_and_spray_short"          v="See &amp; Spray" />
-    <e k="sf_see_and_spray_long"           v="Enable or disable the See &amp; Spray precision spraying system" />
-    <e k="sf_variable_rate_short"          v="Variable Rate" />
-    <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
-    <e k="sf_desc_smartSensorEnabled"      v="Allow players to use Smart Sensor boom-section control based on live soil data" />
-    <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
-    <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
-    <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
-    <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />
-    <e k="sf_panel_hdr_field_boundary"     v="Field Boundary Control" />
-    <e k="sf_field_boundary_short"         v="Boundary Control" />
-    <e k="sf_field_boundary_long"          v="Enable or disable automatic field boundary section control" />
-    <e k="sf_desc_fieldBoundaryControl"    v="Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." />
-    <e k="sf_panel_hdr_overlap_prev"      v="Overlap Prevention" />
-    <e k="sf_overlap_prev_short"           v="Overlap Prevention" />
-    <e k="sf_overlap_prev_long"            v="Enable or disable density-map-based overlap prevention" />
-    <e k="sf_desc_overlapPrevention"       v="Automatically shuts off boom sections over ground that is already fully fertilized, preventing wasteful re-application on overlapping swaths." />
+    <e k="sf_sensor_panel_title" v="SLIMME SENSOREN" eh="33809906" />
+    <e k="sf_sensor_pest"        v="Plagsensor" />
+    <e k="sf_sensor_disease"     v="Ziektesensor" />
+    <e k="sf_sensor_nutrient"    v="Voedingsstoffensensor" />
+    <e k="sf_sensor_state_on"    v="AAN" />
+    <e k="sf_sensor_state_off"   v="UIT" />
+    <e k="action_SF_SENSOR_PEST"     v="SF: Plagsensor omschakelen" />
+    <e k="action_SF_SENSOR_DISEASE"  v="SF: Ziektesensor omschakelen" />
+    <!-- SMART SYSTEMS -->
+    <e k="sf_panel_hdr_smart_systems"      v="Slimme systemen" />
+    <e k="sf_nav_smart_systems_label"      v="Slimme systemen" />
+    <e k="sf_nav_smart_systems_desc"       v="Slimme sensor, Zie &amp; Sproei en Variabele doseringssystemen configureren" />
+    <e k="sf_nav_tuning_label"            v="Constanten afstemeditor" />
+    <e k="sf_nav_tuning_desc"             v="Simulatieconstanten fijnafstellen: uitputtingssnelheden, stressgroei, beginwaarden bodem" />
+    <e k="sf_panel_hdr_smart_sensor_sys"   v="Slimme sensorsysteem" />
+    <e k="sf_panel_hdr_see_spray_sys"      v="Zie &amp; Sproei systeem" />
+    <e k="sf_panel_hdr_var_rate_sys"       v="Variabele doseringssysteem" />
+    <e k="sf_smart_sensor_short"           v="Slimme sensor" />
+    <e k="sf_smart_sensor_long"            v="Het slimme sproeisensorsysteem in- of uitschakelen" />
+    <e k="sf_see_and_spray_short"          v="Zie &amp; Sproei" />
+    <e k="sf_see_and_spray_long"           v="Het Zie &amp; Sproei precisiesproeisysteem in- of uitschakelen" />
+    <e k="sf_variable_rate_short"          v="Variabele dosering" />
+    <e k="sf_variable_rate_long"           v="Variabele dosering op basis van bodemtekorten in- of uitschakelen" />
+    <e k="sf_desc_smartSensorEnabled"      v="Spelers toestaan de slimme sensor voor boomregeling te gebruiken op basis van live bodemgegevens" />
+    <e k="sf_desc_seeAndSprayEnabled"      v="Boomsecties onderdrukken boven gebieden die geen bespuiting nodig hebben" />
+    <e k="sf_config_seeSprayWeed"          v="Zie &amp; Sproei: Onkruid" />
+    <e k="sf_config_seeSprayPest"          v="Zie &amp; Sproei: Plaag" />
+    <e k="sf_config_seeSprayDisease"       v="Zie &amp; Sproei: Ziekte" />
+    <e k="sf_desc_variableRateEnabled"     v="Doseringsnelheid per sectie aanpassen op basis van bodemvoedingsstoftekorten" />
+    <e k="sf_panel_hdr_field_boundary"     v="Veldbegrenzingsregeling" />
+    <e k="sf_field_boundary_short"         v="Begrenzingsregeling" />
+    <e k="sf_field_boundary_long"          v="Automatische veldbegrenzingssectieregeling in- of uitschakelen" />
+    <e k="sf_desc_fieldBoundaryControl"    v="Sluit automatisch boomsecties die buiten de veldgrenzen uitsteken, om toepassing buiten het veld te voorkomen." />
+    <e k="sf_panel_hdr_overlap_prev"      v="Overlappreventie" />
+    <e k="sf_overlap_prev_short"           v="Overlappreventie" />
+    <e k="sf_overlap_prev_long"            v="Overlappreventie op basis van de dichtheidskaart in- of uitschakelen" />
+    <e k="sf_desc_overlapPrevention"       v="Sluit automatisch boomsecties boven grond die al volledig bemest is, om verspillende hertoepassing op overlappende banen te voorkomen." />
 
     <!-- SMART SENSOR PANEL -->
-    <e k="sf_sensor_pest"        v="Pest Sensor" />
-    <e k="sf_sensor_disease"     v="Disease Sensor" />
-    <e k="sf_sensor_nutrient"    v="Nutrient Sensor" />
-    <e k="sf_sensor_state_on"    v="ON" />
-    <e k="sf_sensor_state_off"   v="OFF" />
+    <e k="sf_sensor_pest"        v="Plagsensor" />
+    <e k="sf_sensor_disease"     v="Ziektesensor" />
+    <e k="sf_sensor_nutrient"    v="Voedingsstoffensensor" />
+    <e k="sf_sensor_state_on"    v="AAN" />
+    <e k="sf_sensor_state_off"   v="UIT" />
     <!-- SEE AND SPRAY PANEL -->
-    <e k="sf_see_spray_panel_title" v="[EN] SEE &amp; SPRAY" eh="a7e00bf0" />
-    <e k="sf_see_spray_pest"        v="Pest" />
-    <e k="sf_see_spray_disease"     v="Disease" />
-    <e k="sf_see_spray_weed"        v="Weed" />
-    <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
+    <e k="sf_see_spray_panel_title" v="ZIE &amp; SPROEI" eh="a7e00bf0" />
+    <e k="sf_see_spray_pest"        v="Plaag" />
+    <e k="sf_see_spray_disease"     v="Ziekte" />
+    <e k="sf_see_spray_weed"        v="Onkruid" />
+    <e k="sf_see_spray_suppressed"  v="Alle secties onderdrukt: geen druk gedetecteerd" />
     <!-- VARIABLE RATE PANEL -->
-    <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
-    <e k="sf_var_rate_label"       v="Var. Rate" />
+    <e k="sf_var_rate_panel_title" v="VARIABELE DOSERING" eh="799c3bf7" />
+    <e k="sf_var_rate_label"       v="Var. dosering" />
     <!-- INPUT ACTIONS -->
-    <e k="action_SF_SENSOR_PEST"       v="SF: Toggle Pest Sensor" />
-    <e k="action_SF_SENSOR_DISEASE"    v="SF: Toggle Disease Sensor" />
-    <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Toggle Nutrient Sensor" />
-    <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Toggle See &amp; Spray Pest" />
-    <e k="action_SF_SEE_SPRAY_DISEASE" v="[EN] SF: Toggle See &amp; Spray Disease" eh="205a3668" />
-    <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Toggle See &amp; Spray Weed" />
-    <e k="action_SF_VARIABLE_RATE"     v="SF: Toggle Variable Rate" />
-        <!-- HUD LAYOUT DRAG BUTTON -->
-    <e k="sf_panel_hdr_hud_layout"   v="HUD Layout" />
-    <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
-    <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />    <e k="sf_hud_enter_drag_label"   v="Move &amp; Resize Panels" />
-    <e k="sf_hud_enter_drag_desc"    v="Drag HUD to reposition — drag corner to resize — RMB or Esc to finish" />
-    <e k="sf_guide_sub_1" v="[EN] Overview — What this mod tracks and why it matters" eh="83e88693" />
-    <e k="sf_guide_sub_2" v="[EN] HUD Guide — Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
-    <e k="sf_guide_sub_3" v="[EN] Workflow — Your daily and seasonal soil management routine" eh="75d263dd" />
-    <e k="sf_guide_sub_4" v="[EN] Products — What each fertilizer affects and when to use it" eh="2a127c60" />
-    <e k="sf_guide_sub_5" v="[EN] F.A.Q. — Common questions answered" eh="4384cacf" />
-    <e k="sf_guide_p1_01" v="[EN] WHAT IS THIS MOD" eh="fe4d3283" />
-    <e k="sf_guide_p1_02" v="[EN] Tracks 5 soil nutrients per field across your" eh="93e6595b" />
-    <e k="sf_guide_p1_03" v="[EN] farm. Crops deplete nutrients on harvest." eh="5e6dc5a8" />
-    <e k="sf_guide_p1_04" v="[EN] Fertilizer replenishes them. Weather and" eh="325d9382" />
-    <e k="sf_guide_p1_05" v="[EN] seasons add realistic pressure over time." eh="bd62219e" />
-    <e k="sf_guide_p1_06" v="[EN] THE 5 SOIL PARAMETERS" eh="6c5948d1" />
-    <e k="sf_guide_p1_07" v="[EN] N   Nitrogen       Fast depletion. Every harvest." eh="df28927d" />
-    <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
-    <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
-    <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
-    <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
-    <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
-    <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
-    <e k="sf_guide_p1_15" v="[EN] FAIR (yellow) Below optimal." eh="0d30dbe4" />
-    <e k="sf_guide_p1_16" v="Plan a top-up. Yield slightly reduced." eh="0363160b" />
-    <e k="sf_guide_p1_17" v="[EN] POOR (red)    Below minimum threshold." eh="96f2a246" />
-    <e k="sf_guide_p1_18" v="Act now — yield impact is severe." eh="64e9e4f9" />
-    <e k="sf_guide_p1_19" v="[EN] QUICK START (5 STEPS)" eh="f1bcfcdb" />
-    <e k="sf_guide_p1_20" v="[EN] 1. Open PDA (game menu) &gt; Soil &amp; Fertilizer." eh="22539c14" />
-    <e k="sf_guide_p1_21" v="[EN] 2. Check Farm Overview for red-flagged fields." eh="d4e823e8" />
-    <e k="sf_guide_p1_22" v="[EN] 3. Use Treatment Plan to see what's needed." eh="1a0c7961" />
-    <e k="sf_guide_p1_23" v="[EN] 4. Apply the right fertilizer product." eh="b44bcac2" />
-    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally — nutrients auto-deduct." eh="ba4b5846" />
-    <e k="sf_guide_p1_25" v="[EN] TOOLS AT A GLANCE" eh="103ce1b5" />
-    <e k="sf_guide_p1_26" v="[EN] HUD Bars     Soil levels for your current field." eh="4d0661d7" />
-    <e k="sf_guide_p1_27" v="Key: SF Toggle HUD (Controls &gt; Mods)" eh="fde6e9c0" />
-    <e k="sf_guide_p1_28" v="[EN] PDA Screen   Full farm overview + treatment plan." eh="a6cc969d" />
-    <e k="sf_guide_p1_29" v="Open via the game's tablet menu." eh="dbe326fc" />
-    <e k="sf_guide_p1_30" v="[EN] Soil Map     Per-cell nutrient colour overlay." eh="1ade7e4f" />
-    <e k="sf_guide_p1_31" v="Key: SF Toggle Cell Map" eh="6f62d699" />
-    <e k="sf_guide_p1_32" v="[EN] Field Report Detailed single-field breakdown." eh="4398ce6d" />
-    <e k="sf_guide_p1_33" v="Key: SF Soil Report" eh="364f8595" />
-    <e k="sf_guide_p1_34" v="[EN] Smart Sensor Blocks sections with no active need." eh="dd267572" />
-    <e k="sf_guide_p1_35" v="Toggles: Alt+1/2/3 in a VWW sprayer." eh="5ea6ea68" />
-    <e k="sf_guide_p1_36" v="[EN] See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
-    <e k="sf_guide_p1_37" v="Toggles: Alt+4/5/6 in a VWW sprayer." eh="cd45ce04" />
-    <e k="sf_guide_p1_38" v="[EN] Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
-    <e k="sf_guide_p1_39" v="Toggle:  Alt+7.  Enable in Admin." eh="31e42fb5" />
-    <e k="sf_guide_p1_40" v="[EN] KEYBINDINGS" eh="07a9ae0d" />
-    <e k="sf_guide_p1_41" v="[EN] All keys ship UNBOUND to avoid conflicts." eh="9ec7b5b5" />
-    <e k="sf_guide_p1_42" v="[EN] Go to: Options &gt; Controls &gt; Mods" eh="e4e8a969" />
-    <e k="sf_guide_p1_43" v="[EN] Look for actions starting with SF_" eh="48d5d3e4" />
-    <e k="sf_guide_p1_44" v="[EN] Assign keys that don't clash with other mods." eh="8c2e27c5" />
-    <e k="sf_guide_p2_01" v="[EN] THE NUTRIENT BARS" eh="ad76f0e9" />
-    <e k="sf_guide_p2_02" v="[EN] The HUD shows one bar per nutrient: N P K OM pH." eh="b84d3955" />
-    <e k="sf_guide_p2_03" v="[EN] Bar fills left (0) to right (100 = maximum)." eh="fb617f3c" />
-    <e k="sf_guide_p2_04" v="[EN] Bar colour tells you status at a glance." eh="e07e4240" />
-    <e k="sf_guide_p2_05" v="[EN] THE THREE TICK MARKS" eh="70556f5d" />
-    <e k="sf_guide_p2_06" v="[EN] Every bar has three small vertical tick marks." eh="65bb2211" />
-    <e k="sf_guide_p2_07" v="[EN] ORANGE tick — Poor/Fair boundary." eh="3eafb9fd" />
-    <e k="sf_guide_p2_08" v="Bar is RED below this line." eh="4cebe452" />
-    <e k="sf_guide_p2_09" v="Your soil is in POOR condition." eh="7a3175e4" />
-    <e k="sf_guide_p2_10" v="Action: apply fertilizer immediately." eh="209e2635" />
-    <e k="sf_guide_p2_11" v="[EN] YELLOW tick — Fair/Good boundary." eh="9f1b02a2" />
-    <e k="sf_guide_p2_12" v="Bar is YELLOW between orange and yellow ticks." eh="cac82a8d" />
-    <e k="sf_guide_p2_13" v="Your soil is FAIR — below the crop's optimum." eh="1ae66c9c" />
-    <e k="sf_guide_p2_14" v="Action: plan a top-up this season." eh="3cf7dfa3" />
-    <e k="sf_guide_p2_15" v="[EN] CYAN tick — Your planted crop's optimal target." eh="20b6c223" />
-    <e k="sf_guide_p2_16" v="Reach this point for maximum yield." eh="cc7c263f" />
-    <e k="sf_guide_p2_17" v="Bar is GREEN when you reach it." eh="b5e669ea" />
-    <e k="sf_guide_p2_18" v="Each crop has different N/P/K targets." eh="d25b96a5" />
-    <e k="sf_guide_p2_19" v="[EN] THE GHOST BAR" eh="becfc79a" />
-    <e k="sf_guide_p2_20" v="[EN] A faint extension of the bar (same colour, dimmer)." eh="98f8ec88" />
-    <e k="sf_guide_p2_21" v="[EN] Shows your projected level AFTER applying the" eh="61741e0c" />
-    <e k="sf_guide_p2_22" v="[EN] fertilizer currently loaded in your sprayer." eh="7f65010e" />
-    <e k="sf_guide_p2_23" v="[EN] Drive to a field with a loaded sprayer to see it." eh="771539b2" />
-    <e k="sf_guide_p2_24" v="[EN] Use it to avoid wasting fertilizer by over-applying." eh="23015626" />
-    <e k="sf_guide_p2_25" v="[EN] READING THE NUMBERS" eh="1764c3ed" />
-    <e k="sf_guide_p2_26" v="[EN] Format:  value  /  target  ( +projected )" eh="6368d79f" />
-    <e k="sf_guide_p2_27" v="[EN] Example: 245 / 320 (+85)" eh="b40caf59" />
-    <e k="sf_guide_p2_28" v="[EN] " eh="d41d8cd9" />
-    <e k="sf_guide_p2_29" v="[EN] 245  = your current nitrogen level in ppm" eh="fd4fee69" />
-    <e k="sf_guide_p2_30" v="[EN] 320  = the crop's optimal nitrogen target" eh="29f8fc0d" />
-    <e k="sf_guide_p2_31" v="[EN] +85  = how much your sprayer load will add" eh="00ac0744" />
-    <e k="sf_guide_p2_32" v="[EN] STATUS COLOURS" eh="e29e5046" />
-    <e k="sf_guide_p2_33" v="[EN] RED bar    Below the orange tick (POOR)." eh="f9522ff8" />
-    <e k="sf_guide_p2_34" v="Yield penalty. Apply now." eh="121691a9" />
-    <e k="sf_guide_p2_35" v="[EN] YELLOW bar Between orange and yellow ticks (FAIR)." eh="3c16bbc5" />
-    <e k="sf_guide_p2_36" v="Slight penalty. Plan ahead." eh="74d99045" />
-    <e k="sf_guide_p2_37" v="[EN] GREEN bar  Above the yellow tick (GOOD)." eh="922aa27a" />
-    <e k="sf_guide_p2_38" v="At or above crop optimal. No action." eh="37eb57bb" />
-    <e k="sf_guide_p2_39" v="[EN] SMART SYSTEM PANELS (VWW sprayer required)" eh="0aabd1ee" />
-    <e k="sf_guide_p2_40" v="[EN] Three panels appear when in a VWW-capable sprayer:" eh="94268ff4" />
-    <e k="sf_guide_p2_41" v="[EN] Smart Sensor / See &amp; Spray / Variable Rate." eh="c55d00f9" />
-    <e k="sf_guide_p2_42" v="[EN] Enable each via Admin &gt; Smart Systems in Settings." eh="1148de7e" />
-    <e k="sf_guide_p2_43" v="[EN] FREE PANEL LAYOUT" eh="49225d9e" />
-    <e k="sf_guide_p2_44" v="[EN] Enable in Settings &gt; Display. Use Shift+H to drag." eh="d0d2147c" />
-    <e k="sf_guide_p2_45" v="[EN] Press [-] in any title bar to collapse a panel." eh="44f81359" />
-    <e k="sf_guide_p3_01" v="[EN] THE FARMING CYCLE" eh="168fa544" />
-    <e k="sf_guide_p3_02" v="[EN] DEPLETE  Harvest removes N/P/K from soil." eh="cc585bcd" />
-    <e k="sf_guide_p3_03" v="The amount depends on crop type and yield." eh="261e13ac" />
-    <e k="sf_guide_p3_04" v="[EN] REPLENISH Apply fertilizer to restore nutrients." eh="91b11b7a" />
-    <e k="sf_guide_p3_05" v="[EN] BALANCE  pH and OM change slowly over time." eh="d6421178" />
-    <e k="sf_guide_p3_06" v="Requires long-term management." eh="7adc65a7" />
-    <e k="sf_guide_p3_07" v="[EN] DAILY HABITS" eh="9df55db7" />
-    <e k="sf_guide_p3_08" v="[EN] 1. Glance at the HUD before working a field." eh="73ebf080" />
-    <e k="sf_guide_p3_09" v="[EN] 2. Red bar = apply fertilizer before or after crop." eh="b0e925a7" />
-    <e k="sf_guide_p3_10" v="[EN] 3. Yellow bar = note the field, treat this season." eh="c93dd62c" />
-    <e k="sf_guide_p3_11" v="[EN] 4. Green bar = carry on, nothing needed." eh="107f713e" />
-    <e k="sf_guide_p3_12" v="[EN] WEEKLY ROUTINE" eh="a303bfde" />
-    <e k="sf_guide_p3_13" v="[EN] Open PDA &gt; Treatment Plan tab." eh="2e03b237" />
-    <e k="sf_guide_p3_14" v="[EN] Fields are sorted by urgency (worst first)." eh="dece938b" />
-    <e k="sf_guide_p3_15" v="[EN] Work top-down — treat highest-priority fields first." eh="3fa2f44c" />
-    <e k="sf_guide_p3_16" v="[EN] Click a row to open detailed field view." eh="147b8267" />
-    <e k="sf_guide_p3_17" v="[EN] READING THE TREATMENT PLAN" eh="ff6ee8e4" />
-    <e k="sf_guide_p3_18" v="[EN] Priority scores weigh how far below target each" eh="39d2360b" />
-    <e k="sf_guide_p3_19" v="[EN] nutrient is. A field in the red on two nutrients" eh="dc519211" />
-    <e k="sf_guide_p3_20" v="[EN] ranks higher than one with a single fair level." eh="41d157db" />
-    <e k="sf_guide_p3_21" v="[EN] PRE-PLANTING CHECKLIST" eh="14b36869" />
-    <e k="sf_guide_p3_22" v="[EN] 1. Check N level — depletes every harvest." eh="3c4a5b54" />
-    <e k="sf_guide_p3_23" v="Apply nitrogen if FAIR or POOR." eh="4c69f9f8" />
-    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K — change more slowly." eh="fa732940" />
-    <e k="sf_guide_p3_25" v="Top up if below the fair threshold." eh="81a25810" />
-    <e k="sf_guide_p3_26" v="[EN] 3. Check pH — lime if acidic, gypsum if alkaline." eh="fa766780" />
-    <e k="sf_guide_p3_27" v="[EN] 4. Check OM — add manure or compost if low." eh="08abc4f1" />
-    <e k="sf_guide_p3_28" v="[EN] POST-HARVEST ACTIONS" eh="eb52e29f" />
-    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted — apply fertilizer soon." eh="b2c1db96" />
-    <e k="sf_guide_p3_30" v="[EN] 2. Legume crops (soy, clover) add free N" eh="75f466af" />
-    <e k="sf_guide_p3_31" v="bonus for the NEXT season automatically." eh="80169436" />
-    <e k="sf_guide_p3_32" v="[EN] 3. Add manure or compost to build OM long-term." eh="dc25a4c7" />
-    <e k="sf_guide_p3_33" v="[EN] SEASONAL NOTES" eh="bb392619" />
-    <e k="sf_guide_p3_34" v="[EN] SPRING  N demand peaks. Apply before planting." eh="b402526b" />
-    <e k="sf_guide_p3_35" v="[EN] SUMMER  Monitor pest and disease pressure." eh="76b840ad" />
-    <e k="sf_guide_p3_36" v="[EN] AUTUMN  Avoid heavy N before forecast rain" eh="1d1c0439" />
-    <e k="sf_guide_p3_37" v="(rain leaches N from soil)." eh="6c48f9c9" />
-    <e k="sf_guide_p3_38" v="[EN] WINTER  Fallow fields slowly recover nutrients." eh="b68db0d1" />
-    <e k="sf_guide_p3_39" v="Leave a field bare to let it rest." eh="0f67aea5" />
-    <e k="sf_guide_p4_01" v="[EN] NITROGEN (N) PRODUCTS" eh="6040f0f5" />
-    <e k="sf_guide_p4_02" v="[EN] UAN Solution   High N, fast release liquid." eh="60baf1c0" />
-    <e k="sf_guide_p4_03" v="[EN] Urea           High N, standard solid form." eh="7619f3d7" />
-    <e k="sf_guide_p4_04" v="[EN] AMS            Nitrogen + minor sulphur benefit." eh="9430151c" />
-    <e k="sf_guide_p4_05" v="[EN] Manure         Moderate N + large OM boost." eh="36e4eeef" />
-    <e k="sf_guide_p4_06" v="[EN] Biosolids      N + P + large OM boost." eh="70b8003e" />
-    <e k="sf_guide_p4_07" v="[EN] Digestate      Moderate N + light OM benefit." eh="70740674" />
-    <e k="sf_guide_p4_08" v="[EN] PHOSPHORUS (P) PRODUCTS" eh="b143a8c7" />
-    <e k="sf_guide_p4_09" v="[EN] MAP            High P, small N contribution." eh="f7e3a5e4" />
-    <e k="sf_guide_p4_10" v="[EN] DAP            High P + nitrogen blend." eh="1674361e" />
-    <e k="sf_guide_p4_11" v="[EN] Liquid MAP     High P, faster uptake." eh="59782949" />
-    <e k="sf_guide_p4_12" v="[EN] Liquid DAP     High P + N, liquid form." eh="6eb70f1d" />
-    <e k="sf_guide_p4_13" v="[EN] Biosolids      P + N + OM. Efficient multi-nutrient." eh="7adb8104" />
-    <e k="sf_guide_p4_14" v="[EN] POTASSIUM (K) PRODUCTS" eh="7a9f5cc7" />
-    <e k="sf_guide_p4_15" v="[EN] Potash         High K, solid form." eh="cb71f3a0" />
-    <e k="sf_guide_p4_16" v="[EN] Liquid Potash  High K, liquid. Faster uptake." eh="0c3d2ad4" />
-    <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
-    <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
-    <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
-    <e k="sf_guide_p4_21" v="Apply LIME — raises pH toward neutral." eh="4df3e7fa" />
-    <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
-    <e k="sf_guide_p4_23" v="Apply GYPSUM — lowers pH toward neutral." eh="e71fa617" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
-    <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
-    <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
-    <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
-    <e k="sf_guide_p4_28" v="[EN] Biosolids      OM + N + P. Very efficient." eh="ba425a0e" />
-    <e k="sf_guide_p4_29" v="[EN] Digestate      Light OM benefit." eh="73cd0835" />
-    <e k="sf_guide_p4_30" v="[EN] Fallow (bare field) slowly recovers OM over time." eh="da732797" />
-    <e k="sf_guide_p4_31" v="[EN] APPLICATION TIPS" eh="180e4a50" />
-    <e k="sf_guide_p4_32" v="[EN] * Load fertilizer and check the ghost bar first." eh="2126b07c" />
-    <e k="sf_guide_p4_33" v="It shows your projected result before you apply." eh="7ee23768" />
-    <e k="sf_guide_p4_34" v="[EN] * Liquid products generally work faster than solid." eh="a5b6f4a7" />
-    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N — very efficient." eh="707c5fe6" />
-    <e k="sf_guide_p4_36" v="[EN] * Apply liquid N before rain if possible" eh="50d601b0" />
-    <e k="sf_guide_p4_37" v="(rain leaches some nitrogen after application)." eh="c10189dd" />
-    <e k="sf_guide_p4_38" v="[EN] * Check crop targets for what you're planting" eh="a3ccec1e" />
-    <e k="sf_guide_p4_39" v="— different crops need different NPK ratios." eh="10bc6a29" />
-    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY — IS IT BROKEN?" eh="8772a2e4" />
-    <e k="sf_guide_p5_02" v="[EN] No. Soil starts at low base levels on a new save." eh="459b03bb" />
-    <e k="sf_guide_p5_03" v="[EN] A field that was never fertilized shows real values." eh="0d7762f2" />
-    <e k="sf_guide_p5_04" v="[EN] Apply fertilizer to build levels over time." eh="4419bc2a" />
-    <e k="sf_guide_p5_05" v="[EN] This is intentional — it reflects real soil depletion." eh="50618796" />
-    <e k="sf_guide_p5_06" v="[EN] WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" eh="0717d029" />
-    <e k="sf_guide_p5_07" v="[EN] Options &gt; Controls &gt; Mods" eh="7cf00a23" />
-    <e k="sf_guide_p5_08" v="[EN] All SF_ keys ship unbound to avoid conflicts" eh="f6ca8742" />
-    <e k="sf_guide_p5_09" v="[EN] with other mods. Find the SF_ actions and" eh="6bf65ffa" />
-    <e k="sf_guide_p5_10" v="[EN] assign keys that work for your setup." eh="66e0458d" />
-    <e k="sf_guide_p5_11" v="[EN] WHY DID MY NITROGEN DROP AFTER RAIN?" eh="114dc15a" />
-    <e k="sf_guide_p5_12" v="[EN] Heavy rain leaches nitrogen from soil." eh="e8e84bec" />
-    <e k="sf_guide_p5_13" v="[EN] This is intentional and realistic." eh="e3636ff4" />
-    <e k="sf_guide_p5_14" v="[EN] Plan N applications before dry weather," eh="795c7892" />
-    <e k="sf_guide_p5_15" v="[EN] not before heavy rain forecasts." eh="73782fd0" />
-    <e k="sf_guide_p5_16" v="[EN] You can adjust rain sensitivity in Settings." eh="2b64da19" />
-    <e k="sf_guide_p5_17" v="[EN] WHAT IS THE GHOST BAR?" eh="f0a1df7e" />
-    <e k="sf_guide_p5_18" v="[EN] The faint extension on a bar shows how much" eh="6b72696f" />
-    <e k="sf_guide_p5_19" v="[EN] your loaded sprayer will add if applied here." eh="dfee8857" />
-    <e k="sf_guide_p5_20" v="[EN] Load a fertilizer into a sprayer, drive to any" eh="605a9e8e" />
-    <e k="sf_guide_p5_21" v="[EN] field, and the ghost bar appears automatically." eh="0c120b03" />
-    <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
-    <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
-    <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
-    <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
-    <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
-    <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
-    <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />
-    <e k="sf_guide_p5_31" v="[EN] deficit). See &amp; Spray shows live pressure per cell." eh="7bba77a1" />
-    <e k="sf_guide_p5_32" v="[EN] Variable Rate adjusts boom output from soil data." eh="a820fc55" />
-    <e k="sf_guide_p5_33" v="[EN] All 3 need a VWW-capable sprayer. Enable via" eh="c3fdd607" />
-    <e k="sf_guide_p5_34" v="[EN] Settings &gt; Admin &gt; Smart Systems." eh="628b6090" />
-    <e k="sf_guide_p5_35" v="[EN] CAN I USE THIS IN MULTIPLAYER?" eh="c58f827c" />
-    <e k="sf_guide_p5_36" v="[EN] Yes. The mod is fully multiplayer-compatible." eh="bb26b4d3" />
-    <e k="sf_guide_p5_37" v="[EN] Soil data is server-authoritative." eh="e8c6a85e" />
-    <e k="sf_guide_p5_38" v="[EN] Clients sync on join. Settings changes require" eh="1d2473fd" />
-    <e k="sf_guide_p5_39" v="[EN] admin permissions in multiplayer sessions." eh="a48c5146" />
-    <e k="sf_guide_p5_40" v="[EN] HOW DOES SOIL AFFECT YIELD?" eh="456d3c9f" />
-    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield — no penalty." eh="7fd13553" />
-    <e k="sf_guide_p5_42" v="[EN] FAIR soil: ~5-15% yield penalty per nutrient." eh="bced6a1c" />
-    <e k="sf_guide_p5_43" v="[EN] POOR soil: up to 40% penalty. Correct it fast." eh="244d5bf2" />
-    <e k="sf_guide_p5_44" v="[EN] Penalties stack: POOR N + FAIR P = severe loss." eh="8afb61f9" />
-    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer — Field Guide" eh="bb56610f" />
-    <e k="sf_guide_tab_1" v="[EN] OVERVIEW" eh="3b9ae4ee" />
-    <e k="sf_guide_tab_2" v="[EN] HUD GUIDE" eh="843ca8c2" />
-    <e k="sf_guide_tab_3" v="[EN] WORKFLOW" eh="7337e059" />
-    <e k="sf_guide_tab_4" v="[EN] PRODUCTS" eh="d71bd8a0" />
-    <e k="sf_guide_tab_5" v="[EN] F.A.Q." eh="a922ea47" />
-    <e k="sf_report_fields_tracked"   v="Fields Tracked:" />
-    <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
-    <e k="sf_report_rotation_fatigue" v="Fatigue: same crop" />
-    <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
-    <e k="sf_report_rec_good"         v="Good" />
-    <e k="sf_report_rec_fair"         v="Fair" />
-    <e k="sf_report_rec_poor"         v="Poor" />
+    <e k="action_SF_SENSOR_PEST"       v="SF: Plagsensor omschakelen" />
+    <e k="action_SF_SENSOR_DISEASE"    v="SF: Ziektesensor omschakelen" />
+    <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Voedingsstoffensensor omschakelen" />
+    <e k="action_SF_SEE_SPRAY_PEST"    v="SF: Zie &amp; Sproei Plaag omschakelen" />
+    <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Zie &amp; Sproei Ziekte omschakelen" eh="205a3668" />
+    <e k="action_SF_SEE_SPRAY_WEED"    v="SF: Zie &amp; Sproei Onkruid omschakelen" />
+    <e k="action_SF_VARIABLE_RATE"     v="SF: Variabele dosering omschakelen" />
+    <!-- HUD LAYOUT DRAG BUTTON -->
+    <e k="sf_panel_hdr_hud_layout"   v="HUD-indeling" />
+    <e k="sf_independent_panels_short" v="Vrije paneelindeling" eh="704a20a4" />
+    <e k="sf_independent_panels_long" v="Slimme systeempanelen toestaan onafhankelijk te worden gepositioneerd in de bewerkingsmodus" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="Sleep elk paneel vrij via de Shift+H bewerkingsmodus. Klap panelen in met de − knop in hun titelbalk." eh="7c60edfc" />
+    <e k="sf_hud_enter_drag_label"   v="Panelen verplaatsen &amp; vergroten/verkleinen" />
+    <e k="sf_hud_enter_drag_desc"    v="Sleep HUD om te verplaatsen — sleep hoek om formaat aan te passen — RMB of Esc om te voltooien" />
+    <e k="sf_guide_sub_1" v="Overzicht — Wat deze mod bijhoudt en waarom het belangrijk is" eh="83e88693" />
+    <e k="sf_guide_sub_2" v="HUD-gids — De voedingsstofbalken en schermweergaven lezen" eh="ffbe123f" />
+    <e k="sf_guide_sub_3" v="Werkwijze — Je dagelijkse en seizoensgebonden bodembeheerroutine" eh="75d263dd" />
+    <e k="sf_guide_sub_4" v="Producten — Wat elke meststof beïnvloedt en wanneer te gebruiken" eh="2a127c60" />
+    <e k="sf_guide_sub_5" v="V.A.Q. — Veelgestelde vragen beantwoord" eh="4384cacf" />
+    <e k="sf_guide_p1_01" v="WAT IS DEZE MOD" eh="fe4d3283" />
+    <e k="sf_guide_p1_02" v="Houdt 5 bodemvoedingsstoffen per veld bij over je" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="boerderij. Gewassen putten voedingsstoffen uit bij de oogst." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="Meststof vult ze aan. Weer en" eh="325d9382" />
+    <e k="sf_guide_p1_05" v="seizoenen zorgen in de loop van de tijd voor realistische druk." eh="bd62219e" />
+    <e k="sf_guide_p1_06" v="DE 5 BODEMPARAMETERS" eh="6c5948d1" />
+    <e k="sf_guide_p1_07" v="N   Stikstof         Snelle uitputting. Bij elke oogst." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="P   Fosfor           Langzame uitputting. Wortelgewassen." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="K   Kalium           Wortelgewassen putten dit zwaar uit." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="OS  Organische stof  Bouwt langzaam op over meerdere seizoenen." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="pH  Bodemzuurgraad.  Streefbereik: 6,5 – 7,0." eh="e8145861" />
+    <e k="sf_guide_p1_12" v="STATUSNIVEAUS" eh="b081c2c6" />
+    <e k="sf_guide_p1_13" v="GOED (groen)   Op of boven het optimale doel van het gewas." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="Geen actie nodig dit seizoen." eh="58b36ac2" />
+    <e k="sf_guide_p1_15" v="REDELIJK (geel) Onder optimaal." eh="0d30dbe4" />
+    <e k="sf_guide_p1_16" v="Plan een bijvulbeurt. Opbrengst licht verminderd." eh="0363160b" />
+    <e k="sf_guide_p1_17" v="SLECHT (rood)   Onder de minimumdrempel." eh="96f2a246" />
+    <e k="sf_guide_p1_18" v="Handel nu — opbrengsteffect is ernstig." eh="64e9e4f9" />
+    <e k="sf_guide_p1_19" v="SNEL AAN DE SLAG (5 STAPPEN)" eh="f1bcfcdb" />
+    <e k="sf_guide_p1_20" v="1. Open PDA (spelmenu) > Bodem &amp; Meststoffen." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="2. Controleer Boerderijoverzicht op roodgemarkeerde velden." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="3. Gebruik Behandelplan om te zien wat nodig is." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="4. Breng het juiste meststofproduct aan." eh="b44bcac2" />
+    <e k="sf_guide_p1_24" v="5. Oogst normaal — voedingsstoffen worden automatisch afgetrokken." eh="ba4b5846" />
+    <e k="sf_guide_p1_25" v="HULPMIDDELEN IN EEN OOGOPSLAG" eh="103ce1b5" />
+    <e k="sf_guide_p1_26" v="HUD-balken     Bodemwaarden voor het huidige veld." eh="4d0661d7" />
+    <e k="sf_guide_p1_27" v="Toets: SF HUD omschakelen (Opties > Besturing > Mods)" eh="fde6e9c0" />
+    <e k="sf_guide_p1_28" v="PDA-scherm     Volledig boerderijoverzicht + behandelplan." eh="a6cc969d" />
+    <e k="sf_guide_p1_29" v="Openen via het tabletmenu van het spel." eh="dbe326fc" />
+    <e k="sf_guide_p1_30" v="Bodemkaart     Voedingsstofkleuroverlay per cel." eh="1ade7e4f" />
+    <e k="sf_guide_p1_31" v="Toets: SF Celkaart omschakelen" eh="6f62d699" />
+    <e k="sf_guide_p1_32" v="Veldrapport    Gedetailleerde uitsplitsing per veld." eh="4398ce6d" />
+    <e k="sf_guide_p1_33" v="Toets: SF Bodemrapport" eh="364f8595" />
+    <e k="sf_guide_p1_34" v="Slimme sensor  Blokkeert secties zonder actieve behoefte." eh="dd267572" />
+    <e k="sf_guide_p1_35" v="Schakelaars: Alt+1/2/3 in een VWW-sproeier." eh="5ea6ea68" />
+    <e k="sf_guide_p1_36" v="Zie &amp; Sproei  Live druk per cel in het voertuig." eh="cddacb27" />
+    <e k="sf_guide_p1_37" v="Schakelaars: Alt+4/5/6 in een VWW-sproeier." eh="cd45ce04" />
+    <e k="sf_guide_p1_38" v="Variabele dos. Past boomsnelheid automatisch aan op tekorten." eh="38a5c159" />
+    <e k="sf_guide_p1_39" v="Schakelaar: Alt+7. Inschakelen via Admin." eh="31e42fb5" />
+    <e k="sf_guide_p1_40" v="TOETSBINDINGEN" eh="07a9ae0d" />
+    <e k="sf_guide_p1_41" v="Alle toetsen worden ONGEBONDEN geleverd om conflicten te vermijden." eh="9ec7b5b5" />
+    <e k="sf_guide_p1_42" v="Ga naar: Opties > Besturing > Mods" eh="e4e8a969" />
+    <e k="sf_guide_p1_43" v="Zoek naar acties die beginnen met SF_" eh="48d5d3e4" />
+    <e k="sf_guide_p1_44" v="Wijs toetsen toe die niet botsen met andere mods." eh="8c2e27c5" />
+    <e k="sf_guide_p2_01" v="DE VOEDINGSSTOFBALKEN" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="De HUD toont één balk per voedingsstof: N P K OS pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="Balk loopt van links (0) naar rechts (100 = maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_04" v="Balkkleur toont de status in één oogopslag." eh="e07e4240" />
+    <e k="sf_guide_p2_05" v="DE DRIE STREEPJEMARKERINGEN" eh="70556f5d" />
+    <e k="sf_guide_p2_06" v="Elke balk heeft drie kleine verticale streepjemarkeringen." eh="65bb2211" />
+    <e k="sf_guide_p2_07" v="ORANJE streepje — Slecht/Redelijk grens." eh="3eafb9fd" />
+    <e k="sf_guide_p2_08" v="Balk is ROOD onder deze lijn." eh="4cebe452" />
+    <e k="sf_guide_p2_09" v="Je bodem is in SLECHTE staat." eh="7a3175e4" />
+    <e k="sf_guide_p2_10" v="Actie: meststof onmiddellijk aanbrengen." eh="209e2635" />
+    <e k="sf_guide_p2_11" v="GEEL streepje — Redelijk/Goed grens." eh="9f1b02a2" />
+    <e k="sf_guide_p2_12" v="Balk is GEEL tussen oranje en geel streepje." eh="cac82a8d" />
+    <e k="sf_guide_p2_13" v="Je bodem is REDELIJK — onder het optimum van het gewas." eh="1ae66c9c" />
+    <e k="sf_guide_p2_14" v="Actie: plan een bijvulbeurt dit seizoen." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_15" v="CYAAN streepje — Het optimale doel van het geplante gewas." eh="20b6c223" />
+    <e k="sf_guide_p2_16" v="Bereik dit punt voor maximale opbrengst." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Balk is GROEN wanneer je het bereikt." eh="b5e669ea" />
+    <e k="sf_guide_p2_18" v="Elk gewas heeft verschillende N/P/K-doelen." eh="d25b96a5" />
+    <e k="sf_guide_p2_19" v="DE SPOOKBALK" eh="becfc79a" />
+    <e k="sf_guide_p2_20" v="Een vage verlenging van de balk (zelfde kleur, dimmer)." eh="98f8ec88" />
+    <e k="sf_guide_p2_21" v="Toont je verwachte niveau NA het aanbrengen van de" eh="61741e0c" />
+    <e k="sf_guide_p2_22" v="meststof die momenteel in je sproeier is geladen." eh="7f65010e" />
+    <e k="sf_guide_p2_23" v="Rijd naar een veld met een geladen sproeier om het te zien." eh="771539b2" />
+    <e k="sf_guide_p2_24" v="Gebruik het om verspilling door overbemesting te vermijden." eh="23015626" />
+    <e k="sf_guide_p2_25" v="DE GETALLEN LEZEN" eh="1764c3ed" />
+    <e k="sf_guide_p2_26" v="Formaat:  waarde  /  doel  ( +verwacht )" eh="6368d79f" />
+    <e k="sf_guide_p2_27" v="Voorbeeld: 245 / 320 (+85)" eh="b40caf59" />
+    <e k="sf_guide_p2_28" v="" eh="d41d8cd9" />
+    <e k="sf_guide_p2_29" v="245  = je huidige stikstofniveau in ppm" eh="fd4fee69" />
+    <e k="sf_guide_p2_30" v="320  = het optimale stikstofstreefcijfer van het gewas" eh="29f8fc0d" />
+    <e k="sf_guide_p2_31" v="+85  = hoeveel je sproeierinhoud zal toevoegen" eh="00ac0744" />
+    <e k="sf_guide_p2_32" v="STATUSKLEUREN" eh="e29e5046" />
+    <e k="sf_guide_p2_33" v="RODE balk    Onder het oranje streepje (SLECHT)." eh="f9522ff8" />
+    <e k="sf_guide_p2_34" v="Opbrengstpenalty. Nu aanbrengen." eh="121691a9" />
+    <e k="sf_guide_p2_35" v="GELE balk    Tussen oranje en geel streepje (REDELIJK)." eh="3c16bbc5" />
+    <e k="sf_guide_p2_36" v="Lichte penalty. Vooruit plannen." eh="74d99045" />
+    <e k="sf_guide_p2_37" v="GROENE balk  Boven het gele streepje (GOED)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="Op of boven gewasoptimum. Geen actie." eh="37eb57bb" />
+    <e k="sf_guide_p2_39" v="SLIMME SYSTEEMPANELEN (VWW-sproeier vereist)" eh="0aabd1ee" />
+    <e k="sf_guide_p2_40" v="Drie panelen verschijnen in een VWW-geschikte sproeier:" eh="94268ff4" />
+    <e k="sf_guide_p2_41" v="Slimme sensor / Zie &amp; Sproei / Variabele dosering." eh="c55d00f9" />
+    <e k="sf_guide_p2_42" v="Inschakelen via Admin > Slimme systemen in Instellingen." eh="1148de7e" />
+    <e k="sf_guide_p2_43" v="VRIJE PANEELINDELING" eh="49225d9e" />
+    <e k="sf_guide_p2_44" v="Inschakelen via Instellingen > Weergave. Gebruik Shift+H om te slepen." eh="d0d2147c" />
+    <e k="sf_guide_p2_45" v="Druk op [-] in een titelbalk om een paneel in te klappen." eh="44f81359" />
+    <e k="sf_guide_p3_01" v="DE LANDBOUWCYCLUS" eh="168fa544" />
+    <e k="sf_guide_p3_02" v="UITPUTTEN  Oogst verwijdert N/P/K uit de bodem." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="De hoeveelheid hangt af van gewastype en opbrengst." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="AANVULLEN  Breng meststof aan om voedingsstoffen te herstellen." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="BALANCEREN  pH en OS veranderen langzaam in de loop van de tijd." eh="d6421178" />
+    <e k="sf_guide_p3_06" v="Vereist langetermijnbeheer." eh="7adc65a7" />
+    <e k="sf_guide_p3_07" v="DAGELIJKSE GEWOONTEN" eh="9df55db7" />
+    <e k="sf_guide_p3_08" v="1. Bekijk de HUD vluchtig voor het bewerken van een veld." eh="73ebf080" />
+    <e k="sf_guide_p3_09" v="2. Rode balk = meststof aanbrengen voor of na het gewas." eh="b0e925a7" />
+    <e k="sf_guide_p3_10" v="3. Gele balk = veld noteren, dit seizoen behandelen." eh="c93dd62c" />
+    <e k="sf_guide_p3_11" v="4. Groene balk = doorgaan, niets nodig." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="WEKELIJKSE ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="Open PDA > tabblad Behandelplan." eh="2e03b237" />
+    <e k="sf_guide_p3_14" v="Velden zijn gesorteerd op urgentie (slechtste eerst)." eh="dece938b" />
+    <e k="sf_guide_p3_15" v="Werk van boven naar beneden — behandel hoogst-urgente velden eerst." eh="3fa2f44c" />
+    <e k="sf_guide_p3_16" v="Klik op een rij om de gedetailleerde veldweergave te openen." eh="147b8267" />
+    <e k="sf_guide_p3_17" v="HET BEHANDELPLAN LEZEN" eh="ff6ee8e4" />
+    <e k="sf_guide_p3_18" v="Prioriteitsscores wegen hoe ver onder het doel elke" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="voedingsstof zit. Een veld dat rood staat op twee voedingsstoffen" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="staat hoger dan één met een enkel redelijk niveau." eh="41d157db" />
+    <e k="sf_guide_p3_21" v="CONTROLELIJST VOOR HET PLANTEN" eh="14b36869" />
+    <e k="sf_guide_p3_22" v="1. Controleer N-niveau — putt bij elke oogst uit." eh="3c4a5b54" />
+    <e k="sf_guide_p3_23" v="Breng stikstof aan bij REDELIJK of SLECHT." eh="4c69f9f8" />
+    <e k="sf_guide_p3_24" v="2. Controleer P en K — veranderen langzamer." eh="fa732940" />
+    <e k="sf_guide_p3_25" v="Bijvullen als onder de redelijkheidsdrempel." eh="81a25810" />
+    <e k="sf_guide_p3_26" v="3. Controleer pH — kalk bij zuur, gips bij alkalisch." eh="fa766780" />
+    <e k="sf_guide_p3_27" v="4. Controleer OS — voeg mest of compost toe bij laag gehalte." eh="08abc4f1" />
+    <e k="sf_guide_p3_28" v="ACTIES NA DE OOGST" eh="eb52e29f" />
+    <e k="sf_guide_p3_29" v="1. Stikstof is uitgeput — binnenkort meststof aanbrengen." eh="b2c1db96" />
+    <e k="sf_guide_p3_30" v="2. Vlinderbloemige gewassen (soja, klaver) voegen gratis N toe" eh="75f466af" />
+    <e k="sf_guide_p3_31" v="bonus voor het VOLGENDE seizoen automatisch." eh="80169436" />
+    <e k="sf_guide_p3_32" v="3. Voeg mest of compost toe om OS langdurig op te bouwen." eh="dc25a4c7" />
+    <e k="sf_guide_p3_33" v="SEIZOENSNOTITIES" eh="bb392619" />
+    <e k="sf_guide_p3_34" v="LENTE   N-vraag piekt. Aanbrengen voor het planten." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="ZOMER   Plaag- en ziektedruk bewaken." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="HERFST  Vermijd zware N voor verwachte regenval" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(regen spoelt N uit de bodem)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="WINTER  Braakliggende velden herstellen langzaam voedingsstoffen." eh="b68db0d1" />
+    <e k="sf_guide_p3_39" v="Laat een veld kaal liggen om het te laten rusten." eh="0f67aea5" />
+    <e k="sf_guide_p4_01" v="STIKSTOF (N) PRODUCTEN" eh="6040f0f5" />
+    <e k="sf_guide_p4_02" v="UAN-oplossing  Hoog N, snelle afgifte vloeibaar." eh="60baf1c0" />
+    <e k="sf_guide_p4_03" v="Ureum          Hoog N, standaard vaste vorm." eh="7619f3d7" />
+    <e k="sf_guide_p4_04" v="AMS            Stikstof + klein zwavelbenefit." eh="9430151c" />
+    <e k="sf_guide_p4_05" v="Mest           Matige N + grote OS-boost." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="Biogrondstoffen N + P + grote OS-boost." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="Digestaat      Matige N + licht OS-benifit." eh="70740674" />
+    <e k="sf_guide_p4_08" v="FOSFOR (P) PRODUCTEN" eh="b143a8c7" />
+    <e k="sf_guide_p4_09" v="MAP            Hoog P, kleine N-bijdrage." eh="f7e3a5e4" />
+    <e k="sf_guide_p4_10" v="DAP            Hoog P + stikstofmengsel." eh="1674361e" />
+    <e k="sf_guide_p4_11" v="Vloeibare MAP  Hoog P, snellere opname." eh="59782949" />
+    <e k="sf_guide_p4_12" v="Vloeibare DAP  Hoog P + N, vloeibare vorm." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="Biogrondstoffen P + N + OS. Efficiënte multivoedinsstof." eh="7adb8104" />
+    <e k="sf_guide_p4_14" v="KALIUM (K) PRODUCTEN" eh="7a9f5cc7" />
+    <e k="sf_guide_p4_15" v="Kali           Hoog K, vaste vorm." eh="cb71f3a0" />
+    <e k="sf_guide_p4_16" v="Vloeibare kali Hoog K, vloeibaar. Snellere opname." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_17" v="PH-CORRECTIE" eh="dfe729d7" />
+    <e k="sf_guide_p4_18" v="Streefbereik: 6,5 – 7,0 voor de meeste gewassen." eh="3fd904c3" />
+    <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
+    <e k="sf_guide_p4_20" v="pH te LAAG (zuur, onder 6,5):" eh="0ec6357e" />
+    <e k="sf_guide_p4_21" v="KALK aanbrengen — verhoogt pH naar neutraal." eh="4df3e7fa" />
+    <e k="sf_guide_p4_22" v="pH te HOOG (alkalisch, boven 7,5):" eh="4204b7df" />
+    <e k="sf_guide_p4_23" v="GIPS aanbrengen — verlaagt pH naar neutraal." eh="e71fa617" />
+    <e k="sf_guide_p4_24" v="Laat 1–2 seizoenen toe voor volledige normalisatie." eh="1f31526d" />
+    <e k="sf_guide_p4_25" v="ORGANISCHE STOF (OS)" eh="4b06f65b" />
+    <e k="sf_guide_p4_26" v="Mest           Beste OS-opbouwer. Voegt ook N toe." eh="99834812" />
+    <e k="sf_guide_p4_27" v="Compost        Matige OS, goed gebalanceerd." eh="d9b0e2f9" />
+    <e k="sf_guide_p4_28" v="Biogrondstoffen OS + N + P. Zeer efficiënt." eh="ba425a0e" />
+    <e k="sf_guide_p4_29" v="Digestaat      Licht OS-benefit." eh="73cd0835" />
+    <e k="sf_guide_p4_30" v="Braak (kaal veld) herstelt OS langzaam in de loop van de tijd." eh="da732797" />
+    <e k="sf_guide_p4_31" v="TOEPASSINGSTIPS" eh="180e4a50" />
+    <e k="sf_guide_p4_32" v="* Laad meststof en controleer eerst de spookbalk." eh="2126b07c" />
+    <e k="sf_guide_p4_33" v="Het toont je verwachte resultaat voor je aanbrengt." eh="7ee23768" />
+    <e k="sf_guide_p4_34" v="* Vloeibare producten werken over het algemeen sneller dan vaste." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_35" v="* Mest verbetert OS EN voegt N toe — zeer efficiënt." eh="707c5fe6" />
+    <e k="sf_guide_p4_36" v="* Breng vloeibare N aan voor regen indien mogelijk" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(regen spoelt wat stikstof na toepassing uit)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="* Controleer gewasstreefwaarden voor wat je plant" eh="a3ccec1e" />
+    <e k="sf_guide_p4_39" v="— verschillende gewassen hebben verschillende NPK-verhoudingen nodig." eh="10bc6a29" />
+    <e k="sf_guide_p5_01" v="MIJN BALKEN ZIJN ALTIJD LEEG — IS HET KAPOT?" eh="8772a2e4" />
+    <e k="sf_guide_p5_02" v="Nee. De bodem begint op lage basiswaarden bij een nieuw opgeslagen spel." eh="459b03bb" />
+    <e k="sf_guide_p5_03" v="Een veld dat nooit bemest is, toont echte waarden." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="Breng meststof aan om de waarden in de loop van de tijd op te bouwen." eh="4419bc2a" />
+    <e k="sf_guide_p5_05" v="Dit is opzettelijk — het weerspiegelt echte bodemuitputting." eh="50618796" />
+    <e k="sf_guide_p5_06" v="WAAR WIJ IK TOETSBINDINGEN INSTELLEN?" eh="0717d029" />
+    <e k="sf_guide_p5_07" v="Opties > Besturing > Mods" eh="7cf00a23" />
+    <e k="sf_guide_p5_08" v="Alle SF_-toetsen worden ongebonden geleverd om conflicten" eh="f6ca8742" />
+    <e k="sf_guide_p5_09" v="met andere mods te vermijden. Zoek de SF_-acties en" eh="6bf65ffa" />
+    <e k="sf_guide_p5_10" v="wijs toetsen toe die werken voor jouw configuratie." eh="66e0458d" />
+    <e k="sf_guide_p5_11" v="WAAROM DAALDE MIJN STIKSTOF NA REGEN?" eh="114dc15a" />
+    <e k="sf_guide_p5_12" v="Zware regen spoelt stikstof uit de bodem." eh="e8e84bec" />
+    <e k="sf_guide_p5_13" v="Dit is opzettelijk en realistisch." eh="e3636ff4" />
+    <e k="sf_guide_p5_14" v="Plan N-toepassingen voor droog weer," eh="795c7892" />
+    <e k="sf_guide_p5_15" v="niet voor verwachte zware regenbuien." eh="73782fd0" />
+    <e k="sf_guide_p5_16" v="Je kunt de regengevoeligheid aanpassen in Instellingen." eh="2b64da19" />
+    <e k="sf_guide_p5_17" v="WAT IS DE SPOOKBALK?" eh="f0a1df7e" />
+    <e k="sf_guide_p5_18" v="De vage verlenging op een balk toont hoeveel" eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="je geladen sproeier hier zal toevoegen bij toepassing." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="Laad een meststof in een sproeier, rijd naar een" eh="605a9e8e" />
+    <e k="sf_guide_p5_21" v="veld en de spookbalk verschijnt automatisch." eh="0c120b03" />
+    <e k="sf_guide_p5_22" v="MOET IK ELK SEIZOEN BEMESTEN?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="Stikstof: Ja, elk seizoen indien mogelijk." eh="5232d8d2" />
+    <e k="sf_guide_p5_24" v="Het putt zwaar uit bij elke oogst." eh="696ed55e" />
+    <e k="sf_guide_p5_25" v="P en K: Eens per 2–3 seizoenen is doorgaans genoeg." eh="0757cb47" />
+    <e k="sf_guide_p5_26" v="Organische OS: Langdurig. Eens per jaar mest toevoegen." eh="78827593" />
+    <e k="sf_guide_p5_27" v="pH: Alleen buiten het bereik van 6,5–7,0." eh="373553dc" />
+    <e k="sf_guide_p5_28" v="HOE WERKEN DE SLIMME SENSORSYSTEMEN?" eh="3b9aa5b3" />
+    <e k="sf_guide_p5_29" v="Slimme sensor blokkeert individuele boomsecties wanneer" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="geen behoefte wordt gedetecteerd (geen plaag, ziekte of voedings-" eh="22de015a" />
+    <e k="sf_guide_p5_31" v="stoftekort). Zie &amp; Sproei toont live druk per cel." eh="7bba77a1" />
+    <e k="sf_guide_p5_32" v="Variabele dosering past boomafgifte aan op bodemgegevens." eh="a820fc55" />
+    <e k="sf_guide_p5_33" v="Alle 3 hebben een VWW-geschikte sproeier nodig. Inschakelen via" eh="c3fdd607" />
+    <e k="sf_guide_p5_34" v="Instellingen > Admin > Slimme systemen." eh="628b6090" />
+    <e k="sf_guide_p5_35" v="KAN IK DIT IN MULTIPLAYER GEBRUIKEN?" eh="c58f827c" />
+    <e k="sf_guide_p5_36" v="Ja. De mod is volledig multiplayer-compatibel." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="Bodemgegevens zijn server-gezaghebbend." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="Clients synchroniseren bij aansluiting. Instellingswijzigingen vereisen" eh="1d2473fd" />
+    <e k="sf_guide_p5_39" v="beheerdersrechten in multiplayersessies." eh="a48c5146" />
+    <e k="sf_guide_p5_40" v="HOE BEÏNVLOEDT DE BODEM DE OPBRENGST?" eh="456d3c9f" />
+    <e k="sf_guide_p5_41" v="GOEDE bodem: volle opbrengst — geen penalty." eh="7fd13553" />
+    <e k="sf_guide_p5_42" v="REDELIJKE bodem: ~5-15% opbrengstpenalty per voedingsstof." eh="bced6a1c" />
+    <e k="sf_guide_p5_43" v="SLECHTE bodem: tot 40% penalty. Snel corrigeren." eh="244d5bf2" />
+    <e k="sf_guide_p5_44" v="Penalties stapelen: SLECHTE N + REDELIJKE P = ernstig verlies." eh="8afb61f9" />
+    <e k="sf_guide_title" v="Bodem &amp; Meststoffen — Veldgids" eh="bb56610f" />
+    <e k="sf_guide_tab_1" v="OVERZICHT" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_2" v="HUD-GIDS" eh="843ca8c2" />
+    <e k="sf_guide_tab_3" v="WERKWIJZE" eh="7337e059" />
+    <e k="sf_guide_tab_4" v="PRODUCTEN" eh="d71bd8a0" />
+    <e k="sf_guide_tab_5" v="V.A.Q." eh="a922ea47" />
+    <e k="sf_report_fields_tracked"   v="Bijgehouden velden:" />
+    <e k="sf_report_rotation_bonus"   v="Rotatiebonus" />
+    <e k="sf_report_rotation_fatigue" v="Vermoeidheid: zelfde gewas" />
+    <e k="sf_report_rotation_ok"      v="Rotatie: OK" />
+    <e k="sf_report_rec_optimal"      v="Bodemgezondheid: Optimaal" />
+    <e k="sf_report_rec_good"         v="Goed" />
+    <e k="sf_report_rec_fair"         v="Redelijk" />
+    <e k="sf_report_rec_poor"         v="Slecht" />
     </elements>
 
 


### PR DESCRIPTION
Completed the Dutch translation. Replaced all the remaining English placeholder strings with native Dutch for the newer keys:

- Work trail, sprayer panel, harvester panel toggles
- Disease climate setting and its arid/temperate/humid/wet levels
- Colorblind mode and field info box
- Sensor and see-and-spray input bindings
- Polifoska name plus all the big bag fertilizer function descriptions (now using Dutch number format, e.g. 60,8 L/ha)

No more [EN] markers left in translation_nl.xml and the file is valid XML.