### PR TITLE
Release 2.4.2.5 — Yield map layer + yield monitor fix (+ texture/storage/minimap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SF fertilizers, lime and organics now work in bulk and silo storage (#605). A runtime hook injects the SF fill types into any placeable silo whose storage, unload trigger or load trigger already accepts the matching base type (FERTILIZER, LIME, MANURE or LIQUIDFERTILIZER). Works automatically with third-party storage bins, no manual configuration. Multiplayer safe: injection runs identically on server and client so storage sync ordering stays consistent.
 
+### Changed
+- Minimap layer label now shows the full localized name plus its short code, e.g. "Nitrogen [N]" or "Stickstoff [N]" (#622). The name is pulled from the same l10n keys as the big-map Overview, so there is a single set of strings to translate. The label font shrinks automatically for long names so it always fits the minimap. Thanks to Drehverschluss for the suggestion.
+
 ---
 
 ## [2.4.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.4.2.5]
+## [2.4.2.4]
 
 ### Fixed
 - Fixed major texture loss introduced in 2.4.1.0. The fill plane textures were converted from DDS to PNG, which produced a mipmap count mismatch (7 vs 8) in the game's shared fill plane texture array and broke pile textures across the whole game. Reverted to DDS and removed the orphaned PNG files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **2.4.2.5**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
+**FS25_SoilFertilizer** is a Farming Simulator 25 mod that adds realistic soil nutrient management. It tracks Nitrogen, Phosphorus, Potassium, Organic Matter, and pH per field, with crop-specific depletion, fertilizer replenishment, weather effects, and seasonal cycles. Current version: **2.4.2.4**. Fully supports multiplayer with admin-only settings enforcement. 26-language localization via separate translation files in `translations/` (referenced from `modDesc.xml` via `filenamePrefix`).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Maintainers merge development → main on a release cycle, not per-PR.
 Good bug reports save everyone time. Please include:
 
 ```
-**Version**: [e.g. 2.4.2.5, check modDesc.xml or the mod menu]
+**Version**: [e.g. 2.4.2.4, check modDesc.xml or the mod menu]
 **Singleplayer or Multiplayer**: [SP / MP Host / MP Client]
 **Difficulty**: [Simple / Realistic / Hardcore]
 **Other mods**: [Paste the list or note if it's a clean mod set]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # FS25_SoilFertilizer - Developer Guide
 
-**Version**: 2.4.2.5
+**Version**: 2.4.2.4
 **Last Updated**: 2026-06-13
 
 ---

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 
 ---
 
-## 🆕 What's New in v2.4.2.5
+## 🆕 What's New in v2.4.2.4
 
 **Fixes:**
 - Fixed the major texture loss introduced in 2.4.1.0. Fill plane textures are back to DDS, so the game's shared pile texture array no longer breaks and every pile renders correctly again
@@ -466,7 +466,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.2.5
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.2.4
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 **New:**
 - SF fertilizers, lime and organics now work in bulk and silo storage. Any silo or storage bin that already accepts base game fertilizer, lime or manure will now also accept the matching SF products, including bins from third-party storage mods
 
+**Improved:**
+- The minimap layer label now shows the full localized name plus its short code, for example "Nitrogen [N]" or "Stickstoff [N]". It uses the same translations as the big map, so there are no language gaps
+
 <details>
 <summary>Previous releases</summary>
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each field builds its own history. Nitrogen drops after a heavy wheat crop. Rain
 ## 🆕 What's New in v2.4.2.4
 
 **Fixes:**
+- Fixed the yield reading. The yield % shown in the soil monitor now matches the grain you actually harvest. It no longer slides downward as the combine crosses the field. The monitor forecast and the real harvest now share a single field-average calculation, and the value is held steady for the duration of a harvest pass
 - Fixed the major texture loss introduced in 2.4.1.0. Fill plane textures are back to DDS, so the game's shared pile texture array no longer breaks and every pile renders correctly again
 - Restored the unique pile colours for each product
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.2.5</version>
+    <version>2.4.2.4</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -203,32 +203,28 @@ end
 ---@param fruitTypeIndex number FS25 fruit type index
 ---@param liters number Amount harvested in liters
 ---@param strawRatio number 0.0-1.0 fraction of straw that was chopped (0 = dropped/collected, 1 = fully chopped)
---- Computes the combined yield modifier for a harvest event.
---- All yield-reducing factors (nutrients, weeds, pests, disease) are multiplied together.
---- Returns a value in [1-MAX_PENALTY, 1.0] — applied to liters BEFORE the combine hopper
---- receives grain in HookManager, so the game engine actually sees fewer liters.
----@param fieldId number
----@param fruitTypeIndex number
----@return number modifier  Combined yield multiplier
-function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
-    if not self.settings.enabled then return 1.0 end
-
-    local field = self.fieldData[fieldId]
-    if not field then return 1.0 end
-
-    -- Return the frozen modifier if this crop's harvest is already in progress (#556).
-    -- Without this, nutrient depletion from earlier passes drops the modifier for later
-    -- passes of the same harvest run, causing yield to fall as the combine crosses the field.
-    if field.frozenYieldModifier and field.frozenYieldFruitType == fruitTypeIndex then
-        return field.frozenYieldModifier
-    end
-
+--- Pure yield-modifier calculation — the SINGLE source of truth for both the
+--- applied harvest reduction (computeYieldModifier) and the monitor's forecast
+--- (getFieldInfo.yieldEfficiency). Reads explicit N/P/K so callers control the
+--- nutrient source; BOTH call sites pass FIELD-AVERAGE values, so the number the
+--- monitor shows always equals the grain the combine actually receives.
+--- Read-only: never mutates field state. The amendment-burn one-shot is consumed
+--- by the real harvest path (computeYieldModifier), not here, so the display can
+--- evaluate it as often as it likes without clearing it.
+---@param field table       Field data record
+---@param cropName string   Fruit name (lowercased internally)
+---@param nVal number       Nitrogen value to evaluate
+---@param pVal number       Phosphorus value
+---@param kVal number       Potassium value
+---@param logFieldId number|nil  Field id for per-factor debug logging; nil = silent (display path)
+---@return number modifier  Combined yield multiplier in [1-MAX_PENALTY, 1.0]
+function SoilFertilitySystem:_yieldModifierFromNutrients(field, cropName, nVal, pVal, kVal, logFieldId)
     local modifier = 1.0
+    cropName = cropName and string.lower(cropName) or ""
+    local ys      = SoilConstants.YIELD_SENSITIVITY
+    local isGrass = ys and ys.NON_CROP_NAMES and ys.NON_CROP_NAMES[cropName]
 
-    local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
-    local cropName  = fruitDesc and string.lower(fruitDesc.name or "") or ""
-    local ys        = SoilConstants.YIELD_SENSITIVITY
-    local isGrass   = ys and ys.NON_CROP_NAMES and ys.NON_CROP_NAMES[cropName]
+    local function plog(...) if logFieldId then self:log(...) end end
 
     -- Nutrient-based modifier (only when nutrientCycles enabled, skipped for grass/non-crop)
     if self.settings.nutrientCycles and ys and not isGrass then
@@ -236,17 +232,17 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         local tierData = ys.TIERS[tier]
         local thresh   = ys.OPTIMAL_THRESHOLD
 
-        local nDef = math.max(0, thresh - field.nitrogen)   / thresh
-        local pDef = math.max(0, thresh - field.phosphorus) / thresh
-        local kDef = math.max(0, thresh - field.potassium)  / thresh
+        local nDef = math.max(0, thresh - nVal) / thresh
+        local pDef = math.max(0, thresh - pVal) / thresh
+        local kDef = math.max(0, thresh - kVal) / thresh
 
         local avgDef = (nDef + pDef + kDef) / 3
 
         local nutrientPenalty = math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
         if nutrientPenalty > 0 then
             modifier = modifier * (1.0 - nutrientPenalty)
-            self:log("Nutrient penalty field %d (%s/%s): N=%.0f P=%.0f K=%.0f → -%.0f%%",
-                fieldId, cropName, tier, field.nitrogen, field.phosphorus, field.potassium, nutrientPenalty * 100)
+            plog("Nutrient penalty field %d (%s/%s): N=%.0f P=%.0f K=%.0f → -%.0f%%",
+                logFieldId, cropName, tier, nVal, pVal, kVal, nutrientPenalty * 100)
         end
     end
 
@@ -263,7 +259,7 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
             else                              penalty = wp.YIELD_PENALTY_PEAK end
             if penalty > 0 then
                 modifier = modifier * (1.0 - penalty)
-                self:log("Weed penalty field %d: pressure=%.0f → -%.0f%%", fieldId, pressure, penalty * 100)
+                plog("Weed penalty field %d: pressure=%.0f → -%.0f%%", logFieldId, pressure, penalty * 100)
             end
         end
     end
@@ -279,7 +275,7 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         else                              penalty = pp.YIELD_PENALTY_PEAK end
         if penalty > 0 then
             modifier = modifier * (1.0 - penalty)
-            self:log("Pest penalty field %d: pressure=%.0f → -%.0f%%", fieldId, pressure, penalty * 100)
+            plog("Pest penalty field %d: pressure=%.0f → -%.0f%%", logFieldId, pressure, penalty * 100)
         end
     end
 
@@ -294,15 +290,53 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
         else                              penalty = dp.YIELD_PENALTY_PEAK end
         if penalty > 0 then
             modifier = modifier * (1.0 - penalty)
-            self:log("Disease penalty field %d: pressure=%.0f → -%.0f%%", fieldId, pressure, penalty * 100)
+            plog("Disease penalty field %d: pressure=%.0f → -%.0f%%", logFieldId, pressure, penalty * 100)
         end
     end
 
-    -- Amendment burn penalty: lime or OM applied to growing crop (issue #437)
+    -- Amendment burn penalty: lime or OM applied to growing crop (issue #437).
+    -- Evaluated read-only here; computeYieldModifier consumes the one-shot after applying it.
     if field.amendBurnPenalty and field.amendBurnPenalty > 0 then
-        local burnPct = field.amendBurnPenalty
-        modifier = modifier * (1.0 - burnPct)
-        self:log("Amendment burn penalty field %d: -%.0f%%", fieldId, burnPct * 100)
+        modifier = modifier * (1.0 - field.amendBurnPenalty)
+        plog("Amendment burn penalty field %d: -%.0f%%", logFieldId, field.amendBurnPenalty * 100)
+    end
+
+    return modifier
+end
+
+--- Computes the combined yield modifier actually applied at harvest. All yield-reducing
+--- factors are multiplied together and the result is applied to liters BEFORE the combine
+--- hopper receives grain in HookManager, so the engine sees fewer liters. Snapshotted
+--- (frozen) on the first cut so the value does not slide as the combine crosses the field.
+---@param fieldId number
+---@param fruitTypeIndex number
+---@return number modifier  Combined yield multiplier in [1-MAX_PENALTY, 1.0]
+function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
+    if not self.settings.enabled then return 1.0 end
+
+    local field = self.fieldData[fieldId]
+    if not field then return 1.0 end
+
+    -- Return the frozen modifier if this crop's harvest is already in progress (#556).
+    -- Without this, nutrient depletion from earlier passes drops the modifier for later
+    -- passes of the same harvest run, causing yield to fall as the combine crosses the field.
+    if field.frozenYieldModifier and field.frozenYieldFruitType == fruitTypeIndex then
+        return field.frozenYieldModifier
+    end
+
+    local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    local cropName  = fruitDesc and (fruitDesc.name or "") or ""
+
+    -- Single source of truth: the applied reduction is driven by FIELD-AVERAGE
+    -- nutrients. getFieldInfo()'s monitor forecast calls this same helper with the
+    -- same field-average values, so the displayed "Yield eff." always equals the
+    -- grain the hopper actually receives.
+    local modifier = self:_yieldModifierFromNutrients(
+        field, cropName, field.nitrogen, field.phosphorus, field.potassium, fieldId)
+
+    -- Amendment burn is a one-shot: consume it now that it has been applied so the
+    -- next harvest is not penalised again (the display path never clears it).
+    if field.amendBurnPenalty and field.amendBurnPenalty > 0 then
         field.amendBurnPenalty   = nil
         field._amendBurnNotified = nil
     end
@@ -3388,6 +3422,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     -- returns the wrong field or nil depending on list position.
     -- Correct approach: iterate g_fieldManager.fields and match farmland.id.
     local cropName = nil
+    local liveFruitTypeIndex = nil  -- set when a live crop is detected; used to match the harvest freeze
     if g_fieldManager and g_fieldManager.fields then
         local fsField = nil
         for _, f in ipairs(g_fieldManager.fields) do
@@ -3411,6 +3446,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
                     return fs
                 end)
                 if ok and fieldState and fieldState.fruitTypeIndex ~= FruitType.UNKNOWN then
+                    liveFruitTypeIndex = fieldState.fruitTypeIndex
                     local fruitDesc = g_fruitTypeManager and
                         g_fruitTypeManager:getFruitTypeByIndex(fieldState.fruitTypeIndex)
                     if fruitDesc and fruitDesc.name then
@@ -3458,40 +3494,31 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     local cropLowerInfo = cropName and string.lower(cropName) or ""
     local isNonCropField = nonCrops[cropLowerInfo]
 
-    -- Yield efficiency estimate: combines nutrient deficit + weed/pest/disease penalties.
+    -- Yield efficiency forecast — MUST equal the grain the combine actually receives.
+    -- The applied reduction (computeYieldModifier) is driven by FIELD-AVERAGE nutrients
+    -- and frozen for the duration of a harvest pass, so this forecast does the same:
+    --   * during an active harvest of this crop -> return the frozen applied value, so
+    --     the % does NOT slide downward as the combine depletes nutrients mid-field
+    --     (the "field was 100%, now it's 90%" report)
+    --   * otherwise -> call the shared helper with field-average N/P/K (NOT the local
+    --     zone-cell n/p/k used for the nutrient readouts above)
+    -- Gated on the same conditions as the hopper hook (enabled + nutrientCycles) so the
+    -- monitor reads "--" exactly when the game applies no reduction at all.
     -- nil when no managed crop is present (bare, grass, forage).
-    -- Mirrors computeYieldModifier but reads from local variables already resolved above.
     local yieldEfficiency = nil
-    if not isNonCropField and cropName and cropName ~= "" then
-        local ys = SoilConstants.YIELD_SENSITIVITY
-        if ys and ys.TIERS and ys.OPTIMAL_THRESHOLD then
-            local thresh = ys.OPTIMAL_THRESHOLD
-            local nDef = math.max(0, thresh - n) / thresh
-            local pDef = math.max(0, thresh - p) / thresh
-            local kDef = math.max(0, thresh - k) / thresh
-
-            local avgDef = (nDef + pDef + kDef) / 3
-
-            local tier     = ys.CROP_TIERS[cropLowerInfo] or ys.DEFAULT_TIER
-            local tierData = ys.TIERS[tier]
-            local mod = 1.0 - math.min(ys.MAX_PENALTY, avgDef * tierData.scale)
-
-            local function applyPressurePenalty(settingKey, pressureTable, pressureValue)
-                if not (self.settings[settingKey] and pressureTable) then return mod end
-                local pv = pressureValue or 0
-                local penalty = pv < pressureTable.LOW    and pressureTable.YIELD_PENALTY_LOW  or
-                                pv < pressureTable.MEDIUM and pressureTable.YIELD_PENALTY_MID  or
-                                pv < pressureTable.HIGH   and pressureTable.YIELD_PENALTY_HIGH or
-                                pressureTable.YIELD_PENALTY_PEAK
-                return mod * (1.0 - penalty)
-            end
-
-            mod = applyPressurePenalty("weedPressure",    SoilConstants.WEED_PRESSURE,    field.weedPressure)
-            mod = applyPressurePenalty("pestPressure",    SoilConstants.PEST_PRESSURE,    field.pestPressure)
-            mod = applyPressurePenalty("diseasePressure", SoilConstants.DISEASE_PRESSURE, field.diseasePressure)
-
-            yieldEfficiency = math.floor(mod * 100 + 0.5)
+    if self.settings.enabled and self.settings.nutrientCycles
+       and not isNonCropField and cropName and cropName ~= "" then
+        local mod
+        if field.frozenYieldModifier and liveFruitTypeIndex
+           and field.frozenYieldFruitType == liveFruitTypeIndex then
+            mod = field.frozenYieldModifier
+        else
+            local avgN = field.nitrogen   or SoilConstants.FIELD_DEFAULTS.nitrogen
+            local avgP = field.phosphorus or SoilConstants.FIELD_DEFAULTS.phosphorus
+            local avgK = field.potassium  or SoilConstants.FIELD_DEFAULTS.potassium
+            mod = self:_yieldModifierFromNutrients(field, cropName, avgN, avgP, avgK, nil)
         end
+        yieldEfficiency = math.floor(mod * 100 + 0.5)
     end
 
     return {

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -412,30 +412,74 @@ local LAYER_LABEL_COLOR = {
     [9]  = {0.80, 0.10, 0.80},  [10] = {0.55, 0.30, 0.10},
 }
 
--- Draws a small "N", "pH", etc. tag in the top-left corner of the minimap widget.
+-- Short abbreviations worth showing in brackets after the full name. Only the
+-- nutrient layers, where "N"/"P"/"K"/etc. are meaningful shorthand; the
+-- pressure/compaction layers read better as the full localized name alone.
+local LAYER_ABBREV = {
+    [1] = "N", [2] = "P", [3] = "K", [4] = "pH", [5] = "OM",
+}
+
+-- Safe localized text lookup (never crashes the HUD on a missing key).
+local function sfTr(key, fallback)
+    if key and g_i18n then
+        local ok, text = pcall(function() return g_i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            return text
+        end
+    end
+    return fallback
+end
+
+-- Builds the minimap corner label, e.g. "Nitrogen [N]" / "Stickstoff [N]" (#622).
+-- The full name comes from the SAME l10n keys as the big-map Overview
+-- (SoilMapOverlay.LAYER_KEYS), so there is a single set of strings to translate.
+-- The bracketed short code is only appended where it differs from the full name.
+function SoilMinimapLayer.buildLayerLabel(layerIdx)
+    local key = SoilMapOverlay and SoilMapOverlay.LAYER_KEYS and SoilMapOverlay.LAYER_KEYS[layerIdx]
+    local fullName = sfTr(key, LAYER_LABEL[layerIdx])
+    if not fullName then return nil end
+
+    local abbr = LAYER_ABBREV[layerIdx]
+    if abbr and abbr:lower() ~= fullName:lower() then
+        return fullName .. " [" .. abbr .. "]"
+    end
+    return fullName
+end
+
+-- Draws the active layer name tag in the top-left corner of the minimap widget.
 -- mx/my = bottom-left of the (clipped) minimap rect; mw/mh = size.
 function SoilMinimapLayer:drawLayerIndicator(mx, my, mw, mh, layerIdx)
-    local label = LAYER_LABEL[layerIdx]
+    local label = SoilMinimapLayer.buildLayerLabel(layerIdx)
     if not label then return end
 
     local col = LAYER_LABEL_COLOR[layerIdx] or {1, 1, 1}
-    local sz  = 0.014   -- larger for readability
     local pad = 0.005
+
+    -- Keep the full localized name but shrink it if needed so a long name
+    -- (e.g. "Organische Substanz [OM]") never runs past the minimap width.
+    -- Floor keeps it readable.
+    setTextBold(true)
+    local sz = 0.014
+    local maxW = math.max(mw - pad * 2, 0.0001)
+    local textW = getTextWidth(sz, label)
+    if textW > maxW and textW > 0 then
+        sz = math.max(sz * (maxW / textW), 0.0085)
+        textW = getTextWidth(sz, label)
+    end
 
     -- Top-left corner: y goes up from bottom, so top = my + mh
     local tx = mx + pad
     local ty = my + mh - sz - pad
 
-    -- Dark semi-transparent pill background
+    -- Dark semi-transparent pill background sized to the actual rendered text
     if self._dotOverlay and self._dotOverlay ~= 0 then
-        local bgW = sz * (#label * 0.62 + 0.4)
-        local bgH = sz * 1.35
+        local bgW = textW + pad * 1.2
+        local bgH = sz * 1.5
         setOverlayColor(self._dotOverlay, 0, 0, 0, 0.52)
         renderOverlay(self._dotOverlay, tx - pad * 0.5, ty - pad * 0.3, bgW, bgH)
     end
 
     -- Text with shadow
-    setTextBold(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(0, 0, 0, 0.70)
     renderText(tx + 0.0008, ty - 0.0008, sz, label)

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -31,6 +31,8 @@ SoilVersionDialog.CHANGELOG = {
     "  (any silo or storage bin that already takes base fertilizer, lime or",
     "   manure will now accept the matching SF products, including third-party bins)",
     "- Custom pile colours for each product are restored",
+    "- Improved: Minimap layer label now shows the full translated name plus its",
+    "  short code, e.g. Nitrogen [N] / Stickstoff [N] (thanks Drehverschluss)",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,9 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: Yield % in the soil monitor now matches the grain you actually harvest",
+    "  (the shown yield no longer slides down as the combine crosses the field -",
+    "   monitor and real harvest now use one field-average calculation)",
     "- Fixed: Major texture loss after 2.4.1.0",
     "  (fill plane textures are back to DDS, so the game's shared pile",
     "   texture array no longer breaks and piles render correctly again)",


### PR DESCRIPTION
## 2.4.2.5

Supersedes the unreleased 2.4.2.4 (main is at 2.4.2.3); all of this dev work releases together as 2.4.2.5.

### New — Yield soil-map layer
The overlay and minimap can now show a **Yield** layer: each field coloured red → amber → green by its yield potential. The value is **field-average** — the exact same number the Soil Monitor shows and the grain the combine delivers — so the map can never disagree with the harvest.

- `SoilLayerSystem`: registers the `soilYield` GRLE (field-uniform; painted from `field.yieldEfficiency` on the daily write)
- `SoilFertilitySystem`: refreshes `field.yieldEfficiency` each day from the single-source `_yieldModifierFromNutrients` helper
- `SoilMapOverlay` / `SoilMinimapLayer`: layer #11 wired into colours, labels, abbrev, tooltip
- l10n: `sf_map_layer_yield` in all 26 languages
- Companion PR in **FS25_SoilLayerInstaller** adds `soilYield` to the injected layers (the installer `.exe` must be rebuilt to ship it)

### Headline fix — yield monitor matches the actual harvest
The displayed yield % and the applied harvest reduction were two drifted copies of one formula; the monitor read zone-cell nutrients and recomputed live, so it slid from 100% → 90% mid-harvest. Now one `_yieldModifierFromNutrients` helper drives both, on field-average nutrients, frozen during a harvest pass.

### Also in this release (already on development)
- Fill-plane texture loss fix (DDS), SF products in bulk/silo storage, pile colours, minimap layer labels, spray Pass% fixes, compaction trail, JD R700i/R975i overlap, Dutch + German translations, 14-fix review pass.

### Testing
Built and deployed locally. In-game verification pending.