### PR TITLE
Ground-pressure compaction model + Variable Tire Pressure support (2.4.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.1
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.1
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.4.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.4.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.5.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.2.9
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.3.1</version>
+    <version>2.4.4.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.2.9</version>
+    <version>2.4.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.3.0</version>
+    <version>2.4.3.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.4.0</version>
+    <version>2.4.5.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -260,6 +260,12 @@ function FieldSentry_API.attachBridge(mission)
         toggleSleep        = SoilNetworkEvents_SendFieldSentryToggle,
         toggleMeadow       = SoilNetworkEvents_SendFieldMeadowToggle,
         isPlayerAdmin      = SoilNetworkEvents_IsPlayerAdmin,
+        -- Contract providers (#654/#56) — server-authoritative. Lets another mod (NPCFavor)
+        -- register an eligibility callback so its contract fields are masked from the sim.
+        registerContractProvider   = FieldSentry_API.registerContractProvider,
+        unregisterContractProvider = FieldSentry_API.unregisterContractProvider,
+        applyRetroactiveHarvest    = FieldSentry_API.applyRetroactiveHarvest,
+        favorTierThreshold         = FieldSentry_Core.FAVOR_TIER_THRESHOLD,
     }
 end
 

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -235,6 +235,34 @@ function FieldSentry_API.getUIStatus(fieldId)
     }
 end
 
+-- =========================================================
+-- Cross-mod bridge (#83 — FarmTablet FieldSentry app)
+-- =========================================================
+-- FS25 scopes mod globals per-mod, so FieldSentry_API is invisible to other mods.
+-- Publish a small read + control surface on g_currentMission (a shared C++ object)
+-- so the FarmTablet app can show per-field status and request toggles. Reads are
+-- safe on any peer (synced state); toggles route through the existing admin-gated,
+-- server-validated network events — NOT direct FieldSentry_API mutation, which
+-- would not sync in multiplayer.
+---@param mission table  g_currentMission
+function FieldSentry_API.attachBridge(mission)
+    if mission == nil then return end
+    mission.fieldSentry = {
+        -- Read
+        getUIStatus        = FieldSentry_API.getUIStatus,
+        isFieldSimDisabled = FieldSentry_API.isFieldSimDisabled,
+        isFieldManual      = FieldSentry_API.isFieldManual,
+        isFieldMeadow      = FieldSentry_API.isFieldMeadow,
+        isFieldDeco        = FieldSentry_API.isFieldDeco,
+        reasonName         = FieldSentry_Core.reasonName,
+        reasonL10nKey      = FieldSentry_Core.reasonL10nKey,
+        -- Control (client -> server request events; admin-gated server-side)
+        toggleSleep        = SoilNetworkEvents_SendFieldSentryToggle,
+        toggleMeadow       = SoilNetworkEvents_SendFieldMeadowToggle,
+        isPlayerAdmin      = SoilNetworkEvents_IsPlayerAdmin,
+    }
+end
+
 --- Set the manual blacklist for a field.
 ---@param fieldId number
 ---@param enabled boolean

--- a/src/SoilCompactionModel.lua
+++ b/src/SoilCompactionModel.lua
@@ -1,0 +1,195 @@
+-- =====================================================================================
+-- SoilCompactionModel.lua
+-- -------------------------------------------------------------------------------------
+-- Ground-pressure compaction model, grounded in extension agronomy (Penn State,
+-- Missouri) rather than raw vehicle mass. Compaction per pass is two independent terms,
+-- scaled by a soil-moisture multiplier:
+--
+--   SURFACE  ∝ ground contact pressure ≈ tyre inflation pressure. Wide / flotation /
+--             aired-down tyres spread the load → low pressure → little surface packing.
+--   SUBSOIL  ∝ axle load (independent of tyres). ~10 t/axle damages subsoil; <5 t/axle
+--             does not. The permanent-damage term that a big tyre cannot avoid.
+--   MOISTURE multiplier: wet soil compacts far worse ("hydraulic ram"); dry resists.
+--
+-- Variable Tire Pressure (HotShotPepper, ModHub) integration:
+--   When VTP is installed it exposes a live, transition-interpolated effective pressure
+--   in bar via vehicle:vtpGetDashboardPressureBar(). Surface contact pressure ≈ tyre
+--   inflation pressure (PSU), so we read that bar value DIRECTLY as our surface pressure
+--   — airing down to FIELD mode automatically lowers compaction. With VTP absent we
+--   approximate contact pressure from live wheel geometry instead.
+--
+-- The vehicle/VTP reads live here; the scoring math (scorePoints / advanceWetness) is
+-- pure and unit-tested under tools/test.
+-- =====================================================================================
+
+SoilCompactionModel = {}
+
+local function clamp(v, lo, hi)
+    if v < lo then return lo end
+    if v > hi then return hi end
+    return v
+end
+
+local GRAVITY = 9.81
+
+-- -------------------------------------------------------------------------------------
+-- PURE: compaction points for a single pass.
+--   pressureKPa : surface contact pressure (nil → no surface term)
+--   axleLoadT   : tonnes per axle  (nil → no subsoil term)
+--   wetness01   : 0 (bone dry) .. 1 (saturated)
+--   rateMult    : tuningCompactionRate multiplier (0 disables all build-up)
+-- -------------------------------------------------------------------------------------
+function SoilCompactionModel.scorePoints(pressureKPa, axleLoadT, wetness01, rateMult)
+    local cp = SoilConstants and SoilConstants.COMPACTION
+    if not cp then return 0 end
+
+    rateMult = rateMult or 1.0
+    if rateMult <= 0 then return 0 end
+    wetness01 = clamp(wetness01 or 0, 0, 1)
+
+    -- Surface term: contact pressure between FLOOR and REF maps linearly to 0..SURFACE_MAX.
+    local surface = 0
+    local gp = cp.GROUND_PRESSURE
+    if gp and pressureKPa and pressureKPa > gp.FLOOR_KPA then
+        local span = math.max(1e-6, gp.REF_KPA - gp.FLOOR_KPA)
+        surface = gp.SURFACE_MAX * clamp((pressureKPa - gp.FLOOR_KPA) / span, 0, 1)
+    end
+
+    -- Subsoil term: axle load between FLOOR_T and REF_T maps linearly to 0..SUBSOIL_MAX.
+    local subsoil = 0
+    local al = cp.AXLE_LOAD
+    if al and axleLoadT and axleLoadT > al.FLOOR_T then
+        local span = math.max(1e-6, al.REF_T - al.FLOOR_T)
+        subsoil = al.SUBSOIL_MAX * clamp((axleLoadT - al.FLOOR_T) / span, 0, 1)
+    end
+
+    -- Moisture multiplier scales the combined damage.
+    local moist = 1.0
+    local m = cp.MOISTURE
+    if m then
+        moist = m.DRY_MULT + (m.WET_MULT - m.DRY_MULT) * wetness01
+    end
+
+    return (surface + subsoil) * moist * rateMult
+end
+
+-- -------------------------------------------------------------------------------------
+-- PURE: advance a decaying soil-wetness value (0..1).
+--   Raining pins it to 1; otherwise it fades to 0 over MOISTURE.DECAY_HOURS.
+-- -------------------------------------------------------------------------------------
+function SoilCompactionModel.advanceWetness(prev, dtHours, isRaining)
+    if isRaining then return 1.0 end
+    prev = prev or 0
+    local cp = SoilConstants and SoilConstants.COMPACTION
+    local decayHours = (cp and cp.MOISTURE and cp.MOISTURE.DECAY_HOURS) or 12.0
+    local dec = (dtHours or 0) / math.max(0.01, decayHours)
+    return math.max(0, prev - dec)
+end
+
+-- -------------------------------------------------------------------------------------
+-- VTP read: live effective contact pressure in kPa, or nil when VTP is not driving
+-- this vehicle. Detection is by the registered getter + spec presence, never a guess.
+-- -------------------------------------------------------------------------------------
+function SoilCompactionModel.readVTPPressureKPa(vehicle)
+    if vehicle == nil then return nil end
+    if type(vehicle.vtpGetDashboardPressureBar) ~= "function" then return nil end
+    if vehicle.spec_variableTirePressure == nil then return nil end
+    local ok, bar = pcall(vehicle.vtpGetDashboardPressureBar, vehicle)
+    if not ok or type(bar) ~= "number" or bar <= 0 then return nil end
+    local gp = SoilConstants.COMPACTION.GROUND_PRESSURE
+    return bar * gp.BAR_TO_KPA + gp.CONTACT_OFFSET_KPA
+end
+
+-- -------------------------------------------------------------------------------------
+-- Geometry fallback: contact pressure ≈ (own weight) / (Σ tyre contact patch), where a
+-- patch ≈ width × (radius × CONTACT_LENGTH_FACTOR). Reads live wheel geometry, so VTP's
+-- physics-radius reduction is still partially reflected even on this path.
+-- -------------------------------------------------------------------------------------
+function SoilCompactionModel.readGeometryPressureKPa(vehicle, massT)
+    if vehicle == nil or not massT or massT <= 0 then return nil end
+    local spec = vehicle.spec_wheels
+    if spec == nil or spec.wheels == nil then return nil end
+
+    local gp = SoilConstants.COMPACTION.GROUND_PRESSURE
+    local sumAreaM2 = 0
+    for _, wheel in pairs(spec.wheels) do
+        local phys = wheel.physics
+        if phys then
+            local width  = phys.wheelShapeWidth
+            local radius = phys.radius
+            if width and radius and width > 0 and radius > 0 then
+                sumAreaM2 = sumAreaM2 + width * (radius * gp.CONTACT_LENGTH_FACTOR)
+            end
+        end
+    end
+    if sumAreaM2 <= 0 then return nil end
+
+    local loadN = massT * 1000.0 * GRAVITY
+    return (loadN / sumAreaM2) / 1000.0  -- Pa → kPa
+end
+
+-- Count distinct axles by bucketing wheels on their local Z position (handles duals,
+-- where 4 wheels share one axle). Falls back to a wheel-count estimate.
+local function countAxles(vehicle)
+    local cp = SoilConstants.COMPACTION
+    local perAxle = (cp.AXLE_LOAD and cp.AXLE_LOAD.WHEELS_PER_AXLE) or 2
+    local spec = vehicle.spec_wheels
+    if spec == nil or spec.wheels == nil then return 2 end
+
+    local buckets, axleCount, wheelCount = {}, 0, 0
+    for _, wheel in pairs(spec.wheels) do
+        wheelCount = wheelCount + 1
+        local phys = wheel.physics
+        local z = phys and phys.positionZ
+        if z then
+            local key = math.floor(z * 2 + 0.5)  -- ~0.5 m buckets
+            if not buckets[key] then
+                buckets[key] = true
+                axleCount = axleCount + 1
+            end
+        end
+    end
+    if axleCount > 0 then return axleCount end
+    if wheelCount > 0 then return math.max(1, math.ceil(wheelCount / perAxle)) end
+    return 2
+end
+
+local function readMass(vehicle, onlyThis)
+    local ok, m = pcall(function() return vehicle:getTotalMass(onlyThis) end)
+    if ok and type(m) == "number" and m > 0 then return m end
+    return nil
+end
+
+-- -------------------------------------------------------------------------------------
+-- Resolve (pressureKPa, axleLoadT, source) for a vehicle. Everything is self-consistent
+-- to THIS vehicle (its own mass over its own wheels). Returns nil if mass is unreadable.
+--   source ∈ "vtp" | "geometry"
+-- -------------------------------------------------------------------------------------
+function SoilCompactionModel.computeForVehicle(vehicle)
+    if vehicle == nil then return nil end
+    local massT = readMass(vehicle, true) or readMass(vehicle, false)
+    if not massT then return nil end
+
+    local source = "geometry"
+    local pressureKPa = SoilCompactionModel.readVTPPressureKPa(vehicle)
+    if pressureKPa then
+        source = "vtp"
+    else
+        pressureKPa = SoilCompactionModel.readGeometryPressureKPa(vehicle, massT)
+    end
+
+    local axleLoadT = massT / countAxles(vehicle)
+    return pressureKPa, axleLoadT, source
+end
+
+-- -------------------------------------------------------------------------------------
+-- Convenience: full points value for a vehicle in one call (used by hooks).
+-- Returns points (>=0) and the source string for logging.
+-- -------------------------------------------------------------------------------------
+function SoilCompactionModel.pointsForVehicle(vehicle, wetness01, rateMult)
+    local pressureKPa, axleLoadT, source = SoilCompactionModel.computeForVehicle(vehicle)
+    if pressureKPa == nil and axleLoadT == nil then return 0, source end
+    return SoilCompactionModel.scorePoints(pressureKPa, axleLoadT, wetness01, rateMult), source
+end
+
+SoilLogger.info("SoilCompactionModel loaded")

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -643,18 +643,6 @@ function SoilFertilityManager:onMissionStarted()
             end
         end
 
-        -- Queue version dialog before any risky init so a crash can't suppress it.
-        if SoilVersionDialog then
-            local modInfo = g_modManager and g_modManager:getModByName(self.modName)
-            local version = (modInfo and modInfo.version) or "?"
-            SoilLogger.info("Version check: save=%s mod=%s", tostring(self.lastSeenVersion), tostring(version))
-            if self.lastSeenVersion ~= version then
-                SoilLogger.info("New version detected — dialog queued (3s delay)")
-                self._pendingVersionDialog      = version
-                self._pendingVersionDialogDelay = 3000
-            end
-        end
-
         if not self.settings.enabled then
             SoilLogger.info("Mod disabled in settings — skipping soil system init")
             return
@@ -669,6 +657,22 @@ function SoilFertilityManager:onMissionStarted()
         end
 
         self:loadSoilData()
+
+        -- Version "What's new" dialog — queued AFTER loadSoilData so the comparison uses the
+        -- SAVED lastSeenVersion. It used to be queued before the load, which always compared
+        -- against the "" default, so the dialog reappeared on every load and the
+        -- "Don't show again" button never stuck (#665).
+        if SoilVersionDialog then
+            local modInfo = g_modManager and g_modManager:getModByName(self.modName)
+            local version = (modInfo and modInfo.version) or "?"
+            SoilLogger.info("Version check: save=%s mod=%s", tostring(self.lastSeenVersion), tostring(version))
+            if self.lastSeenVersion ~= version then
+                SoilLogger.info("New version detected — dialog queued (3s delay)")
+                self._pendingVersionDialog      = version
+                self._pendingVersionDialogDelay = 3000
+            end
+        end
+
         self.soilSystem:prePopulateAllZoneData()
         self:seedGRLEFromFieldData()
     end)

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1174,47 +1174,80 @@ function SoilFertilityManager:update(dt)
     self:updateAutoRates(dt)
 end
 
+--- Advance the decaying soil-wetness value (0..1) that feeds the compaction moisture
+--- multiplier. Pinned to 1 while raining, fades to 0 over MOISTURE.DECAY_HOURS of game
+--- time afterwards. Uses a monotonic game-hours clock from currentDay + dayTime.
+function SoilFertilityManager:_updateSoilWetness()
+    local env = g_currentMission and g_currentMission.environment
+    if not env then return end
+
+    local gameH = ((env.currentDay or 0) * 24) + ((env.dayTime or 0) / 3600000.0)
+    local lastH = self._wetnessLastGameH
+    local dtH = 0
+    if lastH then
+        dtH = gameH - lastH
+        if dtH < 0 then dtH = 0 end     -- clock moved backwards (load): treat as no time
+        if dtH > 24 then dtH = 24 end   -- clamp big jumps (sleep / fast-forward)
+    end
+    self._wetnessLastGameH = gameH
+
+    local isRaining = false
+    if env.weather and env.weather.getRainFallScale then
+        local okR, rs = pcall(function() return env.weather:getRainFallScale() end)
+        local thr = (SoilConstants.RAIN and SoilConstants.RAIN.MIN_RAIN_THRESHOLD) or 0.1
+        isRaining = okR and rs ~= nil and rs > thr
+    end
+
+    self._soilWetness01 = SoilCompactionModel.advanceWetness(self._soilWetness01, dtH, isRaining)
+end
+
 function SoilFertilityManager:_checkVehicleCompaction()
     if not (self.settings.compactionEnabled and SoilConstants.COMPACTION) then return end
     if not (self.soilSystem and self.soilSystem.hookManager) then return end
-    local cp      = SoilConstants.COMPACTION
+    local cp = SoilConstants.COMPACTION
+
+    -- Keep the moisture term current even when no heavy vehicle is around.
+    self:_updateSoilWetness()
+
     local vehicle = getPlayerVehicle()
     if not vehicle or not vehicle.rootNode then return end
     local okM, totalMass = pcall(function() return vehicle:getTotalMass(false) end)
+    -- Cheap relevance gate: skip light vehicles (cars/quads) entirely. This is a perf
+    -- floor only — actual compaction is decided by ground pressure, not this threshold.
     if not (okM and totalMass and totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T) then return end
     local ok, x, _, z = pcall(getWorldTranslation, vehicle.rootNode)
     if not (ok and x) then return end
 
-    -- Compact a single world point if it sits on a field (onCompaction throttles
-    -- each cell to once/day, so repeated calls on the same cell are cheap no-ops).
+    -- Ground-pressure points for this vehicle this pass (identical for every sub-step of
+    -- the driven segment). Reads Variable Tire Pressure live when installed, else wheel
+    -- geometry. Big flotation tyres / aired-down / dry soil → ~0 → nothing is laid.
+    local points, source = SoilCompactionModel.pointsForVehicle(vehicle, self._soilWetness01 or 0)
+    if not points or points <= 0 then
+        self._lastCompactionX, self._lastCompactionZ = x, z  -- keep continuity, lay nothing
+        return
+    end
+
+    -- Compact a single world point if it sits on a field (onCompaction gates each cell to
+    -- once/day and to real field ground, so repeated calls are cheap no-ops).
     local function compactAt(px, pz)
         local fid = self.soilSystem.hookManager:getFieldIdAtWorldPosition(px, pz, false)
         if fid and fid > 0 then
-            pcall(function() self.soilSystem:onCompaction(fid, px, pz) end)
+            pcall(function() self.soilSystem:onCompaction(fid, px, pz, points) end)
         end
     end
 
     local lx, lz = self._lastCompactionX, self._lastCompactionZ
     self._lastCompactionX, self._lastCompactionZ = x, z
 
-    -- First sample (or after a discontinuity): just compact the current cell.
-    if not (lx and lz) then
-        compactAt(x, z)
-        return
-    end
+    -- First sample, or a teleport/fast-travel jump: record position but lay NOTHING.
+    -- Compaction only accrues along ground actually driven over, so sitting still or
+    -- spawning on a field never raises it (Talia: "equipment just sitting raises it").
+    if not (lx and lz) then return end
 
     local dx, dz = x - lx, z - lz
     local dist   = math.sqrt(dx * dx + dz * dz)
-
-    -- Parked / barely moved: nothing new to lay this tick.
-    if dist < (cp.MIN_MOVE_DISTANCE_M or 2.0) then return end
-
-    -- Discontinuity (teleport / fast-travel / re-entered a vehicle far away):
-    -- don't draw a compaction line across the gap — just compact where we are.
-    if dist > (cp.MAX_SEGMENT_M or 30.0) then
-        compactAt(x, z)
-        return
-    end
+    if dist < (cp.MIN_MOVE_DISTANCE_M or 2.0) then return end   -- parked / barely moved
+    if dist > (cp.MAX_SEGMENT_M or 30.0) then return end        -- discontinuity: no line across the gap
 
     -- Walk the driven segment in ~half-cell steps so no cell is skipped at speed.
     -- This is what keeps the trail continuous whether crawling or driving fast.
@@ -1225,6 +1258,9 @@ function SoilFertilityManager:_checkVehicleCompaction()
         local t = i / steps
         compactAt(lx + dx * t, lz + dz * t)
     end
+
+    SoilLogger.debug("Compaction: %s pass +%.2f raw pts/cell  wet=%.2f  steps=%d",
+        tostring(source), points, self._soilWetness01 or 0, steps)
 end
 
 --- Auto-rate control update — throttled, client-side only.

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1332,17 +1332,11 @@ function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
             multiplier = 1.0
 
         else
-            -- Check if this is an OM-primary product (manure, compost, digestate, etc.)
-            local omPrimary = SoilConstants.SPRAYER_RATE.OM_PRIMARY_PRODUCTS
-            if omPrimary and omPrimary[fillType.name] and profile.OM and profile.OM > 0 then
-                -- Drive rate from OM deficit only — NPK is secondary for organics
-                local omDeficit = math.max(0, targets.OM - fieldData.organicMatter) / math.max(0.01, targets.OM)
-                multiplier = MULT_MIN + omDeficit * (MULT_MAX - MULT_MIN)
-                SoilLogger.debug(
-                    "Auto-rate calc (OM-primary): %s | omDeficit=%.3f | target multiplier=%.3f",
-                    fillType.name, omDeficit, multiplier)
-            else
-                -- Nutrient fertilizer: weighted deficit across profile nutrients
+            -- Weighted nutrient deficit across the profile's N/P/K/pH (and optionally OM).
+            -- Each nutrient's deficit is weighted by its coefficient in the product profile,
+            -- so a product is sized by the nutrients it actually carries. Returns nil when the
+            -- profile contributes no weighted nutrients.
+            local function weightedNutrientDeficit(includeOM)
                 local totalWeight     = 0
                 local weightedDeficit = 0
 
@@ -1362,7 +1356,7 @@ function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
                     totalWeight     = totalWeight     + profile.K
                 end
                 if profile.pH and profile.pH > 0 then
-                    -- pH: how far below target (7.0) normalised to the possible range [5.0, 7.0]
+                    -- pH: how far below target normalised to the possible range [PH_MIN, target]
                     local phRange = targets.pH - phMin
                     if phRange > 0 then
                         local deficit = math.max(0, targets.pH - fieldData.pH) / phRange
@@ -1370,15 +1364,37 @@ function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
                         totalWeight     = totalWeight     + profile.pH
                     end
                 end
-                if profile.OM and profile.OM > 0 then
+                if includeOM and profile.OM and profile.OM > 0 then
                     local deficit = math.max(0, targets.OM - fieldData.organicMatter) / targets.OM
                     weightedDeficit = weightedDeficit + deficit * profile.OM
                     totalWeight     = totalWeight     + profile.OM
                 end
 
                 if totalWeight > 0 then
+                    return weightedDeficit / totalWeight
+                end
+                return nil
+            end
+
+            -- Check if this is an OM-primary product (manure, compost, digestate, etc.)
+            local omPrimary = SoilConstants.SPRAYER_RATE.OM_PRIMARY_PRODUCTS
+            if omPrimary and omPrimary[fillType.name] and profile.OM and profile.OM > 0 then
+                -- Organic product. Size the pass by whichever need is bigger: organic matter
+                -- OR the N/P/K it carries. Driving off OM deficit alone starved a nutrient-rich
+                -- organic (chicken / pelletized manure) on a field that was already high in OM
+                -- but low in N/P/K — the exact situation a player reaches for it (#668).
+                local omDeficit  = math.max(0, targets.OM - fieldData.organicMatter) / math.max(0.01, targets.OM)
+                local npkDeficit = weightedNutrientDeficit(false) or 0
+                local effective  = math.max(omDeficit, npkDeficit)
+                multiplier = MULT_MIN + effective * (MULT_MAX - MULT_MIN)
+                SoilLogger.debug(
+                    "Auto-rate calc (organic): %s | omDeficit=%.3f | npkDeficit=%.3f | using=%.3f | target multiplier=%.3f",
+                    fillType.name, omDeficit, npkDeficit, effective, multiplier)
+            else
+                -- Nutrient fertilizer: weighted deficit across all profile nutrients (incl. OM).
+                local deficitFraction = weightedNutrientDeficit(true)
+                if deficitFraction then
                     -- Map [0, 1] deficit fraction → [0.20, 1.20] multiplier
-                    local deficitFraction = weightedDeficit / totalWeight
                     multiplier = MULT_MIN + deficitFraction * (MULT_MAX - MULT_MIN)
                     SoilLogger.debug(
                         "Auto-rate calc: %s | deficit=%.3f | target multiplier=%.3f",

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -673,12 +673,63 @@ function SoilFertilitySystem:resetSessionCoverage(fieldId, reason)
     SoilLogger.debug("Session coverage reset: field %d (%s)", fieldId, reason or "?")
 end
 
+--- #674: incorporate standing/dead crop biomass (green manure) into the soil.
+--- Applied on top of residue incorporation when a tillage or mulch pass works through
+--- a detected crop. Scales the profile's OM/N/P/K by the crop biomass (0..1) and the
+--- field-fraction processed this tick, and mirrors the bump into the local zoneData
+--- cell so the HUD/overlay reflect it. Returns true if anything changed.
+---@param fieldId number
+---@param field table The field data table
+---@param profile table A SoilConstants.CROP_INCORPORATION.* profile (OM/N/P/K)
+---@param biomass number Crop biomass factor 0..1 (from growth state)
+---@param factor number Field-fraction processed this tick (clampedArea / fieldAreaHa)
+---@param areaHa number Area processed this tick, in hectares (for the per-cell write)
+---@return boolean changed
+function SoilFertilitySystem:_applyCropIncorporation(fieldId, field, profile, biomass, factor, areaHa)
+    if not profile or not biomass or biomass <= 0 or not factor or factor <= 0 then return false end
+    local limits = SoilConstants.NUTRIENT_LIMITS
+    local scale  = factor * biomass
+
+    local omBefore = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
+    field.organicMatter = math.min(limits.ORGANIC_MATTER_MAX, omBefore + profile.OM * scale)
+    field.nitrogen   = math.min(limits.MAX, (field.nitrogen   or 0) + profile.N * scale)
+    field.phosphorus = math.min(limits.MAX, (field.phosphorus or 0) + profile.P * scale)
+    field.potassium  = math.min(limits.MAX, (field.potassium  or 0) + profile.K * scale)
+
+    -- Local zoneData cell update for HUD/PDA visibility (same pattern as residue).
+    local tx, tz = self._lastTillageX, self._lastTillageZ
+    if tx and tz then
+        local zone = SoilConstants.ZONE
+        local cellKey = tostring(math.floor(tx / zone.CELL_SIZE) * 10000 + math.floor(tz / zone.CELL_SIZE))
+        if not field.zoneData then field.zoneData = {} end
+        if not field.zoneData[cellKey] then
+            field.zoneData[cellKey] = {
+                N = field.nitrogen, P = field.phosphorus, K = field.potassium,
+                pH = field.pH, OM = field.organicMatter,
+                weedPressure = field.weedPressure, pestPressure = field.pestPressure,
+                diseasePressure = field.diseasePressure, compaction = field.compaction
+            }
+        end
+        local cell = field.zoneData[cellKey]
+        local cellScale = ((areaHa or 0) / zone.CELL_AREA_HA) * biomass
+        cell.OM = math.min(limits.ORGANIC_MATTER_MAX, (cell.OM or field.organicMatter) + profile.OM * cellScale)
+        cell.N  = math.min(limits.MAX, (cell.N or 0) + profile.N * cellScale)
+        cell.P  = math.min(limits.MAX, (cell.P or 0) + profile.P * cellScale)
+        cell.K  = math.min(limits.MAX, (cell.K or 0) + profile.K * cellScale)
+    end
+
+    SoilLogger.debug("Crop incorporation field %d: +OM%.3f +N%.3f (biomass=%.2f factor=%.4f)",
+        fieldId or -1, profile.OM * scale, profile.N * scale, biomass, factor)
+    return true
+end
+
 --- Hook delegate: called by HookManager when plowing occurs
 --- Increases organic matter and normalizes pH
 ---@param fieldId number The field being plowed
 ---@param area number Area processed in hectares (e.g. from lastStatsArea)
 ---@param isAlsoSprayer boolean|nil True if the implement also sprays (combo tools) — skip coverage reset
-function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer)
+---@param cropBiomass number|nil Crop biomass factor 0..1 if a standing/dead crop was incorporated (#674)
+function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer, cropBiomass)
     if not fieldId or fieldId <= 0 then return end
 
     local field = self:getOrCreateField(fieldId, true)
@@ -821,6 +872,17 @@ function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer)
         end
     end
 
+    -- Plowing benefit 7 (#674): green-manure incorporation — plowing in a STANDING or
+    -- dead crop (cover crop, failed/burned crop, tall stubble) returns its biomass to the
+    -- soil as a large OM + N boost, far above the bare-stubble residue release above.
+    if self.settings.residueIncorporation and cropBiomass and cropBiomass > 0
+       and SoilConstants.CROP_INCORPORATION then
+        if self:_applyCropIncorporation(fieldId, field, SoilConstants.CROP_INCORPORATION.PLOW,
+                                        cropBiomass, factor, areaHa) then
+            changed = true
+        end
+    end
+
     if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
         if SoilFieldUpdateEvent then
             local now = g_currentMission.time or 0
@@ -839,7 +901,8 @@ end
 ---@param fieldId number
 ---@param area number Area processed in hectares (e.g. from lastStatsArea)
 ---@param isAlsoSprayer boolean|nil True if the implement also sprays (combo tools) — skip coverage reset
-function SoilFertilitySystem:onCultivation(fieldId, area, isAlsoSprayer)
+---@param cropBiomass number|nil Crop biomass factor 0..1 if a standing/dead crop was incorporated (#674)
+function SoilFertilitySystem:onCultivation(fieldId, area, isAlsoSprayer, cropBiomass)
     if not fieldId or fieldId <= 0 then return end
     if not SoilConstants.CULTIVATION then return end
 
@@ -945,6 +1008,66 @@ function SoilFertilitySystem:onCultivation(fieldId, area, isAlsoSprayer)
             end
         end
     end
+
+    -- #674: green-manure incorporation — cultivating in a standing/dead cover crop mixes
+    -- its biomass into the topsoil (shallower than plowing, so a smaller boost).
+    if self.settings.residueIncorporation and cropBiomass and cropBiomass > 0
+       and SoilConstants.CROP_INCORPORATION then
+        if self:_applyCropIncorporation(fieldId, field, SoilConstants.CROP_INCORPORATION.CULTIVATOR,
+                                        cropBiomass, factor, areaHa) then
+            changed = true
+        end
+    end
+
+    if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
+        if SoilFieldUpdateEvent then
+            local now = g_currentMission.time or 0
+            if not self._tillBroadcastTime then self._tillBroadcastTime = {} end
+            local last = self._tillBroadcastTime[fieldId] or 0
+            if (now - last) >= 5000 then
+                self._tillBroadcastTime[fieldId] = now
+                g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+            end
+        end
+    end
+end
+
+--- Hook delegate (#674): called by HookManager when a mulcher actively chops crop/stubble.
+--- Mulching returns surface biomass to the soil as organic matter (no soil inversion, so
+--- a smaller boost than tillage). Area is estimated from speed × width by the hook and is
+--- bounded to one full-field-equivalent per day by the same per-day cap as plowing.
+---@param fieldId number
+---@param area number Estimated area processed this tick, in hectares
+---@param cropBiomass number Crop/stubble biomass factor 0..1
+function SoilFertilitySystem:onMulching(fieldId, area, cropBiomass)
+    if not fieldId or fieldId <= 0 then return end
+    if not self.settings.residueIncorporation then return end
+    if not cropBiomass or cropBiomass <= 0 then return end
+    if not SoilConstants.CROP_INCORPORATION then return end
+
+    local field = self:getOrCreateField(fieldId, true)
+    if not field then return end
+
+    local areaHa = area or 0.001
+    local fieldAreaHa = field.fieldArea and field.fieldArea > 0 and field.fieldArea or 1.0
+
+    -- Per-day area cap (same rationale as onPlowing/onCultivation): total mulch effect
+    -- cannot exceed one full-field-equivalent per day regardless of pass count.
+    local today = (g_currentMission and g_currentMission.environment and
+                   g_currentMission.environment.currentDay) or 0
+    if not self._mulchAreaToday then self._mulchAreaToday = {} end
+    local entry = self._mulchAreaToday[fieldId]
+    if not entry or entry.day ~= today then
+        entry = { day = today, used = 0 }
+        self._mulchAreaToday[fieldId] = entry
+    end
+    local clampedArea = math.min(areaHa, math.max(0, fieldAreaHa - entry.used))
+    if clampedArea <= 0 then return end
+    entry.used = entry.used + clampedArea
+    local factor = clampedArea / fieldAreaHa
+
+    local changed = self:_applyCropIncorporation(fieldId, field, SoilConstants.CROP_INCORPORATION.MULCHER,
+                                                 cropBiomass, factor, clampedArea)
 
     if changed and g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
         if SoilFieldUpdateEvent then
@@ -4313,6 +4436,15 @@ function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ)
     if not self.settings.compactionEnabled then return end
     local cp = SoilConstants.COMPACTION
     if not cp then return end
+
+    -- Build-up rate is independently tunable (#674 Discord / Talia): the
+    -- tuningCompactionRate slider scales how much compaction each heavy pass adds.
+    -- ZERO_MULT LUT: idx 1 = 0x (no build-up), 3 = 1x (default), 5 = 2x. At 0x we
+    -- skip everything so no stray cells are created.
+    local rateMult = getTuningMult(self.settings, "tuningCompactionRate", "ZERO_MULT")
+    local added = cp.COMPACTION_PER_PASS * rateMult
+    if added <= 0 then return end
+
     local field = self:getOrCreateField(farmlandId, false)
     if not field then return end
 
@@ -4340,7 +4472,7 @@ function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ)
     end
     local cell = field.zoneData[cellKey]
     local prev = cell.compaction or 0
-    local newVal = math.min(cp.MAX_COMPACTION, prev + cp.COMPACTION_PER_PASS)
+    local newVal = math.min(cp.MAX_COMPACTION, prev + added)
     cell.compaction = newVal
 
     -- 2. Update field average

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -385,6 +385,7 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField.sessionLastProduct      = nil
         harvestField._farmlandAreaConfirmed  = nil  -- re-confirm on next session's first spray (#507)
         harvestField.sprayTrailPts           = nil
+        harvestField.sownCrop                = nil  -- crop harvested; lastCrop now carries it (#661)
         -- frozenYieldModifier is NOT cleared here (#598): onHarvest fires per-cut, so
         -- clearing here defeats the freeze and causes yield to drop with each combine pass.
         -- The freeze is cleared once per game day in _processOneDailyField instead.
@@ -554,10 +555,24 @@ end
 --- the clearing was unnecessary and harmful to rotation history accuracy.
 ---@param fieldId number The field being sown
 ---@param area number Area processed in hectares
-function SoilFertilitySystem:onSowing(fieldId, area)
+---@param seedsFruitType number|nil  Fruit type index of the seed going in the ground
+function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType)
     if not fieldId or fieldId <= 0 then return end
     local field = self:getOrCreateField(fieldId, true)
     if not field then return end
+
+    -- Record the crop being seeded so the HUD/map show it right away (#661). Live FieldState
+    -- detection only returns the new crop once the sampled point (field centroid) has actually
+    -- been seeded, so on a half-finished pass the readout fell back to lastCrop and showed the
+    -- PREVIOUS crop (e.g. "beans" while drilling wheat). sownCrop is a display-only bridge:
+    -- it does NOT touch the lastCrop rotation-history chain (kept intact for #204) and is
+    -- cleared on harvest. getFieldInfo prefers it over lastCrop when no live crop is detected.
+    if seedsFruitType and g_fruitTypeManager then
+        local seedDesc = g_fruitTypeManager:getFruitTypeByIndex(seedsFruitType)
+        if seedDesc and seedDesc.name and seedDesc.name ~= "" then
+            field.sownCrop = seedDesc.name
+        end
+    end
 
     local areaHa = area or 0.001
     local fieldAreaHa = field.fieldArea and field.fieldArea > 0 and field.fieldArea or 1.0
@@ -2065,6 +2080,36 @@ function SoilFertilitySystem:_prePopulateZoneData(fieldId)
     SoilLogger.debug("Pre-populated zone data: field %d, %d cells (step=%.0fm)", fieldId, count, step)
 end
 
+--- Re-stamp the per-cell overlay (zoneData) to the field's CURRENT average N/P/K/pH/OM.
+--- Used after an admin "set field state" so the in-game map overlay reflects the change
+--- immediately. The HUD reads field-average values live, but the map overlay reads the
+--- per-cell zoneData written during the last spray pass, so without this the map kept
+--- showing the pre-change values until the next fertiliser pass (#661).
+---@param fieldId number
+function SoilFertilitySystem:refreshFieldOverlay(fieldId)
+    local field = self.fieldData and self.fieldData[fieldId]
+    if not field then return end
+    field.zoneData = field.zoneData or {}
+
+    -- Overlay never built this session (no spray yet) → build it from the polygon, which
+    -- stamps every in-polygon cell with the current field-average values.
+    if next(field.zoneData) == nil then
+        self:_prePopulateZoneData(fieldId)
+        return
+    end
+
+    -- Overlay already exists → overwrite every cell so the whole field shows the new
+    -- uniform value (an admin override sets the field-average, so per-cell variation
+    -- from earlier partial passes is intentionally flattened).
+    for _, cell in pairs(field.zoneData) do
+        cell.N  = field.nitrogen
+        cell.P  = field.phosphorus
+        cell.K  = field.potassium
+        cell.pH = field.pH
+        cell.OM = field.organicMatter
+    end
+end
+
 -- Pre-populate zone data for ALL loaded fields that have empty zoneData.
 -- Called once after loadSoilData() so overlay tiles are visible from session start.
 function SoilFertilitySystem:prePopulateAllZoneData()
@@ -3429,6 +3474,21 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
     if not overlayOnly then
         field.coverageFraction        = math.min(1.0, (field.coveredAreaHa  or 0) / areaInHa)
         field.sessionCoverageFraction = math.min(1.0, (field.sessionCoverageHa or 0) / areaInHa)
+
+        -- Issue #660 / #661 diagnostics: pass% is reported wrong on some implements — the
+        -- fertilizing seeder over-counts (94% at half done), a wide dry-lime spreader on a
+        -- 40 ha field under-counts (35% when nearly done). Log the raw inputs (unique session
+        -- cells, session ha, field ha, fraction, boom-point count, cell ha) throttled once / 2 s
+        -- per field so a single user log shows whether the FIELD AREA or the CELL COUNT is off.
+        local _now = (g_currentMission and g_currentMission.time) or 0
+        if (_now - (field._covDiagAt or 0)) > 2000 then
+            field._covDiagAt = _now
+            local nCells = 0
+            for _ in pairs(field.sessionCoverageCells) do nCells = nCells + 1 end
+            SoilLogger.debug("CoverageDiag field=%d cells=%d sessHa=%.3f fieldHa=%.3f frac=%.0f%% boomPts=%d cellHa=%.4f",
+                fieldId, nCells, field.sessionCoverageHa or 0, areaInHa,
+                (field.sessionCoverageFraction or 0) * 100, #boomPoints, cellArea)
+        end
     end
 
     -- Full pass complete — clear trail so the overlay disappears as a visual reward.
@@ -3769,9 +3829,11 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
             end
         end
     end
-    -- Fall back to lastCrop when the field is fallow (no live fruit detected)
+    -- Fall back to the just-seeded crop, then lastCrop, when no live fruit is detected.
+    -- sownCrop bridges the window between drilling and the centroid actually carrying the
+    -- crop, so a half-finished seeding pass shows the NEW crop instead of the previous one (#661).
     if not cropName or cropName == "" then
-        cropName = field.lastCrop
+        cropName = field.sownCrop or field.lastCrop
     end
 
     -- Compute crop rotation status for external consumers (e.g. FarmTablet)
@@ -3939,6 +4001,13 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
     local defaults = SoilConstants.FIELD_DEFAULTS
     local index = 0
 
+    -- Persist the last day the daily update ran. Without this, lastUpdateDay reset to 0 on
+    -- load and (currentDay ~= 0) always re-fired the daily pass on reload, which cleared the
+    -- frozen yield modifier (so the expected-yield % recomputed lower from the now-depleted
+    -- field-average nutrients) and applied a bonus day of fallow / nutrient drift every time
+    -- you saved and reloaded (#665).
+    setXMLInt(xmlFile, key .. "#lastUpdateDay", self.lastUpdateDay or 0)
+
     for fieldId, field in pairs(self.fieldData) do
         if type(field) == "table" then
             local fieldKey = string.format("%s.field(%d)", key, index)
@@ -4032,6 +4101,13 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
     local defaults = SoilConstants.FIELD_DEFAULTS
     self.fieldData = {}
     local index = 0
+
+    -- Restore the daily-update day (see saveToXMLFile). Default to the CURRENT day when the
+    -- attribute is absent (saves written before 2.4.3.0) so loading an older save does not
+    -- fire one stray daily tick on the first load after updating (#665).
+    local _curDay = (g_currentMission and g_currentMission.environment
+                     and g_currentMission.environment.currentDay) or 0
+    self.lastUpdateDay = getXMLInt(xmlFile, key .. "#lastUpdateDay") or _curDay
 
     while true do
         local fieldKey = string.format("%s.field(%d)", key, index)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -4432,17 +4432,36 @@ end
 ---@param farmlandId number
 ---@param worldX number  world X of the implement's work area centre
 ---@param worldZ number  world Z of the implement's work area centre
-function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ)
+--- Apply compaction at a world position.
+---@param farmlandId number
+---@param worldX number
+---@param worldZ number
+---@param points number|nil Raw ground-pressure points for this pass (surface+subsoil×
+---       moisture, NOT yet rate-scaled). When nil, the legacy flat per-pass amount is
+---       used. Either way the tuningCompactionRate multiplier is applied here, in one place.
+function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ, points)
     if not self.settings.compactionEnabled then return end
     local cp = SoilConstants.COMPACTION
     if not cp then return end
 
-    -- Build-up rate is independently tunable (#674 Discord / Talia): the
-    -- tuningCompactionRate slider scales how much compaction each heavy pass adds.
-    -- ZERO_MULT LUT: idx 1 = 0x (no build-up), 3 = 1x (default), 5 = 2x. At 0x we
-    -- skip everything so no stray cells are created.
+    -- Field-ground gate (Talia, Discord): compaction is keyed on the *farmland* parcel,
+    -- which also covers painted gravel / parking / decoration ground inside that parcel.
+    -- Only pack soil where the engine reports real field ground at this point so a
+    -- parking pad on a field no longer compacts (the #672 overlay uses the same check).
+    -- y is ignored by the lookup; pass 0 like Giants' own code. If the API is missing
+    -- (older build) we proceed rather than silently disabling compaction.
+    if FSDensityMapUtil and FSDensityMapUtil.getFieldDataAtWorldPosition then
+        local ok, isOnField = pcall(FSDensityMapUtil.getFieldDataAtWorldPosition, worldX, 0, worldZ)
+        if ok and isOnField == false then return end
+    end
+
+    -- Build-up amount. The pressure model (driving + harvest hooks) passes raw points;
+    -- legacy callers (none currently) get the flat per-pass amount. The user-facing
+    -- tuningCompactionRate multiplier is applied here so it governs every path equally.
+    -- ZERO_MULT LUT: idx 1 = 0x (no build-up), 3 = 1x, 5 = 2x.
     local rateMult = getTuningMult(self.settings, "tuningCompactionRate", "ZERO_MULT")
-    local added = cp.COMPACTION_PER_PASS * rateMult
+    local base = (points ~= nil) and points or cp.COMPACTION_PER_PASS
+    local added = base * rateMult
     if added <= 0 then return end
 
     local field = self:getOrCreateField(farmlandId, false)

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -180,6 +180,29 @@ SoilConstants.RESIDUE_INCORPORATION = {
 }
 
 -- ========================================
+-- CROP INCORPORATION (Issue #674 — green manure / cover-crop / failed-crop tillage)
+-- ========================================
+-- Working a STANDING or dead crop into the soil — green manure, an over-wintered
+-- cover crop, a failed/burned crop, or a tall stubble — releases far more organic
+-- matter and nitrogen than tilling bare soil. This is applied ON TOP of residue
+-- incorporation, and ONLY when a crop is actually detected at the work position
+-- (via a FieldState query in the onStartWorkAreaProcessing probe, before the tool
+-- clears the fruit). Values below are the maximum per full-field pass at full crop
+-- biomass; they are scaled by the crop's biomass factor (0..1, from growth state)
+-- and the processed area fraction. Gated by the existing residueIncorporation setting.
+--
+-- Agronomic basis: incorporating a green-manure / cover crop (e.g. oilseed radish,
+-- mustard, clover) returns the whole standing biomass to the soil — typically several
+-- tonnes/ha of fresh matter — versus only surface straw for stubble residue.
+SoilConstants.CROP_INCORPORATION = {
+    PLOW       = { OM = 1.2,  N = 6.0, P = 1.2, K = 4.0 },  -- deep inversion — fullest burial
+    CULTIVATOR = { OM = 0.7,  N = 3.5, P = 0.7, K = 2.2 },  -- shallow mixing
+    MULCHER    = { OM = 0.6,  N = 2.5, P = 0.5, K = 1.5 },  -- surface chop, no soil inversion
+    MIN_BIOMASS = 0.30,   -- floor biomass factor once an established crop (past seedling) is detected
+    SEEDLING_GROWTH_STATE = 1,  -- growth states at/below this are negligible biomass (just emerged)
+}
+
+-- ========================================
 -- NUTRIENT LIMITS
 -- ========================================
 SoilConstants.NUTRIENT_LIMITS = {

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -1071,11 +1071,51 @@ SoilConstants.MAP_OVERLAY = {
 -- ========================================
 -- COMPACTION (P2-D)
 -- ========================================
+-- Compaction is modelled on real agronomy (Penn State / Missouri extension), not raw
+-- mass. Two independent terms, scaled by soil moisture:
+--   * SURFACE  ∝ ground contact pressure ≈ tire inflation pressure. Wide/flotation/
+--     aired-down tyres spread the load → low pressure → little surface packing.
+--   * SUBSOIL  ∝ axle load (regardless of tyres). ~10 t/axle damages subsoil; <5 t/axle
+--     does not. This is the permanent-damage term a big tyre can't avoid.
+--   * MOISTURE multiplier: wet soil compacts far worse ("hydraulic ram"); dry soil resists.
+-- The numbers in SoilCompactionModel are calibrated against the contact-pressure
+-- references in those sources (e.g. a 1360 kg car on tiny patches ≈ 827 kPa).
 SoilConstants.COMPACTION = {
-    HEAVY_VEHICLE_THRESHOLD_T = 8.0,   -- tonnes (Vehicle:getTotalMass returns tonnes)
-    COMPACTION_PER_PASS       = 8.0,   -- points added per heavy-vehicle pass over a cell (once/day/cell).
-                                       -- Sized to clear the minimap heatmap's lowest visible bucket
-                                       -- (top-4-bit DMV → first colour at ~6.3%) so a single pass shows.
+    -- Relevance gate: skip the whole calculation for light vehicles (cars, quads, UTVs).
+    -- This is a perf/gameplay floor only — it is NOT the old "≥8 t = compact" rule.
+    HEAVY_VEHICLE_THRESHOLD_T = 3.0,   -- tonnes (Vehicle:getTotalMass returns tonnes)
+
+    -- Surface term: ground contact pressure → points. When Variable Tire Pressure is
+    -- installed we read its live pressure (bar) directly; otherwise we approximate the
+    -- contact pressure from live wheel geometry (see SoilCompactionModel).
+    GROUND_PRESSURE = {
+        FLOOR_KPA          = 80.0,   -- below this, no surface compaction (good flotation tyres / field mode)
+        REF_KPA            = 250.0,  -- at/above this, full surface compaction (narrow road tyres / road mode)
+        SURFACE_MAX        = 6.0,    -- max surface points per pass at/above REF_KPA
+        BAR_TO_KPA         = 100.0,  -- 1 bar = 100 kPa (VTP reports pressure in bar)
+        CONTACT_OFFSET_KPA = 10.0,   -- surface contact pressure ≈ tyre pressure + ~1-2 psi (PSU)
+        CONTACT_LENGTH_FACTOR = 0.35,-- geometry fallback: contact-patch length ≈ radius × this
+    },
+
+    -- Subsoil term: axle load → points. Independent of tyre size (deep damage).
+    AXLE_LOAD = {
+        FLOOR_T         = 5.0,   -- <5 t/axle: no subsoil compaction (PSU)
+        REF_T           = 10.0,  -- 10 t/axle: full subsoil compaction (PSU)
+        SUBSOIL_MAX     = 3.0,   -- max subsoil points per pass at/above REF_T
+        WHEELS_PER_AXLE = 2,     -- mass/axle estimate when wheel layout can't be resolved
+    },
+
+    -- Moisture multiplier applied to (surface + subsoil). Driven by a decaying wetness
+    -- value that rises while raining and fades over DECAY_HOURS after the rain stops.
+    MOISTURE = {
+        DRY_MULT    = 0.6,   -- dry soil resists compaction
+        WET_MULT    = 1.5,   -- saturated soil transfers stress straight down ("hydraulic ram")
+        DECAY_HOURS = 12.0,  -- in-game hours for soil to dry back to DRY_MULT after rain
+    },
+
+    -- Legacy fallback: points added when a caller has no computed pressure (kept so any
+    -- path that calls onCompaction without a points value still does something sane).
+    COMPACTION_PER_PASS       = 6.0,
     NATURAL_DECAY_PER_DAY     = 0.5,   -- points removed per game day (natural recovery)
     SUBSOILER_REDUCTION       = 15.0,  -- points removed per subsoiler pass
     MAX_COMPACTION            = 100.0,

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -376,6 +376,16 @@ SettingsSchema.definitions = {
         max = 5,
         uiId = "sf_tun_comp",
     },
+    {
+        -- How fast compaction BUILDS UP per heavy-traffic pass (separate from decay).
+        -- ZERO_MULT LUT: index 1 = 0x (no build-up), 3 = 1x (default), 5 = 2x.
+        id = "tuningCompactionRate",
+        type = "number",
+        default = 3,
+        min = 1,
+        max = 5,
+        uiId = "sf_tun_comprate",
+    },
 }
 
 -- Build lookup table by id for fast access

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -158,6 +158,17 @@ function HookManager:installAll(soilSystem)
     local dedicatedPlowOk = self:installDedicatedPlowHook()
     if dedicatedPlowOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
+    -- #674: crop-biomass probe — samples the standing crop at the work position in
+    -- onStartWorkAreaProcessing (BEFORE the tool clears the fruit) and stashes a 0..1
+    -- biomass factor on the vehicle, which the plow/cultivator end hooks consume to award
+    -- a green-manure OM boost. Installed for both Cultivator and Plow specs.
+    if self:installCropBiomassProbe(Cultivator, "Cultivator") then successCount = successCount + 1 else failCount = failCount + 1 end
+    if self:installCropBiomassProbe(Plow, "Plow") then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    -- #674: mulcher hook — chopping crop/stubble returns surface biomass to the soil as OM
+    local mulcherOk = self:installMulcherHook()
+    if mulcherOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
     -- Mechanical weed removal (Weeder.onEndWorkAreaProcessing — weeders, inter-row hoes)
     local weedControlOk = self:installWeederHook()
     if weedControlOk then successCount = successCount + 1 else failCount = failCount + 1 end
@@ -3203,43 +3214,39 @@ function HookManager:installPlowingHook()
                     -- tilling — they must not reset the session coverage they just laid.
                     local isAlsoSprayer = cultivatorSelf.spec_sprayer ~= nil
 
+                    -- #674: green-manure biomass sampled (pre-clear) by the crop-biomass probe.
+                    local cropBiomass = cultivatorSelf._sfCropBiomass or 0
+
                     if isPlowingTool then
                         g_SoilFertilityManager.soilSystem._lastTillageX = x
                         g_SoilFertilityManager.soilSystem._lastTillageZ = z
-                        g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa, isAlsoSprayer)
+                        g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa, isAlsoSprayer, cropBiomass)
                         g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
                     else
                         g_SoilFertilityManager.soilSystem._lastTillageX = x
                         g_SoilFertilityManager.soilSystem._lastTillageZ = z
-                        g_SoilFertilityManager.soilSystem:onCultivation(farmlandId, areaHa, isAlsoSprayer)
+                        g_SoilFertilityManager.soilSystem:onCultivation(farmlandId, areaHa, isAlsoSprayer, cropBiomass)
                         g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, false)
                     end
 
-                    -- Compaction: check if subsoiler or heavy vehicle
+                    -- Compaction: tillage LOOSENS soil — it never packs it. Deep tillage
+                    -- (a subsoiler, OR a plow-action cultivator running deep enough to
+                    -- qualify as plowing) relieves compaction; shallow cultivation is
+                    -- neutral. Only harvest traffic (the combine hook) adds compaction.
+                    -- This fixes #672-adjacent reports where a deep-tillage tool built on
+                    -- the Cultivator spec (e.g. a Bourgault SPS configured as a subsoiler)
+                    -- was treated as a heavy vehicle and ADDED compaction every pass.
                     if g_SoilFertilityManager.settings.compactionEnabled and SoilConstants.COMPACTION then
-                        local cp = SoilConstants.COMPACTION
-                        local isSubsoiler = cultivatorSelf.spec_cultivator and
-                                           cultivatorSelf.spec_cultivator.isSubsoiler
-                        if isSubsoiler then
-                            SoilLogger.debug("Compaction: subsoiler pass on farmland=%d veh=%d pos=(%.1f,%.1f)",
-                                farmlandId, cultivatorSelf.id or 0, x, z)
+                        local isSubsoiler = (cultivatorSelf.spec_cultivator and
+                                            cultivatorSelf.spec_cultivator.isSubsoiler) or false
+                        if isSubsoiler or isPlowingTool then
+                            SoilLogger.debug(
+                                "Compaction: deep-tillage relief on farmland=%d veh=%d pos=(%.1f,%.1f) subsoiler=%s plow=%s",
+                                farmlandId, cultivatorSelf.id or 0, x, z,
+                                tostring(isSubsoiler), tostring(isPlowingTool))
                             g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId, x, z)
-                        else
-                            local rootVehicle = cultivatorSelf.rootVehicle or cultivatorSelf
-                            local okM, totalMass = pcall(function()
-                                return rootVehicle:getTotalMass(false)
-                            end)
-                            if okM and totalMass then
-                                SoilLogger.debug(
-                                    "Compaction check: farmland=%d veh=%d  pos=(%.1f,%.1f)  mass=%.1ft  threshold=%.1ft  heavy=%s",
-                                    farmlandId, cultivatorSelf.id or 0, x, z,
-                                    totalMass, cp.HEAVY_VEHICLE_THRESHOLD_T,
-                                    tostring(totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T))
-                                if totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T then
-                                    g_SoilFertilityManager.soilSystem:onCompaction(farmlandId, x, z)
-                                end
-                            end
                         end
+                        -- shallow cultivator: neutral, no compaction change
                     end
                 end
             end)
@@ -3302,28 +3309,23 @@ function HookManager:installDedicatedPlowHook()
                 SoilLogger.debug("[DedicatedPlowHook] pos=(%.1f,%.1f) farmlandId=%s",
                     x, z, tostring(farmlandId))
                 if farmlandId and farmlandId > 0 then
+                    -- #674: green-manure biomass sampled (pre-clear) by the crop-biomass probe.
+                    local cropBiomass = plowSelf._sfCropBiomass or 0
                     g_SoilFertilityManager.soilSystem._lastTillageX = x
                     g_SoilFertilityManager.soilSystem._lastTillageZ = z
-                    g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa)
+                    g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa, false, cropBiomass)
                     g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
 
-                    -- Dedicated plows are always heavy equipment
-                    if g_SoilFertilityManager.settings.compactionEnabled then
-                        local rootVehicle = plowSelf.rootVehicle or plowSelf
-                        local okM, totalMass = pcall(function()
-                            return rootVehicle:getTotalMass(false)
-                        end)
-                        local cp = SoilConstants.COMPACTION
-                        if cp and okM and totalMass then
-                            SoilLogger.debug(
-                                "Compaction check (plow): farmland=%d veh=%d  pos=(%.1f,%.1f)  mass=%.1ft  threshold=%.1ft  heavy=%s",
-                                farmlandId, plowSelf.id or 0, x, z,
-                                totalMass, cp.HEAVY_VEHICLE_THRESHOLD_T,
-                                tostring(totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T))
-                            if totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T then
-                                g_SoilFertilityManager.soilSystem:onCompaction(farmlandId, x, z)
-                            end
-                        end
+                    -- Plowing is deep inversion tillage: it breaks up compacted layers
+                    -- rather than packing them. Relieve compaction on the worked area
+                    -- (no-op if the cell isn't compacted). Previously this ADDED
+                    -- compaction for heavy plows, which made a subsoiler built on the
+                    -- Plow spec climb instead of reset — DeltaFive's "one field keeps
+                    -- climbing" report.
+                    if g_SoilFertilityManager.settings.compactionEnabled and SoilConstants.COMPACTION then
+                        SoilLogger.debug("Compaction: plow relief on farmland=%d veh=%d pos=(%.1f,%.1f)",
+                            farmlandId, plowSelf.id or 0, x, z)
+                        g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId, x, z)
                     end
                 end
             end)
@@ -3335,6 +3337,151 @@ function HookManager:installDedicatedPlowHook()
     )
     self:register(Plow, "onEndWorkAreaProcessing", original, "Plow.onEndWorkAreaProcessing")
     SoilLogger.info("[OK] Dedicated plow hook installed successfully (via onEndWorkAreaProcessing)")
+    return true
+end
+
+-- =========================================================
+-- HOOK 5b-ii: Crop-biomass probe + mulcher (Issue #674)
+-- =========================================================
+--- Sample how much incorporable crop biomass stands at a world position, as a 0..1
+--- factor derived from the live FieldState growth state. Returns 0 for bare/plowed
+--- ground or a just-emerged seedling; ~1 for a mature, withered, or cut crop (all of
+--- which are full biomass to work in). Mirrors the proven FieldState query used
+--- elsewhere in this mod and is fully pcall-guarded.
+---@param worldX number
+---@param worldZ number
+---@return number biomassFactor 0..1
+function HookManager:sampleCropBiomassAt(worldX, worldZ)
+    if worldX == nil or worldZ == nil then return 0 end
+    if FieldState == nil or FruitType == nil or g_fruitTypeManager == nil then return 0 end
+
+    local ok, fs = pcall(function()
+        local s = FieldState.new()
+        s:update(worldX, worldZ)
+        return s
+    end)
+    if not ok or not fs then return 0 end
+
+    local idx = fs.fruitTypeIndex
+    if not idx or idx == FruitType.UNKNOWN then return 0 end
+
+    local fruitDesc = g_fruitTypeManager:getFruitTypeByIndex(idx)
+    if not fruitDesc then return 0 end
+
+    local ci = SoilConstants.CROP_INCORPORATION
+    local gs = fs.growthState or 0
+    local seedling = (ci and ci.SEEDLING_GROWTH_STATE) or 1
+    if gs <= seedling then return 0 end   -- negligible biomass while just emerged
+
+    -- "Full biomass" reference = the crop's harvest-ready growth state. Anything at or
+    -- beyond it (including withered / post-mow cut states, which index higher) clamps to 1.
+    local ref = fruitDesc.maxHarvestingGrowthState
+    if not ref or ref <= 1 then ref = fruitDesc.minHarvestingGrowthState or 6 end
+    local factor = gs / ref
+    if factor > 1 then factor = 1 end
+
+    local minB = (ci and ci.MIN_BIOMASS) or 0.30
+    if factor < minB then factor = minB end   -- floor for any established crop
+    return factor
+end
+
+--- Install an onStartWorkAreaProcessing probe on a tillage/mulch spec. It runs BEFORE
+--- the work-area functions clear the fruit, samples the crop biomass at the implement
+--- position, and stashes it on the vehicle as `_sfCropBiomass` for the matching end hook
+--- to consume. Event listeners dispatch through the class spec table, so replacing the
+--- function reaches already-spawned vehicles too.
+---@param class table The specialization table (Cultivator, Plow, …)
+---@param className string Friendly name for logging/registration
+---@return boolean success
+function HookManager:installCropBiomassProbe(class, className)
+    if not class or type(class.onStartWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install crop-biomass probe - %s.onStartWorkAreaProcessing not available",
+            tostring(className))
+        return false
+    end
+
+    local hookMgrRef = self
+    local original = class.onStartWorkAreaProcessing
+    class.onStartWorkAreaProcessing = Utils.appendedFunction(
+        original,
+        function(vehSelf, dt)
+            if not vehSelf.isServer then return end
+            -- Only pay the FieldState query cost when the feature can actually use it.
+            if not g_SoilFertilityManager or
+               not g_SoilFertilityManager.settings or
+               not g_SoilFertilityManager.settings.enabled or
+               not g_SoilFertilityManager.settings.residueIncorporation then
+                vehSelf._sfCropBiomass = 0
+                return
+            end
+            local node = vehSelf.rootNode
+            if not node then vehSelf._sfCropBiomass = 0; return end
+            local ok, x, _, z = pcall(getWorldTranslation, node)
+            if not ok or x == nil then vehSelf._sfCropBiomass = 0; return end
+            vehSelf._sfCropBiomass = hookMgrRef:sampleCropBiomassAt(x, z)
+        end
+    )
+    self:register(class, "onStartWorkAreaProcessing", original, className .. ".onStartWorkAreaProcessing")
+    SoilLogger.info("[OK] Crop-biomass probe installed on %s (#674)", tostring(className))
+    return true
+end
+
+--- Hooks the Mulcher specialization. When a mulcher is actively chopping crop/stubble,
+--- the surface biomass is returned to the soil as organic matter. The Mulcher spec does
+--- not expose a processed-area accumulator (unlike Cultivator/Mower), so the area is
+--- estimated from forward speed × implement width and bounded by onMulching's per-day
+--- cap. Crop biomass is read from the `_sfCropBiomass` stash set by the probe above.
+---@return boolean success
+function HookManager:installMulcherHook()
+    if not Mulcher or type(Mulcher.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("Could not install Mulcher hook - Mulcher.onEndWorkAreaProcessing not available")
+        return false
+    end
+    -- The biomass probe must also be installed on the Mulcher spec.
+    self:installCropBiomassProbe(Mulcher, "Mulcher")
+
+    local hookMgrRef = self
+    local original = Mulcher.onEndWorkAreaProcessing
+    Mulcher.onEndWorkAreaProcessing = Utils.appendedFunction(
+        original,
+        function(mulcherSelf, dt)
+            if not mulcherSelf.isServer then return end
+            if not g_SoilFertilityManager or
+               not g_SoilFertilityManager.soilSystem or
+               not g_SoilFertilityManager.settings.enabled or
+               not g_SoilFertilityManager.settings.residueIncorporation then
+                return
+            end
+            local spec = mulcherSelf.spec_mulcher
+            if not spec or not spec.isWorking then return end
+
+            local biomass = mulcherSelf._sfCropBiomass or 0
+            if biomass <= 0 then return end
+
+            local success, errorMsg = pcall(function()
+                local x, _, z = getWorldTranslation(mulcherSelf.rootNode)
+                if not x then return end
+                local farmlandId = hookMgrRef:getFieldIdAtWorldPosition(x, z, true)
+                if not farmlandId or farmlandId <= 0 then return end
+
+                -- Estimate area covered this tick: speed (km/h → m/s) × dt(s) × width(m).
+                local speedMs = (mulcherSelf.getLastSpeed and (mulcherSelf:getLastSpeed() or 0) or 0) / 3.6
+                local widthM  = (mulcherSelf.size and mulcherSelf.size.width) or 3.0
+                local dtSec   = (dt or 0) / 1000
+                local areaHa  = (speedMs * dtSec * widthM) / 10000
+                if areaHa <= 0 then return end
+
+                g_SoilFertilityManager.soilSystem._lastTillageX = x
+                g_SoilFertilityManager.soilSystem._lastTillageZ = z
+                g_SoilFertilityManager.soilSystem:onMulching(farmlandId, areaHa, biomass)
+            end)
+            if not success then
+                SoilLogger.error("Mulcher hook failed: %s", tostring(errorMsg))
+            end
+        end
+    )
+    self:register(Mulcher, "onEndWorkAreaProcessing", original, "Mulcher.onEndWorkAreaProcessing")
+    SoilLogger.info("[OK] Mulcher hook installed (#674) — crop/stubble OM incorporation active")
     return true
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2538,7 +2538,27 @@ function HookManager:installSprayerAreaHook()
             local liters        = spec.workAreaParameters.usage
             local sprayFillLevel = spec.workAreaParameters.sprayFillLevel
 
-            if self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then return end
+            -- Issue #668 diagnostics: several spreaders (modded + some modhub manure
+            -- spreaders, e.g. Agromet N250 / JD34) are recognized by the SprayUsage hook
+            -- but never reach the nutrient apply below — a silent early-return drops them.
+            -- Log which guard fired (throttled once / 3 s per vehicle, debug-mode only) so a
+            -- single user log pinpoints the exact cause instead of us guessing.
+            local function _sfApplySkipLog(reason)
+                local _now = (g_currentMission and g_currentMission.time) or 0
+                if not self._sfApplySkipLogAt or (_now - self._sfApplySkipLogAt) > 3000 then
+                    self._sfApplySkipLogAt = _now
+                    local ftName = "?"
+                    local ft = fillTypeIndex and g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
+                    if ft then ftName = ft.name end
+                    SoilLogger.debug("SprayerHook SKIP [%s]: veh=%s type=%s usage=%s fillLevel=%s — nutrient apply skipped",
+                        reason, tostring(self.id), ftName, tostring(liters), tostring(sprayFillLevel))
+                end
+            end
+
+            if self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then
+                _sfApplySkipLog("turnedOff")
+                return
+            end
 
             -- Guard: folded implement must not record nutrient application.
             -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
@@ -2551,7 +2571,10 @@ function HookManager:installSprayerAreaHook()
                 if fa ~= nil then
                     local folded = dir ~= nil and ((dir == -1 and fa ~= 0) or (dir == 1 and fa ~= 1))
                                 or (dir == nil and fa > 0 and fa < 1)
-                    if folded then return end
+                    if folded then
+                        _sfApplySkipLog("folded")
+                        return
+                    end
                 end
             end
 
@@ -2580,13 +2603,31 @@ function HookManager:installSprayerAreaHook()
                 end
                 return
             end
-            if not sprayFillLevel or sprayFillLevel <= 0 then return end
+            if not sprayFillLevel or sprayFillLevel <= 0 then
+                _sfApplySkipLog("noFillLevel")
+                return
+            end
 
             -- Require minimum forward speed (matches WeedSpotSpray.onEndWorkAreaProcessing).
             -- A stationary sprayer drains the tank and consumes liters but covers no ground —
             -- without this guard coverage climbs to 100% without moving.
             local _spd = tonumber(self.getLastSpeed and self:getLastSpeed()) or 0
-            if _spd < 0.5 then return end
+            -- Towed spreaders/sprayers have no independent physics body, so their own
+            -- getLastSpeed() can report ~0 even while the tractor is moving. Borrow the
+            -- rootVehicle (tractor) speed the same way installSprayerUsageHook does
+            -- (issue #668) — without this a moving towed manure spreader is silently
+            -- dropped here even though SprayUsage shows it consuming product.
+            if _spd < 0.5 then
+                local root = self.rootVehicle
+                if root and root ~= self and root.getLastSpeed then
+                    local rootSpd = tonumber(root:getLastSpeed()) or 0
+                    if rootSpd > _spd then _spd = rootSpd end
+                end
+            end
+            if _spd < 0.5 then
+                _sfApplySkipLog(string.format("tooSlow spd=%.2f", _spd))
+                return
+            end
 
             local success, errorMsg = pcall(function()
                 local fillType = g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
@@ -3416,7 +3457,7 @@ function HookManager:installSowingHook()
                 if areaHa <= 0 then return end
                 g_SoilFertilityManager.soilSystem._lastTillageX = x
                 g_SoilFertilityManager.soilSystem._lastTillageZ = z
-                g_SoilFertilityManager.soilSystem:onSowing(fieldId, areaHa)
+                g_SoilFertilityManager.soilSystem:onSowing(fieldId, areaHa, spec.workAreaParameters.seedsFruitType)
             end)
 
             if not ok then

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2538,6 +2538,22 @@ function HookManager:installSprayerAreaHook()
             local liters        = spec.workAreaParameters.usage
             local sprayFillLevel = spec.workAreaParameters.sprayFillLevel
 
+            -- wap.isActive is vanilla's own "I painted terrain and drained product this
+            -- frame" flag: reset to false at the end of every onStartWorkAreaProcessing and
+            -- set true only inside processSprayerArea, which runs only for genuinely active
+            -- (lowered + on) work areas. Vanilla onEndWorkAreaProcessing removes fill ONLY
+            -- when isActive is true, so isActive==true is hard proof the implement is
+            -- applying to the ground right now — regardless of what getIsTurnedOn()/fold
+            -- state report. Some modded spreaders (Agromet N250, JD34, T088 — issue #671)
+            -- spread product while reporting getIsTurnedOn()==false and/or a fold state our
+            -- guard reads as "folded", so the turnedOff/folded guards below would drop them
+            -- every frame even though product is leaving the tank. We use isActive as a
+            -- positive override: when the engine confirms active application, we trust it
+            -- over those flags. We do NOT gate ON isActive (never skip merely because it is
+            -- false) — the saturated-field path where isActive can be false still flows
+            -- through via the turnedOn check and the usage/fillLevel/speed guards below.
+            local wapActive = spec.workAreaParameters.isActive == true
+
             -- Issue #668 diagnostics: several spreaders (modded + some modhub manure
             -- spreaders, e.g. Agromet N250 / JD34) are recognized by the SprayUsage hook
             -- but never reach the nutrient apply below — a silent early-return drops them.
@@ -2550,12 +2566,17 @@ function HookManager:installSprayerAreaHook()
                     local ftName = "?"
                     local ft = fillTypeIndex and g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
                     if ft then ftName = ft.name end
-                    SoilLogger.debug("SprayerHook SKIP [%s]: veh=%s type=%s usage=%s fillLevel=%s — nutrient apply skipped",
-                        reason, tostring(self.id), ftName, tostring(liters), tostring(sprayFillLevel))
+                    SoilLogger.debug("SprayerHook SKIP [%s]: veh=%s type=%s usage=%s fillLevel=%s isActive=%s — nutrient apply skipped",
+                        reason, tostring(self.id), ftName, tostring(liters), tostring(sprayFillLevel), tostring(wapActive))
                 end
             end
 
-            if self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then
+            -- turnedOff guard (issue b16e5df: driving with the implement turned off must
+            -- not apply). Skipped when wapActive — a working spreader that mis-reports
+            -- getIsTurnedOn()==false (issue #671) still applies because the engine confirmed
+            -- ground application this frame. A genuinely-off implement never processes a work
+            -- area, so wapActive is false and this guard still catches it.
+            if not wapActive and self.getIsTurnedOn ~= nil and not self:getIsTurnedOn() then
                 _sfApplySkipLog("turnedOff")
                 return
             end
@@ -2564,7 +2585,11 @@ function HookManager:installSprayerAreaHook()
             -- Mirror vanilla Foldable line 1286: working position is dir==-1,fa==0 OR dir==1,fa==1.
             -- turnOnFoldDirection is always 1 or -1 after Foldable init; nil falls back to
             -- animation-only detection (0 < fa < 1).
-            if self.spec_foldable then
+            -- Skipped when wapActive: a folded implement in transport raises its work areas,
+            -- so the engine never processes them and wapActive stays false — the guard still
+            -- fires. But a working spreader whose foldable spec our heuristic misreads as
+            -- "folded" (issue #671) has wapActive true and is correctly let through.
+            if not wapActive and self.spec_foldable then
                 local foldSpec = self.spec_foldable
                 local fa  = foldSpec.foldAnimTime
                 local dir = foldSpec.turnOnFoldDirection

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2211,19 +2211,25 @@ function HookManager:installHarvestHook()
                 end)
             end
 
-            -- Compaction: heavy harvesters compact the soil on each harvest pass
+            -- Compaction: harvesters pack soil by ground pressure, not raw mass. A combine
+            -- on wide flotation tyres in dry soil adds little; a heavy one on narrow tyres
+            -- in wet soil adds a lot. Same model as the driving check, incl. VTP/moisture.
             if detectedFieldId and detectedX and
                g_SoilFertilityManager.settings.compactionEnabled and
-               SoilConstants.COMPACTION then
+               SoilConstants.COMPACTION and SoilCompactionModel then
                 local cp = SoilConstants.COMPACTION
                 local rootVeh = combineSelf.rootVehicle or combineSelf
                 local okM, totalMass = pcall(function()
                     return rootVeh:getTotalMass(false)
                 end)
                 if okM and totalMass and totalMass >= cp.HEAVY_VEHICLE_THRESHOLD_T then
-                    pcall(function()
-                        g_SoilFertilityManager.soilSystem:onCompaction(detectedFieldId, detectedX, detectedZ)
-                    end)
+                    local wet = g_SoilFertilityManager._soilWetness01 or 0
+                    local points = SoilCompactionModel.pointsForVehicle(rootVeh, wet)
+                    if points and points > 0 then
+                        pcall(function()
+                            g_SoilFertilityManager.soilSystem:onCompaction(detectedFieldId, detectedX, detectedZ, points)
+                        end)
+                    end
                 end
             end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -408,6 +408,10 @@ local function load(mission)
         -- Cross-mod bridge: g_currentMission is a shared C++ object visible to all mods.
         -- getfenv(0) is per-mod scoped in FS25. Use mission property for reliable cross-mod detection.
         mission.soilFertilityManager = sfm
+        -- #83 Cross-mod bridge for the FarmTablet FieldSentry app (read status + request toggles).
+        if FieldSentry_API and FieldSentry_API.attachBridge then
+            FieldSentry_API.attachBridge(mission)
+        end
 
         SoilLogger.info("Initialized in %s mode", disableGUI and "server/console" or "full")
     end
@@ -419,7 +423,10 @@ local function unload()
         sfm:delete()
         sfm = nil
         getfenv(0)["g_SoilFertilityManager"] = nil
-        if g_currentMission then g_currentMission.soilFertilityManager = nil end
+        if g_currentMission then
+            g_currentMission.soilFertilityManager = nil
+            g_currentMission.fieldSentry = nil   -- #83 drop the cross-mod bridge
+        end
     end
     -- Restore InputHelpDisplay.draw if we hooked it, so a session reload doesn't accumulate appends.
     if _inputHelpDisplayOrigDraw and InputHelpDisplay then

--- a/src/main.lua
+++ b/src/main.lua
@@ -35,6 +35,7 @@ source(modDirectory .. "src/utils/AsyncRetryHandler.lua")
 source(modDirectory .. "src/utils/SoilUtils.lua")
 source(modDirectory .. "src/config/Constants.lua")
 source(modDirectory .. "src/config/SettingsSchema.lua")
+source(modDirectory .. "src/SoilCompactionModel.lua")
 
 -- 2. Specializations (must load before core systems so vehicleType registration fires)
 source(modDirectory .. "src/specializations/SFNozzleEffects.lua")

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -745,7 +745,15 @@ function SoilSettingsGUI:consoleCommandSetState(fieldId, n, p, k, ph, om)
     field.potassium = K
     field.pH = pH
     field.organicMatter = OM
-    
+
+    -- Refresh the in-game map overlays so the change shows immediately (#661). The HUD reads
+    -- field-average values live, but the per-cell map overlay (zoneData) and the cached
+    -- minimap GRLE kept showing the pre-change values until the next spray pass.
+    sys:refreshFieldOverlay(fid)
+    if g_SoilFertilityManager.seedGRLEFromFieldData then
+        g_SoilFertilityManager:seedGRLEFromFieldData()
+    end
+
     local isServer = g_currentMission and g_currentMission:getIsServer()
     if isServer then
         g_SoilFertilityManager:saveSoilData()

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1977,17 +1977,18 @@ function SoilHUD:drawSprayerRatePanel()
                     pH = defaults.pH,
                     OM = defaults.OM,
                 } or defaults
-                local isOMPrimary = SoilConstants.OM_PRIMARY_PRODUCTS and SoilConstants.OM_PRIMARY_PRODUCTS[fillType.name]
+                local omPrimarySet = SoilConstants.SPRAYER_RATE and SoilConstants.SPRAYER_RATE.OM_PRIMARY_PRODUCTS
+                local isOMPrimary = omPrimarySet and omPrimarySet[fillType.name]
+                local ppm = SoilConstants.PPM_DISPLAY or { N=1, P=1, K=1 }
+                -- Organic products are sized by whichever need is bigger (OM or N/P/K), so show
+                -- the OM target as well as the nutrients — the readout then matches the rate.
                 if isOMPrimary then
-                    -- OM-primary products target organic matter, not N/P/K
-                    targetText = targetText .. string.format("%.1f", targets.OM) .. "% OM"
-                else
-                    local ppm = SoilConstants.PPM_DISPLAY or { N=1, P=1, K=1 }
-                    if profile.N and profile.N > 0 then targetText = targetText .. math.floor(targets.N * (ppm.N or 1) + 0.5) .. "N " end
-                    if profile.P and profile.P > 0 then targetText = targetText .. math.floor(targets.P * (ppm.P or 1) + 0.5) .. "P " end
-                    if profile.K and profile.K > 0 then targetText = targetText .. math.floor(targets.K * (ppm.K or 1) + 0.5) .. "K " end
-                    if profile.pH and profile.pH > 0 then targetText = targetText .. targets.pH .. "pH " end
+                    targetText = targetText .. string.format("%.1f", targets.OM) .. "% OM "
                 end
+                if profile.N and profile.N > 0 then targetText = targetText .. math.floor(targets.N * (ppm.N or 1) + 0.5) .. "N " end
+                if profile.P and profile.P > 0 then targetText = targetText .. math.floor(targets.P * (ppm.P or 1) + 0.5) .. "P " end
+                if profile.K and profile.K > 0 then targetText = targetText .. math.floor(targets.K * (ppm.K or 1) + 0.5) .. "K " end
+                if profile.pH and profile.pH > 0 then targetText = targetText .. targets.pH .. "pH " end
                 setTextColor(0.7, 0.9, 0.7, 0.8)
                 renderText(cx, scrollY - self:py(6)*s, 0.008 * fontMult * s, targetText)
             end

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -34,6 +34,14 @@ SoilMapOverlay.MINIMAP_DOT_SIZE     = 4   -- screen pixels per fill point (overl
 -- same visual coverage density without hitting the cap mid-field-list.
 SoilMapOverlay.DENSITY_POINTS   = {8000, 20000, 40000}
 
+-- Field-expansion sampling: Field.polygonPoints is static and never grows when a
+-- player plows to enlarge a field, so the polygon alone misses the new area (#672).
+-- The fill scan widens the polygon bounding box by this many cells on every side,
+-- unions in the farmland bounding box when available, and accepts off-polygon cells
+-- that the engine reports as live field ground belonging to the same farmland.
+SoilMapOverlay.EXPANSION_MARGIN_CELLS = 8     -- widen polygon AABB by N cells/side
+SoilMapOverlay.MAX_SCAN_CELLS         = 12000 -- per-farmland guard against a bogus bbox
+
 -- Status colors kept for colorblind fallback and any legacy uses
 SoilMapOverlay.C_POOR = {0.88, 0.25, 0.25}
 SoilMapOverlay.C_FAIR = {0.90, 0.82, 0.18}
@@ -139,7 +147,7 @@ function SoilMapOverlay.new(soilSystem, settings)
     self.isReady = false
 
     -- Cache of polygon fill points per field: fieldId → array of {x, z} world coords.
-    -- Populated lazily in getFieldFillPoints; cleared on requestRefresh.
+    -- Populated lazily in getFarmlandFillPoints; cleared on requestRefresh.
     self.fieldPolyCache = {}
 
     -- Minimap overlay: one centroid dot per field (updated on same cadence as samplePoints)
@@ -400,76 +408,144 @@ local function isPointInPoly(px, pz, verts)
     return inside
 end
 
---- Return an array of world {x, z} sample points that fill the field polygon.
---- Results are cached in self.fieldPolyCache keyed by fsField.fieldId + step.
---- Points outside the polygon are rejected.
----@param fsField table FS25 Field object with polygonPoints and fieldId
----@param step    number  World-unit grid spacing in meters (caller-computed)
+--- Return an array of world {x, z} sample points that fill every field on a
+--- farmland — including player-plowed expansion that lies outside the static
+--- field polygons (#672). Cells inside any predefined polygon are always kept;
+--- cells outside are kept only when the engine reports live field ground that
+--- belongs to this farmland, which is exactly what a plowed extension is.
+--- Results are cached in self.fieldPolyCache keyed by farmlandId + step.
+---
+--- Keyed and scanned per farmland (not per field) so that a multi-field farmland
+--- is filled once: a single call gathers all sibling polygons and the shared
+--- expansion area. Callers must dedupe by farmlandId to avoid re-scanning.
+---@param farmlandId number  The farmland id (the key fieldData uses)
+---@param step       number  World-unit grid spacing in meters (caller-computed)
 ---@return table Array of {x, z}
-function SoilMapOverlay:getFieldFillPoints(fsField, step)
+function SoilMapOverlay:getFarmlandFillPoints(farmlandId, step)
     step = step or SoilMapOverlay.POLYGON_STEP
-    local cacheKey = (fsField.fieldId or tostring(fsField)) .. "@" .. step
+    local cacheKey = tostring(farmlandId) .. "@" .. step
     if self.fieldPolyCache[cacheKey] then
         return self.fieldPolyCache[cacheKey]
     end
 
     local pts = {}
 
-    -- Collect polygon vertices from the i3d node array
-    local polyNodes = fsField.polygonPoints
-    local verts = {}
-    if polyNodes and #polyNodes > 0 then
-        for i = 1, #polyNodes do
-            local nodeId = polyNodes[i]
-            if nodeId and nodeId ~= 0 then
-                local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
-                if ok and wx then
-                    table.insert(verts, {x = wx, z = wz})
+    -- 1. Gather every predefined field polygon on this farmland and the tight
+    --    union bounding box of their vertices.
+    local polys = {}             -- array of vert arrays ({x=, z=})
+    local fallbackX, fallbackZ   -- a field centroid for the data-less fallback
+    local pMinX, pMaxX, pMinZ, pMaxZ
+    local fields = g_fieldManager and g_fieldManager.fields
+    if fields then
+        for _, f in ipairs(fields) do
+            if f and f.farmland and f.farmland.id == farmlandId then
+                local polyNodes = f.polygonPoints
+                local verts = {}
+                if polyNodes and #polyNodes > 0 then
+                    for i = 1, #polyNodes do
+                        local nodeId = polyNodes[i]
+                        if nodeId and nodeId ~= 0 then
+                            local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+                            if ok and wx then
+                                verts[#verts + 1] = {x = wx, z = wz}
+                                if not pMinX or wx < pMinX then pMinX = wx end
+                                if not pMaxX or wx > pMaxX then pMaxX = wx end
+                                if not pMinZ or wz < pMinZ then pMinZ = wz end
+                                if not pMaxZ or wz > pMaxZ then pMaxZ = wz end
+                            end
+                        end
+                    end
                 end
+                if #verts >= 3 then polys[#polys + 1] = verts end
+                if not fallbackX and f.posX then fallbackX, fallbackZ = f.posX, f.posZ end
             end
         end
     end
 
-    -- Fallback: if polygon data unavailable, return the single centroid point
-    if #verts < 3 then
-        if fsField.posX and fsField.posZ then
-            table.insert(pts, {x = fsField.posX, z = fsField.posZ})
-        end
+    -- 2. Build the scan window: the polygon AABB widened by a margin, unioned
+    --    with the farmland bounding box when the engine exposes one. The widened
+    --    window is what lets us reach plowed expansion that the static polygon
+    --    can never describe.
+    local minX, maxX, minZ, maxZ = pMinX, pMaxX, pMinZ, pMaxZ
+    if minX then
+        local margin = SoilMapOverlay.EXPANSION_MARGIN_CELLS * step
+        minX, maxX = minX - margin, maxX + margin
+        minZ, maxZ = minZ - margin, maxZ + margin
+    end
+
+    local farmland = g_farmlandManager and g_farmlandManager.getFarmlandById
+        and g_farmlandManager:getFarmlandById(farmlandId)
+    local bb = farmland and farmland.boundingBox
+    if type(bb) == "table" and type(bb.minX) == "number" and type(bb.maxX) == "number"
+       and type(bb.minZ) == "number" and type(bb.maxZ) == "number"
+       and bb.maxX > bb.minX and bb.maxZ > bb.minZ then
+        minX = minX and math.min(minX, bb.minX) or bb.minX
+        maxX = maxX and math.max(maxX, bb.maxX) or bb.maxX
+        minZ = minZ and math.min(minZ, bb.minZ) or bb.minZ
+        maxZ = maxZ and math.max(maxZ, bb.maxZ) or bb.maxZ
+    end
+
+    -- No geometry resolved at all → single centroid fallback.
+    if not minX then
+        if fallbackX then pts[1] = {x = fallbackX, z = fallbackZ} end
         self.fieldPolyCache[cacheKey] = pts
         return pts
     end
 
-    -- Compute bounding box
-    local minX, maxX = verts[1].x, verts[1].x
-    local minZ, maxZ = verts[1].z, verts[1].z
-    for i = 2, #verts do
-        if verts[i].x < minX then minX = verts[i].x end
-        if verts[i].x > maxX then maxX = verts[i].x end
-        if verts[i].z < minZ then minZ = verts[i].z end
-        if verts[i].z > maxZ then maxZ = verts[i].z end
+    -- Clamp to terrain bounds so a bogus bounding box can't trigger a giant scan.
+    local half = ((g_currentMission and g_currentMission.terrainSize) or 2048) * 0.5
+    minX = math.max(minX, -half); maxX = math.min(maxX, half)
+    minZ = math.max(minZ, -half); maxZ = math.min(maxZ, half)
+
+    -- Final guard: if the window is still pathologically large, drop back to the
+    -- tight polygon AABB (old polygon-only behaviour) rather than risk a hitch.
+    -- With no polygon to bound the scan, fall back to the centroid instead.
+    local nx = math.floor((maxX - minX) / step) + 1
+    local nz = math.floor((maxZ - minZ) / step) + 1
+    if nx * nz > SoilMapOverlay.MAX_SCAN_CELLS then
+        if pMinX then
+            minX, maxX, minZ, maxZ = pMinX, pMaxX, pMinZ, pMaxZ
+        else
+            if fallbackX then pts[1] = {x = fallbackX, z = fallbackZ} end
+            self.fieldPolyCache[cacheKey] = pts
+            return pts
+        end
     end
 
-    -- Grid-sample the bounding box, keep points inside the polygon
-    -- (step is the caller-supplied world-unit spacing, already terrain-scaled)
-    -- Offset start by half-step so points land near field centre, not edges
+    -- 3. Grid-sample. Inside any polygon → always fill (predefined field, no
+    --    density read). Outside → fill only when the engine reports field ground
+    --    on this farmland (the plowed expansion). y is ignored by the field-ground
+    --    lookup, so pass 0 (matches Giants' own PF code).
+    local hasFieldGroundApi = (FSDensityMapUtil ~= nil
+        and FSDensityMapUtil.getFieldDataAtWorldPosition ~= nil)
     local startX = minX + step * 0.5
     local startZ = minZ + step * 0.5
     local x = startX
     while x <= maxX do
         local z = startZ
         while z <= maxZ do
-            if isPointInPoly(x, z, verts) then
-                table.insert(pts, {x = x, z = z})
+            local inField = false
+            for pi = 1, #polys do
+                if isPointInPoly(x, z, polys[pi]) then inField = true; break end
             end
+            if not inField and hasFieldGroundApi then
+                local ok, onField = pcall(FSDensityMapUtil.getFieldDataAtWorldPosition, x, 0, z)
+                if ok and onField then
+                    local fid = g_farmlandManager and g_farmlandManager:getFarmlandIdAtWorldPosition(x, z)
+                    if type(fid) == "table" then fid = fid.id end
+                    if fid == farmlandId then inField = true end
+                end
+            end
+            if inField then pts[#pts + 1] = {x = x, z = z} end
             z = z + step
         end
         x = x + step
     end
 
     -- Ensure at least the centroid if the grid produced nothing
-    -- (can happen for very small or narrow fields)
-    if #pts == 0 and fsField.posX and fsField.posZ then
-        table.insert(pts, {x = fsField.posX, z = fsField.posZ})
+    -- (can happen for very small or narrow fields).
+    if #pts == 0 and fallbackX then
+        pts[1] = {x = fallbackX, z = fallbackZ}
     end
 
     self.fieldPolyCache[cacheKey] = pts
@@ -533,10 +609,11 @@ function SoilMapOverlay:updateSamplePoints(force)
         return
     end
 
-    -- Fill each field polygon with a grid of coloured sample points.
-    -- We match fields to our soil data via farmland.id (the key fieldData uses).
-    -- getFieldFillPoints() handles the grid sampling and caching; it falls back to
-    -- a single centroid point for very small fields or when polygon data is absent.
+    -- Fill each owned farmland with a grid of coloured sample points.
+    -- We match cells to our soil data via farmland.id (the key fieldData uses).
+    -- getFarmlandFillPoints() handles the grid sampling and caching; it covers the
+    -- predefined field polygons plus any plowed expansion (live field ground), and
+    -- falls back to a single centroid point when polygon data is absent.
     -- Only owned fields are sampled — activeFieldIds is maintained by the ownership
     -- hook and already represents the correct set for both SP and MP.
     local fields = g_fieldManager.fields
@@ -562,13 +639,16 @@ function SoilMapOverlay:updateSamplePoints(force)
     local maxPoints    = math.floor(basePoints * mapScale * mapScale)
 
     local totalPoints = 0
+    local seenFarmland = {}  -- fill points are gathered per farmland, so visit each once
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
-            if farmlandId and farmlandId > 0 and activeFieldIds[farmlandId] then
+            if farmlandId and farmlandId > 0 and activeFieldIds[farmlandId]
+               and not seenFarmland[farmlandId] then
+                seenFarmland[farmlandId] = true
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
-                    local polyPts = self:getFieldFillPoints(fsField, scaledStep)
+                    local polyPts = self:getFarmlandFillPoints(farmlandId, scaledStep)
                     -- Per-pixel path: when GRLE density map layers are available (layers 1-5),
                     -- read the soil value at each sample point directly from the layer so that
                     -- sprayed sub-areas show different colours from unsprayed areas.
@@ -1515,10 +1595,13 @@ function SoilMapOverlay:updateMinimapCentroids(force)
     local zone = SoilConstants.ZONE
     local mmStep = zone.CELL_SIZE  -- match zone data resolution exactly
 
+    local seenFarmland = {}  -- fill points are gathered per farmland, so visit each once
     for _, fsField in ipairs(fields) do
         if fsField and fsField.farmland then
             local farmlandId = fsField.farmland.id
-            if farmlandId and farmlandId > 0 and activeFieldIds[farmlandId] then
+            if farmlandId and farmlandId > 0 and activeFieldIds[farmlandId]
+               and not seenFarmland[farmlandId] then
+                seenFarmland[farmlandId] = true
                 local info = self.soilSystem:getFieldInfo(farmlandId)
                 if info then
                     -- Field-average color: fallback for polygon points with no zone data
@@ -1534,7 +1617,7 @@ function SoilMapOverlay:updateMinimapCentroids(force)
                     -- back to the field average. Eliminates the old two-pass approach
                     -- (polygon fill + separate zone overlay) which suffered from a 10m
                     -- vs 12m grid mismatch and 3px vs 4px dot-size bleed-through.
-                    local fillPoints = self:getFieldFillPoints(fsField, mmStep)
+                    local fillPoints = self:getFarmlandFillPoints(farmlandId, mmStep)
                     if #fillPoints > 0 then
                         for _, pt in ipairs(fillPoints) do
                             local pr, pg, pb = avgR, avgG, avgB

--- a/src/ui/SoilTuningPanel.lua
+++ b/src/ui/SoilTuningPanel.lua
@@ -108,6 +108,7 @@ local TUNING_SECTIONS = {
         items  = {
             { id = "tuningPestGrowth",      label = "Pest Growth Rate",    lut = "ZERO_MULT", fmt = "x%.2f" },
             { id = "tuningDiseaseGrowth",   label = "Disease Growth Rate", lut = "ZERO_MULT", fmt = "x%.2f" },
+            { id = "tuningCompactionRate",  label = "Compaction Buildup",  lut = "ZERO_MULT", fmt = "x%.2f" },
             { id = "tuningCompactionDecay", label = "Compaction Decay",    lut = "ZERO_MULT", fmt = "x%.2f" },
         },
     },
@@ -125,7 +126,7 @@ local PRESETS = {
             tuningNutrientDepletion = 2, tuningFertilizerEfficiency = 4,
             tuningRainLeaching = 1, tuningSeasonalStrength = 2,
             tuningPestGrowth = 1, tuningDiseaseGrowth = 1,
-            tuningFallowRecovery = 4, tuningCompactionDecay = 4,
+            tuningFallowRecovery = 4, tuningCompactionDecay = 4, tuningCompactionRate = 2,
         },
     },
     {
@@ -138,7 +139,7 @@ local PRESETS = {
             tuningNutrientDepletion = 3, tuningFertilizerEfficiency = 3,
             tuningRainLeaching = 3, tuningSeasonalStrength = 3,
             tuningPestGrowth = 3, tuningDiseaseGrowth = 3,
-            tuningFallowRecovery = 3, tuningCompactionDecay = 3,
+            tuningFallowRecovery = 3, tuningCompactionDecay = 3, tuningCompactionRate = 3,
         },
     },
     {
@@ -151,7 +152,7 @@ local PRESETS = {
             tuningNutrientDepletion = 4, tuningFertilizerEfficiency = 2,
             tuningRainLeaching = 4, tuningSeasonalStrength = 4,
             tuningPestGrowth = 4, tuningDiseaseGrowth = 4,
-            tuningFallowRecovery = 2, tuningCompactionDecay = 2,
+            tuningFallowRecovery = 2, tuningCompactionDecay = 2, tuningCompactionRate = 4,
         },
     },
     {
@@ -164,7 +165,7 @@ local PRESETS = {
             tuningNutrientDepletion = 3, tuningFertilizerEfficiency = 3,
             tuningRainLeaching = 1, tuningSeasonalStrength = 1,
             tuningPestGrowth = 1, tuningDiseaseGrowth = 1,
-            tuningFallowRecovery = 3, tuningCompactionDecay = 3,
+            tuningFallowRecovery = 3, tuningCompactionDecay = 3, tuningCompactionRate = 1,
         },
     },
 }

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,21 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: Some towed manure spreaders applied product in-game but SF recorded no",
+    "  nutrient or organic-matter change. SF now reads the tractor's speed for towed",
+    "  spreaders so the pass is counted, with extra logging to catch any remaining",
+    "  spreaders that slip through (#668)",
+    "- Fixed: A field's expected yield no longer drops a few percent every time you save",
+    "  and reload mid-harvest. The daily soil pass was re-running on every reload (which",
+    "  also added a stray day of nutrient drift); it now only runs when a real day passes (#665)",
+    "- Fixed: The 'What's new' dialog's 'Don't show again' now sticks. The version check",
+    "  ran before the saved value was loaded, so the dialog reappeared every load (#665)",
+    "- Fixed: Setting a field's values from the admin menu now updates the in-game map",
+    "  overlay right away instead of only the HUD; the map kept showing the old values",
+    "  until the next fertiliser pass (#661)",
+    "- Fixed: While drilling a new crop, the field readout no longer keeps showing the",
+    "  previous crop until you reach the middle of the field; it shows the crop you are",
+    "  seeding as soon as the pass starts (#661)",
     "- Fixed: Texture array warnings from the fill-plane normal and displacement maps. The",
     "  mip levels did not line up with the shared pile texture array, which spams the log",
     "  and can disturb fill-plane rendering. Corrected dds files contributed by Sabo-7 (#657)",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,18 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- New: Plowing, cultivating or mulching a standing or dead crop now gives a real",
+    "  organic matter boost. Working in a cover crop, a failed or burned crop, or tall",
+    "  stubble returns its biomass to the soil, so tilling a crop in is finally worth it",
+    "  instead of just leaving it. The bigger the crop, the bigger the boost (#674)",
+    "- Changed: Tillage now RELIEVES compaction instead of adding it. Plowing and",
+    "  subsoiling break up compacted soil, cultivating is neutral, and only harvesting",
+    "  with a heavy combine packs it down. This matches real farming and fixes the case",
+    "  where a subsoiler-configured tool made one field's compaction keep climbing",
+    "  instead of dropping back to zero",
+    "- New: Added a 'Compaction Buildup' slider in the tuning editor so you can set how",
+    "  fast compaction builds up, separately from how fast it recovers. Turn it down, or",
+    "  all the way to zero, if heavy machinery is packing your fields too quickly",
     "- Fixed: Auto-rate no longer starves manure and other organic fertilizers on a field",
     "  that is already rich in organic matter. The rate now follows whichever need is",
     "  bigger, organic matter or N/P/K, so a nutrient-heavy organic like chicken or",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,23 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Changed: Soil compaction is now based on ground pressure, not vehicle weight. A heavy",
+    "  machine on wide or flotation tyres spreads its load and barely compacts, while the",
+    "  same weight on narrow tyres packs the soil hard, just like real life. Very heavy",
+    "  machines still cause some deep compaction on any tyre because of axle load. The old",
+    "  fixed weight limit is gone",
+    "- New: Variable Tire Pressure support. If you run the Variable Tire Pressure mod, airing",
+    "  your tyres down to field mode genuinely reduces how much you compact the soil, and",
+    "  pumping back up to road mode increases it. Nothing to set up, it just works when the",
+    "  mod is installed",
+    "- New: Wet soil compacts more. Driving heavy equipment over a field while it rains, or",
+    "  in the hours after, packs the soil harder than working it when dry. Let a field dry",
+    "  out before bringing the heavy kit on",
+    "- Fixed: Parking pads, gravel and other painted ground on a field no longer build up",
+    "  compaction. It is now only applied where there is real field ground, so a parking",
+    "  area inside a field stops dragging the whole field's compaction up",
+    "- Fixed: Equipment just sitting on a field no longer raises compaction. It only builds",
+    "  up along ground you actually drive over, never from a parked or idling machine",
     "- New: Plowing, cultivating or mulching a standing or dead crop now gives a real",
     "  organic matter boost. Working in a cover crop, a failed or burned crop, or tall",
     "  stubble returns its biomass to the soil, so tilling a crop in is finally worth it",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,10 @@ SoilVersionDialog.INSTANCE = nil
 -- Any number of lines.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed: Auto-rate no longer starves manure and other organic fertilizers on a field",
+    "  that is already rich in organic matter. The rate now follows whichever need is",
+    "  bigger, organic matter or N/P/K, so a nutrient-heavy organic like chicken or",
+    "  pelletized manure still goes down when the field is short on nutrients (#668)",
     "- Fixed: Some towed manure spreaders applied product in-game but SF recorded no",
     "  nutrient or organic-matter change. SF now reads the tractor's speed for towed",
     "  spreaders so the pass is counted, with extra logging to catch any remaining",

--- a/tools/test/lua/compaction_test.lua
+++ b/tools/test/lua/compaction_test.lua
@@ -1,0 +1,65 @@
+-- compaction_test.lua — pure scoring for the ground-pressure compaction model.
+-- Guards SoilCompactionModel.scorePoints / advanceWetness: the agronomy-based math that
+-- replaced the old flat "≥8 t = +8 points" rule (Talia's Discord feedback). Expected
+-- values are derived from the constants so tuning changes don't false-fail the test.
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/SoilCompactionModel.lua
+
+local cp  = SoilConstants.COMPACTION
+local gp  = cp.GROUND_PRESSURE
+local al  = cp.AXLE_LOAD
+local m   = cp.MOISTURE
+
+local score   = SoilCompactionModel.scorePoints
+local wetnessOf = SoilCompactionModel.advanceWetness
+
+-- Pressures/axle loads chosen relative to the floors/refs so the test tracks tuning.
+local LOW_P   = gp.FLOOR_KPA - 10    -- below surface floor → no surface term
+local LIGHT_A = al.FLOOR_T  - 1      -- below axle floor → no subsoil term
+
+-- 1. Big flotation tyres on dry soil, light axle → nothing. (The whole point Talia made:
+--    a well-tyred machine should NOT compact just for being heavy.)
+T.eq("dry low-pressure light-axle adds nothing", score(LOW_P, LIGHT_A, 0, 1), 0)
+
+-- 2. Full surface pressure, sub-floor axle, dry → exactly SURFACE_MAX × DRY_MULT.
+T.near("full surface dry = SURFACE_MAX*DRY_MULT",
+       score(gp.REF_KPA, LIGHT_A, 0, 1), gp.SURFACE_MAX * m.DRY_MULT)
+
+-- 3. Sub-floor pressure, full axle load, dry → exactly SUBSOIL_MAX × DRY_MULT.
+--    Deep damage a big tyre can't dodge (PSU: subsoil ∝ axle load).
+T.near("full subsoil dry = SUBSOIL_MAX*DRY_MULT",
+       score(LOW_P, al.REF_T, 0, 1), al.SUBSOIL_MAX * m.DRY_MULT)
+
+-- 4. nil pressure still scores the subsoil term (geometry unavailable but mass known).
+T.near("nil pressure → subsoil only",
+       score(nil, al.REF_T, 0, 1), al.SUBSOIL_MAX * m.DRY_MULT)
+
+-- 5. Wet soil compacts more than dry at the same pressure ("hydraulic ram").
+local midP = (gp.FLOOR_KPA + gp.REF_KPA) * 0.5
+T.ok("wet > dry at same pressure", score(midP, LIGHT_A, 1, 1) > score(midP, LIGHT_A, 0, 1))
+T.near("saturated = SURFACE @mid × WET_MULT",
+       score(midP, LIGHT_A, 1, 1),
+       gp.SURFACE_MAX * ((midP - gp.FLOOR_KPA) / (gp.REF_KPA - gp.FLOOR_KPA)) * m.WET_MULT)
+
+-- 6. Variable Tire Pressure payoff: FIELD mode (≈1 bar) packs less than ROAD (≈2 bar).
+--    VTP surface pressure = bar*BAR_TO_KPA + CONTACT_OFFSET_KPA.
+local fieldKPa = 1.0 * gp.BAR_TO_KPA + gp.CONTACT_OFFSET_KPA
+local roadKPa  = 2.0 * gp.BAR_TO_KPA + gp.CONTACT_OFFSET_KPA
+T.ok("VTP field mode compacts less than road mode",
+     score(fieldKPa, LIGHT_A, 0, 1) < score(roadKPa, LIGHT_A, 0, 1))
+
+-- 7. Monotonic in pressure and in axle load.
+T.ok("more pressure → more compaction", score(220, LIGHT_A, 0, 1) > score(160, LIGHT_A, 0, 1))
+T.ok("more axle load → more compaction", score(LOW_P, al.REF_T, 0, 1) > score(LOW_P, al.FLOOR_T + 1, 0, 1))
+
+-- 8. tuningCompactionRate = 0 disables build-up entirely (idx 1 in the ZERO_MULT LUT).
+T.eq("rate 0 → no compaction", score(gp.REF_KPA, al.REF_T, 1, 0), 0)
+-- ...and doubling the rate doubles the result.
+T.near("rate 2x doubles", score(gp.REF_KPA, LIGHT_A, 0, 2), score(gp.REF_KPA, LIGHT_A, 0, 1) * 2)
+
+-- 9. Wetness tracker: rain pins to 1; dries to 0 over DECAY_HOURS; never goes negative.
+T.eq("rain pins wetness to 1", wetnessOf(0.0, 5, true), 1.0)
+T.near("half decay → 0.5", wetnessOf(1.0, m.DECAY_HOURS * 0.5, false), 0.5)
+T.near("full decay → 0", wetnessOf(1.0, m.DECAY_HOURS, false), 0)
+T.eq("over-decay clamps at 0 (no negative)", wetnessOf(1.0, m.DECAY_HOURS * 3, false), 0)
+
+T.summary()


### PR DESCRIPTION
## What this changes

Compaction is now based on **ground pressure**, not raw vehicle weight.

- **Surface compaction** scales with ground contact pressure. Wide or flotation tyres spread the load and barely compact; the same weight on narrow tyres packs the soil hard.
- **Subsoil compaction** scales with axle load on its own, so very heavy machines still cause some deep compaction on any tyre.
- A **soil-moisture** multiplier makes wet fields compact more and dry fields resist, fading over the hours after rain.

## Variable Tire Pressure support

When the Variable Tire Pressure mod is installed, we read its live effective pressure (`vtpGetDashboardPressureBar`) and use it directly as the surface contact pressure. Airing down to field mode compacts less, road mode more. No dependency, it just works when the mod is present; otherwise we estimate from wheel geometry.

## Two fixes from testing

- Parking pads, gravel and other painted ground inside a field no longer build up compaction (gated on real field ground).
- A machine just sitting or idling on a field no longer raises compaction. It only accrues along ground actually driven.

## Notes

- Model lives in `src/SoilCompactionModel.lua`, with pure `scorePoints` / `advanceWetness` covered by `tools/test/lua/compaction_test.lua` (self-test suite green).
- Bumps to 2.4.5.0 (modDesc, README, version dialog changelog).
