### PR TITLE
Stable release 2.4.3.0 (burn fix + See & Spray)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.6.1
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.6.2
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.6.1</version>
+    <version>2.4.6.2</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -546,6 +546,25 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
     end
 end
 
+--- Clears any pending amendment-burn one-shot (lime or OM applied over the previous
+--- growing crop, #437). That penalty belongs to the crop that was growing when the
+--- amendment landed; sowing a NEW crop (including direct drilling over the old one) or
+--- tilling the field voids it. The one-shot is otherwise only consumed at harvest, so
+--- replanting without harvesting left it stuck on the field and it wrongly docked the
+--- next crop's yield by up to 80% — the persistent-burn-after-replant bug reported by
+--- multiple players (direct seeding over a burned field never reset it).
+---@param field table        Field data record
+---@param fieldId number     Field id (logging only)
+---@param reason string      What cleared it ("sowing"/"cultivation"/"plowing"), for logs
+---@return boolean cleared   true if a pending burn was present and removed
+function SoilFertilitySystem:clearAmendmentBurn(field, fieldId, reason)
+    if not field or (field.amendBurnPenalty or 0) <= 0 then return false end
+    field.amendBurnPenalty   = nil
+    field._amendBurnNotified = nil
+    SoilLogger.debug("Amendment burn cleared on %s for field %s", tostring(reason), tostring(fieldId))
+    return true
+end
+
 --- Hook delegate: called by HookManager when sowing/planting occurs on a field.
 --- Called when a field is sown. Reserved for future sowing-time logic.
 --- NOTE: We previously cleared lastCrop here to force live HUD detection (#123),
@@ -579,6 +598,9 @@ function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType)
     local factor = areaHa / fieldAreaHa
 
     local changed = false
+
+    -- Planting a new crop voids any pending amendment burn from the previous crop.
+    if self:clearAmendmentBurn(field, fieldId, "sowing") then changed = true end
 
     -- Seeding disrupts weed seedlings via seed opener soil disturbance.
     -- Partially resets weed pressure based on area processed.
@@ -762,6 +784,9 @@ function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer, cropBiomass
 
     local changed = false
 
+    -- Tilling mixes the soil and ends the crop — void any pending amendment burn.
+    if self:clearAmendmentBurn(field, fieldId, "plowing") then changed = true end
+
     -- Plowing benefits 1 & 2: OM increase and pH normalization (only if plowingBonus enabled)
     if self.settings.plowingBonus then
         local omBefore = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
@@ -933,6 +958,9 @@ function SoilFertilitySystem:onCultivation(fieldId, area, isAlsoSprayer, cropBio
 
     local changed = false
     local c = SoilConstants.CULTIVATION
+
+    -- Tilling mixes the soil and ends the crop — void any pending amendment burn.
+    if self:clearAmendmentBurn(field, fieldId, "cultivation") then changed = true end
 
     if self.settings.weedPressure and c.WEED_PRESSURE_REDUCTION and (field.weedPressure or 0) > 0 then
         local before = field.weedPressure

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,7 @@ SoilVersionDialog.INSTANCE = nil
 -- Max 11 lines are visible in the box; if more exist we stop on a bullet boundary and add a "full changelog on GitHub" note.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fixed burn penalty sticking after replanting (clears on sow/till)",
     "- Fixed: See & Spray buy option now shows on every sprayer",
     "- See & Spray is now one combined buy option",
     "- Variable Rate now applies to See & Spray too",

--- a/tools/test/lua/burn_test.lua
+++ b/tools/test/lua/burn_test.lua
@@ -74,3 +74,23 @@ do
   T.eq("burn: a gap > BURN_PASS_GAP_MS opens a fresh pass (no dock that tick)",
        field.pH, afterPass1)
 end
+
+-- ── Amendment burn one-shot is voided by replanting / tillage ──────────────────
+-- The lime/OM-on-crop penalty (#437) is otherwise only consumed at harvest; replanting
+-- without harvesting (especially direct seeding) left it stuck and it docked the next
+-- crop's yield. clearAmendmentBurn() is the shared reset called by sow/cultivate/plow.
+do
+  local sys = newSys({})
+  local field = { amendBurnPenalty = 0.80, _amendBurnNotified = true }
+  local cleared = sys:clearAmendmentBurn(field, 1, "sowing")
+  T.ok("amend burn: clear reports it removed a pending penalty", cleared == true)
+  T.eq("amend burn: penalty value removed", field.amendBurnPenalty, nil)
+  T.eq("amend burn: notify flag cleared so a fresh burn can re-notify", field._amendBurnNotified, nil)
+end
+
+-- No pending burn → no-op, returns false (so callers don't mark the field changed).
+do
+  local sys = newSys({})
+  T.ok("amend burn: clear is a no-op with no pending penalty", sys:clearAmendmentBurn({}, 1, "sowing") == false)
+  T.ok("amend burn: clear is a no-op at exactly 0", sys:clearAmendmentBurn({ amendBurnPenalty = 0 }, 1, "plowing") == false)
+end


### PR DESCRIPTION
## What this fixes

The lime/OM-on-growing-crop burn penalty (`amendBurnPenalty`, #437) showed up as roughly -80% yield. It was meant to be a one-shot consumed at harvest, but if you replanted the burned crop without harvesting it (especially by direct seeding), nothing ever consumed it. The penalty stayed on the field and docked the next crop.

Reported by several players: lime over freshly sown peas then direct-sow beans kept the burn; replanting wheat after a burn still showed -80%.

## The fix

A pending amendment burn belongs to the crop that was growing when the lime/OM landed, so it is voided the moment that crop's context ends:

- `onSowing` — planting a new crop, including direct drilling over the old one (the players' exact case)
- `onCultivation` / `onPlowing` — tillage mixes the soil and ends the crop

Shared `clearAmendmentBurn()` helper, MP-synced through the existing `changed` broadcast. Harvest still consumes it as before, so the amended crop still pays the penalty; only an innocent replanted successor is spared.

## Testing

- Self-test suite passes (174 assertions, +5 new for the burn clear), Lua 5.1 syntax + lint clean.
- Built and deployed locally for in-game testing.

Version bumped to 2.4.6.2, changelog and README updated.