### PR TITLE
Realign version to 2.4.3.0 for stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.6.2
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.6.2</version>
+    <version>2.4.3.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>


### PR DESCRIPTION
Sets modDesc + README to 2.4.3.0 (the next stable release after v2.4.2.9). Carries the realign commit that missed the #683 merge race.