### PR TITLE
2.4.3.1 — burn fixes, See & Spray, taproot, mid-save, gradual burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.1
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.3.0</version>
+    <version>2.4.3.1</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1634,11 +1634,17 @@ function SoilFertilitySystem:scanFields()
                 local isNew = self.fieldData[actualFieldId] == nil
                 self:getOrCreateField(actualFieldId, true, area)
 
-                -- If this is a newly created field and density layers are available,
-                -- read existing layer values (pre-seeded GRLE) instead of using defaults.
+                -- If this is a newly created field and density layers are available, read
+                -- existing layer values (pre-seeded GRLE) instead of using defaults. On a
+                -- mid-save install the layers are empty (pH 0); readFieldFromLayers now keeps
+                -- the rolled defaults in that case (#685) and returns false, so we paint those
+                -- defaults into the layers here instead of leaving the field at 0/0/0/0.
                 if isNew and self.layerSystem and self.layerSystem.available then
                     -- Pass the Field object (not field.farmland) — Field has polygonPoints for AABB
-                    self.layerSystem:readFieldFromLayers(actualFieldId, self.fieldData[actualFieldId], field)
+                    local seeded = self.layerSystem:readFieldFromLayers(actualFieldId, self.fieldData[actualFieldId], field)
+                    if not seeded then
+                        self.layerSystem:writeFieldToLayers(actualFieldId, self.fieldData[actualFieldId], field, false)
+                    end
                 end
 
                 -- PHASE 1: only owned farmlands enter the active simulation set.
@@ -3045,33 +3051,44 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                 -- risk), so only penalise once it has regrown into its harvest window (tall).
                 -- Annual crops are never exempt. Shared by lime (#646) and organic matter
                 -- (#629/#645).
-                local perennialExempt = false
+                -- A short/early crop must not take the amendment burn. Two cases:
+                --   * Perennial forage: only inside the harvest window (tall sward); young
+                --     regrowth, cut and withered states are exempt (#645/#646).
+                --   * Annual crop: a freshly-sown / seedling crop has no leaf canopy to scorch,
+                --     so starter fertilizer or a pre-plant amendment applied at/just after seeding
+                --     must NOT burn it (#681). Penalise only once it has established past an early
+                --     fraction of the way to harvest-ready.
+                local burnExempt = false
                 if cropFruitIndex then
                     local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(cropFruitIndex)
                     local fruitName = fruitDesc and fruitDesc.name and string.lower(fruitDesc.name)
                     local perennialSet = SoilConstants.PERENNIAL_FORAGE_NAMES
+                    local gs = cropGrowthState or 0
                     if fruitDesc and fruitName and perennialSet and perennialSet[fruitName] then
                         -- Growth states are NOT linearly ordered: the post-mow "cut" state has a
                         -- HIGHER index than the harvest-ready states, so a lower-bound-only check
                         -- let cut grass through as "fully grown" (#645). Penalise ONLY inside the
-                        -- harvest window [minHarvestingGrowthState, maxHarvestingGrowthState];
-                        -- exempt young regrowth, cut and withered states.
+                        -- harvest window [minHarvestingGrowthState, maxHarvestingGrowthState].
                         local minH = fruitDesc.minHarvestingGrowthState
                         local maxH = fruitDesc.maxHarvestingGrowthState
-                        local gs   = cropGrowthState or 0
                         local cutStates = fruitDesc.cutStates
                         local inHarvestWindow = minH and minH > 0 and gs >= minH
                             and (not maxH or maxH <= 0 or gs <= maxH)
                             and not (cutStates and cutStates[gs])
-                        perennialExempt = not inHarvestWindow
+                        burnExempt = not inHarvestWindow
+                    elseif fruitDesc then
+                        -- Annual: exempt early establishment (seedling) stages — no canopy to scorch.
+                        local minH = fruitDesc.minHarvestingGrowthState or 6
+                        local frac = (SoilConstants.AMEND_BURN and SoilConstants.AMEND_BURN.ANNUAL_SEEDLING_FRACTION) or 0.33
+                        local establishedState = math.max(2, math.ceil(minH * frac))
+                        burnExempt = gs < establishedState
                     end
                 end
 
                 if isLimeAmendment then
-                    -- #646: liming early-stage / cut perennial forage is realistic pasture
-                    -- management, so skip the -80% burn there. Tall forage and every annual
-                    -- crop still take it.
-                    if not perennialExempt then
+                    -- #646/#681: liming cut/early perennial forage or a freshly-sown annual is
+                    -- realistic, so skip the -80% burn there. Established crops still take it.
+                    if not burnExempt then
                         field.amendBurnPenalty = 0.80
                         field._amendBurnNotified = true
                         self:showNotification(
@@ -3079,9 +3096,9 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                             string.format(g_i18n:getText("sf_notify_lime_crop_body"), fieldId))
                     end
                 else
-                    -- #629/#645: organic fertilizer (slurry/manure/digestate) on short/cut
-                    -- perennial forage is standard practice, so skip the -20% burn there.
-                    if not perennialExempt then
+                    -- #629/#645/#681: organic fertilizer (slurry/manure/digestate) on short/cut
+                    -- perennial forage or a freshly-sown annual is standard practice, so skip the -20%.
+                    if not burnExempt then
                         field.amendBurnPenalty = math.max(field.amendBurnPenalty or 0, 0.20)
                         field._amendBurnNotified = true
                         self:showNotification(

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -4568,11 +4568,13 @@ function SoilFertilitySystem:onCompaction(farmlandId, worldX, worldZ, points)
         farmlandId, cellKey, prev, newVal, field.compaction)
 end
 
---- Apply subsoiler compaction reduction at a specific world position.
+--- Apply a deep-tillage compaction reduction at a specific world position.
 ---@param farmlandId number
 ---@param worldX number
 ---@param worldZ number
-function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ)
+---@param reliefPoints number|nil  Points to remove from the cell. Defaults to the full
+---                                SUBSOILER_REDUCTION; plows pass the smaller PLOW_RELIEF (#687).
+function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ, reliefPoints)
     if not self.settings.compactionEnabled then return end
     local cp = SoilConstants.COMPACTION
     if not cp then return end
@@ -4597,7 +4599,8 @@ function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ)
     local prev = cell.compaction or 0
     if prev <= 0 then return end
 
-    local newVal = math.max(0, prev - cp.SUBSOILER_REDUCTION)
+    local relief = reliefPoints or cp.SUBSOILER_REDUCTION
+    local newVal = math.max(0, prev - relief)
     cell.compaction = newVal
 
     field.compactionSum = math.max(0, (field.compactionSum or 0) - (prev - newVal))

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2996,6 +2996,36 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
     )
 end
 
+--- Would applying a lime or organic amendment to this crop right now scorch it? (#437/#684)
+--- True only once the crop has leaf area to burn: for perennial forage that means inside the
+--- harvest window (tall sward); for annuals, past the early seedling stage (#681). Shared by
+--- the actual burn gate (applyFertilizer) and the monitor's pre-emptive "burn risk" warning.
+---@param fruitTypeIndex number|nil
+---@param growthState number|nil
+---@return boolean
+function SoilFertilitySystem:isAmendmentBurnRisk(fruitTypeIndex, growthState)
+    if not fruitTypeIndex then return false end
+    local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    if not fruitDesc then return false end
+    local fruitName    = fruitDesc.name and string.lower(fruitDesc.name)
+    local perennialSet = SoilConstants.PERENNIAL_FORAGE_NAMES
+    local gs = growthState or 0
+    if fruitName and perennialSet and perennialSet[fruitName] then
+        -- Perennial forage: burnable only inside the harvest window (tall sward).
+        local minH = fruitDesc.minHarvestingGrowthState
+        local maxH = fruitDesc.maxHarvestingGrowthState
+        local cutStates = fruitDesc.cutStates
+        return (minH and minH > 0 and gs >= minH
+            and (not maxH or maxH <= 0 or gs <= maxH)
+            and not (cutStates and cutStates[gs])) or false
+    end
+    -- Annual: burnable once established past the early seedling stage.
+    local minH = fruitDesc.minHarvestingGrowthState or 6
+    local frac = (SoilConstants.AMEND_BURN and SoilConstants.AMEND_BURN.ANNUAL_SEEDLING_FRACTION) or 0.33
+    local establishedState = math.max(2, math.ceil(minH * frac))
+    return gs >= establishedState
+end
+
 -- Apply fertilizer
 function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     if not self.settings.enabled then return end
@@ -3051,39 +3081,10 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                 -- risk), so only penalise once it has regrown into its harvest window (tall).
                 -- Annual crops are never exempt. Shared by lime (#646) and organic matter
                 -- (#629/#645).
-                -- A short/early crop must not take the amendment burn. Two cases:
-                --   * Perennial forage: only inside the harvest window (tall sward); young
-                --     regrowth, cut and withered states are exempt (#645/#646).
-                --   * Annual crop: a freshly-sown / seedling crop has no leaf canopy to scorch,
-                --     so starter fertilizer or a pre-plant amendment applied at/just after seeding
-                --     must NOT burn it (#681). Penalise only once it has established past an early
-                --     fraction of the way to harvest-ready.
-                local burnExempt = false
-                if cropFruitIndex then
-                    local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(cropFruitIndex)
-                    local fruitName = fruitDesc and fruitDesc.name and string.lower(fruitDesc.name)
-                    local perennialSet = SoilConstants.PERENNIAL_FORAGE_NAMES
-                    local gs = cropGrowthState or 0
-                    if fruitDesc and fruitName and perennialSet and perennialSet[fruitName] then
-                        -- Growth states are NOT linearly ordered: the post-mow "cut" state has a
-                        -- HIGHER index than the harvest-ready states, so a lower-bound-only check
-                        -- let cut grass through as "fully grown" (#645). Penalise ONLY inside the
-                        -- harvest window [minHarvestingGrowthState, maxHarvestingGrowthState].
-                        local minH = fruitDesc.minHarvestingGrowthState
-                        local maxH = fruitDesc.maxHarvestingGrowthState
-                        local cutStates = fruitDesc.cutStates
-                        local inHarvestWindow = minH and minH > 0 and gs >= minH
-                            and (not maxH or maxH <= 0 or gs <= maxH)
-                            and not (cutStates and cutStates[gs])
-                        burnExempt = not inHarvestWindow
-                    elseif fruitDesc then
-                        -- Annual: exempt early establishment (seedling) stages — no canopy to scorch.
-                        local minH = fruitDesc.minHarvestingGrowthState or 6
-                        local frac = (SoilConstants.AMEND_BURN and SoilConstants.AMEND_BURN.ANNUAL_SEEDLING_FRACTION) or 0.33
-                        local establishedState = math.max(2, math.ceil(minH * frac))
-                        burnExempt = gs < establishedState
-                    end
-                end
+                -- A short/early crop must not take the amendment burn: a seedling annual or a
+                -- short/cut perennial sward has no leaf canopy to scorch (#645/#646/#681). The
+                -- shared helper decides whether the crop is established enough to actually burn.
+                local burnExempt = not self:isAmendmentBurnRisk(cropFruitIndex, cropGrowthState)
 
                 if isLimeAmendment then
                     -- #646/#681: liming cut/early perennial forage or a freshly-sown annual is
@@ -3999,6 +4000,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     -- Correct approach: iterate g_fieldManager.fields and match farmland.id.
     local cropName = nil
     local liveFruitTypeIndex = nil  -- set when a live crop is detected; used to match the harvest freeze
+    local liveGrowthState = nil     -- growth state of the live crop, for the amendment-burn-risk check (#684)
     if g_fieldManager and g_fieldManager.fields then
         local fsField = nil
         for _, f in ipairs(g_fieldManager.fields) do
@@ -4023,6 +4025,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
                 end)
                 if ok and fieldState and fieldState.fruitTypeIndex ~= FruitType.UNKNOWN then
                     liveFruitTypeIndex = fieldState.fruitTypeIndex
+                    liveGrowthState    = fieldState.growthState
                     local fruitDesc = g_fruitTypeManager and
                         g_fruitTypeManager:getFruitTypeByIndex(fieldState.fruitTypeIndex)
                     if fruitDesc and fruitDesc.name then
@@ -4136,6 +4139,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         fungicideActive = (field.fungicideDaysLeft or 0) > 0,
         burnDaysLeft = field.burnDaysLeft or 0,
         amendBurnPenalty = field.amendBurnPenalty or 0,  -- pending lime/OM-on-crop burn (0-1); explains a low yield
+        amendBurnRisk = self:isAmendmentBurnRisk(liveFruitTypeIndex, liveGrowthState),  -- (#684) true → liming/manuring NOW would scorch the crop
         nutrientBuffer          = field.nutrientBuffer or {},
         coverageFraction        = field.coverageFraction or 0,
         sessionCoverageFraction = field.sessionCoverageFraction or 0,

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -339,6 +339,7 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
     if field.amendBurnPenalty and field.amendBurnPenalty > 0 then
         field.amendBurnPenalty   = nil
         field._amendBurnNotified = nil
+        field._amendBurnTickTime = nil
     end
 
     -- Freeze for the duration of this harvest cycle. All subsequent modifier
@@ -561,6 +562,7 @@ function SoilFertilitySystem:clearAmendmentBurn(field, fieldId, reason)
     if not field or (field.amendBurnPenalty or 0) <= 0 then return false end
     field.amendBurnPenalty   = nil
     field._amendBurnNotified = nil
+    field._amendBurnTickTime = nil
     SoilLogger.debug("Amendment burn cleared on %s for field %s", tostring(reason), tostring(fieldId))
     return true
 end
@@ -3026,6 +3028,35 @@ function SoilFertilitySystem:isAmendmentBurnRisk(fruitTypeIndex, growthState)
     return gs >= establishedState
 end
 
+--- Gradually build up the amendment burn instead of jumping to the cap (#688). Metered by
+--- application time exactly like the over-application burn: each tick adds a slice of the cap
+--- proportional to the elapsed time since the last application tick, so a brief brush or a
+--- slide onto the field costs only a small fraction and you have time to shut the sprayer off.
+--- Sibling boom sections in the same tick contribute dt == 0 (no double-count). A gap longer
+--- than BURN_PASS_GAP_MS (boom lifted, headland turn) opens a fresh pass. The penalty never
+--- decreases (an OM application won't lower an existing lime burn), and is cleared on harvest
+--- (consumed) or on sow/tillage (#681).
+---@param field table   Field data record
+---@param maxPen number Cap this burn type builds up to (LIME_MAX / OM_MAX)
+---@return number penalty  The current accumulated amendment-burn penalty (0-1)
+function SoilFertilitySystem:applyAmendmentBurnSlice(field, maxPen)
+    local burnCfg = SoilConstants.SPRAYER_RATE
+    local gapMs   = (burnCfg and burnCfg.BURN_PASS_GAP_MS) or 1500
+    local fullMs  = (burnCfg and burnCfg.BURN_FULL_DAMAGE_MS) or 8000
+    local now     = (g_currentMission and g_currentMission.time) or 0
+
+    local last = field._amendBurnTickTime
+    field._amendBurnTickTime = now
+    local dt = (last and (now - last) <= gapMs) and (now - last) or 0
+
+    if dt > 0 and fullMs > 0 then
+        local inc    = maxPen * (dt / fullMs)
+        local ramped = math.min(maxPen, (field.amendBurnPenalty or 0) + inc)
+        field.amendBurnPenalty = math.max(field.amendBurnPenalty or 0, ramped)
+    end
+    return field.amendBurnPenalty or 0
+end
+
 -- Apply fertilizer
 function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
     if not self.settings.enabled then return end
@@ -3086,25 +3117,32 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
                 -- shared helper decides whether the crop is established enough to actually burn.
                 local burnExempt = not self:isAmendmentBurnRisk(cropFruitIndex, cropGrowthState)
 
+                local ab = SoilConstants.AMEND_BURN
                 if isLimeAmendment then
                     -- #646/#681: liming cut/early perennial forage or a freshly-sown annual is
-                    -- realistic, so skip the -80% burn there. Established crops still take it.
+                    -- realistic, so skip the burn there. Established crops still take it, but it
+                    -- now builds up over application time (#688) instead of instant -80%.
                     if not burnExempt then
-                        field.amendBurnPenalty = 0.80
-                        field._amendBurnNotified = true
-                        self:showNotification(
-                            g_i18n:getText("sf_notify_lime_crop_title"),
-                            string.format(g_i18n:getText("sf_notify_lime_crop_body"), fieldId))
+                        self:applyAmendmentBurnSlice(field, (ab and ab.LIME_MAX) or 0.80)
+                        if not field._amendBurnNotified then
+                            field._amendBurnNotified = true
+                            self:showNotification(
+                                g_i18n:getText("sf_notify_lime_crop_title"),
+                                string.format(g_i18n:getText("sf_notify_lime_crop_body"), fieldId))
+                        end
                     end
                 else
                     -- #629/#645/#681: organic fertilizer (slurry/manure/digestate) on short/cut
-                    -- perennial forage or a freshly-sown annual is standard practice, so skip the -20%.
+                    -- perennial forage or a freshly-sown annual is standard practice, so skip it.
+                    -- On an established crop it builds up over application time toward OM_MAX (#688).
                     if not burnExempt then
-                        field.amendBurnPenalty = math.max(field.amendBurnPenalty or 0, 0.20)
-                        field._amendBurnNotified = true
-                        self:showNotification(
-                            g_i18n:getText("sf_notify_om_crop_title"),
-                            string.format(g_i18n:getText("sf_notify_om_crop_body"), fieldId))
+                        self:applyAmendmentBurnSlice(field, (ab and ab.OM_MAX) or 0.20)
+                        if not field._amendBurnNotified then
+                            field._amendBurnNotified = true
+                            self:showNotification(
+                                g_i18n:getText("sf_notify_om_crop_title"),
+                                string.format(g_i18n:getText("sf_notify_om_crop_body"), fieldId))
+                        end
                     end
                 end
             end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2489,6 +2489,24 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         end
     end
 
+    -- ── Taproot bio-drilling decompaction while standing (#687) ──────────────
+    -- Deep-rooting crops (oilseed radish, and to a lesser extent canola) drive roots
+    -- through compacted layers, easing compaction biologically as they grow. A slow,
+    -- passive helper on top of natural decay — never a subsoiler replacement. Mirrors the
+    -- daily natural-decay reduction (field-average), respects the same decay tuning, and
+    -- pauses over winter dormancy. sownCrop keeps it running only while the crop stands.
+    if self.settings.compactionEnabled and SoilConstants.COMPACTION
+       and (field.compaction or 0) > 0 and season ~= seasonal.WINTER_SEASON then
+        local cp   = SoilConstants.COMPACTION
+        local sown = field.sownCrop and string.lower(field.sownCrop) or nil
+        local taprootMult = sown and cp.TAPROOT_CROPS and cp.TAPROOT_CROPS[sown] or nil
+        if taprootMult then
+            local tunComp = getTuningMult(self.settings, "tuningCompactionDecay", "ZERO_MULT")
+            field.compaction = math.max(0,
+                field.compaction - cp.TAPROOT_DECOMPACT_PER_DAY * taprootMult * timeFactor * tunComp)
+        end
+    end
+
     -- ── pH slow drift toward neutral ─────────────────────────────────────────
     if field.pH < limits.PH_NEUTRAL_LOW then
         field.pH = math.min(limits.PH_NEUTRAL_LOW, field.pH + phNorm.RATE * timeFactor)

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -1119,7 +1119,11 @@ SoilConstants.COMPACTION = {
     -- path that calls onCompaction without a points value still does something sane).
     COMPACTION_PER_PASS       = 6.0,
     NATURAL_DECAY_PER_DAY     = 0.5,   -- points removed per game day (natural recovery)
-    SUBSOILER_REDUCTION       = 15.0,  -- points removed per subsoiler pass
+    SUBSOILER_REDUCTION       = 15.0,  -- points removed per subsoiler pass (clears the deep pan)
+    PLOW_RELIEF               = 3.0,   -- points removed per plow pass — a plough only loosens the
+                                       -- topsoil it inverts; the deep pan stays, so it relieves far
+                                       -- less than a subsoiler. Keeps the subsoiler meaningful and
+                                       -- stops routine ploughing from erasing compaction (#687).
     MAX_COMPACTION            = 100.0,
     NUTRIENT_PENALTY_MAX      = 0.20,  -- max 20% extra nutrient extraction at max compaction
     -- Driving-based compaction: any heavy vehicle moving across a field compacts the

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -394,6 +394,14 @@ SoilConstants.HARVEST_HA_FACTOR = 8.0
 -- UPDATED V1.7: Coefficients are now volume-normalized relative to baseRates
 -- to produce realistic soil-test responses (Mehlich-3 ppm) in one pass.
 -- Formula: coeff = (target_ppm / display_mult) / (baseRate * 0.9 / 1000)
+-- Amendment burn (#437) tuning. A freshly-sown / seedling annual has no leaf canopy to
+-- scorch, so applying starter fertilizer or a pre-plant amendment at/just after seeding
+-- must NOT burn it (#681). The burn only applies once the crop has established past this
+-- fraction of the way to its harvest-ready growth state.
+SoilConstants.AMEND_BURN = {
+    ANNUAL_SEEDLING_FRACTION = 0.33,
+}
+
 SoilConstants.FERTILIZER_PROFILES = {
     -- Base game (NPK balanced)
     LIQUIDFERTILIZER  = { N=79.2, P=198.0, K=44.5 },          -- 93.5 L/ha: ~20N, ~10P, ~15K ppm

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -400,6 +400,12 @@ SoilConstants.HARVEST_HA_FACTOR = 8.0
 -- fraction of the way to its harvest-ready growth state.
 SoilConstants.AMEND_BURN = {
     ANNUAL_SEEDLING_FRACTION = 0.33,
+    -- Gradual build-up (#688): the burn ramps toward these caps over the same metered
+    -- application time as the over-application burn (SPRAYER_RATE.BURN_FULL_DAMAGE_MS),
+    -- instead of jumping to the cap on first contact. An accidental brush or a slide onto
+    -- the field costs only a small slice, so you have time to shut the sprayer off.
+    LIME_MAX = 0.80,   -- lime/LIQUIDLIME on an established crop, fully built up
+    OM_MAX   = 0.20,   -- organic amendment (slurry/manure/digestate) fully built up
 }
 
 SoilConstants.FERTILIZER_PROFILES = {

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -1119,6 +1119,12 @@ SoilConstants.COMPACTION = {
     -- path that calls onCompaction without a points value still does something sane).
     COMPACTION_PER_PASS       = 6.0,
     NATURAL_DECAY_PER_DAY     = 0.5,   -- points removed per game day (natural recovery)
+    -- Taproot bio-drilling (#687, long-term): deep-rooting crops drive roots through
+    -- compacted layers and ease compaction as they grow. A small daily reduction while
+    -- the crop stands, on top of natural decay — a slow passive helper, never a subsoiler
+    -- replacement. Scaled per crop: oilseed radish is the classic bio-driller; canola less so.
+    TAPROOT_DECOMPACT_PER_DAY = 0.4,   -- base points/day at full strength while standing
+    TAPROOT_CROPS             = { oilseedradish = 1.0, canola = 0.5 },
     SUBSOILER_REDUCTION       = 15.0,  -- points removed per subsoiler pass (clears the deep pan)
     PLOW_RELIEF               = 3.0,   -- points removed per plow pass — a plough only loosens the
                                        -- topsoil it inverts; the deep pan stays, so it relieves far

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3286,22 +3286,23 @@ function HookManager:installPlowingHook()
                         g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, false)
                     end
 
-                    -- Compaction: tillage LOOSENS soil — it never packs it. Deep tillage
-                    -- (a subsoiler, OR a plow-action cultivator running deep enough to
-                    -- qualify as plowing) relieves compaction; shallow cultivation is
-                    -- neutral. Only harvest traffic (the combine hook) adds compaction.
-                    -- This fixes #672-adjacent reports where a deep-tillage tool built on
-                    -- the Cultivator spec (e.g. a Bourgault SPS configured as a subsoiler)
-                    -- was treated as a heavy vehicle and ADDED compaction every pass.
+                    -- Compaction: tillage LOOSENS soil — it never packs it. A subsoiler clears
+                    -- the deep pan (full relief); a plow-action tool only loosens the topsoil it
+                    -- inverts, so it relieves far less (PLOW_RELIEF) and the pan stays — keeping
+                    -- the subsoiler the real fix (#687). Shallow cultivation is neutral. Only
+                    -- harvest traffic (the combine hook) adds compaction. This still avoids the
+                    -- #672-adjacent bug where a deep-tillage tool built on the Cultivator spec
+                    -- (e.g. a Bourgault SPS configured as a subsoiler) ADDED compaction per pass.
                     if g_SoilFertilityManager.settings.compactionEnabled and SoilConstants.COMPACTION then
                         local isSubsoiler = (cultivatorSelf.spec_cultivator and
                                             cultivatorSelf.spec_cultivator.isSubsoiler) or false
                         if isSubsoiler or isPlowingTool then
+                            local relief = isSubsoiler and nil or SoilConstants.COMPACTION.PLOW_RELIEF
                             SoilLogger.debug(
-                                "Compaction: deep-tillage relief on farmland=%d veh=%d pos=(%.1f,%.1f) subsoiler=%s plow=%s",
+                                "Compaction: deep-tillage relief on farmland=%d veh=%d pos=(%.1f,%.1f) subsoiler=%s plow=%s relief=%s",
                                 farmlandId, cultivatorSelf.id or 0, x, z,
-                                tostring(isSubsoiler), tostring(isPlowingTool))
-                            g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId, x, z)
+                                tostring(isSubsoiler), tostring(isPlowingTool), tostring(relief or "full"))
+                            g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId, x, z, relief)
                         end
                         -- shallow cultivator: neutral, no compaction change
                     end
@@ -3373,16 +3374,16 @@ function HookManager:installDedicatedPlowHook()
                     g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa, false, cropBiomass)
                     g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
 
-                    -- Plowing is deep inversion tillage: it breaks up compacted layers
-                    -- rather than packing them. Relieve compaction on the worked area
-                    -- (no-op if the cell isn't compacted). Previously this ADDED
-                    -- compaction for heavy plows, which made a subsoiler built on the
-                    -- Plow spec climb instead of reset — DeltaFive's "one field keeps
-                    -- climbing" report.
+                    -- Plowing inverts and loosens the topsoil, so it relieves a little
+                    -- compaction (no-op if the cell isn't compacted) — but only the small
+                    -- PLOW_RELIEF, not the full subsoiler amount: a plough leaves the deep
+                    -- pan, so routine ploughing can't erase compaction the way a subsoiler
+                    -- does (#687). It still never ADDS compaction, which keeps DeltaFive's
+                    -- "one field keeps climbing" plow-spec report fixed.
                     if g_SoilFertilityManager.settings.compactionEnabled and SoilConstants.COMPACTION then
-                        SoilLogger.debug("Compaction: plow relief on farmland=%d veh=%d pos=(%.1f,%.1f)",
+                        SoilLogger.debug("Compaction: plow relief (PLOW_RELIEF) on farmland=%d veh=%d pos=(%.1f,%.1f)",
                             farmlandId, plowSelf.id or 0, x, z)
-                        g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId, x, z)
+                        g_SoilFertilityManager.soilSystem:onSubsoilerPass(farmlandId, x, z, SoilConstants.COMPACTION.PLOW_RELIEF)
                     end
                 end
             end)

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -366,6 +366,8 @@ function SoilHUD:calculateHeight()
             if mgr.settings.compactionEnabled and (info.compaction or 0) > 0 then h = h + SoilHUD.LINE_H end
         end
         if (info.amendBurnPenalty or 0) > 0 then h = h + SoilHUD.LINE_H end
+        -- Burn-risk row (#684) is mutually exclusive with the burn row above.
+        if (info.amendBurnPenalty or 0) <= 0 and info.amendBurnRisk == true then h = h + SoilHUD.LINE_H end
         if info.yieldEfficiency then h = h + SoilHUD.LINE_H end
         
         h = h + SoilHUD.PAD * 1.3
@@ -679,6 +681,14 @@ function SoilHUD:update(dt)
         else
             self._fmt_burnText = nil
         end
+        -- Pre-emptive amendment-burn-risk warning (#684): the crop is established enough that
+        -- liming or manuring it NOW would scorch it. Only shown before any burn has hit (the
+        -- burn row above already explains it after the fact).
+        if info.amendBurnRisk == true and burn <= 0 then
+            self._fmt_burnRiskText = g_i18n:getText("sf_hud_burn_risk")
+        else
+            self._fmt_burnRiskText = nil
+        end
         -- Yield efficiency text
         local yieldEff = info.yieldEfficiency
         if yieldEff then
@@ -690,6 +700,7 @@ function SoilHUD:update(dt)
         self._fmt_covText   = nil
         self._fmt_compText  = nil
         self._fmt_burnText  = nil
+        self._fmt_burnRiskText = nil
         self._fmt_yieldText = nil
     end
 end
@@ -1402,6 +1413,17 @@ function SoilHUD:drawPanel()
             setTextColor(0.88, 0.25, 0.25, 1.0)  -- red: this is a penalty
             cy = cy - SoilHUD.LINE_H * s
             renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, burnText)
+        end
+
+        -- Amendment burn-risk row (#684) — heads-up that liming/manuring NOW would scorch the
+        -- crop. Mutually exclusive with the burn row above (only shown before any burn hits).
+        local burnRiskText = self._fmt_burnRiskText
+        if burnRiskText then
+            local pad = SoilHUD.PAD * s
+            setTextAlignment(RenderText.ALIGN_LEFT)
+            setTextColor(0.95, 0.62, 0.15, 1.0)  -- amber: a warning, not yet a penalty
+            cy = cy - SoilHUD.LINE_H * s
+            renderText(px + pad, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s, burnRiskText)
         end
 
         -- Yield efficiency summary (nil when no managed crop)

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -632,22 +632,37 @@ function SoilLayerSystem:readFieldFromLayers(fieldId, fieldData, fsField)
     end
     if not fsField then return false end
 
+    -- Read every layer average first so the whole set can be sanity-checked before applying.
+    local reads = {}
     local anyRead = false
     for _, def in ipairs(LAYER_DEFS) do
         local entry = self.layerHandles[def.name]
         if entry then
             local avg = self:readAverageForFarmland(def.name, fsField)
             if avg ~= nil then
-                fieldData[def.field] = avg
+                reads[def.field] = avg
                 anyRead = true
             end
         end
     end
 
-    if anyRead then
-        SoilLogger.debug("SoilLayerSystem: seeded field %d from density layers", fieldId)
+    if not anyRead then return false end
+
+    -- #685: on a mid-save install the density layers were never seeded, so every layer
+    -- reads 0. A real field never has pH 0 — it is physically impossible — so a zero-pH read
+    -- means "uninitialised layer". Applying it would clobber the field's freshly rolled
+    -- starting defaults to 0/0/0/0 and force a manual admin recovery. Bail out and keep the
+    -- defaults; scanFields() seeds the layers from them so the overlay still matches.
+    if (reads.pH or 0) <= 0 then
+        SoilLogger.debug("SoilLayerSystem: field %d layers uninitialised (pH=0) — keeping rolled defaults", fieldId)
+        return false
     end
-    return anyRead
+
+    for key, value in pairs(reads) do
+        fieldData[key] = value
+    end
+    SoilLogger.debug("SoilLayerSystem: seeded field %d from density layers", fieldId)
+    return true
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -34,7 +34,7 @@ SoilVersionDialog.CHANGELOG = {
     "- Tilling in dead/cover crops boosts organic matter",
     "- Auto-rate follows the bigger need, organic or N/P/K",
     "- Compaction now based on ground pressure, not weight",
-    "- Tillage now relieves compaction instead of adding it",
+    "- Ploughing relieves only a little compaction; subsoiler clears it",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,18 +24,18 @@ SoilVersionDialog.INSTANCE = nil
 -- Max 11 lines are visible in the box; if more exist we stop on a bullet boundary and add a "full changelog on GitHub" note.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Fresh mid-save installs no longer start fields at 0/0/0/0",
+    "- Seeding with starter fertilizer no longer burns young crops",
     "- Fixed burn penalty sticking after replanting (clears on sow/till)",
+    "- Ploughing relieves only a little compaction; subsoiler clears it",
+    "- Radish & canola slowly ease compaction as they grow",
     "- Fixed: See & Spray buy option now shows on every sprayer",
     "- See & Spray is now one combined buy option",
     "- Variable Rate now applies to See & Spray too",
     "- Fixed admin hotkey needing a remap each session",
     "- Added Chinese translation (Simplified + Traditional)",
     "- Legumes now slowly add nitrogen to soil",
-    "- Tilling in dead/cover crops boosts organic matter",
-    "- Auto-rate follows the bigger need, organic or N/P/K",
     "- Compaction now based on ground pressure, not weight",
-    "- Ploughing relieves only a little compaction; subsoiler clears it",
-    "- Radish & canola slowly ease compaction as they grow",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,7 @@ SoilVersionDialog.INSTANCE = nil
 -- Max 11 lines are visible in the box; if more exist we stop on a bullet boundary and add a "full changelog on GitHub" note.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Crop burn now builds up as you spray, no more instant -80%",
     "- Fresh mid-save installs no longer start fields at 0/0/0/0",
     "- Seeding with starter fertilizer no longer burns young crops",
     "- Monitor warns before lime/manure would scorch your crop",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -26,6 +26,7 @@ SoilVersionDialog.INSTANCE = nil
 SoilVersionDialog.CHANGELOG = {
     "- Fresh mid-save installs no longer start fields at 0/0/0/0",
     "- Seeding with starter fertilizer no longer burns young crops",
+    "- Monitor warns before lime/manure would scorch your crop",
     "- Fixed burn penalty sticking after replanting (clears on sow/till)",
     "- Ploughing relieves only a little compaction; subsoiler clears it",
     "- Radish & canola slowly ease compaction as they grow",

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -35,6 +35,7 @@ SoilVersionDialog.CHANGELOG = {
     "- Auto-rate follows the bigger need, organic or N/P/K",
     "- Compaction now based on ground pressure, not weight",
     "- Ploughing relieves only a little compaction; subsoiler clears it",
+    "- Radish & canola slowly ease compaction as they grow",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/tools/test/lua/burn_test.lua
+++ b/tools/test/lua/burn_test.lua
@@ -94,3 +94,61 @@ do
   T.ok("amend burn: clear is a no-op with no pending penalty", sys:clearAmendmentBurn({}, 1, "sowing") == false)
   T.ok("amend burn: clear is a no-op at exactly 0", sys:clearAmendmentBurn({ amendBurnPenalty = 0 }, 1, "plowing") == false)
 end
+
+-- ── Gradual amendment burn build-up (#688) ─────────────────────────────────────
+-- The lime/OM-on-crop burn now ramps over application time (like the over-spray burn)
+-- instead of jumping to the cap, so an accidental brush or a slide onto the field costs
+-- only a small slice and you have time to shut the sprayer off.
+local LIME_MAX = SoilConstants.AMEND_BURN.LIME_MAX
+local OM_MAX   = SoilConstants.AMEND_BURN.OM_MAX
+
+-- First tick of a pass opens it but docks nothing (dt == 0).
+do
+  local field = {}
+  local sys = newSys(field)
+  at(0); sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  T.eq("amend burn: first tick of a pass docks nothing", field.amendBurnPenalty or 0, 0)
+end
+
+-- A 1000ms slice ramps a small proportional fraction of the cap.
+do
+  local field = {}
+  local sys = newSys(field)
+  at(0);    sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  at(1000); sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  T.near("amend burn: 1000ms slice ramps proportionally", field.amendBurnPenalty, LIME_MAX * (1000 / FULL_MS), 1e-6)
+end
+
+-- A sibling boom section in the same tick (dt == 0) adds nothing extra.
+do
+  local field = {}
+  local sys = newSys(field)
+  at(0);    sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  at(1000); sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  local afterFirst = field.amendBurnPenalty
+  sys:applyAmendmentBurnSlice(field, LIME_MAX)  -- same time=1000 → dt==0
+  T.eq("amend burn: sibling section (dt==0) adds nothing", field.amendBurnPenalty, afterFirst)
+end
+
+-- Sustained application ramps to — and caps at — the full magnitude.
+do
+  local field = {}
+  local sys = newSys(field)
+  at(0); sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  local t = 0
+  while t < FULL_MS * 2 do
+    t = t + 1000
+    at(t); sys:applyAmendmentBurnSlice(field, LIME_MAX)
+  end
+  T.near("amend burn: sustained application caps at the max", field.amendBurnPenalty, LIME_MAX, 1e-6)
+  T.ok("amend burn: capped build-up never exceeds the max", field.amendBurnPenalty <= LIME_MAX + 1e-9)
+end
+
+-- The penalty never decreases: a smaller OM build-up can't lower an existing lime burn.
+do
+  local field = { amendBurnPenalty = LIME_MAX }
+  local sys = newSys(field)
+  at(0);    sys:applyAmendmentBurnSlice(field, OM_MAX)
+  at(1000); sys:applyAmendmentBurnSlice(field, OM_MAX)
+  T.eq("amend burn: OM build-up never lowers an existing lime burn", field.amendBurnPenalty, LIME_MAX)
+end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -525,6 +525,7 @@
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -524,6 +524,7 @@
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -525,6 +525,7 @@
     <e k="sf_hud_compaction" v="Zhutnění: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Výnos: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Pakning: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Udbytte: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="PÅFØRINGSRATE (AUTO: TIL)" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="PÅFØRINGSRATE (AUTO: FRA) [%s]" eh="848cc106" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Verdichtung: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Ertrag: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="AUSBRINGUNGSRATE ( AUTO: AN )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="AUSBRINGUNGSRATE  AUTO: AUS [%s]" eh="848cc106" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="TASA APLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TASA APLIC.  AUTO: OFF [%s]" eh="848cc106" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -524,6 +524,7 @@
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="Burn penalty: -%d%%" eh="34059aac" />
+    <e k="sf_hud_burn_risk" v="Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="TASA APLIC. ( AUTO: ON )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TASA APLIC.  AUTO: OFF [%s]" eh="848cc106" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -524,6 +524,7 @@
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -502,6 +502,7 @@
     <e k="sf_hud_compaction" v="Tiivistyminen: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="LEVITYSMÄÄRÄ ( AUTO: PÄÄLLÄ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="LEVITYSMÄÄRÄ  AUTO: POIS [%s]" eh="848cc106" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -984,6 +984,7 @@
         <e k="sf_show_sprayer_panel_long" v="[EN] Show/hide the sprayer nutrient info panel when driving a sprayer" eh="125a6e27" />
     <e k="sf_show_harvester_panel_long" v="[EN] Show/hide the harvester grain tank status panel when harvesting" eh="977f32e8" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 	<e k="sf_fieldsentry_asleep" v="sim. en veille" eh="7d49241b" />
     	<e k="sf_fs_reason_manual" v="manuel" eh="3c78b355" />
     	<e k="sf_fs_reason_npc" v="contrat PNJ" eh="2e1a268b" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -520,6 +520,7 @@
     <e k="sf_hud_compaction" v="Tömörödés: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="KIJUTT. ARÁNY  ( AUTO: BE )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="KIJUTT. ARÁNY  AUTO: KI [%s]" eh="848cc106" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -524,6 +524,7 @@
     <e k="sf_hud_compaction" v="Pemadatan: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -524,6 +524,7 @@
     <e k="sf_hud_compaction" v="Compattazione: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -520,6 +520,7 @@
     <e k="sf_hud_compaction" v="踏み固め: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
     
     <!-- 散布レート HUD -->
     <e k="sf_sprayer_auto_on" v="散布レート (自動: オン)" eh="099b5dac" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -521,6 +521,7 @@
     <e k="sf_hud_compaction" v="압축도: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="살포량 ( 자동: 켬 )" eh="099b5dac" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -522,6 +522,7 @@
     <e k="sf_hud_compaction" v="Verdichting: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Opbrengst: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DOSERING ( AUTO: AAN )" eh="099b5dac" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -522,6 +522,7 @@
     <e k="sf_hud_compaction" v="Pakking: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="PÅFØR. RATE ( AUTO: PÅ )" eh="099b5dac" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -522,6 +522,7 @@
     <e k="sf_hud_compaction" v="Zagęszczenie: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- Sprayer rate HUD -->
     <e k="sf_sprayer_auto_on" v="DAWKA  ( AUTO: WŁ )" eh="099b5dac" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -525,6 +525,7 @@
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -525,6 +525,7 @@
     <e k="sf_hud_compaction" v="Compactare: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <!-- ======================================================
          SPRAYER RATE HUD

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -500,6 +500,7 @@
     <e k="sf_hud_compaction" v="Уплотнение: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
     <e k="sf_sprayer_auto_on" v="НОРМА ВНЕСЕНИЯ ( АВТО: ВКЛ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="НОРМА ВНЕСЕНИЯ АВТО: ВЫКЛ [%s]" eh="848cc106" />
     <e k="sf_sprayer_target" v="Цель:" eh="31d43504" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Packning: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="SPRIDNINGSMÄNGD  ( AUTO: PÅ )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="SPRIDNINGSMÄNGD  AUTO: AV [%s]" eh="848cc106" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -502,6 +502,7 @@
     <e k="sf_hud_compaction" v="Sıkışma: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="UYGULAMA ORANI ( OTO: AÇIK )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="UYGULAMA ORANI  OTO: KAPALI [%s]" eh="848cc106" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Ущільнення: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="НОРМА ВНЕСЕННЯ ( АВТО: УВІМК )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="НОРМА ВНЕСЕННЯ  АВТО: ВИМК [%s]" eh="848cc106" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -501,6 +501,7 @@
     <e k="sf_hud_compaction" v="Độ nén: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="TỶ LỆ BÓN ( TỰ ĐỘNG: BẬT )" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="TỶ LỆ BÓN  TỰ ĐỘNG: TẮT [%s]" eh="848cc106" />


### PR DESCRIPTION
Bundles everything since 2.4.3.0: burn-sticking fix, See & Spray shop fix, plough-relief rebalance + taproot decompaction (#687), seeding-fert burn (#681), mid-save 0/0/0/0 (#685), amendment burn-risk monitor warning (#684), and gradual burn build-up (#688). 180 self-test assertions pass.