### PR TITLE
v2.4.4.0 — OM yield system, mower yield, monitor states, forage/subsoiler/weed fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.4.4.0]
+
+### Added
+- **Organic matter now affects yield** (#695). OM was tracked and displayed but never read by the yield model. It now applies a smooth multiplier on the 0–10 scale: OM ≥ 5.0 gives a +5% bonus, 3.5–5.0 is the neutral healthy band (the default field OM of 3.5 sits exactly at no-penalty), 2.0–3.5 ramps to −10%, and below 2.0 ramps to −25%. Shared with the new mower path via one helper so hay and grain respond to soil health identically.
+- **Passive organic-matter dynamics** (#695). Humus now oxidises ~0.005 OM/day under active cropping (floored at 1.0 so it never grinds to nothing). An idle/fallow field still nets positive because fallow recovery (+0.01/day) outpaces the decay. Ploughing now *costs* ~0.10 OM per full pass (deep inversion aerates buried humus) instead of the old +0.5 bonus — residue incorporation can still offset this when straw/green matter is worked in. Single-pass OM gains from compost, chicken manure, biosolids, pelletized manure, gypsum and chopped straw were lowered to realistic first-season humus conversion.
+- **Mower yield scales with soil nutrients** (#696). Windrow-drop mowers (disc/drum mowers, swathers) bypassed the combine hopper yield hook, so hay tonnage ignored soil fertility. A new hook scales each mower's `fruitTypeConverter.conversionFactor` by a forage nutrient modifier (tolerant tier + OM), restored after each pass. `pickupFillScale` is loaded by the engine but never read on the windrow path, so `conversionFactor` is the correct lever. Nutrient depletion is unchanged (area-based) — only the bale output scales.
+
+### Fixed
+- **Perennial forages no longer trigger false monoculture fatigue** (#694). Alfalfa, meadow, fieldgrass, ryegrass, grass and clover are cut several times per season and legitimately stay on a field for years; the rotation-fatigue check (depletion ×1.15 and the Field Detail "Fatigue" status) now exempts `PERENNIAL_FORAGE_NAMES`, so a 3rd cut is peak management, not a tired field. Also: `alfalfa` (== `luzerne`) added to `LEGUMES`, `CROP_TIERS` (tolerant) and `NON_CROP_NAMES`; `greenbean`/`green_beans` added to `LEGUMES` — so rotating away from them now earns the spring nitrogen bonus and they no longer show a misleading yield % score.
+- **Subsoiler incorporation no longer rounds to nothing** (#693). A subsoiler does its real work deep, so its surface "changed" area (`lastChangedArea`) barely moves and the OM/nitrogen release scaled by it rounded to ~0 (while position-based compaction relief still worked, masking the gap). Subsoilers now scale incorporation by the total processed footprint (`lastTotalArea`); the `lastChangedArea > 0` guard is retained so this can't reintroduce the headland-turn cap drain.
+- **Phantom burnt-weed coverage on clean fields after reload** (#698). When herbicide protection was granted, the weed-map browning painted the withered state across the *entire* field polygon — and when the field had no live weeds, it fell back to painting state 7 anyway. That fabricated "burnt weed" textures on clean fields, baked into the weed density map, and reappeared on every save/reload at 0% pressure. SF now skips the cosmetic browning entirely when there are no live weeds to wither (or the herbicide replacement table is unavailable). Existing baked-in patches clear by cultivating/ploughing the field once.
+
+### Changed
+- **Soil Monitor reflects Field Sentry state** (#692, #697). A field put to sleep in Field Sentry now shows a compact "Field asleep" line in the Soil Monitor instead of stale frozen N/P/K/pH/OM readouts. A field flagged as a meadow now reads "Meadow" instead of "Fallow". `getFieldInfo` surfaces the meadow flag for any consumer.
+
 ## [2.4.2.8]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.3.1
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.4.4.0
 
 © 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.4.3.1</version>
+    <version>2.4.4.0</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -244,6 +244,17 @@ function SoilFertilitySystem:_yieldModifierFromNutrients(field, cropName, nVal, 
             plog("Nutrient penalty field %d (%s/%s): N=%.0f P=%.0f K=%.0f → -%.0f%%",
                 logFieldId, cropName, tier, nVal, pVal, kVal, nutrientPenalty * 100)
         end
+
+        -- Organic matter influence (#695): rich humus gives a small yield bonus, depleted
+        -- soil a penalty. Shared with the mower forage path via _omYieldModifier so hay and
+        -- grain respond to soil health identically. May push the modifier slightly above 1.0
+        -- (a genuine bonus on well-built soil); the hopper hook handles that fine.
+        local omMod = self:_omYieldModifier(field)
+        if omMod ~= 1.0 then
+            modifier = modifier * omMod
+            plog("OM modifier field %d: OM=%.1f → %+.0f%%", logFieldId,
+                 field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter, (omMod - 1.0) * 100)
+        end
     end
 
     -- Weed pressure modifier (skip for grassland; skip when herbicide is active)
@@ -301,6 +312,58 @@ function SoilFertilitySystem:_yieldModifierFromNutrients(field, cropName, nVal, 
         plog("Amendment burn penalty field %d: -%.0f%%", logFieldId, field.amendBurnPenalty * 100)
     end
 
+    return modifier
+end
+
+--- Organic-matter yield factor (#695). Shared by the row-crop yield modifier and the
+--- mower forage modifier (#696) so hay and grain respond to soil health identically.
+--- Returns a multiplier that may sit slightly above 1.0 on well-built soil.
+---@param field table
+---@return number
+function SoilFertilitySystem:_omYieldModifier(field)
+    local omc = SoilConstants.YIELD_SENSITIVITY and SoilConstants.YIELD_SENSITIVITY.OM_YIELD
+    if not omc then return 1.0 end
+    local om = (field and field.organicMatter) or SoilConstants.FIELD_DEFAULTS.organicMatter
+    if om >= omc.BONUS_THRESHOLD then
+        return 1.0 + omc.BONUS_MAX
+    elseif om >= omc.HEALTHY_LOW then
+        return 1.0                                            -- healthy baseline band
+    elseif om >= omc.PENALTY_MID then
+        local f = (omc.HEALTHY_LOW - om) / (omc.HEALTHY_LOW - omc.PENALTY_MID)
+        return 1.0 - f * omc.PENALTY_MID_MAX                  -- 0 → -10%
+    else
+        local f = math.min(1.0, (omc.PENALTY_MID - om) / omc.PENALTY_MID)
+        return 1.0 - (omc.PENALTY_MID_MAX + f * (omc.PENALTY_MAX - omc.PENALTY_MID_MAX))  -- -10% → -25%
+    end
+end
+
+--- Forage yield modifier for windrow-drop mowers (#696). Forage crops are gated out of
+--- _yieldModifierFromNutrients via NON_CROP_NAMES (correct — no yield % score for hay), so
+--- the mower path needs its own nutrient read. Uses the "tolerant" tier (matching
+--- alfalfa/luzerne/clover) plus the shared OM factor. Weed/pest/disease are intentionally
+--- excluded — forage quality is not tracked per field.
+---@param fieldId number
+---@return number modifier  Multiplier applied to windrow liters (≤ ~1.05)
+function SoilFertilitySystem:computeMowerYieldModifier(fieldId)
+    if not self.settings.enabled or not self.settings.nutrientCycles then return 1.0 end
+    local field = self.fieldData[fieldId]
+    if not field then return 1.0 end
+    local ys = SoilConstants.YIELD_SENSITIVITY
+    if not ys then return 1.0 end
+
+    local modifier = 1.0
+    local tierData = ys.TIERS and ys.TIERS["tolerant"]
+    if tierData then
+        local thresh = ys.OPTIMAL_THRESHOLD
+        local nDef = math.max(0, thresh - (field.nitrogen   or 0)) / thresh
+        local pDef = math.max(0, thresh - (field.phosphorus or 0)) / thresh
+        local kDef = math.max(0, thresh - (field.potassium  or 0)) / thresh
+        local penalty = math.min(ys.MAX_PENALTY, ((nDef + pDef + kDef) / 3) * tierData.scale)
+        modifier = modifier * (1.0 - penalty)
+    end
+
+    -- Soil health affects hay tonnage the same way it affects grain.
+    modifier = modifier * self:_omYieldModifier(field)
     return modifier
 end
 
@@ -789,12 +852,18 @@ function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer, cropBiomass
     -- Tilling mixes the soil and ends the crop — void any pending amendment burn.
     if self:clearAmendmentBurn(field, fieldId, "plowing") then changed = true end
 
-    -- Plowing benefits 1 & 2: OM increase and pH normalization (only if plowingBonus enabled)
+    -- Plowing effects 1 & 2: OM oxidation loss and pH normalization (only if plowingBonus enabled)
     if self.settings.plowingBonus then
+        -- Deep inversion exposes buried humus to air, oxidising it — plowing COSTS organic
+        -- matter rather than adding it (#695, reversed from the old +0.5/pass bonus). Residue
+        -- incorporation below (gated separately) can offset this when straw/green matter is
+        -- actually worked in, so a residue-rich plow can still net positive.
+        local omDyn    = SoilConstants.OM_DYNAMICS
+        local omLoss   = (omDyn and omDyn.PLOW_OXIDATION_LOSS or 0) * factor
+        local omFloor  = (omDyn and omDyn.DECAY_FLOOR) or SoilConstants.NUTRIENT_LIMITS.MIN
         local omBefore = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
-        local omIncrease = 0.5 * factor
-        local omAfter = math.min(omBefore + omIncrease, SoilConstants.NUTRIENT_LIMITS.ORGANIC_MATTER_MAX)
-        if omAfter > omBefore then
+        local omAfter  = math.max(omFloor, omBefore - omLoss)
+        if omAfter < omBefore then
             field.organicMatter = omAfter
             changed = true
         end
@@ -1356,8 +1425,21 @@ function SoilFertilitySystem:applyWeedMapState(fieldId, targetState)
                 weedState = replacement
                 self:log("[WeedMap] Using replacement state %d", weedState)
             else
-                self:log("[WeedMap] No replacement for state %d — using fallback state %d", currentState, weedState)
+                -- No live weeds to wither here (state 0, or already withered/dying). Painting the
+                -- withered state across the whole field polygon would fabricate "burnt weed"
+                -- textures on a clean field — and that fake coverage bakes into the weed density
+                -- map, so it reappears on every save/reload even at 0% pressure (#698). Skip:
+                -- leave the weed map untouched. There is nothing to brown.
+                self:log("[WeedMap] SKIP: no live weeds to wither (state %s) on field %d — not painting",
+                    tostring(currentState), fieldId)
+                return
             end
+        else
+            -- Replacement table unavailable: we cannot tell clean ground from weedy, so do NOT
+            -- blanket-paint the withered state onto a possibly-clean field (avoids the #698
+            -- fake-coverage bug). Better to skip the cosmetic browning than fabricate weeds.
+            self:log("[WeedMap] SKIP: herbicide replacement table unavailable — not painting")
+            return
         end
     end
 
@@ -2437,6 +2519,18 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         return
     end
 
+    -- ── Passive organic-matter oxidation (#695) ──────────────────────────────
+    -- Humus oxidizes continuously; without organic returns OM slowly declines. Fallow
+    -- recovery (below) adds it back so an idle field still nets positive (+0.005/day),
+    -- while a field under active cropping with no organic inputs loses ground over seasons.
+    -- Floored so passive decay alone never grinds soil down to nothing. Meadows are exempt
+    -- (the grassland profile above returned already, and only ever builds OM).
+    local omDyn = SoilConstants.OM_DYNAMICS
+    if omDyn and (omDyn.DAILY_DECAY or 0) > 0 then
+        local om = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
+        field.organicMatter = math.max(omDyn.DECAY_FLOOR or 0, om - omDyn.DAILY_DECAY * timeFactor)
+    end
+
     -- ── Fallow recovery ──────────────────────────────────────────────────────
     -- Fallow threshold also scales so it represents the same 'agricultural time' (months)
     local daysSinceFallow = currentDay - (field.lastHarvest or 0)
@@ -2950,8 +3044,14 @@ function SoilFertilitySystem:updateFieldNutrients(fieldId, fruitTypeIndex, harve
         end
     end
 
-    -- Step 3a: Crop rotation fatigue — same crop two seasons running depletes more
-    if self.settings.cropRotation and field.lastCrop2 and field.lastCrop2 == fruitDesc.name then
+    -- Step 3a: Crop rotation fatigue — same crop two seasons running depletes more.
+    -- Perennial forages (alfalfa, grass, ryegrass…) are cut several times per season and
+    -- legitimately stay on the same field for years, so they must NOT trip monoculture
+    -- fatigue — a 3rd cut is peak management, not a tired field (#694).
+    local isPerennialForage = SoilConstants.PERENNIAL_FORAGE_NAMES
+                              and SoilConstants.PERENNIAL_FORAGE_NAMES[name]
+    if self.settings.cropRotation and not isPerennialForage
+       and field.lastCrop2 and field.lastCrop2 == fruitDesc.name then
         factor = factor * SoilConstants.CROP_ROTATION.FATIGUE_MULTIPLIER
         self:log("Rotation fatigue on field %d (%s harvested twice) — factor ×%.2f",
             fieldId, fruitDesc.name, SoilConstants.CROP_ROTATION.FATIGUE_MULTIPLIER)
@@ -4090,9 +4190,19 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         local cr      = SoilConstants.CROP_ROTATION
         local crop1   = string.lower(field.lastCrop)
         local crop2   = string.lower(field.lastCrop2)
-        if cr.LEGUMES[crop1] and not cr.LEGUMES[crop2] then
+        local pf      = SoilConstants.PERENNIAL_FORAGE_NAMES or {}
+        if pf[crop1] then
+            -- Multi-cut perennial forage: the same crop standing across several cuts is
+            -- normal management, not monoculture fatigue (#694). Only flag a bonus if the
+            -- player genuinely rotated INTO it from a non-legume, non-forage crop.
+            if cr.LEGUMES[crop1] and not cr.LEGUMES[crop2] and not pf[crop2] then
+                rotationStatus = "Bonus"
+            else
+                rotationStatus = "OK"
+            end
+        elseif cr.LEGUMES[crop1] and not cr.LEGUMES[crop2] then
             rotationStatus = "Bonus"
-        elseif field.lastCrop == field.lastCrop2 then
+        elseif crop1 == crop2 then
             rotationStatus = "Fatigue"
         else
             rotationStatus = "OK"
@@ -4147,11 +4257,12 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     -- FieldSentry (#651) status, surfaced so any readout (field detail dialog, HUD,
     -- map overlay) can show that a slept field's soil is frozen by intent, not broken.
     -- isFieldSimDisabled is allocation-free, so this stays cheap for per-frame callers.
-    local fsDisabled, fsReason, fsReasonKey = false, "active", nil
+    local fsDisabled, fsReason, fsReasonKey, fsMeadow = false, "active", nil, false
     if FieldSentry_API then
-        local d, r = FieldSentry_API.isFieldSimDisabled(fieldId)
+        local d, r, meadow = FieldSentry_API.isFieldSimDisabled(fieldId)
         fsDisabled = d
         fsReason   = FieldSentry_Core.reasonName(r)
+        fsMeadow   = meadow == true   -- meadow fields still simulate; surfaced for the monitor (#697)
         if FieldSentry_Core.reasonL10nKey then fsReasonKey = FieldSentry_Core.reasonL10nKey(r) end
     end
 
@@ -4161,6 +4272,7 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         simDisabled          = fsDisabled,
         simDisabledReason    = fsReason,
         simDisabledReasonKey = fsReasonKey,
+        isMeadow             = fsMeadow,
         nitrogen = { value = math.floor(n), status = nutrientStatus(n, "nitrogen", cropTargets) },
         phosphorus = { value = math.floor(p), status = nutrientStatus(p, "phosphorus", cropTargets) },
         potassium = { value = math.floor(k), status = nutrientStatus(k, "potassium", cropTargets) },

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2420,7 +2420,9 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         local cp = SoilConstants.COMPACTION
         if (field.compaction or 0) > 0 then
             local tunComp = getTuningMult(self.settings, "tuningCompactionDecay", "ZERO_MULT")
-            field.compaction = math.max(0, field.compaction - cp.NATURAL_DECAY_PER_DAY * timeFactor * tunComp)
+            -- Route through _applyCompactionDecay so the recovery sticks: shaving
+            -- field.compaction alone was wiped by the next per-cell rewrite.
+            self:_applyCompactionDecay(field, cp.NATURAL_DECAY_PER_DAY * timeFactor * tunComp)
         end
     end
 
@@ -2510,8 +2512,10 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         local taprootMult = sown and cp.TAPROOT_CROPS and cp.TAPROOT_CROPS[sown] or nil
         if taprootMult then
             local tunComp = getTuningMult(self.settings, "tuningCompactionDecay", "ZERO_MULT")
-            field.compaction = math.max(0,
-                field.compaction - cp.TAPROOT_DECOMPACT_PER_DAY * taprootMult * timeFactor * tunComp)
+            -- Same persistence fix as natural decay: the bio-drilling gain must land on
+            -- compactionSum/zoneData or the next subsoiler/wheel pass erases it.
+            self:_applyCompactionDecay(field,
+                cp.TAPROOT_DECOMPACT_PER_DAY * taprootMult * timeFactor * tunComp)
         end
     end
 
@@ -4693,6 +4697,43 @@ function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ, reliefP
 
     SoilLogger.debug("Subsoiler: field=%d cell=%s  %.0f→%.0f%%  avg=%.1f%%",
         farmlandId, cellKey, prev, newVal, field.compaction)
+end
+
+--- Apply a field-average compaction reduction (natural decay, taproot bio-drilling) in a
+--- way that PERSISTS through later per-cell rewrites. The displayed average is DERIVED as
+--- compactionSum / compactionTotalCells, so shaving only field.compaction (as the daily
+--- decay used to) was silently discarded the instant onCompaction / onSubsoilerPass
+--- re-derived the average from the untouched compactionSum. That was the "radish
+--- decompaction and natural recovery reset on the first subsoiler or wheel pass" report
+--- (nemrod153, Discord). Fading compactionSum AND every zoneData cell by the same ratio
+--- keeps the accounting total, the
+--- per-cell store (read back as `prev` by onCompaction/onSubsoilerPass) and the average
+--- mutually consistent, and preserves the existing points-per-day tuning exactly
+--- (newAvg = oldAvg - reductionPoints).
+---@param field table  fieldData entry
+---@param reductionPoints number  points to shave off the field-average compaction
+---@return boolean changed
+function SoilFertilitySystem:_applyCompactionDecay(field, reductionPoints)
+    if not field or not reductionPoints or reductionPoints <= 0 then return false end
+    local oldAvg = field.compaction or 0
+    if oldAvg <= 0 then return false end
+
+    local newAvg = math.max(0, oldAvg - reductionPoints)
+    local ratio  = newAvg / oldAvg   -- oldAvg > 0 guaranteed above
+
+    -- Fade the authoritative accounting total so the derived average survives a later
+    -- per-cell rewrite, and fade each per-cell value so relief/build-up math (which reads
+    -- cell.compaction as `prev`) stays in lockstep with the faded sum.
+    field.compactionSum = (field.compactionSum or 0) * ratio
+    if field.zoneData then
+        for _, cell in pairs(field.zoneData) do
+            if cell.compaction and cell.compaction > 0 then
+                cell.compaction = cell.compaction * ratio
+            end
+        end
+    end
+    field.compaction = newAvg
+    return true
 end
 
 --- FieldSentry FR3 (#654): apply a one-shot, lightweight nutrient catch-up to a field's

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -230,6 +230,20 @@ SoilConstants.FALLOW_RECOVERY = {
 }
 
 -- ========================================
+-- ORGANIC MATTER DYNAMICS (#695)
+-- ========================================
+-- Humus oxidizes continuously. Without organic returns, a field under active cropping
+-- slowly loses OM; an idle (fallow) field still nets positive because FALLOW_RECOVERY
+-- adds organicMatter on top of this decay (0.01 recovery − 0.005 decay = +0.005/day).
+-- Deep tillage (plowing) accelerates the loss by exposing buried humus to air.
+-- All on the 0-10 OM scale; per-day rates are month-normalised by the caller.
+SoilConstants.OM_DYNAMICS = {
+    DAILY_DECAY         = 0.005, -- passive humus oxidation, OM pts/day
+    DECAY_FLOOR         = 1.0,   -- passive decay never pushes OM below this (degraded mineral soil)
+    PLOW_OXIDATION_LOSS = 0.10,  -- OM lost per full plow pass (deep inversion aerates buried humus)
+}
+
+-- ========================================
 -- MEADOW PROFILE (FieldSentry Phase 3, #651)
 -- ========================================
 -- Daily grassland rates used when a field is flagged as a meadow in FieldSentry. Opt-in
@@ -258,7 +272,8 @@ SoilConstants.MEADOW = {
 -- regardless of field size. Partial passes add a proportional fraction.
 -- Example: full 5ha field, strawRatio=0.5 → 0.5 × 0.20 = 0.10 OM
 SoilConstants.CHOPPED_STRAW = {
-    OM_RATE = 0.20,   -- OM gain per full-field harvest at strawRatio=1.0
+    OM_RATE = 0.06,   -- OM gain per full-field harvest at strawRatio=1.0 (lowered from 0.20:
+                      -- straw is fresh carbon that takes months to stabilise into humus, #695)
 }
 
 -- ========================================
@@ -281,7 +296,10 @@ SoilConstants.CROP_ROTATION = {
     LEGUME_BONUS_DAYS       = 3,     -- spring bonus lasts this many days
     LEGUME_GROWTH_N_PER_DAY = 0.15,  -- small live N trickle while a legume is standing (nodule fixation surplus, #674) — deliberately well below the post-crop bonus so we don't double-count
     FATIGUE_MULTIPLIER      = 1.15,  -- nutrient extraction ×1.15 for same-crop consecutive seasons
-    LEGUMES = { soybean = true, peas = true, beans = true, luzerne = true, clover = true },
+    -- alfalfa == luzerne (NA vs EU name); greenbean/green_beans match field beans.
+    -- All fix nitrogen, so rotating away from them earns the spring N bonus (#694).
+    LEGUMES = { soybean = true, peas = true, beans = true, luzerne = true, clover = true,
+                alfalfa = true, greenbean = true, green_beans = true },
 }
 
 -- ========================================
@@ -430,7 +448,7 @@ SoilConstants.FERTILIZER_PROFILES = {
     STARTER           = { N=63.5, P=595.0, K=0.00 }, -- 46.8 L/ha: ~8N, ~15P ppm
 
     -- Gypsum: mild pH lowering + OM/structure boost
-    GYPSUM            = { pH=-0.10, OM=0.22 }, -- 1500 kg/ha: -0.25 pH shift, OM boost
+    GYPSUM            = { pH=-0.10, OM=0.03 }, -- 1500 kg/ha: -0.25 pH shift; gypsum is Ca/S, not a humus source — minimal OM (#695)
 
     -- Phosphorus & potassium sources (Dry bulk)
     MAP               = { N=11.1, P=411.5, K=0.00 }, -- 225 kg/ha: ~45P ppm
@@ -446,10 +464,12 @@ SoilConstants.FERTILIZER_PROFILES = {
     LIQUID_POTASH     = { N=0.00, P=0.00, K=100.0 },
 
     -- Organic / slow-release
-    COMPOST           = { N=0.74, P=0.55, K=0.55, OM=0.60 }, -- 5000 kg/ha
-    BIOSOLIDS         = { N=2.05, P=1.20, K=1.23, OM=0.45 }, -- 4500 kg/ha: ~+9N, +5P, +5K pts/pass
-    CHICKEN_MANURE    = { N=3.70, P=2.80, K=2.78, OM=0.55 }, -- 2000 kg/ha: ~+7N, +5P, +5K pts/pass
-    PELLETIZED_MANURE = { N=16.4, P=8.20, K=18.5, OM=0.40 }, -- 450 kg/ha:  ~+7N, +3P, +8K pts/pass
+    -- OM gains lowered to realistic first-season humus conversion (~10-15% of applied
+    -- carbon stabilises in year one). N/P/K unchanged — only the humus build rate (#695).
+    COMPOST           = { N=0.74, P=0.55, K=0.55, OM=0.12 }, -- 5000 kg/ha
+    BIOSOLIDS         = { N=2.05, P=1.20, K=1.23, OM=0.10 }, -- 4500 kg/ha: ~+9N, +5P, +5K pts/pass
+    CHICKEN_MANURE    = { N=3.70, P=2.80, K=2.78, OM=0.10 }, -- 2000 kg/ha: ~+7N, +5P, +5K pts/pass
+    PELLETIZED_MANURE = { N=16.4, P=8.20, K=18.5, OM=0.08 }, -- 450 kg/ha:  ~+7N, +3P, +8K pts/pass
 
     -- Crop protection products (Handled via effectiveness calculation)
     INSECTICIDE = { pestReduction = 1.0 },
@@ -628,6 +648,7 @@ SoilConstants.YIELD_SENSITIVITY = {
         rye        = "tolerant",
         sorghum    = "tolerant",
         luzerne    = "tolerant",   -- legume forage — fixes own N
+        alfalfa    = "tolerant",   -- == luzerne (NA name); fixes own N (#694)
         clover     = "tolerant",   -- legume forage — fixes own N
         -- Moderate: standard response to nutrient levels
         wheat      = "moderate",
@@ -644,10 +665,24 @@ SoilConstants.YIELD_SENSITIVITY = {
 
     DEFAULT_TIER = "moderate",
 
+    -- Organic matter yield influence (#695). OM is a long-term soil-health investment:
+    -- rich humus gives a small bonus, depleted soil a penalty. Bands on the 0-10 OM scale.
+    -- The healthy band starts at the default field OM (3.5) so a fresh/average field sits
+    -- exactly at no-penalty, and only neglected (declining) or invested (rising) soils move.
+    OM_YIELD = {
+        BONUS_THRESHOLD = 5.0,   -- OM at/above this earns the full bonus
+        BONUS_MAX       = 0.05,  -- +5% yield at/above BONUS_THRESHOLD
+        HEALTHY_LOW     = 3.5,   -- 3.5–5.0 = healthy baseline, no penalty (matches default OM)
+        PENALTY_MID     = 2.0,   -- 2.0–3.5 ramps 0 → PENALTY_MID_MAX
+        PENALTY_MID_MAX = 0.10,  -- -10% at PENALTY_MID
+        PENALTY_MAX     = 0.25,  -- -25% as OM approaches 0
+    },
+
     -- Crops that are not row-crop harvests; skip yield forecast for these
     NON_CROP_NAMES = {
-        grass = true, drygrass = true, poplar = true, oilseedradish = true,
-        luzerne = true, clover = true,
+        grass = true, meadow = true, drygrass = true, fieldgrass = true, ryegrass = true,
+        poplar = true, oilseedradish = true,
+        luzerne = true, clover = true, alfalfa = true,
     },
 }
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -138,6 +138,10 @@ function HookManager:installAll(soilSystem)
     local mowerOk = self:installMowerHook()
     if mowerOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
+    -- Mower yield hook (#696): windrow output scales with soil nutrients via conversionFactor
+    local mowerYieldOk = self:installMowerYieldHook()
+    if mowerYieldOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
     -- Fertilizer application hook (covers ALL sprayers + spreaders via Sprayer specialization)
     local sprayerAreaOk = self:installSprayerAreaHook()
     if sprayerAreaOk then successCount = successCount + 1 else failCount = failCount + 1 end
@@ -2556,6 +2560,100 @@ function HookManager:installMowerHook()
 end
 
 -- =========================================================
+-- HOOK 1d: Mower yield scaling (#696)
+-- =========================================================
+-- Windrow-drop mowers (disc/drum mowers, swathers) bypass the combine hopper yield hook —
+-- they never call addFillUnitFillLevel with spec_combine set. Inside processMowerArea the
+-- windrow volume is:  litersToDrop = areaLiters × harvestMultiplier × converterData.conversionFactor
+-- (verified against the Mower LUADOC). pickupFillScale is loaded but NEVER read on that path,
+-- so the only lever that scales windrow output is conversionFactor on each fruitTypeConverter.
+--
+-- Approach: in onStartWorkAreaProcessing (before processMowerArea runs) multiply each
+-- converter's conversionFactor by the field's forage nutrient modifier; restore it in
+-- onEndWorkAreaProcessing. A pristine base (_sfBaseCF) is captured once per converter so
+-- repeated passes never compound, even if an onEnd is somehow skipped. Nutrient DEPLETION
+-- is untouched (area-based via the onEnd depletion hook) — only the bale output scales,
+-- mirroring the combine path where the soil gives up nutrients regardless of yield.
+---@return boolean success
+function HookManager:installMowerYieldHook()
+    if not Mower
+       or type(Mower.onStartWorkAreaProcessing) ~= "function"
+       or type(Mower.onEndWorkAreaProcessing) ~= "function" then
+        SoilLogger.warning("[MowerYield] Mower work-area functions not available — forage yield scaling skipped")
+        return false
+    end
+
+    local hookMgrRef = self
+
+    -- Return every converter on this mower to its pristine conversionFactor.
+    local function restoreConverters(spec)
+        if not spec or not spec.fruitTypeConverters then return end
+        for _, converterData in pairs(spec.fruitTypeConverters) do
+            if converterData._sfBaseCF ~= nil then
+                converterData.conversionFactor = converterData._sfBaseCF
+            end
+        end
+    end
+
+    local origStart = Mower.onStartWorkAreaProcessing
+    Mower.onStartWorkAreaProcessing = Utils.appendedFunction(
+        origStart,
+        function(mowerSelf, dt)
+            if not mowerSelf.isServer then return end
+            local spec = mowerSelf.spec_mower
+            if not spec or not spec.fruitTypeConverters then return end
+            if not g_SoilFertilityManager
+               or not g_SoilFertilityManager.soilSystem
+               or not g_SoilFertilityManager.settings.enabled
+               or not g_SoilFertilityManager.settings.nutrientCycles then
+                restoreConverters(spec)   -- never leave stale scaling when the system is off
+                return
+            end
+
+            local ok, errMsg = pcall(function()
+                local x, _, z = getWorldTranslation(mowerSelf.rootNode)
+                if not x then return end
+                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(x, z)
+                if not fieldId or fieldId <= 0 then
+                    restoreConverters(spec)
+                    return
+                end
+
+                local modifier = g_SoilFertilityManager.soilSystem:computeMowerYieldModifier(fieldId)
+                for _, converterData in pairs(spec.fruitTypeConverters) do
+                    -- Capture the pristine factor once; always scale from it so passes never compound.
+                    if converterData._sfBaseCF == nil then
+                        converterData._sfBaseCF = converterData.conversionFactor
+                    end
+                    converterData.conversionFactor = converterData._sfBaseCF * modifier
+                end
+                if modifier ~= 1.0 then
+                    SoilLogger.debug("[MowerYield] Field %d forage modifier=%.3f", fieldId, modifier)
+                end
+            end)
+            if not ok then
+                SoilLogger.error("[MowerYield] start hook failed: %s", tostring(errMsg))
+                restoreConverters(spec)
+            end
+        end
+    )
+    self:register(Mower, "onStartWorkAreaProcessing", origStart, "Mower.onStartWorkAreaProcessing (forage yield scale)")
+
+    local origEnd = Mower.onEndWorkAreaProcessing
+    Mower.onEndWorkAreaProcessing = Utils.appendedFunction(
+        origEnd,
+        function(mowerSelf, dt, hasProcessed)
+            if not mowerSelf.isServer then return end
+            restoreConverters(mowerSelf.spec_mower)
+        end
+    )
+    self:register(Mower, "onEndWorkAreaProcessing", origEnd, "Mower.onEndWorkAreaProcessing (forage yield restore)")
+
+    SoilLogger.info("[OK] Mower yield hook installed — windrow forage output now scales with soil nutrients")
+    return true
+end
+
+-- =========================================================
 -- HOOK 2: All fertilizer application (Sprayer + Spreader)
 -- =========================================================
 --- Hooks Sprayer.onEndWorkAreaProcessing, which covers ALL fertilizer vehicles:
@@ -3245,13 +3343,26 @@ function HookManager:installPlowingHook()
 
             local isPlowSpec = cultivatorSelf.spec_plow ~= nil or cultivatorSelf.spec_subsoiler ~= nil
 
+            -- Subsoiler area fix (#693): a subsoiler does its real work DEEP — its surface
+            -- "changed" area (lastChangedArea) barely moves, so incorporation scaled by it
+            -- rounds to ~nothing even though the tines worked a full strip. (Compaction relief
+            -- is position-based, so it looked fine and masked the gap.) Use the total processed
+            -- footprint (lastTotalArea) for the incorporation magnitude instead. lastChangedArea
+            -- > 0 above already proved this is genuine work, not a lifted headland pass, so this
+            -- can't reintroduce the turn-time cap drain the lastChangedArea guard was added for.
+            local areaPixels = statsArea
+            if spec.isSubsoiler then
+                local total = spec.workAreaParameters.lastTotalArea
+                if total and total > areaPixels then areaPixels = total end
+            end
+
             -- Convert density-map pixels → hectares (same as mower hook).
             if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
-            local areaHa = MathUtil.areaToHa(statsArea, g_currentMission:getFruitPixelsToSqm())
+            local areaHa = MathUtil.areaToHa(areaPixels, g_currentMission:getFruitPixelsToSqm())
             if areaHa <= 0 then return end
 
-            SoilLogger.debug("[PlowHook] onEndWorkAreaProcessing fired — isPlow=%s area=%.1f px (%.5f ha)",
-                tostring(isPlowSpec), statsArea, areaHa)
+            SoilLogger.debug("[PlowHook] onEndWorkAreaProcessing fired — isPlow=%s subsoiler=%s area=%.1f px (%.5f ha)",
+                tostring(isPlowSpec), tostring(spec.isSubsoiler), areaPixels, areaHa)
 
             local x, _, z = getWorldTranslation(cultivatorSelf.rootNode)
             local success, errorMsg = pcall(function()

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -345,10 +345,16 @@ function SoilHUD:calculateHeight()
     local info = self.cachedFieldInfo
     local ys = SoilConstants and SoilConstants.YIELD_SENSITIVITY
     
-    if info then
+    if info and info.simDisabled then
+        -- Compact "field asleep" layout (#692): field/crop row + one message line, no metrics.
+        h = h + SoilHUD.LINE_H        -- field / crop row
+        h = h + SoilHUD.PAD * 1.6     -- divider gap before the message
+        h = h + SoilHUD.LINE_H        -- asleep message line
+        h = h + SoilHUD.PAD * 1.6     -- divider gap after the message
+    elseif info then
         h = h + SoilHUD.LINE_H
         h = h + SoilHUD.PAD * 1.6
-        
+
         h = h + SoilHUD.ROW_H * 3
         h = h + SoilHUD.PAD * 1.3
 
@@ -911,6 +917,9 @@ function SoilHUD:refreshFieldData()
         local cropText = SoilUtils.getCropDisplayName(info.lastCrop)
         if cropText then
             self._fmt_cropText = cropText
+        elseif info.isMeadow then
+            -- Field Sentry meadow: a managed sward, not idle ground — say so (#697)
+            self._fmt_cropText = g_i18n:getText("sf_hud_meadow")
         else
             self._fmt_cropText = g_i18n:getText("sf_hud_fallow")
         end
@@ -1276,13 +1285,16 @@ function SoilHUD:drawPanel()
     local ty   = py + ph - titleH * 0.5  -- vertical center of title bar
 
     local info = self.cachedFieldInfo
+    -- Field put to sleep / disabled by Field Sentry: soil is frozen by intent, so the
+    -- monitor shows that state instead of stale frozen metrics (#692).
+    local asleep = info ~= nil and info.simDisabled == true
 
     -- Title + overall status badge
     setTextBold(true)
     setTextColor(1, 1, 1, 1)
     renderText(tx, ty - 0.006*s, 0.012 * fontMult * s, g_i18n:getText("sf_hud_title"))
 
-    if info then
+    if info and not asleep then
         local statusLabel, statusCol = self:overallStatus(info)
         setTextAlignment(RenderText.ALIGN_RIGHT)
         setTextColor(statusCol[1], statusCol[2], statusCol[3], 1.0)
@@ -1308,17 +1320,36 @@ function SoilHUD:drawPanel()
         setTextAlignment(RenderText.ALIGN_LEFT)
     end
 
+    if asleep then
+        -- Asleep / disabled field (#692): one explanatory line in place of the soil metrics,
+        -- bracketed by dividers so the compact panel still reads as a deliberate state.
+        cy = cy - pad * 0.8
+        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        cy = cy - pad * 0.8
+        cy = cy - SoilHUD.LINE_H * s
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], SoilHUD.C_DIM[4])
+        renderText(px + pw * 0.5, cy + (SoilHUD.LINE_H - 0.010) * 0.5 * s, 0.010 * fontMult * s,
+            g_i18n:getText("sf_hud_asleep"))
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        cy = cy - pad * 0.8
+        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        cy = cy - pad * 0.8
+    end
+
     -- Divider above N/P/K block; "(ppm)" unit label right-aligned on the same line
     -- so the user sees the unit context once, not repeated on every row.
-    cy = cy - pad * 0.8
-    self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
-    setTextAlignment(RenderText.ALIGN_RIGHT)
-    setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], 0.60)
-    renderText(px + pw - pad, cy + 0.001*s, 0.007 * fontMult * s, g_i18n:getText("sf_hud_unit_ppm"))
-    setTextAlignment(RenderText.ALIGN_LEFT)
-    cy = cy - pad * 0.8
+    if not asleep then
+        cy = cy - pad * 0.8
+        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        setTextAlignment(RenderText.ALIGN_RIGHT)
+        setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], 0.60)
+        renderText(px + pw - pad, cy + 0.001*s, 0.007 * fontMult * s, g_i18n:getText("sf_hud_unit_ppm"))
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        cy = cy - pad * 0.8
+    end
 
-    if info then
+    if info and not asleep then
         -- Use cached sprayer state (populated in update() to keep draw() free of game-object traversal)
         local sprayer        = self._cachedSprayer
         local fillType       = self._cachedFillType
@@ -1448,8 +1479,8 @@ function SoilHUD:drawPanel()
         cy = cy - pad * 0.5
         self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
-    else
-        cy = cy - SoilHUD.LINE_H * s * 4  -- skip nutrient rows space
+    elseif not info then
+        cy = cy - SoilHUD.LINE_H * s * 4  -- skip nutrient rows space (no field; asleep draws its own line)
     end
 
     -- Hint row

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,20 +24,14 @@ SoilVersionDialog.INSTANCE = nil
 -- Max 11 lines are visible in the box; if more exist we stop on a bullet boundary and add a "full changelog on GitHub" note.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
-    "- Crop burn now builds up as you spray, no more instant -80%",
-    "- Fresh mid-save installs no longer start fields at 0/0/0/0",
-    "- Seeding with starter fertilizer no longer burns young crops",
-    "- Monitor warns before lime/manure would scorch your crop",
-    "- Fixed burn penalty sticking after replanting (clears on sow/till)",
-    "- Ploughing relieves only a little compaction; subsoiler clears it",
-    "- Radish & canola slowly ease compaction as they grow",
-    "- Fixed: See & Spray buy option now shows on every sprayer",
-    "- See & Spray is now one combined buy option",
-    "- Variable Rate now applies to See & Spray too",
-    "- Fixed admin hotkey needing a remap each session",
-    "- Added Chinese translation (Simplified + Traditional)",
-    "- Legumes now slowly add nitrogen to soil",
-    "- Compaction now based on ground pressure, not weight",
+    "- Alfalfa, grass & clover no longer get a false 'tired field' penalty on later cuts",
+    "- Organic matter now affects yield: rich soil gives a boost, poor soil a penalty",
+    "- Organic matter builds more slowly; ploughing now slowly burns it off",
+    "- Mowed hay & grass yield now responds to your soil nutrients",
+    "- Soil Monitor shows 'Meadow' instead of 'Fallow' on meadow fields",
+    "- Soil Monitor pauses readouts for fields put to sleep in Field Sentry",
+    "- Subsoilers now properly work organic matter & nitrogen into the soil",
+    "- Fixed phantom burnt-weed patches on clean fields after a reload",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/tools/test/lua/compaction_decay_test.lua
+++ b/tools/test/lua/compaction_decay_test.lua
@@ -1,0 +1,68 @@
+-- compaction_decay_test.lua — persistence of compaction recovery (nemrod153 Discord report).
+-- Natural decay and taproot bio-drilling shave points off the field-average compaction.
+-- The average is DERIVED as compactionSum / compactionTotalCells, so the old code (which
+-- only lowered field.compaction) was silently wiped the instant onCompaction /
+-- onSubsoilerPass re-derived the average from the untouched compactionSum — that is the
+-- nemrod153 "radish decompaction reset the moment I started subsoiling" report.
+-- _applyCompactionDecay must fade compactionSum AND every zoneData cell so the recovery
+-- survives a later per-cell rewrite.
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/SoilFertilitySystem.lua
+
+local function sys()
+  return setmetatable({ settings = {} }, { __index = SoilFertilitySystem })
+end
+
+-- A field compacted over 4 tracked cells (the other cells implicitly 0). Set up so the
+-- accounting total and the per-cell store agree: sum 160 over 4 cells → average 40.
+local function makeField()
+  return {
+    compaction           = 40,
+    compactionSum        = 160,
+    compactionTotalCells = 4,
+    zoneData = {
+      ["1"] = { compaction = 40 },
+      ["2"] = { compaction = 40 },
+      ["3"] = { compaction = 40 },
+      ["4"] = { compaction = 40 },
+    },
+  }
+end
+
+-- Re-derive the field average the way onCompaction (4632) and onSubsoilerPass (4685) do.
+-- This is the operation that erased the old decay.
+local function rederive(f)
+  return f.compactionSum / f.compactionTotalCells
+end
+
+-- 1. A 4-point decay (oldAvg 40 → 36, ratio 0.9) lands on the average...
+local f = makeField()
+local changed = sys():_applyCompactionDecay(f, 4)
+T.ok("decay reports a change", changed == true)
+T.near("average dropped by the reduction", f.compaction, 36)
+
+-- 2. ...AND on compactionSum + every cell, so re-deriving the average keeps the recovery.
+T.near("compactionSum faded proportionally", f.compactionSum, 144)
+T.near("cell value faded proportionally", f.zoneData["1"].compaction, 36)
+T.near("REGRESSION: re-derived average survives (was snapping back to 40)", rederive(f), 36)
+
+-- 3. Stacking decays (e.g. several winter days) keeps shrinking and stays consistent.
+sys():_applyCompactionDecay(f, 6)   -- 36 → 30, ratio 30/36
+T.near("second decay lowers the average", f.compaction, 30)
+T.near("re-derived average still matches after stacking", rederive(f), 30)
+
+-- 4. A reduction larger than the current average clamps everything to zero.
+local g = makeField()
+sys():_applyCompactionDecay(g, 999)
+T.eq("over-decay clamps average to 0", g.compaction, 0)
+T.eq("over-decay clamps compactionSum to 0", g.compactionSum, 0)
+T.eq("over-decay clamps re-derived average to 0", rederive(g), 0)
+
+-- 5. No-ops: nothing to decay, or a non-positive reduction, leave the field untouched.
+local h = makeField()
+T.ok("zero reduction is a no-op", sys():_applyCompactionDecay(h, 0) == false)
+T.near("compactionSum unchanged on no-op", h.compactionSum, 160)
+
+local z = { compaction = 0, compactionSum = 0, compactionTotalCells = 4, zoneData = {} }
+T.ok("decay on an uncompacted field is a no-op", sys():_applyCompactionDecay(z, 5) == false)
+
+T.summary()

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Vá até um campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Pousio" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Pragas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Doença" eh="e7067a8c" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="請走入田地" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="休耕" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="害蟲" eh="2fed5101" />
     <e k="sf_hud_disease" v="疾病" eh="e7067a8c" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Vstupte na pole" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Úhor" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Škůdci" eh="2fed5101" />
     <e k="sf_hud_disease" v="Choroby" eh="e7067a8c" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Gå ud på en mark" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Brak" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />
     <e k="sf_hud_disease" v="Sygdom" eh="e7067a8c" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Betreten Sie ein Feld" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Brach" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Schädlinge" eh="2fed5101" />
     <e k="sf_hud_disease" v="Krankheit" eh="e7067a8c" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Camine por un campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Barbecho" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Plagas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Enfermedad" eh="e7067a8c" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Walk onto a field" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Fallow" eh="eafe5913" />
+    <e k="sf_hud_meadow" v="Meadow" eh="f34c07d8" />
+    <e k="sf_hud_asleep" v="Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Pests" eh="2fed5101" />
     <e k="sf_hud_disease" v="Disease" eh="e7067a8c" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Camina por un campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Barbecho" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Plagas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Enfermedad" eh="e7067a8c" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="请进入任意田地" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="休耕" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="虫害" eh="2fed5101" />
     <e k="sf_hud_disease" v="病害" eh="e7067a8c" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Kävele pellolle" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Kesanto" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Tuholaiset" eh="2fed5101" />
     <e k="sf_hud_disease" v="Taudit" eh="e7067a8c" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -182,6 +182,8 @@
     <e k="sf_hud_noField" v="Entrez dans un champ" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Jachère" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Ravageurs" eh="2fed5101" />
     <e k="sf_hud_disease" v="Maladie" eh="e7067a8c" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Sétáljon egy mezőre" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Ugar" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Kártevők" eh="2fed5101" />
     <e k="sf_hud_disease" v="Betegség" eh="e7067a8c" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Masuk ke dalam lahan" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Bera" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Hama" eh="2fed5101" />
     <e k="sf_hud_disease" v="Penyakit" eh="e7067a8c" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -189,6 +189,8 @@
 		<e k="sf_hud_noField" v="Cammina su un campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
 		<e k="sf_hud_fallow" v="Maggese" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
 		<e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
 		<e k="sf_hud_pests" v="Parassiti" eh="2fed5101" />
 		<e k="sf_hud_disease" v="Malattie" eh="e7067a8c" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="フィールドに入ってください" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="休耕" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="害虫" eh="2fed5101" />
     <e k="sf_hud_disease" v="病害" eh="e7067a8c" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="필드에 입장하세요" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="휴경지" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="해충" eh="2fed5101" />
     <e k="sf_hud_disease" v="병해" eh="e7067a8c" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Loop een veld op" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Braak" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Plagen" eh="2fed5101" />
     <e k="sf_hud_disease" v="Ziekte" eh="e7067a8c" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Gå ut på et felt" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Brakklagt" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Skadedyr" eh="2fed5101" />
     <e k="sf_hud_disease" v="Sykdom" eh="e7067a8c" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Wejdź na pole" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Ugór" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Szkodniki" eh="2fed5101" />
     <e k="sf_hud_disease" v="Choroby" eh="e7067a8c" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Caminhe sobre um campo" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Pousio" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Pragas" eh="2fed5101" />
     <e k="sf_hud_disease" v="Doenças" eh="e7067a8c" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Mergeți pe un câmp" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Pârloagă" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Dăunători" eh="2fed5101" />
     <e k="sf_hud_disease" v="Boli" eh="e7067a8c" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Выйдите на поле" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Пар" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Вредители" eh="2fed5101" />
     <e k="sf_hud_disease" v="Болезни" eh="e7067a8c" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Gå ut på ett fält" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Träda" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Skadedjur" eh="2fed5101" />
     <e k="sf_hud_disease" v="Sjukdomar" eh="e7067a8c" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Bir tarlaya gidin" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Nadas" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Zararlılar" eh="2fed5101" />
     <e k="sf_hud_disease" v="Hastalık" eh="e7067a8c" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Вийдіть на поле" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Пар" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Шкідники" eh="2fed5101" />
     <e k="sf_hud_disease" v="Хвороби" eh="e7067a8c" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -189,6 +189,8 @@
     <e k="sf_hud_noField" v="Hãy đi vào cánh đồng" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="[EN] Drive onto a field" eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Để hoang" eh="eafe5913" />
+		<e k="sf_hud_meadow" v="[EN] Meadow" eh="f34c07d8" />
+		<e k="sf_hud_asleep" v="[EN] Field asleep (Field Sentry)" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="[EN] Weed Risk" eh="0ec7e90d" />
     <e k="sf_hud_pests" v="Sâu bệnh" eh="2fed5101" />
     <e k="sf_hud_disease" v="Bệnh hại" eh="e7067a8c" />


### PR DESCRIPTION
Batch of fixes and features covering issues #692 through #698.

## Features
- **#695 Organic matter affects yield.** Bonus at/above OM 5.0, neutral 3.5 to 5.0, penalty below (default 3.5 = neutral). OM oxidises slowly under cropping, ploughing now burns OM off instead of adding it, and single-pass OM gains were lowered to realistic first-season humus levels.
- **#696 Mower yield scales with soil nutrients.** Windrow-drop mowers (disc/drum/swather) bypassed the combine hopper hook. New computeMowerYieldModifier scales each mower's fruitTypeConverter.conversionFactor (pickupFillScale is unused on the windrow path). Depletion unchanged.

## Fixes
- **#694** Perennial forages no longer trip monoculture fatigue on later cuts. alfalfa added to LEGUMES/CROP_TIERS/NON_CROP_NAMES, greenbean/green_beans to LEGUMES.
- **#693** Subsoiler incorporation now uses lastTotalArea (worked strip) instead of the near-zero surface-change lastChangedArea.
- **#698** Herbicide weed-map browning no longer fabricates burnt-weed coverage on clean fields, which fixes phantom patches reappearing on reload.

## Changed
- **#692 / #697** Soil Monitor shows a compact "asleep" line for slept fields and "Meadow" instead of "Fallow" on meadow fields. getFieldInfo surfaces isMeadow.

## Notes
- New l10n keys sf_hud_meadow / sf_hud_asleep synced to all 26 languages (English placeholders pending translation).
- Self-test suite: 193 assertions, 0 failed. Syntax + lint clean.
- Going out as a pre-release for in-game testing before merge.
