### PR TITLE
fix: correct sprayer product under AI/Courseplay control (#708)

### DIFF
--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2704,6 +2704,16 @@ function HookManager:installSprayerAreaHook()
             local liters        = spec.workAreaParameters.usage
             local sprayFillLevel = spec.workAreaParameters.sprayFillLevel
 
+            -- Issue #708: under AI/Courseplay control, vanilla onStartWorkAreaProcessing can
+            -- leave wap.sprayFillType pointing at a different fill type than what is physically
+            -- in the tank (multi-fill-unit machines, after a headland restart). Reading it as
+            -- the product source then credits the WRONG nutrient profile to the soil and
+            -- mislabels the HUD. Override at the top with the physical tank contents so the
+            -- one fix corrects nutrient application, coverage label, and the custom-fill stamp
+            -- together. The tank only wins when it holds a valid non-UNKNOWN type, so
+            -- external-fill BUY mode (empty tank → keep wap value) is preserved.
+            fillTypeIndex = SoilUtils.resolveSprayerFillTypeIndex(self, fillTypeIndex)
+
             -- wap.isActive is vanilla's own "I painted terrain and drained product this
             -- frame" flag: reset to false at the end of every onStartWorkAreaProcessing and
             -- set true only inside processSprayerArea, which runs only for genuinely active

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1777,6 +1777,11 @@ function SoilHUD:getSprayerFillType(sprayer)
         if ft and ft > 0 then fillTypeIndex = ft end
     end
 
+    -- Issue #708: prefer the physical tank contents over wap.sprayFillType, which AI/CP
+    -- can leave pointing at the wrong product after a headland restart. Keeps the wap
+    -- value only when the tank is empty/UNKNOWN (external-fill BUY mode).
+    fillTypeIndex = SoilUtils.resolveSprayerFillTypeIndex(sprayer, fillTypeIndex)
+
     -- Fall back to fill unit query (works when parked)
     if not fillTypeIndex then
         local ok, units = pcall(function() return sprayer:getFillUnits() end)

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -292,6 +292,9 @@ function SoilSprayerInfoPanel:getSprayerFillType(sprayer)
         local ft = spec.workAreaParameters.sprayFillType
         if ft and ft > 0 then fillTypeIndex = ft end
     end
+    -- Issue #708: physical tank contents win over wap.sprayFillType (AI/CP can set the
+    -- wrong one after a headland restart); falls back to wap when the tank is empty.
+    fillTypeIndex = SoilUtils.resolveSprayerFillTypeIndex(sprayer, fillTypeIndex)
     if not fillTypeIndex then
         local ok, units = pcall(function() return sprayer:getFillUnits() end)
         if ok and units then

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -33,6 +33,7 @@ SoilVersionDialog.CHANGELOG = {
     "- Console: SoilScout, SoilTreat, SoilFungicides, SoilSetDiseaseDifficulty",
     "- FIX: Field compaction can no longer read above 100%, the average is now capped",
     "- FIX: Precision Farming is now detected only when it is actually enabled for your save, not just installed in the mods folder",
+    "- FIX: Soil Monitor and applied nutrients now follow the product physically in the tank, even when AI or Courseplay is driving",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/src/utils/SoilUtils.lua
+++ b/src/utils/SoilUtils.lua
@@ -39,3 +39,36 @@ function SoilUtils.getCropDisplayName(name)
     end
     return (name:sub(1, 1):upper() .. name:sub(2):lower()):gsub("_", " ")
 end
+
+--- Resolves the authoritative fill-type INDEX for a sprayer/spreader (issue #708).
+---
+--- The physical tank contents are the ground truth for what is actually being applied.
+--- When AI/Courseplay restarts the implement at a headland turn, vanilla
+--- Sprayer:onStartWorkAreaProcessing can resolve wap.sprayFillType through the AI's
+--- fill-type selection / external-source path. On machines with multiple eligible fill
+--- units this leaves wap.sprayFillType pointing at a different fill type than what is
+--- physically loaded, which both mislabels the HUD "Pass:" line AND credits the wrong
+--- nutrient profile to the soil.
+---
+--- Rule: if getSprayerFillUnitIndex() + getFillUnitFillType() returns a valid, non-UNKNOWN
+--- type, the physical tank wins. Only when the tank reads empty/UNKNOWN — external-fill
+--- BUY mode, or a source trailer feeding an empty sprayer — do we keep the passed-in
+--- fallback (typically wap.sprayFillType), which then legitimately carries the intended
+--- product. All pcall-wrapped so a malformed modded sprayer can never crash the caller.
+---
+--- @param sprayer table  the Sprayer-spec vehicle
+--- @param fallbackIndex number|nil  index to use when the tank is empty/UNKNOWN
+--- @return number|nil  the resolved fill-type index (physical tank, else fallbackIndex)
+function SoilUtils.resolveSprayerFillTypeIndex(sprayer, fallbackIndex)
+    if not sprayer or sprayer.getSprayerFillUnitIndex == nil or sprayer.getFillUnitFillType == nil then
+        return fallbackIndex
+    end
+    local okFui, fillUnitIndex = pcall(function() return sprayer:getSprayerFillUnitIndex() end)
+    if okFui and fillUnitIndex then
+        local okFt, tankFt = pcall(function() return sprayer:getFillUnitFillType(fillUnitIndex) end)
+        if okFt and tankFt and tankFt > 0 and tankFt ~= FillType.UNKNOWN then
+            return tankFt
+        end
+    end
+    return fallbackIndex
+end


### PR DESCRIPTION
## Summary

Fixes #708. Under AI/Courseplay control, vanilla `Sprayer:onStartWorkAreaProcessing` can leave `wap.sprayFillType` pointing at a different fill type than what is physically loaded on multi-fill-unit machines after a headland restart. The mod read `wap.sprayFillType` as the authoritative product, so both the Soil Monitor "Pass:" label **and the nutrient profile credited to the soil** picked up the wrong product.

## Fix

New shared helper `SoilUtils.resolveSprayerFillTypeIndex(sprayer, fallbackIndex)`:
- Reads the physical tank via `getSprayerFillUnitIndex()` + `getFillUnitFillType()`.
- The tank wins only when it holds a valid, non-`UNKNOWN` type; otherwise the fallback is kept, so external-fill **BUY mode** (empty tank, intended product in `wap.sprayFillType`) still works.
- All `pcall`-wrapped so a malformed modded sprayer cannot crash the caller.

Applied in three places:
- `HookManager:installSprayerAreaHook()` overrides `fillTypeIndex` once at the top, correcting nutrient application, the coverage label, and the custom-fill stamp together.
- `SoilHUD:getSprayerFillType()`
- `SoilSprayerInfoPanel:getSprayerFillType()`

## Notes

- Scope kept tight: the See & Spray, Variable Rate, and Overlap Prevention hooks still read `wap.sprayFillType` (section/coverage geometry, not the nutrient credit or label).
- Added a player-facing bullet to the in-dev version dialog.

## Testing

Self-test suite: 193 assertions passed, 0 failed across 9 files. API verified against the Community LUADOC `Sprayer.md`.