### PR TITLE
fix(ui): rotation planner dialog prev/next field footer (#744)

### DIFF
--- a/src/ui/RotationPlannerDialog.lua
+++ b/src/ui/RotationPlannerDialog.lua
@@ -98,21 +98,17 @@ function RotationPlannerDialog:onOpen()
             if id == self._startFieldId then self._index = i break end
         end
     end
-    self.menuButtonInfo = {
-        { inputAction = "MENU_BACK", callback = function() self:onClickBack() end },
-        { inputAction = "MENU_PAGE_PREV", text = tr("sf_rp_prev", "Prev field"),
-          callback = function() self:_step(-1) end },
-        { inputAction = "MENU_PAGE_NEXT", text = tr("sf_rp_next", "Next field"),
-          callback = function() self:_step(1) end },
-    }
-    -- setMenuButtonInfo is a TabbedMenuFrameElement API, not available on a
-    -- ScreenElement dialog. Calling it unconditionally aborted onOpen before
-    -- _refresh(), leaving the dialog blank (#744). ESC/Back comes from the XML
-    -- buttonBack; guard the call so the content always populates.
-    if self.setMenuButtonInfo ~= nil then
-        self:setMenuButtonInfo(self.menuButtonInfo)
-    end
+    -- Field cycling is XML footer Prev/Next (ScreenElement dialogs do not get
+    -- TabbedMenuFrame setMenuButtonInfo). Back stays on the XML buttonBack.
     self:_refresh()
+end
+
+function RotationPlannerDialog:onClickPrev()
+    self:_step(-1)
+end
+
+function RotationPlannerDialog:onClickNext()
+    self:_step(1)
 end
 
 function RotationPlannerDialog:onClickBack()

--- a/xml/gui/RotationPlannerDialog.xml
+++ b/xml/gui/RotationPlannerDialog.xml
@@ -42,8 +42,10 @@
             position="0px -360px" size="520px 80px" wrapText="true"/>
     </GuiElement>
 
-    <GuiElement profile="fs25_dialogButtonBox">
-      <Button profile="buttonBack" text="$l10n_button_back" onClick="onClickBack"/>
-    </GuiElement>
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonOK"   id="rpPrevBtn" text="$l10n_sf_rp_prev" onClick="onClickPrev"/>
+      <Button profile="buttonOK"   id="rpNextBtn" text="$l10n_sf_rp_next" onClick="onClickNext"/>
+      <Button profile="buttonBack" id="rpBackBtn" text="$l10n_button_back" onClick="onClickBack"/>
+    </BoxLayout>
   </GuiElement>
 </GUI>


### PR DESCRIPTION
## What
#744 polish: real Prev/Next field footer buttons on the Rotation Planner dialog.

Prev/next were wired through `setMenuButtonInfo` (TabbedMenuFrame API) which does nothing on a ScreenElement dialog. Replaced with XML footer buttons (SoilScoutDialog BoxLayout pattern).

- `onClickPrev` / `onClickNext` call existing `_step`
- Reuse `sf_rp_prev` / `sf_rp_next` i18n (already in all 27 langs)
- Remove dead `menuButtonInfo` block from `onOpen`
- Back button unchanged

## Test
Open Rotation Planner from Soil PDA → content fills → Prev/Next cycles `Field #id (i / n)` + candidates → Back closes.

-- Wizard