### PR TITLE
feat(ui): #740 World Climate selection (short-month fill)

### DIFF
--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -50,7 +50,9 @@ local CARD_H    = 0.32
 local CARD_Y    = CY_BOT + (CH - CARD_H) / 2
 
 -- Category page rows
-local ROW_H     = 0.036
+local ROW_H        = 0.036
+-- Taller row for the #740 world-climate picker (chips + wetness + blurb).
+local CLIMATE_ROW_H = 0.112
 local SEC_H     = 0.026
 local TOGGLE_W  = 0.048   -- single pill width
 local TOGGLE_H  = 0.026
@@ -763,6 +765,13 @@ end
 
 -- ── Scroll helpers ────────────────────────────────────────
 
+local function settingRowHeight(settingId)
+    if settingId == "weatherSource" then
+        return CLIMATE_ROW_H
+    end
+    return ROW_H
+end
+
 --- Total rendered height of all sections + items in a category (for scrollbar).
 function SoilSettingsPanel:_catContentHeight(cat)
     local h = 0
@@ -770,7 +779,7 @@ function SoilSettingsPanel:_catContentHeight(cat)
         h = h + SEC_H + 0.005
         for _, item in ipairs(sec.items) do
             if type(item) == "string" then
-                h = h + ROW_H
+                h = h + settingRowHeight(item)
             elseif type(item) == "table" then
                 h = h + ADMIN_ACT_H
             end
@@ -885,7 +894,8 @@ function SoilSettingsPanel:drawCategoryPage()
             local itemDef   = type(item) == "table"  and item or nil
 
             if settingId then
-                curY = curY - ROW_H
+                local rh = settingRowHeight(settingId)
+                curY = curY - rh
                 if curY < CY_BOT then break end
                 rowIdx = rowIdx + 1
                 if curY <= CY_TOP then
@@ -1478,14 +1488,22 @@ function SoilSettingsPanel:drawSettingRow(x, y, w, settingId, rowIdx, isAdmin)
     local def = SettingsSchema.byId[settingId]
     if not def then return end
 
+    -- #740: world climate gets a dedicated chip picker (farm-terms wetness preview).
+    if settingId == "weatherSource" then
+        self:drawClimateSettingRow(x, y, w, rowIdx, isAdmin)
+        return
+    end
+
+    local rh = ROW_H
+
     -- Alternating row background
     if rowIdx % 2 == 0 then
-        self:drawRect(x, y, w, ROW_H, C.row_alt)
+        self:drawRect(x, y, w, rh, C.row_alt)
     end
 
     -- Hover highlight (only on the left/label portion)
-    if self:hitTest(x, y, w, ROW_H, self.mouseX, self.mouseY) then
-        self:drawRect(x, y, w, ROW_H, C.row_hover)
+    if self:hitTest(x, y, w, rh, self.mouseX, self.mouseY) then
+        self:drawRect(x, y, w, rh, C.row_hover)
     end
 
     local locked = not def.localOnly and not isAdmin
@@ -1494,23 +1512,23 @@ function SoilSettingsPanel:drawSettingRow(x, y, w, settingId, rowIdx, isAdmin)
 
     -- Lock indicator
     if locked then
-        self:drawRect(x, y, 0.003, ROW_H, {0.88, 0.60, 0.18, 0.45})
+        self:drawRect(x, y, 0.003, rh, {0.88, 0.60, 0.18, 0.45})
     end
 
     -- Setting label
     local labelX = x + (locked and 0.010 or 0.008)
-    local labelY = y + ROW_H * 0.52
+    local labelY = y + rh * 0.52
     local labelText = tr(def.uiId .. "_short", settingId)
     self:drawText(labelX, labelY, TS_BODY, labelText, labelColor, RenderText.ALIGN_LEFT, not locked)
 
     -- Description
     local descKey = SETTING_DESCS[settingId]
     local desc = (descKey and tr(descKey)) or ""
-    self:drawText(labelX, y + ROW_H * 0.15, TS_TINY, desc, descColor, RenderText.ALIGN_LEFT, false)
+    self:drawText(labelX, y + rh * 0.15, TS_TINY, desc, descColor, RenderText.ALIGN_LEFT, false)
 
     -- Control (toggle or multi-select) on the right
     local ctrlX = x + w - 0.012
-    local ctrlY = y + (ROW_H - TOGGLE_H) / 2
+    local ctrlY = y + (rh - TOGGLE_H) / 2
 
     if def.type == "boolean" then
         self:drawToggleControl(ctrlX, ctrlY, settingId, locked)
@@ -1519,6 +1537,93 @@ function SoilSettingsPanel:drawSettingRow(x, y, w, settingId, rowIdx, isAdmin)
     end
 
     -- Row bottom divider
+    self:drawRect(x, y, w, 0.0005, C.divider, 0.35)
+end
+
+-- Wetness bars for climate chips (visual only; 1=real/opt-out flat, 2-4 = arid..wet).
+local CLIMATE_WETNESS = { 0, 1, 2, 3 }
+local CLIMATE_CHIP_COLORS = {
+    {0.55, 0.58, 0.62, 1.0}, -- real sky (neutral)
+    {0.78, 0.62, 0.28, 1.0}, -- arid
+    {0.35, 0.72, 0.48, 1.0}, -- normal
+    {0.28, 0.55, 0.88, 1.0}, -- wet
+}
+
+--- #740 creative climate picker: four chips with wetness preview + selected farm-terms blurb.
+function SoilSettingsPanel:drawClimateSettingRow(x, y, w, rowIdx, isAdmin)
+    local def = SettingsSchema.byId.weatherSource
+    if not def then return end
+    local rh = CLIMATE_ROW_H
+    local locked = not def.localOnly and not isAdmin
+
+    if rowIdx % 2 == 0 then
+        self:drawRect(x, y, w, rh, C.row_alt)
+    end
+    if locked then
+        self:drawRect(x, y, 0.003, rh, {0.88, 0.60, 0.18, 0.45})
+    end
+
+    local labelX = x + (locked and 0.010 or 0.008)
+    local labelColor = locked and C.lock_text or C.white
+    local descColor  = locked and {C.lock_text[1]*0.7, C.lock_text[2]*0.7, C.lock_text[3]*0.7, 1} or C.dim
+
+    self:drawText(labelX, y + rh - 0.018, TS_BODY,
+        tr("sf_ws_short", "World Climate"), labelColor, RenderText.ALIGN_LEFT, not locked)
+    self:drawText(labelX, y + rh - 0.032, TS_TINY,
+        tr("sf_desc_weatherSource", ""), descColor, RenderText.ALIGN_LEFT, false)
+    self:drawText(labelX, y + rh - 0.044, TS_TINY,
+        tr("sf_ws_world_note", "World setting - admin only in multiplayer; changes soil for everyone."),
+        locked and descColor or {0.88, 0.72, 0.35, 1.0}, RenderText.ALIGN_LEFT, false)
+
+    local val = self:getValue("weatherSource")
+    if val == nil then val = def.default or 3 end
+
+    local chipPad = 0.006
+    local chipW = (w - 0.016 - chipPad * 3) / 4
+    local chipH = 0.038
+    local chipY = y + 0.028
+    local chipX0 = x + 0.008
+
+    for i = 1, 4 do
+        local cx = chipX0 + (i - 1) * (chipW + chipPad)
+        local selected = (val == i)
+        local hover = not locked and self:hitTest(cx, chipY, chipW, chipH, self.mouseX, self.mouseY)
+        local accent = CLIMATE_CHIP_COLORS[i]
+        local bg = selected and {accent[1] * 0.35, accent[2] * 0.35, accent[3] * 0.35, 0.95}
+            or (hover and C.back_hover or {0.10, 0.11, 0.15, 0.92})
+        self:drawRect(cx, chipY, chipW, chipH, bg)
+        if selected then
+            self:drawRect(cx, chipY, chipW, 0.0022, accent)
+            self:drawRect(cx, chipY + chipH - 0.0022, chipW, 0.0022, accent)
+        end
+
+        -- Wetness preview bars (real sky = dashed flat line feel via zero fill + dim track)
+        local bars = CLIMATE_WETNESS[i] or 0
+        local barW = 0.008
+        local barGap = 0.003
+        local barMaxH = 0.014
+        local barsX = cx + chipW * 0.5 - (4 * barW + 3 * barGap) * 0.5
+        local barsY = chipY + chipH - 0.018
+        for b = 1, 4 do
+            local bx = barsX + (b - 1) * (barW + barGap)
+            local filled = (b <= bars)
+            local bh = barMaxH * (0.35 + 0.22 * b)
+            self:drawRect(bx, barsY, barW, bh, filled and accent or {0.22, 0.24, 0.28, 0.90})
+        end
+
+        local optKey = "sf_ws_" .. i
+        local optLabel = tr(optKey, tostring(i))
+        self:drawText(cx + chipW * 0.5, chipY + 0.004, TS_TINY,
+            optLabel, selected and C.white or C.dim, RenderText.ALIGN_CENTER, selected)
+
+        if not locked then
+            self:registerClick("climate_" .. i, cx, chipY, chipW, chipH,
+                { id = "weatherSource", value = i })
+        end
+    end
+
+    local blurb = tr("sf_ws_blurb_" .. tostring(val), "")
+    self:drawText(labelX, y + 0.008, TS_TINY, blurb, descColor, RenderText.ALIGN_LEFT, false)
     self:drawRect(x, y, w, 0.0005, C.divider, 0.35)
 end
 
@@ -1658,6 +1763,11 @@ function SoilSettingsPanel:handleClick(id, data)
 
     elseif id:sub(1, 10) == "toggle_on_" then
         if data then self:requestChange(data.id, true) end
+
+    elseif id:sub(1, 8) == "climate_" then
+        if data and data.id and data.value then
+            self:requestChange(data.id, data.value)
+        end
 
     elseif id:sub(1, 10) == "multi_prev" then
         if data then

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -43,8 +43,9 @@ SoilVersionDialog.CHANGELOG = {
     "    finished. The target is now underwritten so the contract can complete.",
     "- Short months feel a living climate. On short calendars the game rarely",
     "    rains, so soil went stale; SoilFertilizer now tops up the rain a short",
-    "    month skips, at your chosen climate (Arid / Normal / Wet). Real weather",
-    "    stays in charge, and normal-length saves are unchanged.",
+    "    month skips, at your World Climate (Arid / Normal / Wet). Real sky only",
+    "    opts out of the fill. Real weather stays in charge; normal-length saves",
+    "    are unchanged.",
 }
 
 -- ── i18n helper ───────────────────────────────────────────

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Ativar/desativar impacto sazonal nos nutrientes do solo (impulso primaveril, desaceleração outonal)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efeitos Chuva" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Ativar/desativar impacto chuva no solo (lixiviação nutrientes, alterações pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bônus Aração" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ativar/desativar benefícios aração para fertilidade solo (melhor nitrogênio e matéria orgânica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporação de Resíduos" eh="f4352cb5" />
@@ -644,7 +650,6 @@
     <e k="sf_desc_hudTransparency" v="Transparência do fundo do HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Mudanças no solo impulsionadas pelas estações" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="A chuva causa lixiviação de nutrientes" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bônus de arado para recuperação do solo" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="O preparo do solo libera nutrientes dos resíduos" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Rastrear e penalizar a propagação de ervas daninhas" eh="df20c38d" />

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="开启/关闭季节对土壤养分的影响（春季生长加成、秋季生长减缓）" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="降雨影响" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="开启/关闭降雨对土壤的影响（养分流失、酸碱度变化）" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="耕地增益" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="开启/关闭耕地带来的土壤肥力加成（提升氮元素与有机质含量）" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="秸秆还田养分释放" eh="f4352cb5" />
@@ -646,7 +652,6 @@
     <e k="sf_desc_hudTransparency" v="HUD背景透明度" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="季节变化带来土壤动态改变" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="降雨会造成土壤养分淋溶流失" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="深耕犁地可加速土壤肥力恢复" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="秸秆还田分解释放土壤养分" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="模拟杂草滋生并带来产量惩罚" eh="df20c38d" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="啟用/禁用季節對土壤養分的影響（春季生長加速，秋季放緩）" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="降雨效應" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="啟用/禁用降雨對土壤的影響（養分流失、pH 值變化）" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="翻耕獎勵" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="啟用/禁用翻耕對土壤肥力的好處（改善氮和有機質）" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residue Incorporation" eh="f4352cb5" />
@@ -646,7 +652,6 @@
     <e k="sf_desc_hudTransparency" v="HUD background transparency" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Season-driven soil changes" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Rain causes nutrient leaching" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Plow bonus for soil recovery" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Tillage releases residue nutrients" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Track and penalize weed spread" eh="df20c38d" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Povolit/zakázat sezónní vliv na půdní živiny (jarní růstový impuls, podzimní zpomalení)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Dešťové efekty" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Povolit/zakázat vliv deště na půdu (vymývání živin, změny pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonus orby" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Povolit/zakázat výhody orby pro úrodnost půdy (zlepšený dusík a organická hmota)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Zapracování posklizňových zbytků" eh="f4352cb5" />
@@ -650,7 +656,6 @@
     <e k="sf_desc_hudTransparency" v="Průhlednost pozadí HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Změny půdy ovlivněné ročním obdobím" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Déšť způsobuje vymývání živin" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bonus orby pro obnovu půdy" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Zpracování půdy uvolňuje živiny ze zbytků" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Sledovat a penalizovat šíření plevele" eh="df20c38d" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktiver/deaktiver sæsonmæssig påvirkning af jordnæringsstoffer (forårsvækst, efterårsstagnation)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktiver/deaktiver regnens påvirkning af jord (næringsstofudvaskning, pH-ændringer)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Pløjebonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktiver/deaktiver pløjningens fordele for jordfrugtbarhed (forbedret kvælstof og organisk materiale)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Indarbejdelse af planterester" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="HUD-baggrundens gennemsigtighed" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Sæsonbaserede jordændringer" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Regn forårsager udvaskning af næringsstoffer" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Pløjebonus for jordforbedring" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Jordbearbejdning frigiver næringsstoffer fra planterester" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Spor og straf ukrudtsspredning" eh="df20c38d" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Saisonale Auswirkungen auf Bodennährstoffe ein-/ausschalten (Frühjahrswachstumsschub, Herbstverlangsamung)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regeneffekte" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Regenauswirkungen auf Boden ein-/ausschalten (Nährstoffauswaschung, pH-Änderungen)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Pflugbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Pflugvorteile für Bodenfruchtbarkeit ein-/ausschalten (verbesserter Stickstoff und organische Substanz)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Einarbeitung von Ernterückständen" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="HUD-Hintergrundtransparenz" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Saisonbedingte Bodenveränderungen" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Regen verursacht Nährstoffauswaschung" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Pflugbonus für Bodenwiederherstellung" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Bodenbearbeitung setzt Nährstoffe aus Rückständen frei" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Unkrautausbreitung verfolgen und bestrafen" eh="df20c38d" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activar/desactivar el impacto estacional en los nutrientes del suelo (impulso de crecimiento en primavera, ralentización en otoño)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efectos de la Lluvia" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activar/desactivar el impacto de la lluvia en el suelo (lixiviación de nutrientes, cambios de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonificación por Arado" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activar/desactivar beneficios del arado para la fertilidad del suelo (mejora de nitrógeno y materia orgánica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporación de Residuos" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="Transparencia de fondo del HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Cambios de suelo por estaciones" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="La lluvia causa lixiviación de nutrientes" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bono por arado para recuperación" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="El labrado libera nutrientes de residuos" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Seguimiento y penalización por maleza" eh="df20c38d" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Enable/disable seasonal impact on soil nutrients (spring growth boost, fall slowdown)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Rain Effects" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Plowing Bonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residue Incorporation" eh="f4352cb5" />
@@ -646,7 +652,6 @@
     <e k="sf_desc_hudTransparency" v="HUD background transparency" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Season-driven soil changes" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Rain causes nutrient leaching" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Plow bonus for soil recovery" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Tillage releases residue nutrients" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Track and penalize weed spread" eh="df20c38d" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activar/desactivar el impacto estacional en los nutrientes del suelo (impulso de crecimiento en primavera, ralentización en otoño)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efectos de lluvia" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activar/desactivar el impacto de la lluvia en el suelo (lixiviación de nutrientes, cambios de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bono por arado" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activar/desactivar beneficios del arado para la fertilidad del suelo (mejora de nitrógeno y materia orgánica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporación de residuos" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="Transparencia de fondo del HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Cambios de suelo por estaciones" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="La lluvia causa lixiviación de nutrientes" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bono por arado para recuperación" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="El labrado libera nutrientes de residuos" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Seguimiento y penalización por maleza" eh="df20c38d" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="开启/关闭季节对土壤养分的影响（春季生长加成、秋季生长减缓）" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="降雨影响" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="开启/关闭降雨对土壤的影响（养分流失、酸碱度变化）" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="耕地增益" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="开启/关闭耕地带来的土壤肥力加成（提升氮元素与有机质含量）" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residue Incorporation" eh="f4352cb5" />
@@ -646,7 +652,6 @@
     <e k="sf_desc_hudTransparency" v="HUD background transparency" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Season-driven soil changes" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Rain causes nutrient leaching" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Plow bonus for soil recovery" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Tillage releases residue nutrients" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Track and penalize weed spread" eh="df20c38d" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Ota käyttöön/poista käytöstä vuodenaikojen vaikutus ravinteisiin (keväinen kasvupyrähdys, syksyinen hidastuminen)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Sadevaikutukset" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Ota käyttöön/poista käytöstä sateen vaikutus maaperään (ravinteiden huuhtoutuminen, pH-muutokset)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Kyntöbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ota käyttöön/poista käytöstä kynnön hyödyt maaperän hedelmällisyydelle (parantunut typpi ja orgaaninen aines)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Kasvijätteen muokkaus" eh="f4352cb5" />
@@ -606,7 +612,6 @@
     <e k="sf_desc_hudTransparency" v="HUDin taustan läpinäkyvyys" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Vuodenaikojen mukaiset muutokset" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Sade huuhtoo ravinteita maasta" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Kyntö parantaa maan palautumista" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Muokkaus vapauttaa ravinteita kasvijätteestä" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Seuraa rikkakasvien leviämistä" eh="df20c38d" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activer/désactiver l'impact des saisons sur les nutriments du sol (croissance accélérée au printemps, ralentissement en automne)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Effets de la pluie" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activer/désactiver l'impact de la pluie sur le sol (lessivage des nutriments, variations de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonus de labour" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activer/désactiver les effets du labour sur la fertilité du sol (amélioration de l'azote et de la matière organique)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporation des résidus" eh="f4352cb5" />
@@ -640,7 +646,6 @@
     <e k="sf_desc_hudTransparency" v="Transparence de l’arrière-plan du HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Changements du sol liés aux saisons" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="La pluie provoque le lessivage des nutriments" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bonus de labour pour la récupération du sol" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Le travail du sol libère les nutriments des résidus" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Suivre et pénaliser la propagation des mauvaises herbes" eh="df20c38d" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Évszak hatásának engedélyezése/tiltása a talaj tápanyagaira (tavaszi növekedési gyorsítás, őszi lassítás)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Eső Hatások" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Engedélyezze/tiltsa az eső hatását a talajra (tápanyag kimosódás, pH-változások)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Szántás Bónusz" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="A szántás előnyeinek engedélyezése/tiltása a talaj termékenységére (javított nitrogén és szerves anyag)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Maradvány beforgatás" eh="f4352cb5" />
@@ -624,7 +630,6 @@
     <e k="sf_desc_hudTransparency" v="HUD háttér átlátszósága" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Évszakokhoz kötött talajváltozások" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Az eső tápanyag-kimosódást okoz" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Szántási bónusz a talaj regenerációjához" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="A talajművelés felszabadítja a maradványok tápanyagait" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Gyomterjedés követése és büntetése" eh="df20c38d" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktifkan/nonaktifkan dampak musiman pada nutrisi tanah (dorongan pertumbuhan musim semi, perlambatan musim gugur)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efek Hujan" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktifkan/nonaktifkan dampak hujan pada tanah (pencucian nutrisi, perubahan pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonus Membajak" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktifkan/nonaktifkan manfaat membajak bagi kesuburan tanah (peningkatan nitrogen dan bahan organik)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Inkorporasi Residu" eh="f4352cb5" />
@@ -643,7 +649,6 @@
     <e k="sf_desc_hudTransparency" v="Transparansi latar belakang HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Perubahan tanah berdasarkan musim" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Hujan menyebabkan pencucian nutrisi" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bonus bajak untuk pemulihan tanah" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Pengolahan tanah melepaskan nutrisi residu" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Lacak dan beri penalti penyebaran gulma" eh="df20c38d" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Attiva/disattiva impatto stagionale sui nutrienti del suolo (spinta primaverile, rallentamento autunnale)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Effetti Pioggia" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Attiva/disattiva impatto pioggia su suolo (lisciviazione nutrienti, cambiamenti pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonus Aratura" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Attiva/disattiva benefici aratura per fertilità suolo (miglior azoto e materia organica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporamento residui" eh="f4352cb5" />
@@ -643,7 +649,6 @@
     <e k="sf_desc_hudTransparency" v="Trasparenza dello sfondo dell'HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Cambiamenti del suolo basati sulle stagioni" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="La pioggia causa il lisciviamento dei nutrienti" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bonus aratura per il recupero del suolo" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="La lavorazione del terreno rilascia i nutrienti dai residui" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Monitora e penalizza la diffusione delle erbacce" eh="df20c38d" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="土壌養分への季節的な影響（春の成長促進、秋の停滞）を有効/無効にします" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="雨の影響" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="土壌への雨の影響（養分の流出、pHの変化）を有効/無効にします" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="耕耘ボーナス" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="土壌肥沃度に対する耕耘のメリット（窒素と有機物の改善）を有効/無効にします" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="残渣のすき込み" eh="f4352cb5" />
@@ -629,7 +635,6 @@
     <e k="sf_desc_hudTransparency" v="HUD 背景の透明度" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="季節による土壌の変化" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="雨による養分の流出" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="土壌回復に対する耕耘ボーナス" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="耕耘による残渣からの養分放出" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="雑草の広がりを追跡し、収量に反映させます" eh="df20c38d" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="토양 영양분에 대한 계절적 영향 활성화/비활성화 (봄철 성장 촉진, 가을철 성장 둔화)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="강우 효과" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="토양에 대한 강우 영향 활성화/비활성화 (영양분 용탈, pH 변화)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="쟁기질 보너스" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="토양 비옥도에 대한 쟁기질 혜택 활성화/비활성화 (질소 및 유기물 개선)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="잔사 혼입" eh="f4352cb5" />
@@ -630,7 +636,6 @@
     <e k="sf_desc_hudTransparency" v="HUD 배경 투명도" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="계절에 따른 토양 변화" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="비로 인한 영양분 용탈 발생" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="토양 회복을 위한 쟁기질 보너스" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="경운 작업 시 잔사 영양분 방출" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="잡초 확산 추적 및 불이익 부여" eh="df20c38d" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Seizoensgebonden impact op bodemvoedingsstoffen in-/uitschakelen (groeiboost in de lente, vertraging in de herfst)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regeneffecten" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Regenimpact op de bodem in-/uitschakelen (uitspoeling van voedingsstoffen, pH-veranderingen)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Ploegbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ploegvoordelen voor bodemvruchtbaarheid in-/uitschakelen (verbeterde stikstof en organische stof)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Gewasresten inwerken" eh="f4352cb5" />
@@ -631,7 +637,6 @@
     <e k="sf_desc_hudTransparency" v="HUD-achtergrondtransparantie" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Seizoensgestuurde bodemveranderingen" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Regen veroorzaakt uitspoeling van voedingsstoffen" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Ploegbonus voor bodemherstel" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Grondbewerking geeft voedingsstoffen uit resten vrij" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Onkruidverspreiding bijhouden en bestraffen" eh="df20c38d" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktiver/deaktiver sesongpåvirkning på næringsstoffer i jorda (vårvekstboost, høstoppbremsing)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktiver/deaktiver regnpåvirkning på jord (næringslekkasje, pH-endringer)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Pløyebonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktiver/deaktiver fordeler ved pløying for jordfruktbarhet (forbedret nitrogen og organisk materiale)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Innforming av planterester" eh="f4352cb5" />
@@ -631,7 +637,6 @@
     <e k="sf_desc_hudTransparency" v="Bakgrunnsgjennomsiktighet for HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Sesongdrevne jordendringer" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Regn forårsaker utvasking av næringsstoffer" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Pløyebonus for jordgjenoppretting" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Jordbearbeiding frigjør næringsstoffer fra rester" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Spor og straff ugressspredning" eh="df20c38d" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Włącz/wyłącz wpływ sezonowy na składniki odżywcze gleby (wiosenny wzrost, jesienne spowolnienie)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efekty deszczu" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Włącz/wyłącz wpływ deszczu na glebę (wypłukiwanie składników, zmiany pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonus za orkę" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Włącz/wyłącz korzyści z orki dla żyzności gleby (poprawa zawartości azotu i materii organicznej)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Mieszanie resztek" eh="f4352cb5" />
@@ -631,7 +637,6 @@
     <e k="sf_desc_hudTransparency" v="Przezroczystość tła HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Zmiany gleby zależne od pory roku" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Deszcz powoduje wypłukiwanie składników" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bonus orki dla regeneracji gleby" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Uprawa uwalnia składniki z resztek" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Śledź i karz rozprzestrzenianie chwastów" eh="df20c38d" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Ativar/desativar impacto sazonal nos nutrientes do solo (impulso de crescimento na primavera, abrandamento no outono)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efeitos da Chuva" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Ativar/desativar impacto da chuva no solo (lixiviação de nutrientes, mudanças de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bónus de Lavoura" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ativar/desativar benefícios da lavoura para a fertilidade do solo (melhoria de nitrogénio e matéria orgânica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporação de Resíduos" eh="f4352cb5" />
@@ -644,7 +650,6 @@
     <e k="sf_desc_hudTransparency" v="Transparência do fundo do HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Mudanças de solo impulsionadas pela estação" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="A chuva causa lixiviação de nutrientes" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bónus de arado para recuperação do solo" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="O preparo liberta nutrientes dos resíduos" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Monitorizar e penalizar propagação de ervas daninhas" eh="df20c38d" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activează/dezactivează impactul sezonier asupra nutrienților din sol (spor de creștere primăvara, încetinire toamna)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efectele Ploii" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activează/dezactivează impactul ploii asupra solului (spălarea nutrienților, modificări de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Bonus de Arat" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activează/dezactivează beneficiile aratului pentru fertilitatea solului (îmbunătățirea azotului și a materiei organice)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Încorporarea Reziduurilor" eh="f4352cb5" />
@@ -644,7 +650,6 @@
     <e k="sf_desc_hudTransparency" v="Transparența fundalului HUD-ului" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Modificări ale solului în funcție de sezon" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Ploaia cauzează spălarea nutrienților" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Bonus de plug pentru recuperarea solului" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Prelucrarea solului eliberează nutrienții din reziduuri" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Urmărește și penalizează răspândirea buruienilor" eh="df20c38d" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Включить/отключить сезонное влияние на питательные вещества почвы (весенний рост, осеннее замедление)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Эффекты дождя" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Включить/выключить влияние дождя на почву (вымывание питательных веществ, изменение pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Бонус за вспашку" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Включить/отключить преимущества вспашки для плодородия почвы (повышение содержания азота и органического вещества)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Заделка растительных остатков" eh="f4352cb5" />
@@ -599,7 +605,6 @@
     <e k="sf_desc_hudTransparency" v="Прозрачность фона HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Изменения по сезонам" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Вымывание при дожде" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Бонус вспашки для почвы" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Выход питания из остатков" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Распространение сорняков" eh="df20c38d" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktivera/inaktivera säsongspåverkan på marknäring (tillväxtökning på våren, avmattning på hösten)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktivera/inaktivera regnets påverkan på marken (näringsläckage, pH-förändringar)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Plogningsbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktivera/inaktivera fördelar med plogning för markens bördighet (förbättrat kväve och organiskt material)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residuinblandning" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="Bakgrundsgenomskinlighet i HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Säsongsdrivna markförändringar" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Regn orsakar näringsläckage" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Plogningsbonus för markens återhämtning" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Jordbearbetning frigör näring från rester" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Spåra och bestraffa ogrässpridning" eh="df20c38d" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Mevsimlerin toprak besin maddeleri üzerindeki etkisini etkinleştir/devre dışı bırak (bahar büyüme desteği, sonbahar yavaşlaması)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Yağmur Etkileri" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Yağmurun toprak üzerindeki etkisini etkinleştir/devre dışı bırak (besin yıkanması, pH değişiklikleri)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Sürme Bonusu" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Toprak verimliliğine sürme faydalarını etkinleştir/devre dışı bırak (iyileştirilmiş azot ve organik madde)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Anız Karıştırma" eh="f4352cb5" />
@@ -606,7 +612,6 @@
     <e k="sf_desc_hudTransparency" v="HUD arka plan şeffaflığı" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Mevsim kaynaklı toprak değişiklikleri" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Yağmur besin yıkanmasına neden olur" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Toprak iyileşmesi için pulluk sürüm bonusu" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Toprak işleme, anızdaki besinleri salar" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Yabancı ot yayılımını takip edin ve cezalandırın" eh="df20c38d" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Увімкнути/вимкнути сезонний вплив на поживні речовини ґрунту (весняне зростання, осіннє сповільнення)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Ефекти дощу" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Увімкнути/вимкнути вплив дощу на ґрунт (вилуговування поживних речовин, зміни pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Бонус оранки" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Увімкнути/вимкнути переваги оранки для родючості ґрунту (покращений азот та органічна речовина)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Внесення пожнивних залишків" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="Прозорість фону HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Сезонні зміни в ґрунті" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Дощ спричиняє вимивання речовин" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Бонус оранки для відновлення ґрунту" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Обробка вивільняє речовини з решток" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Відстеження та штраф за бур'яни" eh="df20c38d" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -10,12 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Bật/tắt tác động theo mùa đối với chất dinh dưỡng trong đất (thúc đẩy tăng trưởng vụ xuân, làm chậm vụ thu)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Hiệu ứng mưa" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Bật/tắt tác động của mưa đối với đất (rửa trôi chất dinh dưỡng, thay đổi pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Weather Source" />
-    <e k="sf_ws_long" v="Where soil rain effects read precipitation from. In-game Weather uses the real forecast; Arid, Normal or Wet use a synthetic per-season climate so rain effects still work on short months. Does not change the in-game visual weather." />
-    <e k="sf_ws_1" v="In-game Weather" />
+    <e k="sf_ws_short" v="World Climate" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
+    <e k="sf_ws_1" v="Real sky only" />
     <e k="sf_ws_2" v="Arid" />
     <e k="sf_ws_3" v="Normal" />
     <e k="sf_ws_4" v="Wet" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
     <e k="sf_plowing_bonus_short" v="Thưởng khi cày" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Bật/tắt lợi ích của việc cày đối với độ phì nhiêu của đất (cải thiện đạm và chất hữu cơ)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Vùi phụ phẩm" eh="f4352cb5" />
@@ -605,7 +611,6 @@
     <e k="sf_desc_hudTransparency" v="Độ trong suốt của nền HUD" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="Thay đổi đất đai theo mùa" eh="f515f484" />
     <e k="sf_desc_rainEffects" v="Mưa gây rửa trôi chất dinh dưỡng" eh="82fec75d" />
-    <e k="sf_desc_weatherSource" v="Rain source for soil effects: real weather, or a synthetic Arid/Normal/Wet climate for short months" />
     <e k="sf_desc_plowingBonus" v="Thưởng khi cày để phục hồi đất" eh="23522b97" />
     <e k="sf_desc_residueIncorporation" v="Làm đất giải phóng dinh dưỡng từ phụ phẩm" eh="e8cd556b" />
     <e k="sf_desc_weedPressure" v="Theo dõi và phạt khi cỏ dại lan rộng" eh="df20c38d" />


### PR DESCRIPTION
## Summary
Player-facing climate control for the #740 short-month rain fill (mechanism already on development via K).

- Renames the control to **World Climate** with farm-terms copy (fill climate, not sky override)
- Rich chip picker with wetness preview + selected blurb + multiplayer world/admin note
- Options: Real sky only / Arid / Normal / Wet (same ``weatherSource`` 1-4 values)
- 26-language strings; startup changelog wording aligned

## Test plan
- [ ] Settings → Environment: World Climate shows 4 chips
- [ ] Selecting a chip updates setting via admin path in MP
- [ ] Non-admin sees locked control + world note
- [ ] Blurb text matches selected climate
- [ ] Normal-length saves still unaffected by mechanism (K)