### PR TITLE
docs: track #749 grass drying / rotting bales on ROADMAP and TODO

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@
 - [ ] Lock the provisional module ids with Claude(A): `SoilFertilizer_Soil` (StateLedger) and `SoilFertilizer_Sync` (NetworkSync) before they ship in a release.
 
 ## Mid-term (this season)
+- [ ] Grass drying to hay + rotting when wet (#749): dry grass in sun / ted passes; rot loose grass and bales under long rain. Community request (Mankan81). Design path open (SF vs SCS vs dedicated surface); no build until owned.
 - [ ] ProStaff fertilizer discount bridge (silent, pcall-guarded read of `getFertilizerDiscount`) once scheduled. Not built today by decision (Point 8).
 - [ ] Decide whether `getFieldInfo` should expose FieldSentry state (isSleeping/isMeadow/contractMaskActive) instead of companions reading `g_currentMission.fieldSentry` directly.
 - [ ] Emit a clean disease-at-harvest signal (pathogen id + pressure) for an external diseased-food/mycotoxin model. Data already retained on fieldData at harvest; expose it deliberately.

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - [ ] None open from the audit. Track new ones from GitHub issues here.
 
 ## Features / enhancements
+- [ ] Grass drying to hay + rotting when wet (#749): community request (Mankan81). Dry grass in sun / ted passes; rot loose grass and bales if rain exposure too long. Similar idea to Ozz moisture mod. Tracked from GitHub; needs design path (SF vs SCS vs new surface) before build. Not started.
 - [x] Refined per-pixel value-map engine (WizardlyPayload's #736): adopted and folded into development (cd871bd7). Four merge-review fixes landed with it: migration coord fix, skipped-day batch-tail simulation, undiscovered-disease display-map gate, and the SoilMapOverlay semantic review. Per-cell spray now paints the value maps instead of the field average (#735). Our simulation kept on top of the storage engine.
 - [x] Organic certification multiplayer sync (81d7f9d8): state serialized on every field path, fixing the co-op client wipe. Backed by an ephemeral 3-state status-map layer painted at cert changes (a54098f1) and surfaced as map layer 12. Answers the ecosystem organic-cert MP-sync open call.
 - [x] No-till organic-matter dynamics (#738, f0f5aab8): per-tillage oxidation gradient + fenced no-till daily credit; the flat OM_BOOST retired.


### PR DESCRIPTION
## Summary
Per @TheCodingDad-TisonK on #749: add grass drying to hay + rotting bales to ROADMAP/TODO.

Docs only. Design path (SF vs SCS vs dedicated) still open before any build.

## Test plan
- [ ] ROADMAP mid-term + TODO features rows reference #749