### PR TITLE
fix(net): stop value map resync storm on dedicated servers

### DIFF
--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -691,12 +691,26 @@ function SoilValueMaps:readSyncRow(key, gy)
     return row
 end
 
+--- Wipe an entire value-map layer to raw 0 ("no data"). Used before a layer
+--- resync so residual local paint cannot survive a server stream that only
+--- paints non-zero states into empty cells.
+function SoilValueMaps:clearLayer(key)
+    local entry = self.layers[key]
+    if not entry or not entry.modifier then return end
+    local m = entry.modifier
+    local half = self.terrainSize * 0.5
+    m:setParallelogramWorldCoords(
+        -half, -half, half, -half, -half, half,
+        DensityCoordType.POINT_POINT_POINT)
+    m:executeSet(0)
+end
+
 --- Apply one received sync row: paints stride-sized blocks with the state's
---- mid-range semantic value. State 0 = no data (skipped).
+--- mid-range semantic value. State 0 = no data and MUST clear residual paint
+--- (executeSet 0); skipping zeros left stale pixels that made checksums diverge.
 function SoilValueMaps:applySyncRow(key, gy, row)
     local entry = self.layers[key]
     if not entry then return end
-    local def = entry.def
     local m = entry.modifier
     local stride = self:getSyncStride()
     local mPerPx = self.terrainSize / self.resolution
@@ -707,19 +721,20 @@ function SoilValueMaps:applySyncRow(key, gy, row)
     local gx = 0
     local n = #row
     while gx < n do
-        local state = row[gx + 1]
+        local state = row[gx + 1] or 0
         -- Run-length: extend over identical neighbouring states for fewer modifier calls
         local runStart = gx
         while gx + 1 < n and row[gx + 2] == state do gx = gx + 1 end
-        if state and state > 0 then
-            local raw = state * 16 + 8   -- mid of the 16-raw band
-            local x1 = (runStart * stride) * mPerPx - half
-            local x2 = ((gx + 1) * stride) * mPerPx - half
-            m:setParallelogramWorldCoords(
-                x1, wz, x2, wz, x1, wz + blockM,
-                DensityCoordType.POINT_POINT_POINT)
-            m:executeSet(math.min(RAW_MAX, raw))
+        local raw = 0
+        if state > 0 then
+            raw = math.min(RAW_MAX, state * 16 + 8)   -- mid of the 16-raw band
         end
+        local x1 = (runStart * stride) * mPerPx - half
+        local x2 = ((gx + 1) * stride) * mPerPx - half
+        m:setParallelogramWorldCoords(
+            x1, wz, x2, wz, x1, wz + blockM,
+            DensityCoordType.POINT_POINT_POINT)
+        m:executeSet(raw)
         gx = gx + 1
     end
 end

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1864,6 +1864,13 @@ function SoilValueMapChunkEvent:run(connection)
     local def = SoilValueMaps.LAYER_DEFS[self.layerIdx]
     if not def then return end
 
+    -- First chunk of a layer (gyStart == 0): wipe residual local paint so the
+    -- server stream can converge. Without this, state-0 cells used to skip and
+    -- leftover pixels kept checksums permanently drifted.
+    if self.gyStart == 0 and vm.clearLayer then
+        vm:clearLayer(def.key)
+    end
+
     for i, row in ipairs(self.rows) do
         vm:applySyncRow(def.key, self.gyStart + (i - 1), row)
     end
@@ -1933,6 +1940,11 @@ function SoilValueMapChecksumEvent:readStream(streamId, connection)
     self:run(connection)
 end
 
+-- Per-layer client resync attempt counts for this session. Caps the storm when
+-- a layer still cannot converge after clear+reapply (e.g. transient race).
+local sfValueMapResyncAttempts = {}
+local SF_VALUE_MAP_RESYNC_MAX = 2
+
 function SoilValueMapChecksumEvent:run(connection)
     -- CLIENT ONLY: compare against the local maps; request a resync when a
     -- layer has drifted (tolerance covers coarse-grid quantisation noise).
@@ -1947,11 +1959,24 @@ function SoilValueMapChecksumEvent:run(connection)
             local sumDrift = math.abs(localSum - cs.sum)
             local tolerance = math.max(64, cs.nonZero * 0.02)   -- 2% of painted cells
             if sumDrift > tolerance then
-                SoilLogger.warning("Client: value map '%s' drifted (local sum=%d server=%d) - requesting resync",
-                    def.key, localSum, cs.sum)
-                if g_client then
-                    g_client:getServerConnection():sendEvent(SoilRequestValueMapEvent.new(layerIdx))
+                local attempts = sfValueMapResyncAttempts[layerIdx] or 0
+                if attempts >= SF_VALUE_MAP_RESYNC_MAX then
+                    if attempts == SF_VALUE_MAP_RESYNC_MAX then
+                        SoilLogger.warning(
+                            "Client: value map '%s' still drifted after %d resyncs (local sum=%d server=%d) - stopping requests this session",
+                            def.key, SF_VALUE_MAP_RESYNC_MAX, localSum, cs.sum)
+                        sfValueMapResyncAttempts[layerIdx] = attempts + 1  -- only log once
+                    end
+                else
+                    sfValueMapResyncAttempts[layerIdx] = attempts + 1
+                    SoilLogger.warning("Client: value map '%s' drifted (local sum=%d server=%d) - requesting resync (%d/%d)",
+                        def.key, localSum, cs.sum, attempts + 1, SF_VALUE_MAP_RESYNC_MAX)
+                    if g_client then
+                        g_client:getServerConnection():sendEvent(SoilRequestValueMapEvent.new(layerIdx))
+                    end
                 end
+            else
+                sfValueMapResyncAttempts[layerIdx] = 0
             end
         end
     end


### PR DESCRIPTION
## Summary

Fixes an endless value map resync loop on dedicated servers. The server log fills with `value maps sent synchronously (32 chunks)` roughly once per second, forever, and clients never converge.

**Root cause:** `SoilValueMaps:applySyncRow` skipped runs where the state was `0` ("no data"). Any residual local paint in those cells survived the incoming server stream, so the client checksum could never match the server. Each checksum tick then fired another `SoilRequestValueMapEvent`, which triggered another full layer stream, with no upper bound. Observed on compaction: local sum 442 vs server 338, never closing.

## Changes

- `applySyncRow` now writes raw `0` for state `0` instead of skipping the run, so a sync clears stale cells.
- New `SoilValueMaps:clearLayer(key)` wipes a layer to raw `0`; called from `SoilValueMapChunkEvent:run` when `gyStart == 0` so each resync starts from a clean slate.
- `SoilValueMapChecksumEvent:run` caps resync requests at 2 attempts per layer per session, logging once if a layer still will not converge. The counter resets when the layer matches.

## Test plan

- [x] `tools/test/run.sh` - 835 assertions, 0 failed across 26 files (includes `network_events_roundtrip_test.lua`, `vm_discovery_gate_test.lua`, `vm_migration_negcoord_test.lua`)
- [x] Built and deployed to a live GPortal dedicated server plus client; the repeating 32-chunk resync spam stops
- [ ] Second playtest on a fresh join to confirm value maps still paint correctly for a late joiner
