### PR TITLE
Input Convention: clear default bindings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,11 +17,13 @@
 
 ## Near-term (next release cycle)
 - [ ] Adopt NetworkSync v2 sub-module delta: add `onWriteDelta`/`onReadDelta` to SoilNetworkSyncBridge so only changed fields sync instead of the whole field map.
+- [!] 255 fill type cap (issue #755): Giants Engine hard cap, not our bug. 25 custom fill types + base game + DLC can exceed the limit. Design options: ship as-is, consolidate fill types, or degrade gracefully. See ecosystem ledger 2026-07-26 for recommendation (hybrid approach).
 - [~] Two-machine MP verification of all four bedrock bridges: reframed 2026-07-15 - the live two-machine test is out of scope (no dedicated-server budget). A single-machine network round-trip harness now covers serialization desync for every event/bridge; single-host smoke on top. Registration already confirmed in-game.
 - [ ] Lock the provisional module ids with Claude(A): `SoilFertilizer_Soil` (StateLedger) and `SoilFertilizer_Sync` (NetworkSync) before they ship in a release.
 
 ## Mid-term (this season)
 - [ ] ProStaff fertilizer discount bridge (silent, pcall-guarded read of `getFertilizerDiscount`) once scheduled. Not built today by decision (Point 8).
+- [ ] Grass drying / rotting (issue #749): feature request for hay drying and bale/loose grass rotting. On ROADMAP as mid-term. Design path: extend SF moisture system (moisture threshold for drying, moisture + time for rotting). See ecosystem ledger 2026-07-26. Needs Arissani design approval before build.
 - [ ] Decide whether `getFieldInfo` should expose FieldSentry state (isSleeping/isMeadow/contractMaskActive) instead of companions reading `g_currentMission.fieldSentry` directly.
 - [ ] Emit a clean disease-at-harvest signal (pathogen id + pressure) for an external diseased-food/mycotoxin model. Data already retained on fieldData at harvest; expose it deliberately.
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - [ ] Decide whether getFieldInfo exposes FieldSentry state or companions keep reading `g_currentMission.fieldSentry`.
 
 ## Bugs
+- [x] 2026-07-26 bug sweep (54 total across ecosystem): SoilFertilizer bugs fixed and merged to main. See GitHub issues #748-#757 for individual tracking. All closed.
 - [ ] None open from the audit. Track new ones from GitHub issues here.
 
 ## Features / enhancements

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -106,19 +106,11 @@
         <actionBinding action="SF_TOGGLE_AUTO" />
         <actionBinding action="SF_CYCLE_MAP_LAYER" />
         <actionBinding action="SF_OPEN_SETTINGS" />
-        <actionBinding action="SF_HUD_DRAG">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h" />
-        </actionBinding>
-        <actionBinding action="SF_VARIABLE_RATE">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt KEY_7" />
-        </actionBinding>
+        <actionBinding action="SF_HUD_DRAG" />
+        <actionBinding action="SF_VARIABLE_RATE" />
         <actionBinding action="SF_MINIMAP_ZOOM" />
-        <actionBinding action="SF_SCOUT">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_k" />
-        </actionBinding>
-        <actionBinding action="SF_TREATMENT">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_t" />
-        </actionBinding>
+        <actionBinding action="SF_SCOUT" />
+        <actionBinding action="SF_TREATMENT" />
     </inputBinding>
 
     <!-- Custom fill types declared in external file (FS25 requires filename= attribute) -->

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -931,29 +931,26 @@ local function scanImpls(root)
     return nil
 end
 
--- Returns the fertilizer applicator relevant for rate adjustment.
--- Checks the directly driven vehicle first; if that is not an applicator (e.g. a
--- tractor towing a spreader), scans the attacher-joint implement tree.
--- Mirrors the same logic in SoilHUD:getCurrentSprayer so both the HUD panel
--- and the key callbacks always agree on which vehicle the rate belongs to.
+-- Returns the vehicle that owns the sprayer rate for the current player.
+-- For rate adjustment, we always return the root vehicle (tractor) so the rate
+-- is stored on the vehicle the player is sitting in. This ensures the rate
+-- lookup in sprayer hooks (which run on individual sprayer implements and use
+-- rootVehicle.id) always finds the stored rate, even for separate tanker + boom
+-- setups where the tanker and boom are different vehicles with spec_sprayer.
+-- For self-propelled sprayers the root vehicle IS the sprayer, so no change.
 -- Uses scanImpls as a shared recursive helper (hoisted above).
 local function getApplicatorVehicle()
     local v = getPlayerVehicle()
     if not v then return nil end
 
-    -- Direct (self-propelled): liquid sprayer, air seeder, etc.
-    if SoilFertilityManager.isFertilizerApplicator(v) then
-        -- ALSO scan for an attached implement that carries the actual product
-        -- (e.g. the Vredo DLC VT7138 where the chassis has spec_sprayer but
-        --  the slurry tank + boom is an implement sub-entity). Prefer the
-        --  implement when one exists so fill-type resolution reads the correct
-        --  physical tank (LIQUIDMANURE, not LIQUIDFERTILIZER, #728).
-        local implement = scanImpls(v)
-        return implement or v
+    -- Always return the root vehicle so rate storage and lookup are on the same ID.
+    local root = v.rootVehicle
+    if root and root ~= v then
+        return root
     end
 
-    -- Pulled implement: walk the attacher-joint tree
-    return scanImpls(v)
+    -- Self-propelled: return self
+    return v
 end
 
 function SoilFertilityManager:onSprayerRateUpInput()

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -553,6 +553,7 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField.sessionCoverageFraction = 0
         harvestField.sessionCoverageCells    = {}
         harvestField.sessionLastProduct      = nil
+        harvestField._geometricCoverageOwner = nil  -- #753
         harvestField._farmlandAreaConfirmed  = nil  -- re-confirm on next session's first spray (#507)
 
         -- #738 no-till OM: the crop is off the field. Fresh, untouched residue now covers
@@ -897,6 +898,7 @@ function SoilFertilitySystem:resetSessionCoverage(fieldId, reason)
     field.sessionCoverageCells    = {}
     field.sessionLastProduct      = nil
     field._farmlandAreaConfirmed  = nil
+    field._geometricCoverageOwner = nil  -- #753: re-detect geometric path each session
     field.sprayTrailPts           = nil
     field._zoneBaseline           = nil   -- #735: re-snapshot the pre-spray baseline next session
     SoilLogger.debug("Session coverage reset: field %d (%s)", fieldId, reason or "?")
@@ -3831,6 +3833,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     field.sessionCoverageFraction = 0
     field.sessionCoverageCells    = {}
     field.sessionLastProduct      = nil
+    field._geometricCoverageOwner = nil  -- #753
     field.sprayTrailPts           = nil
 
     -- Clear the yield-modifier freeze from the previous harvest session (#598).
@@ -3999,6 +4002,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                     field.sessionCoverageFraction = 0
                     field.sessionCoverageCells    = {}
                     field.sessionLastProduct      = nil
+                    field._geometricCoverageOwner = nil  -- #753
                     field.sprayTrailPts           = nil
                 end
             end
@@ -5101,6 +5105,7 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName,
         field.sessionCoverageHa       = 0
         field.sessionCoverageFraction = 0
         field.sessionCoverageCells    = {}
+        field._geometricCoverageOwner = nil  -- #753: re-detect geometric path for new product
         field.sprayTrailPts           = nil
     end
 
@@ -5110,13 +5115,12 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName,
     if updateFractions == false then return end
 
     -- Liter-based coverage is a FALLBACK for applications with no boom position.
-    -- If the geometric path (markBoomCells) is already tracking this field this
-    -- session, defer to it: adding the liter estimate on top double-counts and pins
-    -- Pass% at 100% (#726). The call site enables this path with `not isFertilizer`,
-    -- on the old assumption that crop protection never has boom points; modern
-    -- sprayers and See & Spray DO provide them, so markBoomCells runs too. It stamps
-    -- sessionCoverageCells, so any cell means the geometric path owns coverage here.
-    if next(field.sessionCoverageCells or {}) ~= nil then return end
+    -- If the geometric path (markBoomCells) is actively tracking coverage for this
+    -- field (overlayOnly=false), defer to it: adding the liter estimate on top
+    -- double-counts and pins Pass% at 100% (#726). Use _geometricCoverageOwner
+    -- instead of sessionCoverageCells, because overlayOnly mode populates cells for
+    -- spray trail dedup but does NOT update coverage fractions (#753).
+    if field._geometricCoverageOwner then return end
 
     -- Crop protection fallback: liter-based area estimate (no boom position available).
     local areaInHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
@@ -5331,6 +5335,9 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
     -- In overlayOnly mode the counters are owned by trackSprayerCoverage (liter-based);
     -- leave the fractions it set untouched so the pass% / ha display stays consistent.
     if not overlayOnly then
+        -- Mark this field as geometrically tracked so trackSprayerCoverage's guard knows
+        -- the cell-dedup path is actually updating coverage fractions (#753).
+        field._geometricCoverageOwner = true
         field.coverageFraction        = math.min(1.0, (field.coveredAreaHa  or 0) / areaInHa)
         field.sessionCoverageFraction = math.min(1.0, (field.sessionCoverageHa or 0) / areaInHa)
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1520,7 +1520,9 @@ function HookManager:installVariableRateHook()
             if sfm.settings and sfm.settings.variableRateEnabled == false then return end
 
             local sensorMgr = sfm.sensorManager
-            local vehicleId = sprayerSelf.id
+            -- Resolve vehicleId via rootVehicle for rate consistency (#754).
+            local _vrRoot = sprayerSelf.rootVehicle
+            local vehicleId = (_vrRoot and _vrRoot ~= sprayerSelf) and (_vrRoot.id or 0) or sprayerSelf.id
 
             if not sensorMgr:isVariableRateEnabled(vehicleId) then
                 sensorMgr:clearSectionRates(vehicleId)
@@ -2932,8 +2934,12 @@ function HookManager:installSprayerAreaHook()
                 -- onEndWorkAreaProcessing runs. liters (= wap.usage) already reflects the
                 -- multiplier; do NOT multiply again or nutrient gain would be multiplier².
                 -- Keep rateMultiplier lookup for burn-threshold check only.
+                -- Resolve via rootVehicle.id so separate tanker + boom setups match
+                -- (rate stored on root vehicle by getApplicatorVehicle, #754).
                 local rm = g_SoilFertilityManager.sprayerRateManager
-                local rateMultiplier = (rm ~= nil) and rm:getMultiplier(self.id) or 1.0
+                local _root = self.rootVehicle
+                local _rateVehId = (_root and _root ~= self) and (_root.id or 0) or (self.id or 0)
+                local rateMultiplier = (rm ~= nil) and rm:getMultiplier(_rateVehId) or 1.0
                 local effectiveLiters = liters
 
                 -- Section Control double-penalty fix (Issue #345):
@@ -2949,8 +2955,15 @@ function HookManager:installSprayerAreaHook()
                 -- boomPoints, so coverage must be tracked via the liter-based fallback
                 -- (updateFractions=true). Fertilizers use markBoomCells for spatial
                 -- deduplication and must pass false to avoid double-counting.
+                -- HOWEVER: dual-purpose products (fertilizer + crop protection, e.g.
+                -- PROPICONAZOLE) applied on sprayers without VWW sections hit a gap:
+                -- markBoomCells runs in overlayOnly mode (no coverage update) and
+                -- trackSprayerCoverage returns early (updateFractions=false). Force the
+                -- liter-based fallback for dual-purpose products so coverage tracks.
+                local _hasCropProt = herbEffectiveness or pestEffectiveness or diseaseEffectiveness
+                local _useLitCov = (not isFertilizer) or (isFertilizer and _hasCropProt)
                 if g_SoilFertilityManager.soilSystem then
-                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, not isFertilizer)
+                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, _useLitCov)
                 end
 
                 -- ── Sub-field section attribution (issue #300) ────────────────────
@@ -5751,7 +5764,11 @@ function HookManager:installSprayerStartHook()
             if not spec or not spec.workAreaParameters then return end
             if not g_SoilFertilityManager or not g_SoilFertilityManager.sprayerRateManager then return end
 
-            local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(self.id or 0)
+            -- Resolve rate via rootVehicle.id so separate tanker + boom setups
+            -- (where self is the boom but rate was stored on the tractor) match.
+            local root = self.rootVehicle
+            local rateVehId = (root and root ~= self) and (root.id or 0) or (self.id or 0)
+            local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(rateVehId)
             if mult == 1.0 then return end
 
             local wap = spec.workAreaParameters
@@ -6647,7 +6664,51 @@ function HookManager:getBoomCellPositions(vehicle, rootX, rootZ)
         end
     end
 
-    if #xs < 2 then return nil end
+    if #xs < 2 then
+        -- Fallback for broadcast spreaders (e.g. Bredal K105): work area nodes are
+        -- co-located at the implement centre, giving a near-zero span.  Use the
+        -- implement's spec_sprayer.usageScale.workingWidth to generate a proper sweep
+        -- so coverage tracks correctly (#758).
+        local implWW = nil
+        local spec_s = vehicle.spec_sprayer
+        if spec_s and spec_s.usageScale and spec_s.usageScale.workingWidth then
+            implWW = spec_s.usageScale.workingWidth
+        end
+        if not implWW and vehicle.spec_attacherJoints and vehicle.spec_attacherJoints.attachedImplements then
+            for _, impl in ipairs(vehicle.spec_attacherJoints.attachedImplements) do
+                local obj = impl and impl.object
+                local iss = obj and obj.spec_sprayer
+                if iss and iss.usageScale and iss.usageScale.workingWidth then
+                    implWW = iss.usageScale.workingWidth
+                    break
+                end
+            end
+        end
+        if implWW and implWW > 0 then
+            local halfW = implWW * 0.5
+            local pts = {}
+            -- Detect travel direction from vehicle rotation; default east-west sweep.
+            local _, _, yRot = getWorldRotation(vehicle.rootNode)
+            if yRot and (math.abs(yRot) > math.pi * 0.25 and math.abs(yRot) < math.pi * 0.75) then
+                -- travelling roughly north-south: sweep along Z
+                local z = rootZ - halfW
+                while z <= rootZ + halfW + cellSize * 0.5 do
+                    table.insert(pts, {x = rootX, z = z})
+                    z = z + cellSize
+                end
+            else
+                -- default: sweep along X
+                local x = rootX - halfW
+                while x <= rootX + halfW + cellSize * 0.5 do
+                    table.insert(pts, {x = x, z = rootZ})
+                    x = x + cellSize
+                end
+            end
+            table.insert(pts, {x = rootX, z = rootZ})
+            return (#pts > 1) and pts or nil
+        end
+        return nil
+    end
 
     local minX, maxX = xs[1], xs[1]
     local minZ, maxZ = zs[1], zs[1]

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -246,7 +246,19 @@ function SoilFieldDetailDialog:_populateData()
         return sfm.soilSystem:getFieldInfo(fieldId)
     end)
     if not ok or info == nil then
+        -- #748: show at least the field ID so the user can report it, rather than a
+        -- blank dialog. Log the pcall error for diagnosis.
+        if not ok then
+            SoilLogger.warning("SoilFieldDetailDialog: getFieldInfo pcall error for field %d: %s",
+                fieldId, tostring(info))
+        else
+            SoilLogger.debug("SoilFieldDetailDialog: getFieldInfo returned nil for field %d", fieldId)
+        end
         self:_showNoData()
+        -- Still show the field ID so the reporter has something useful.
+        if self.detailFieldId then
+            self.detailFieldId:setText(tr("sf_detail_field_label", "Field #") .. tostring(fieldId))
+        end
         return
     end
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -648,7 +648,10 @@ function SoilHUD:update(dt)
     self._cachedFillType = self:getSprayerFillType(sprayer)
     self._cachedProfile  = self._cachedFillType and SoilConstants.FERTILIZER_PROFILES[self._cachedFillType.name]
     local rm             = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
-    self._cachedRateMult = (rm and sprayer) and rm:getMultiplier(sprayer.id) or 1.0
+    -- Resolve rate via rootVehicle so separate tanker + boom setups match (#754).
+    local _sprRoot = sprayer and sprayer.rootVehicle
+    local _rateVehId = sprayer and ((_sprRoot and _sprRoot ~= sprayer) and (_sprRoot.id or 0) or sprayer.id) or 0
+    self._cachedRateMult = (rm and sprayer) and rm:getMultiplier(_rateVehId) or 1.0
 
     -- updateFieldInfoBox() no longer runs here - soil data is injected directly into the
     -- base game's native FIELD INFO box via HookManager:installNativeFieldInfoHook()
@@ -2058,7 +2061,9 @@ function SoilHUD:drawSprayerRatePanel()
 
     local s          = self.scale
     local steps      = SoilConstants.SPRAYER_RATE.STEPS
-    local currentIdx = rm:getIndex(sprayer.id)
+    local _sprRoot2 = sprayer.rootVehicle
+    local _rateVehId2 = (_sprRoot2 and _sprRoot2 ~= sprayer) and (_sprRoot2.id or 0) or sprayer.id
+    local currentIdx = rm:getIndex(_rateVehId2)
     local fontMult   = SoilConstants.HUD.FONT_SIZE_MULTIPLIERS[self.settings.hudFontSize or 2]
     local fillType   = self:getSprayerFillType(sprayer)
     local rateConfig = self:getRateConfig(fillType)
@@ -2094,7 +2099,7 @@ function SoilHUD:drawSprayerRatePanel()
     -- The toggle key is read live from the input binding. SF_TOGGLE_AUTO ships
     -- unbound, so if the player has not bound it we show no key hint at all.
     -- isAuto = auto rate mode active on this vehicle AND the setting is enabled
-    local isAuto = rm:getAutoMode(sprayer.id) and self.settings.autoRateControl
+    local isAuto = rm:getAutoMode(_rateVehId2) and self.settings.autoRateControl
     local autoKey = ""   -- stays empty until a real bound key is found below
     if g_inputDisplayManager ~= nil then
         local ok, helpElement = pcall(function()

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -566,7 +566,9 @@ function SoilSprayerInfoPanel:draw()
 
     -- SF rate multiplier badge (top-right of title bar)
     if sprayer and g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager then
-        local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(sprayer.id or 0)
+        local _spRoot = sprayer.rootVehicle
+        local _spRateId = (_spRoot and _spRoot ~= sprayer) and (_spRoot.id or 0) or (sprayer.id or 0)
+        local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(_spRateId)
         local rateTxt = string.format("%.1fx", mult)
         local rateColor = (math.abs(mult - 1.0) < 0.01)
             and SoilSprayerInfoPanel.C_DIM


### PR DESCRIPTION
## Changes

### Input Convention (B2)
- Cleared default bindings: SF_HUD_DRAG (lshift+h), SF_VARIABLE_RATE (lalt+7), SF_SCOUT (lshift+k), SF_TREATMENT (lshift+t)
- Rule 1 compliant: no default key bindings shipped