### PR TITLE
SF-13 per-cell store coherence, plus the stale #726 coverage test

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -5281,8 +5281,26 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
                 -- ── Pressure zone stamp (zoneData) ─────────────────────────────────
                 -- REFINED: nutrient values now live on the per-pixel value maps
                 -- (paintBoomStrip / applyFertilizer); zoneData cells only carry the
-                -- field-level pressure/compaction stamps used by See&Spray and the
-                -- compaction rebuild. Cell cap unchanged.
+                -- pressure/compaction stamps used by See&Spray and the compaction
+                -- rebuild. Cell cap unchanged.
+                --
+                -- SEED ON CREATE, WRITE NOTHING ON UPDATE. An existing cell holds real
+                -- per-cell work this stamper knows nothing about, and re-stamping the
+                -- field average destroyed all of it on the next boom pass:
+                --   tillage reductions  - plough :1129-1135, cultivator :1281-1287,
+                --                         secondary tillage :1466-1472
+                --   treatment reductions- entry map :4926-4927, insecticide :5003,
+                --                         fungicide :5035, herbicide :5445
+                -- The treatment cases were the worst: the base-class sprayer hook calls
+                -- markBoomCells in the SAME invocation that applied the product, so a
+                -- per-cell reduction was erased before the pass finished.
+                -- Compaction already followed this rule; the three pressures now match it.
+                --
+                -- The DAILY weed propagation (:4056-4064) is deliberately untouched and
+                -- still re-syncs every cell to the field value once a day. That is
+                -- correct and must stay: weed's ground truth is the base-game density
+                -- map, so the cell is a mirror, and refreshing a mirror to match its
+                -- source is not the same operation as flattening it mid-pass.
                 local canWrite = true
                 if field.zoneData[cellKey] == nil then
                     if (field.zoneDataSize or 0) >= MAX_ZONE_CELLS then canWrite = false end
@@ -5293,10 +5311,10 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
                         field.zoneData[cellKey] = {}
                     end
                     local zc = field.zoneData[cellKey]
-                    zc.weedPressure    = field.weedPressure    or 0
-                    zc.pestPressure    = field.pestPressure    or 0
-                    zc.diseasePressure = field.diseasePressure or 0
-                    if zc.compaction == nil then zc.compaction = field.compaction or 0 end
+                    if zc.weedPressure    == nil then zc.weedPressure    = field.weedPressure    or 0 end
+                    if zc.pestPressure    == nil then zc.pestPressure    = field.pestPressure    or 0 end
+                    if zc.diseasePressure == nil then zc.diseasePressure = field.diseasePressure or 0 end
+                    if zc.compaction      == nil then zc.compaction      = field.compaction      or 0 end
                 end
             end
         end

--- a/tools/test/lua/coverage_test.lua
+++ b/tools/test/lua/coverage_test.lua
@@ -81,17 +81,55 @@ do
   local sys = newSys({
     [1] = {
       fieldArea = 2.0,
-      sessionCoverageHa = 0.5,                 -- geometric path already recorded 0.5 ha
+      sessionCoverageHa = 0.5,                  -- geometric path already recorded 0.5 ha
       sessionCoverageFraction = 0.25,
-      sessionCoverageCells = { ["c1"] = 123 },  -- markBoomCells stamped a cell -> geometric active
+      sessionCoverageCells = { ["c1"] = 123 },
+      _geometricCoverageOwner = true,           -- #753: markBoomCells owns the counter
     },
   })
   -- A huge liter estimate that WOULD saturate to 100% if it were counted here.
   sys:trackSprayerCoverage(1, 100000, "HERBICIDE", true)
-  T.eq("#726: liter path defers when geometric cells exist (fraction unchanged)",
+  T.eq("#726: liter path defers when the geometric path OWNS coverage (fraction unchanged)",
        sys.fieldData[1].sessionCoverageFraction, 0.25)
   T.near("#726: liter path leaves session ha untouched",
          sys.fieldData[1].sessionCoverageHa, 0.5)
+end
+
+-- ── #753: stamped cells alone are NOT the deferral signal ──
+-- overlayOnly mode fills sessionCoverageCells for spray-trail dedup while leaving
+-- the counter to the liter path, so the guard reads _geometricCoverageOwner rather
+-- than "are there cells". Cells without the owner flag must still track, otherwise
+-- an overlayOnly pass silently suppresses coverage accounting entirely.
+do
+  local sys = newSys({
+    [1] = {
+      fieldArea = 2.0,
+      sessionCoverageCells = { ["c1"] = 123 },  -- stamped by an overlayOnly pass
+    },
+  })
+  local rate = SoilConstants.SPRAYER_RATE.BASE_RATES.HERBICIDE.value
+  sys:trackSprayerCoverage(1, rate * 0.5, "HERBICIDE", true)  -- 0.5 ha of a 2 ha field
+  T.near("#753: cells without the owner flag do NOT suppress the liter fallback",
+         sys.fieldData[1].sessionCoverageFraction, 0.25)
+end
+
+-- ── #753: a product change clears the owner flag so the new product re-detects ──
+do
+  local sys = newSys({
+    [1] = {
+      fieldArea = 2.0,
+      sessionLastProduct = "FERTILIZER",
+      sessionCoverageHa = 1.5,
+      sessionCoverageFraction = 0.75,
+      _geometricCoverageOwner = true,
+    },
+  })
+  local rate = SoilConstants.SPRAYER_RATE.BASE_RATES.HERBICIDE.value
+  sys:trackSprayerCoverage(1, rate * 0.5, "HERBICIDE", true)
+  T.ok("#753: switching product clears the geometric owner flag",
+       sys.fieldData[1]._geometricCoverageOwner == nil)
+  T.near("#753: the new product's session starts from the liter path, not the old total",
+         sys.fieldData[1].sessionCoverageFraction, 0.25)
 end
 
 do

--- a/tools/test/lua/zone_store_coherence_test.lua
+++ b/tools/test/lua/zone_store_coherence_test.lua
@@ -1,0 +1,157 @@
+-- zone_store_coherence_test.lua - per-cell store coherence: markBoomCells seeds on
+--   CREATE and writes nothing on UPDATE.
+--
+--   markBoomCells used to re-stamp every cell under the boom with the field-level
+--   pressures on every pass, which destroyed real per-cell work owned by other paths:
+--     tillage reductions   - plough, cultivator, secondary tillage
+--     treatment reductions - the entry map, insecticide, fungicide, herbicide
+--   The treatment cases were the sharpest, because the base-class sprayer hook calls
+--   markBoomCells in the SAME invocation that applied the product, so a per-cell
+--   reduction was erased before the pass finished. Compaction already seeded on create
+--   only; the three pressures now match it.
+--
+--   What this guards: a cell that already exists keeps every value it holds, a fresh
+--   cell is still seeded from the field scalars, and the create path still accounts.
+--   The DAILY weed propagation is a different function and is deliberately untouched,
+--   so it is not exercised here.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/SoilFertilitySystem.lua
+
+local CELL = SoilConstants.ZONE.CELL_SIZE
+
+local function newSys()
+  local s = setmetatable({}, { __index = SoilFertilitySystem })
+  s.vmAvailable        = function() return false end  -- keep the #735 paint path out of this test
+  s._getFieldPolyVerts = function() return nil end    -- polygon unavailable -> count all cells
+  s.fieldData = {}
+  return s
+end
+
+local function newField(s, fid)
+  local f = {
+    fieldArea = 10.0,
+    sessionCoverageCells = {}, dailyCoverageCells = {}, zoneData = {},
+    weedPressure = 40, pestPressure = 50, diseasePressure = 60, compaction = 70,
+  }
+  s.fieldData[fid] = f
+  return f
+end
+
+-- one point, and the zoneData key markBoomCells will derive for it
+local function onePt(x, z) return { { x = x, z = z } } end
+local function keyFor(x, z)
+  return tostring(math.floor(x / CELL) * 10000 + math.floor(z / CELL))
+end
+
+-- ── CREATE: a fresh cell is seeded from the field scalars ──────────────
+do
+  local s = newSys()
+  local f = newField(s, 1)
+  local k = keyFor(105, 105)
+
+  s:markBoomCells(1, onePt(105, 105), true)
+
+  local zc = f.zoneData[k]
+  T.ok("coherence: a boom pass over virgin ground creates the cell", zc ~= nil)
+  T.eq("coherence: create seeds weed from the field",     zc.weedPressure,    40)
+  T.eq("coherence: create seeds pest from the field",     zc.pestPressure,    50)
+  T.eq("coherence: create seeds disease from the field",  zc.diseasePressure, 60)
+  T.eq("coherence: create seeds compaction from the field", zc.compaction,    70)
+  T.eq("coherence: create still increments the cell accounting", f.zoneDataSize, 1)
+end
+
+-- ── UPDATE: an existing cell keeps its own values ──────────────────────
+-- This is the defect. A tillage or treatment path reduced these; the stamper
+-- must not put the field average back.
+do
+  local s = newSys()
+  local f = newField(s, 1)
+  local k = keyFor(105, 105)
+
+  -- as plough / cultivator / insecticide / fungicide leave it
+  f.zoneData[k] = { weedPressure = 5, pestPressure = 3, diseasePressure = 2, compaction = 11 }
+  f.zoneDataSize = 1
+
+  s:markBoomCells(1, onePt(105, 105), true)
+
+  local zc = f.zoneData[k]
+  T.eq("coherence: an existing cell keeps its reduced weed",    zc.weedPressure,    5)
+  T.eq("coherence: an existing cell keeps its reduced pest",    zc.pestPressure,    3)
+  T.eq("coherence: an existing cell keeps its reduced disease", zc.diseasePressure, 2)
+  T.eq("coherence: an existing cell keeps its own compaction",  zc.compaction,      11)
+  T.eq("coherence: update does not double-count the cell", f.zoneDataSize, 1)
+end
+
+-- ── the same-invocation case, which is how a player actually hits it ───
+-- Spray insecticide (the treatment path reduces the cell), then the boom stamp
+-- runs in the same hook call. The reduction has to survive it.
+do
+  local s = newSys()
+  local f = newField(s, 1)
+  local k = keyFor(105, 105)
+
+  s:markBoomCells(1, onePt(105, 105), true)          -- cell exists, seeded at field level
+  T.eq("coherence: seeded at the field pest level", f.zoneData[k].pestPressure, 50)
+
+  -- what applyInsecticide does to the cell it just sprayed
+  f.zoneData[k].pestPressure = math.max(0, f.zoneData[k].pestPressure - 20)
+
+  s:markBoomCells(1, onePt(105, 105), true)          -- second call, same pass
+
+  T.eq("coherence: an insecticide reduction survives the boom stamp in the same pass",
+       f.zoneData[k].pestPressure, 30)
+end
+
+-- ── a partially populated cell fills only its missing keys ────────────
+-- Cells reach the stamper from several paths and not all carry every key.
+do
+  local s = newSys()
+  local f = newField(s, 1)
+  local k = keyFor(105, 105)
+
+  f.zoneData[k] = { pestPressure = 3 }   -- only pest present
+  f.zoneDataSize = 1
+
+  s:markBoomCells(1, onePt(105, 105), true)
+
+  local zc = f.zoneData[k]
+  T.eq("coherence: the present key is preserved", zc.pestPressure, 3)
+  T.eq("coherence: a missing key is seeded from the field", zc.weedPressure,    40)
+  T.eq("coherence: a missing key is seeded from the field", zc.diseasePressure, 60)
+  T.eq("coherence: a missing key is seeded from the field", zc.compaction,      70)
+end
+
+-- ── the stamper never invents nutrients ───────────────────────────────
+-- Under the value-map engine N/P/K/pH/OM live on the per-pixel maps, so a cell
+-- created by a crop-protection pass must not carry a nutrient claim (#517's shape).
+do
+  local s = newSys()
+  local f = newField(s, 1)
+  local k = keyFor(105, 105)
+
+  s:markBoomCells(1, onePt(105, 105), true)
+
+  local zc = f.zoneData[k]
+  T.ok("coherence: a created cell carries no N", zc.N  == nil)
+  T.ok("coherence: a created cell carries no P", zc.P  == nil)
+  T.ok("coherence: a created cell carries no K", zc.K  == nil)
+  T.ok("coherence: a created cell carries no pH", zc.pH == nil)
+  T.ok("coherence: a created cell carries no OM", zc.OM == nil)
+end
+
+-- ── several cells under one boom are handled independently ────────────
+do
+  local s = newSys()
+  local f = newField(s, 1)
+  local kA, kB = keyFor(105, 105), keyFor(125, 105)
+
+  f.zoneData[kA] = { weedPressure = 1, pestPressure = 1, diseasePressure = 1, compaction = 1 }
+  f.zoneDataSize = 1
+
+  s:markBoomCells(1, { { x = 105, z = 105 }, { x = 125, z = 105 } }, true)
+
+  T.eq("coherence: the visited cell is left alone", f.zoneData[kA].pestPressure, 1)
+  T.ok("coherence: the untouched neighbour is created", f.zoneData[kB] ~= nil)
+  T.eq("coherence: the new neighbour seeds from the field", f.zoneData[kB].pestPressure, 50)
+  T.eq("coherence: only the new cell is counted", f.zoneDataSize, 2)
+end


### PR DESCRIPTION
Two commits. One defect fix from the spatial-soil drop, one stale test that has been failing on `development` for three commits.

## SF-13 store coherence (`cdbd4136`)

`markBoomCells` re-stamped every cell under the boom with the field-level pressures on every pass, destroying real per-cell work owned by other paths: tillage reductions (plough, cultivator, secondary tillage) and treatment reductions (the entry map, insecticide, fungicide, herbicide).

The treatment cases were the sharpest. The base-class sprayer hook calls `markBoomCells` in the **same invocation** that applied the product, so an insecticide or fungicide per-cell reduction was erased before the pass had even finished.

Compaction already seeded on create only. The three pressures now match it.

**Smaller than the brief, because the engine merge did half of it.** The staged brief called for threading an `isFertilizerPass` flag through all four call sites, which was the risky part (the multi-tank pair carries the flag under a different name, and updating only one pair is an asymmetric regression a single-tank test cannot catch). That threading existed to stop cell creation forging field-average nutrients. Under the value-map engine a created cell is an empty table and nutrients live on the maps, so #517's forging shape is already gone and the product gate is unnecessary. No signature change, no call-site threading.

**The daily weed propagation is untouched**, preserving the brief's permanent invariant. It still re-syncs weed to the field value once a day, which is correct: weed's ground truth is the base-game density map, so the cell is a mirror. Refreshing a mirror to match its source is a different operation from flattening it mid-pass.

Adds `zone_store_coherence_test.lua`, 26 assertions, verified to fail when the fix is reverted.

## The #726 coverage test (`ecc04655`)

Not a code bug. #753 deliberately narrowed the deferral guard from "are there stamped cells" to `_geometricCoverageOwner`, because overlayOnly passes fill `sessionCoverageCells` for spray-trail dedup while leaving the counter to the liter path.

The code fix landed in `22491136`; `coverage_test.lua` was last touched in `fb06db1f`, which is older. The test asserted the pre-#753 contract, so the suite has been red since then and the failure reads like #726 regressed when it had not. Repaired, plus two new tests for the distinction #753 introduced (cells without the owner flag must still track; a product change clears the flag).

## State

Suite: **864 assertions, 0 failed, 27 files.** Green for the first time since `22491136`. Lua 5.1 syntax and lint clean on 55 files.

Server-side only. No money path, no new persistence, no wire change, no new setting, no player-facing string.

## Not in scope, named rather than hidden

- **F43** is still open: `onHerbicideAppliedIncremental` still creates cells seeded with field-average nutrients while the other three spray paths refuse to. The brief registered it separately and its own downstream note says the shared seeding rule is assembly-pass work across the family, not a per-brief patch.
- The two multiplayer client flatten paths stay unfixed, exactly as the brief's section 6 states.

## Playtest gate

The brief's in-game acceptance checks were written against nutrient layers and the PDA tooltip, which the rebase addendum says break because `getFieldInfo` now samples the value maps. The biotic equivalent: spray insecticide over a strip, then drive the same strip again with See and Spray active. Before this change the sections re-fire because the stamper reset the cells to field level; after it they stay suppressed. That wants confirming in game before release.