### PR TITLE
Ground material programme: MATERIAL DOWN, WHAT THE SKY DID, STRAW DOWN, THE HAY BET, THE YARD LADDER

### DIFF
--- a/src/HayBet.lua
+++ b/src/HayBet.lua
@@ -1,0 +1,333 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - THE HAY BET (SF-44)
+-- =========================================================
+-- Grass cures by the sky into hay, spoils in the swath, and the
+-- machines stop lying. One settle pass, one tedder interaction,
+-- one read-time spoil verdict.
+--
+-- CONVERSION is gated on ENABLE_CONVERSION (false by default)
+-- because the base-game confirm that changeFillTypeAtArea accepts
+-- windrow height types is BOUNCED. When it lands, flip the flag.
+-- Until then the settle pass only reads and reports, never writes.
+--
+-- SERVER ONLY. No new layer, no new store, no new state, no sync.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class HayBet
+HayBet = {}
+local HayBet_mt = Class(HayBet)
+
+-- The fit boundary: moisture at or below this threshold means the
+-- grass is dry enough to cure as hay. Ruled 20% (raw 52).
+HayBet.FIT_PCT       = 20
+HayBet.FIT_RAW       = 52   -- math.floor(20 / 100 * 254) with brief's ruling
+-- Tedder one-time drying delta: 8 percentage points (raw ~20).
+-- Conservative edge of Pattey's published 15-30% acceleration.
+HayBet.TED_DELTA_PCT = 8
+HayBet.TED_DELTA_RAW = 20
+-- Spoil threshold: how many separate rain-days before going-off.
+-- Ruled 3 for hay.
+HayBet.SPOIL_RAIN_DAYS = 3
+
+-- CONVERSION GATE. Flip to true when the base-game confirm lands
+-- that DensityMapHeightUtil.changeFillTypeAtArea accepts windrow
+-- height types. Until then, the settle pass reads and reports but
+-- never converts, and the tedder applies its drying delta without
+-- the corrective pass.
+HayBet.ENABLE_CONVERSION = false
+
+-- =========================================================
+-- Construction
+-- =========================================================
+
+function HayBet.new()
+    local self = setmetatable({}, HayBet_mt)
+    self.materialDown    = nil
+    self.materialWetness = nil
+    self.armed           = false
+    -- Pending-corrections queue: flat vertex arrays enqueued by
+    -- the tedder hook and drained at end of frame.
+    self._correctionQueue = {}
+    return self
+end
+
+---@param materialDown    MaterialDown
+---@param materialWetness MaterialWetness
+function HayBet:arm(materialDown, materialWetness)
+    self.armed = false
+    if materialDown == nil or not materialDown:isArmed() then
+        SoilLogger.info("[HayBet] MaterialDown not armed - standing down")
+        return false
+    end
+    if materialWetness == nil or not materialWetness:isArmed() then
+        SoilLogger.info("[HayBet] MaterialWetness not armed - standing down")
+        return false
+    end
+    self.materialDown    = materialDown
+    self.materialWetness = materialWetness
+    self.armed           = true
+    SoilLogger.info("[OK] HayBet armed (fit=%d%%, ted-delta=%d%%, spoil=%d rain-days, conversion=%s)",
+        HayBet.FIT_PCT, HayBet.TED_DELTA_PCT, HayBet.SPOIL_RAIN_DAYS,
+        tostring(HayBet.ENABLE_CONVERSION))
+    return true
+end
+
+function HayBet:isArmed()
+    return self.armed
+end
+
+-- =========================================================
+-- Settle pass (priority 10, before the age tick)
+-- =========================================================
+-- Called once per game day in the MEMBER_RESOLUTION slot. Reads
+-- condition for active fields and converts grass to hay where
+-- the grass is fit. The conversion write is gated on the
+-- ENABLE_CONVERSION flag.
+
+function HayBet:onSettle(ctx)
+    if not self:isArmed() then return end
+    if g_server == nil then return end
+
+    local md = self.materialDown
+    local mw = self.materialWetness
+    if not md:isArmed() or not mw:isArmed() then return end
+
+    -- [SF-49] The hay member reads the wetness layer to decide
+    -- whether material is fit. A sentinel or refused condition
+    -- always blocks conversion — the conservative direction.
+    md:enumerateActiveFields(function(fieldId)
+        if type(fieldId) ~= "number" then return end
+        pcall(function()
+            self:_settleField(fieldId, md, mw)
+        end)
+    end)
+end
+
+--- Process one active field on the settle pass.
+---@param fieldId number
+---@param md MaterialDown
+---@param mw MaterialWetness
+function HayBet:_settleField(fieldId, md, mw)
+    -- Get the field polygon from the field manager.
+    local verts = self:_getFieldPolygon(fieldId)
+    if not verts then return end
+
+    -- [FIND] Check if material-age records exist in this field
+    local mdOk, hasAge = pcall(function()
+        return md.valueMaps:hasAnyInBand(
+            MaterialDown.LAYER_KEY, verts, 1, 254)
+    end)
+    if not mdOk or not hasAge then return end
+
+    -- Check if there is actual grass on the ground
+    local grassFT  = self:_fillTypeIndex("GRASS_WINDROW")
+    if not grassFT then return end
+    local sx, sz = verts[1], verts[2]
+    local wx, wz = verts[3], verts[4]
+    local hx, hz = verts[5], verts[7]   -- third vertex = hx, fourth vertex Z = hz
+    -- Actually use the correct vertices: bounding box {minX,minZ, maxX,minZ, maxX,maxZ, minX,maxZ}
+    -- start = (minX, minZ), width = (maxX, minZ), height = (minX, maxZ)
+    sx, sz = verts[1], verts[2]
+    wx, wz = verts[3], verts[4]
+    hx, hz = verts[7], verts[8]   -- minX, maxZ
+
+    local fillOk, fillLevel = pcall(function()
+        return DensityMapHeightUtil.getFillLevelAtArea(grassFT, sx, sz, wx, wz, hx, hz)
+    end)
+    if not fillOk or not fillLevel or fillLevel <= 0 then return end
+
+    -- [CONDITION READ] Check if the grass is fit enough to cure
+    local condition = mw:readCondition(verts, fillLevel)
+    if condition.status ~= "ok" then return end
+    if condition.pct > HayBet.FIT_PCT then return end
+
+    -- [CONVERT] Gated on the bounced confirm
+    if not HayBet.ENABLE_CONVERSION then return end
+
+    local hayFT = self:_fillTypeIndex("DRYGRASS_WINDROW")
+    if not hayFT then return end
+
+    local convOk = pcall(function()
+        DensityMapHeightUtil.changeFillTypeAtArea(
+            sx, sz, wx, wz, hx, hz, grassFT, hayFT)
+    end)
+    if convOk then
+        SoilLogger.debug("[HayBet] settle convert: field %d, grass -> hay (condition=%.1f%%)",
+            fieldId, condition.pct)
+    end
+end
+
+-- =========================================================
+-- Fill type index cache
+-- =========================================================
+
+local _fillTypeCache = {}
+
+--- Resolve a fill type name to its numeric index, cached.
+---@param name string  e.g. "GRASS_WINDROW"
+---@return number|nil
+function HayBet:_fillTypeIndex(name)
+    if _fillTypeCache[name] ~= nil then return _fillTypeCache[name] end
+    local idx = g_fruitTypeManager and g_fruitTypeManager:getFillTypeIndexByName(name)
+    _fillTypeCache[name] = idx
+    return idx
+end
+
+-- =========================================================
+-- Field polygon (from the field manager)
+-- =========================================================
+
+function HayBet:_getFieldPolygon(fieldId)
+    if g_fieldManager == nil then return nil end
+    local ok, field = pcall(function()
+        return g_fieldManager:getFieldByFarmlandId(fieldId)
+    end)
+    if not ok or not field then return nil end
+    local poly = field.polygon or (field.fieldPolygon and field.fieldPolygon.points)
+    if not poly or #poly < 3 then return nil end
+    -- Convert {x,z, x,z, ...} table or {x,z,...} flat array
+    local verts = {}
+    for i, p in ipairs(poly) do
+        if type(p) == "table" and p.x and p.z then
+            verts[#verts + 1] = p.x
+            verts[#verts + 1] = p.z
+        elseif type(p) == "number" and i % 2 == 1 then
+            -- Already flat
+            verts[i] = p
+        end
+    end
+    if #verts < 6 then return nil end
+    return verts
+end
+
+-- =========================================================
+-- Tedder interaction (the drying delta + corrective queue)
+-- =========================================================
+
+--- Apply the tedder's one-time drying delta to the condition
+--- layer over the given vertices. Clamps at the equilibrium
+--- floor; the sentinel band passes through untouched.
+---@param verts table  flat vertex array {x1,z1, x2,z2, ...}
+---@return boolean applied
+function HayBet:applyTedderDelta(verts)
+    if not self:isArmed() or not verts or #verts < 6 then return false end
+    local mw = self.materialWetness
+    if not mw:isArmed() then return false end
+
+    -- Read the condition at the work area
+    local condition = mw:readCondition(verts, 1)
+    if condition.status ~= "ok" then return false end
+
+    -- Apply the drying delta via a raw delta add on the condition
+    -- (wetness) layer. The sentinel band (raw 1 to RAW_FLOOR-1) is
+    -- excluded by the filter, so a refusal-conservative block is
+    -- never dried lower than it already reads.
+    local newPct = condition.pct - HayBet.TED_DELTA_PCT
+    if newPct < 0 then newPct = 0 end
+
+    -- The delta to apply: how many raw units to subtract
+    local currentRaw = MaterialWetness.pctToRaw and MaterialWetness.pctToRaw(condition.pct) or math.floor(condition.pct * 2.54)
+    local targetRaw = MaterialWetness.pctToRaw and MaterialWetness.pctToRaw(newPct) or math.floor(newPct * 2.54)
+    local delta = currentRaw - targetRaw
+    if delta <= 0 then return false end
+
+    local ok = pcall(function()
+        mw.valueMaps:applyRawDeltaToLayer(
+            MaterialWetness.LAYER_KEY, -delta,
+            MaterialWetness.RAW_FLOOR, SoilValueMaps.RAW_MAX - 1)
+    end)
+    return ok == true
+end
+
+--- Enqueue a work area's vertex list for the end-of-frame
+--- corrective pass. The queue is drained by onUpdate.
+---@param verts table  flat vertex array
+function HayBet:enqueueCorrection(verts)
+    if not verts or #verts < 6 then return end
+    self._correctionQueue[#self._correctionQueue + 1] = verts
+end
+
+--- Drain the correction queue. For each enqueued area, check
+--- the condition: where the material is NOT fit (still wet),
+--- convert hay back to grass. This is the drop-then-correct
+--- honesty gate.
+--- Called at end of frame from the mod's update loop.
+function HayBet:drainCorrectionQueue()
+    if not self:isArmed() then return end
+    if not HayBet.ENABLE_CONVERSION then
+        -- Without conversion enabled, just clear the queue
+        self._correctionQueue = {}
+        return
+    end
+    if #self._correctionQueue == 0 then return end
+
+    local mw = self.materialWetness
+    local queue = self._correctionQueue
+    self._correctionQueue = {}
+
+    local grassFT = self:_fillTypeIndex("GRASS_WINDROW")
+    local hayFT   = self:_fillTypeIndex("DRYGRASS_WINDROW")
+    if not grassFT or not hayFT then return end
+
+    for _, verts in ipairs(queue) do
+        pcall(function()
+            -- Read the condition for this correction area
+            local condition = mw:readCondition(verts, 1)
+            if condition.status ~= "ok" then return end
+            -- Only correct if still wet (above fit)
+            if condition.pct <= HayBet.FIT_PCT then return end
+
+            -- Convert hay back to grass
+            local sx, sz = verts[1], verts[2]
+            local wx, wz = verts[3], verts[4]
+            local hx, hz = verts[7], verts[8]
+            DensityMapHeightUtil.changeFillTypeAtArea(
+                sx, sz, wx, wz, hx, hz, hayFT, grassFT)
+            SoilLogger.debug("[HayBet] corrective: hay -> grass (condition=%.1f%%)",
+                condition.pct)
+        end)
+    end
+end
+
+-- =========================================================
+-- Spoil verdict (read-time, never a write)
+-- =========================================================
+
+--- Derive the spoil verdict for a block of material: at read
+--- time, check rain-days-down against the ruled count.
+---
+--- This is the hay member's contribution to the published read
+--- surface. The verdicts are read at the same time as days-down
+--- and condition.
+---
+---@param daysDown    number  full days the material has been lying
+---@param rainDays    number  count of rain-days in that window
+---@return string verdict  "fresh" | "goingOff" | "spoiled" | "unknown"
+function HayBet:spoilVerdict(daysDown, rainDays)
+    if type(daysDown) ~= "number" or daysDown < 0 then return "unknown" end
+    if type(rainDays) ~= "number" or rainDays < 0 then return "unknown" end
+
+    -- Insufficient data: the window is shorter than the spoil count
+    if rainDays < HayBet.SPOIL_RAIN_DAYS then
+        if rainDays == 0 then
+            return "fresh"
+        end
+        return "unknown"   -- REFUSAL: not enough rain history to rule
+    end
+
+    return "goingOff"
+end
+
+-- =========================================================
+-- End-of-frame update (drains the correction queue)
+-- =========================================================
+
+--- Called from the mod's update loop (FSBaseMission.update hook)
+--- to drain the tedder's corrective queue at end of frame.
+function HayBet:onUpdate()
+    self:drainCorrectionQueue()
+end
+
+SoilLogger.info("HayBet (SF-44) loaded")

--- a/src/HayBet.lua
+++ b/src/HayBet.lua
@@ -96,7 +96,7 @@ function HayBet:onSettle(ctx)
 
     -- [SF-49] The hay member reads the wetness layer to decide
     -- whether material is fit. A sentinel or refused condition
-    -- always blocks conversion — the conservative direction.
+    -- always blocks conversion - the conservative direction.
     md:enumerateActiveFields(function(fieldId)
         if type(fieldId) ~= "number" then return end
         pcall(function()
@@ -187,18 +187,32 @@ function HayBet:_getFieldPolygon(fieldId)
     if not ok or not field then return nil end
     local poly = field.polygon or (field.fieldPolygon and field.fieldPolygon.points)
     if not poly or #poly < 3 then return nil end
-    -- Convert {x,z, x,z, ...} table or {x,z,...} flat array
+
+    -- THE OUTPUT IS {{x=,z=}, ...}, NOT A FLAT ARRAY. Every store method reads v.x
+    -- and v.z; a flat array indexes a number inside the store's pcall, which used to
+    -- be mistaken for "the engine has no polygon ops" and latched every aimed write
+    -- in the mod off for the session. The store now refuses a malformed polygon
+    -- without latching, but the shape still has to be right for anything to be read
+    -- or written at all.
+    --
+    -- The source can arrive either way, so both are accepted and normalised here.
     local verts = {}
-    for i, p in ipairs(poly) do
-        if type(p) == "table" and p.x and p.z then
-            verts[#verts + 1] = p.x
-            verts[#verts + 1] = p.z
-        elseif type(p) == "number" and i % 2 == 1 then
-            -- Already flat
-            verts[i] = p
+    if type(poly[1]) == "table" then
+        for _, p in ipairs(poly) do
+            if type(p.x) == "number" and type(p.z) == "number" then
+                verts[#verts + 1] = { x = p.x, z = p.z }
+            end
+        end
+    else
+        for i = 1, #poly - 1, 2 do
+            local x, z = poly[i], poly[i + 1]
+            if type(x) == "number" and type(z) == "number" then
+                verts[#verts + 1] = { x = x, z = z }
+            end
         end
     end
-    if #verts < 6 then return nil end
+
+    if #verts < 3 then return nil end
     return verts
 end
 
@@ -209,10 +223,13 @@ end
 --- Apply the tedder's one-time drying delta to the condition
 --- layer over the given vertices. Clamps at the equilibrium
 --- floor; the sentinel band passes through untouched.
----@param verts table  flat vertex array {x1,z1, x2,z2, ...}
+---@param verts table  vertex array {{x=,z=}, ...}
 ---@return boolean applied
 function HayBet:applyTedderDelta(verts)
-    if not self:isArmed() or not verts or #verts < 6 then return false end
+    -- #verts is a COUNT OF VERTICES, not of numbers. The old guard read `< 6`, which
+    -- was correct for a flat {x1,z1,...} array and silently rejects every polygon
+    -- once the shape is {x=,z=} objects: a four-corner work area is length 4.
+    if not self:isArmed() or not verts or #verts < 3 then return false end
     local mw = self.materialWetness
     if not mw:isArmed() then return false end
 
@@ -233,19 +250,24 @@ function HayBet:applyTedderDelta(verts)
     local delta = currentRaw - targetRaw
     if delta <= 0 then return false end
 
+    -- SCOPED TO THE WORKED AREA, not the whole layer. applyRawDeltaToLayer walks
+    -- every pixel on the map, so the tedder was drying every swath in the world by
+    -- eight points each time it passed over one of them. The brief says "over the
+    -- worked area" and the polygon-banded call is the one that means it.
+    local applied = nil
     local ok = pcall(function()
-        mw.valueMaps:applyRawDeltaToLayer(
-            MaterialWetness.LAYER_KEY, -delta,
+        applied = mw.valueMaps:applyRawDeltaToPolygonBand(
+            MaterialWetness.LAYER_KEY, verts, -delta,
             MaterialWetness.RAW_FLOOR, SoilValueMaps.RAW_MAX - 1)
     end)
-    return ok == true
+    return ok and applied ~= nil
 end
 
 --- Enqueue a work area's vertex list for the end-of-frame
 --- corrective pass. The queue is drained by onUpdate.
----@param verts table  flat vertex array
+---@param verts table  vertex array {{x=,z=}, ...}
 function HayBet:enqueueCorrection(verts)
-    if not verts or #verts < 6 then return end
+    if not verts or #verts < 3 then return end
     self._correctionQueue[#self._correctionQueue + 1] = verts
 end
 
@@ -279,10 +301,12 @@ function HayBet:drainCorrectionQueue()
             -- Only correct if still wet (above fit)
             if condition.pct <= HayBet.FIT_PCT then return end
 
-            -- Convert hay back to grass
-            local sx, sz = verts[1], verts[2]
-            local wx, wz = verts[3], verts[4]
-            local hx, hz = verts[7], verts[8]
+            -- Convert hay back to grass. start / width / height corners, read off
+            -- the {x=,z=} vertices rather than a flat number pair.
+            local sx, sz = verts[1].x, verts[1].z
+            local wx, wz = verts[2].x, verts[2].z
+            local hx, hz = verts[4] and verts[4].x or verts[3].x,
+                           verts[4] and verts[4].z or verts[3].z
             DensityMapHeightUtil.changeFillTypeAtArea(
                 sx, sz, wx, wz, hx, hz, hayFT, grassFT)
             SoilLogger.debug("[HayBet] corrective: hay -> grass (condition=%.1f%%)",

--- a/src/MaterialDown.lua
+++ b/src/MaterialDown.lua
@@ -1,0 +1,471 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - MATERIAL DOWN (SF-43)
+-- =========================================================
+-- The ground remembers how long cut material has been lying on it.
+--
+-- A farmer knows the swath went down Tuesday. Nothing in the game does. This adds
+-- one 8-bit value-map layer holding HOW MANY DAYS material has lain at each spot,
+-- aged by ONE filtered engine call per day, born when a machine is observed making
+-- material, and cleared when the material genuinely leaves.
+--
+-- It makes NO farming rule of its own. The hay member reads it later and asks the
+-- one question nothing else in the game can answer: how many days has this been
+-- down - or refuses to say.
+--
+-- ENCODING (materialAge, minVal 0 / maxVal 254 so one raw step is exactly one day):
+--   raw 0   = NO RECORD. Bare ground. Never ages into a record.
+--   raw 1   = born today (0 full days down).
+--   raw 255 = AT OR PAST THE CEILING. A REFUSAL TO RULE, never a value.
+--
+-- THE ONE DIRECTION THIS DESIGN FORBIDS is age looking FRESHER than it is. Every
+-- rule below that seems fussy - the movement inheritance, the no-periodic-wipe
+-- rule, the merge filter - exists to close a laundering path.
+--
+-- SERVER ONLY. The layer is excluded from MP sync and never allocated client-side
+-- (SoilValueMaps asks 4+5, coupled). Bands cross to clients by event when the
+-- reading surface ships; that surface is a later member and is not built here.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class MaterialDown
+MaterialDown = {}
+local MaterialDown_mt = Class(MaterialDown)
+
+MaterialDown.LAYER_KEY = "materialAge"
+
+-- Every layer key this PACKAGE (SF-43 + its sibling SF-49) owns. The bind-time
+-- self-check asserts each one resolves before the system arms. The sibling appends
+-- its wetness key here when it builds; until then this list is correct at one entry.
+MaterialDown.PACKAGE_LAYER_KEYS = { "materialAge" }
+
+local RAW_NO_RECORD = 0
+local RAW_BORN      = 1
+local RAW_CEILING   = 255   -- SoilValueMaps.RAW_MAX; asserted against it at arm()
+
+-- Land type under observed material. All four AGE IDENTICALLY in v1 - material
+-- lying out is weather, not soil simulation, which is exactly why sim-disabled
+-- ground still counts. The branch exists because the consuming members
+-- differentiate (grassland rules differ from arable), so the fact is captured at
+-- birth rather than re-derived later against a field record that may have changed.
+MaterialDown.LAND = {
+    NORMAL       = 1,
+    MEADOW       = 2,
+    SIM_DISABLED = 3,
+    NO_RECORD    = 4,   -- no field record under this position
+}
+
+-- Publication result status. Two named neutrals, per the v1 wire contract.
+MaterialDown.RESULT = {
+    OK          = "ok",           -- days is an exact integer
+    NO_RECORD   = "noRecord",     -- nothing has been observed lying here
+    CEILING     = "ceiling",      -- at or past the ceiling: we refuse to rule
+    UNAVAILABLE = "unavailable",  -- layer absent, not armed, or not the server
+}
+
+-- Days-down publication bands. The day count is exact (it is a counter, not an
+-- estimate), so it is published alongside; the band is what a reading surface
+-- should lead with so nobody reads spurious precision into a number that only
+-- moves once per day.
+-- floor = the lowest day count in the band.
+MaterialDown.BANDS = {
+    { name = "veryOld",  floor = 60 },
+    { name = "old",      floor = 30 },
+    { name = "ageing",   floor = 14 },
+    { name = "week",     floor = 7  },
+    { name = "settling", floor = 4  },
+    { name = "recent",   floor = 2  },
+    { name = "fresh",    floor = 0  },
+}
+
+-- VALIDATION SWEEP ARMING. The four-quadrant presence rule's ratios are a bounced
+-- confirm (SF-43 section 6, the numbers pass) and the base game's bunker 0.5 is
+-- explicitly REJECTED as a default - a windrow's covered fraction never reaches
+-- half. The mechanism below is built and testable, but it runs in REPORT-ONLY mode
+-- until a real ratio lands, because clearing on a guessed threshold destroys
+-- records that no later pass can reconstruct. Flip this when the numbers arrive.
+MaterialDown.VALIDATION_ARMED = false
+MaterialDown.PLACEHOLDER_PRESENCE_RATIO = 0.15   -- PLACEHOLDER, not a ruled number
+
+-- =========================================================
+-- Construction
+-- =========================================================
+
+function MaterialDown.new()
+    local self = setmetatable({}, MaterialDown_mt)
+    self.armed     = false
+    self.valueMaps = nil
+    -- Persisted watermark: the last game day whose age tick has been applied.
+    -- Belt and braces against the scheduler's per-accrual retry (a throw AFTER the
+    -- add would otherwise re-add map-wide on the next tick).
+    self.ageAppliedThroughDay = nil
+    -- Object ledger MECHANISM (built here, consumed by the bale member later).
+    -- Keyed on an OPAQUE OWNER TOKEN; enumerate-not-list. NO rows in v1.
+    self.objects   = {}
+    self.stoodDown = false   -- true once a fence refused; the layer is inert
+    return self
+end
+
+-- =========================================================
+-- Bind-time self-check
+-- =========================================================
+-- The community fork declares the same SoilValueMaps global with byte-identical
+-- filenames and NONE of our defs. Every store method returns early and SILENTLY
+-- when a key is unknown, so without this check the whole system would look healthy
+-- while recording nothing at all. Refuse to arm, loudly, exactly once.
+--
+-- Must run after every candidate has loaded AND after SoilValueMaps:initialize.
+---@return boolean armed
+function MaterialDown:arm(valueMaps)
+    self.armed = false
+    self.valueMaps = nil
+
+    if g_server == nil then
+        -- Not an error: the layer is server-only by design. Stay silently inert.
+        return false
+    end
+    if valueMaps == nil or not valueMaps.available then
+        SoilLogger.warning("[MaterialDown] value maps unavailable - MATERIAL DOWN stands down")
+        return false
+    end
+    if valueMaps.applyRawDeltaToLayer == nil or valueMaps.setPolygonWhere == nil
+       or valueMaps.hasAnyInBand == nil or valueMaps.readRawAtWorld == nil then
+        SoilLogger.warning(
+            "[MaterialDown] the SoilValueMaps in scope has none of the SF-43 methods - this is the " ..
+            "community-fork collision (same global, same filenames, different code). MATERIAL DOWN stands down.")
+        return false
+    end
+    if SoilValueMaps.RAW_MAX ~= RAW_CEILING then
+        SoilLogger.warning("[MaterialDown] RAW_MAX is %s, expected %d - MATERIAL DOWN stands down",
+            tostring(SoilValueMaps.RAW_MAX), RAW_CEILING)
+        return false
+    end
+
+    for _, key in ipairs(MaterialDown.PACKAGE_LAYER_KEYS) do
+        if valueMaps:getLayerEntry(key) == nil then
+            SoilLogger.warning(
+                "[MaterialDown] package layer '%s' did not resolve - MATERIAL DOWN stands down " ..
+                "(every store call would no-op silently, so an inert system is the honest state)", key)
+            return false
+        end
+    end
+
+    self.valueMaps = valueMaps
+    self.armed     = true
+    self.stoodDown = false
+    SoilLogger.info("[OK] MaterialDown armed (%d package layer(s), server-only)",
+        #MaterialDown.PACKAGE_LAYER_KEYS)
+    return true
+end
+
+function MaterialDown:isArmed()
+    return self.armed and not self.stoodDown
+end
+
+-- Called by any fence that refuses. Once inert, the system stays inert for the
+-- session rather than retrying a call that already proved it would fabricate.
+function MaterialDown:_standDown(why)
+    if self.stoodDown then return end
+    self.stoodDown = true
+    SoilLogger.warning("[MaterialDown] STANDING DOWN for this session: %s", tostring(why))
+end
+
+-- =========================================================
+-- The tick (Time Guard, day cadence)
+-- =========================================================
+
+--- The age accrual body. ONE engine call on the ordinary path, by construction:
+--- at rawDelta 1 the saturating window in applyRawDeltaToLayer is empty.
+---
+--- The guard window excludes raw 0 (bare ground never ages into a record) and
+--- raw 255 (a saturated pixel stops counting - the refusal is terminal).
+---
+--- ctx.proration is IGNORED, deliberately: a +1 raw add has no meaningful fraction,
+--- and both accruals register with firstPeriodPolicy="skip" so no partial first
+--- period is ever settled. A non-increasing ctx.monotonicDay is a no-op.
+function MaterialDown:onAgeTick(ctx)
+    if not self:isArmed() then return end
+
+    local day = ctx and tonumber(ctx.monotonicDay)
+    -- The scheduler's getter falls back to 0 rather than nil, so a missing clock
+    -- reads as day 0 and simply never advances the watermark.
+    if day == nil then return end
+
+    -- IDEMPOTENCY. The scheduler retries a failed accrual with the SAME
+    -- boundariesCrossed, so a throw after the add would re-add across the whole
+    -- map. The watermark is checked before any add and persisted after it.
+    if self.ageAppliedThroughDay ~= nil and day <= self.ageAppliedThroughDay then
+        return
+    end
+
+    local boundaries = math.floor(tonumber(ctx.boundariesCrossed) or 1)
+    if boundaries < 1 then boundaries = 1 end
+
+    -- CATCH-UP is the same call with a larger delta plus the saturating second
+    -- pass; applyRawDeltaToLayer owns both, and both are flat in area.
+    local applied = self.valueMaps:applyRawDeltaToLayer(
+        MaterialDown.LAYER_KEY, boundaries, RAW_BORN, RAW_CEILING - 1)
+
+    if applied == nil then
+        -- THE FABRICATION FENCE fired: executeAdd is unavailable or failed. The
+        -- store refused rather than falling back to the block-walk that would
+        -- invent records on bare ground. Honestly inert beats quietly inventing.
+        self:_standDown("the aimed delta was refused by the store (see the SoilValueMaps warning above)")
+        return
+    end
+
+    self.ageAppliedThroughDay = day
+end
+
+--- Everything that is NOT the age tick: the validation sweep and publication
+--- bookkeeping. Separated so the tick above can stay a single engine call and
+--- therefore cannot throw after its own add.
+function MaterialDown:onMaintenanceTick(ctx)
+    if not self:isArmed() then return end
+    self:runValidationSweep()
+end
+
+-- =========================================================
+-- Birth, movement, clearing
+-- =========================================================
+
+--- Resolve the land type under a position.
+---
+--- OPEN CONFIRM (SF-43 section 6): the no-fieldId lookup form on ground with no
+--- field record. Until that is settled we return NO_RECORD and still record the
+--- age, because material lying on unregistered ground is still material lying out.
+function MaterialDown:resolveLandType(fieldId)
+    if fieldId == nil then return MaterialDown.LAND.NO_RECORD end
+    if FieldSentry_API == nil or FieldSentry_API.isFieldSimDisabled == nil then
+        -- Neutral when absent: FieldSentry is optional, so an absent sentry means
+        -- "ordinary field", never "do not record".
+        return MaterialDown.LAND.NORMAL
+    end
+    local ok, disabled, _, meadow = pcall(FieldSentry_API.isFieldSimDisabled, fieldId)
+    if not ok then return MaterialDown.LAND.NORMAL end
+    if meadow  then return MaterialDown.LAND.MEADOW end
+    -- Sim-disabled ground STILL AGES: lying out is weather, not soil simulation.
+    if disabled then return MaterialDown.LAND.SIM_DISABLED end
+    return MaterialDown.LAND.NORMAL
+end
+
+--- BIRTH. Material observed in `verts` with no record yet is dated today (raw 1).
+---
+--- The [0,0] band is the merge rule: a pixel that already carries an age is outside
+--- the filter, so arriving material can NEVER lower an existing age. There is no
+--- read-compare-write here and therefore nothing to race.
+---
+--- A machine we failed to observe leaves an UNRECORDED patch, which is a gap in
+--- knowledge, not a defect - the read refuses on raw 0 rather than guessing.
+---@return boolean recorded
+function MaterialDown:noteMaterialAt(verts, fieldId)
+    if not self:isArmed() or not verts or #verts < 3 then return false end
+    local landType = self:resolveLandType(fieldId)
+    local ok = self.valueMaps:setPolygonWhere(
+        MaterialDown.LAYER_KEY, verts, RAW_BORN, RAW_NO_RECORD, RAW_NO_RECORD)
+    if not ok then
+        self:_standDown("the aimed write was refused by the store (polygon ops unavailable)")
+        return false
+    end
+    return true, landType
+end
+
+--- MOVEMENT INHERITANCE - the anti-laundering rule. Skipping this defeats the
+--- whole feature.
+---
+--- A tedder or windrower DROPS material into a different work area than it picks
+--- up from, so most destinations have no record and would be born today. Raking a
+--- week-old row would make it read fresh, which is precisely the direction this
+--- design forbids.
+---
+--- RULE: a birth inside a movement operation inherits the SOURCE area's OLDEST
+--- RECORDED BAND, probed downward band by band with the filtered-executeGet idiom.
+---
+---   * The CEILING band is probed FIRST. If any source pixel is at the ceiling the
+---     destination inherits the ceiling too, so the refusal propagates rather than
+---     collapsing into a number.
+---   * The inherited value is the band's FLOOR, so it is an age some real pixel in
+---     the source actually held. Never the average: an average invents an age no
+---     pixel ever had, which is why readAverageOfPolygon is forbidden here.
+---   * A source area with no record at all births today, correctly.
+---@return boolean recorded
+function MaterialDown:noteMaterialMoved(srcVerts, dstVerts, fieldId)
+    if not self:isArmed() or not dstVerts or #dstVerts < 3 then return false end
+    if not srcVerts or #srcVerts < 3 then
+        return self:noteMaterialAt(dstVerts, fieldId)
+    end
+
+    local vm = self.valueMaps
+
+    -- The ceiling first, so a refusal propagates instead of being averaged away.
+    local atCeiling = vm:hasAnyInBand(MaterialDown.LAYER_KEY, srcVerts, RAW_CEILING, RAW_CEILING)
+    if atCeiling == nil then
+        self:_standDown("the band probe was refused by the store (polygon ops unavailable)")
+        return false
+    end
+    local inheritRaw = nil
+    if atCeiling then
+        inheritRaw = RAW_CEILING
+    else
+        for _, band in ipairs(MaterialDown.BANDS) do
+            -- floor is in DAYS; raw = days + 1 because raw 1 is day 0.
+            local bandLowRaw  = math.max(RAW_BORN, band.floor + 1)
+            local bandHighRaw = RAW_CEILING - 1
+            if inheritRaw == nil and bandLowRaw <= bandHighRaw then
+                local present = vm:hasAnyInBand(MaterialDown.LAYER_KEY, srcVerts, bandLowRaw, bandHighRaw)
+                if present == nil then
+                    self:_standDown("the band probe was refused by the store (polygon ops unavailable)")
+                    return false
+                end
+                if present then inheritRaw = bandLowRaw end
+            end
+        end
+    end
+
+    -- No record anywhere in the source: this material is genuinely new here.
+    if inheritRaw == nil then inheritRaw = RAW_BORN end
+
+    local ok = vm:setPolygonWhere(
+        MaterialDown.LAYER_KEY, dstVerts, inheritRaw, RAW_NO_RECORD, RAW_NO_RECORD)
+    if not ok then
+        self:_standDown("the aimed write was refused by the store (polygon ops unavailable)")
+        return false
+    end
+    return true
+end
+
+--- CLEARING. Only where the material genuinely left, and only through the aimed
+--- filter. There is NO periodic wipe anywhere in this system, ever: clearing to
+--- raw 0 lets BIRTH re-date the pixel as today, which launders age in the one
+--- direction the design forbids.
+---@return boolean cleared
+function MaterialDown:noteMaterialGone(verts)
+    if not self:isArmed() or not verts or #verts < 3 then return false end
+    local ok = self.valueMaps:clearPolygonWhere(
+        MaterialDown.LAYER_KEY, verts, RAW_BORN, RAW_CEILING)
+    if not ok then
+        self:_standDown("the filtered clear was refused by the store (polygon ops unavailable)")
+        return false
+    end
+    return true
+end
+
+-- =========================================================
+-- Validation sweep
+-- =========================================================
+
+--- Presence re-read against the engine: a record whose material is no longer there
+--- should not keep ageing. See VALIDATION_ARMED above - the four-quadrant rule's
+--- ratios are a bounced confirm, so this reports rather than clears until they land.
+--- totalPixels == 0 is a no-op, not a clear.
+function MaterialDown:runValidationSweep()
+    if not self:isArmed() then return end
+    if not MaterialDown.VALIDATION_ARMED then
+        SoilLogger.debug(
+            "[MaterialDown] validation sweep is REPORT-ONLY: the four-quadrant presence ratios are " ..
+            "still a bounced confirm (the base game's bunker 0.5 is rejected as a default)")
+        return
+    end
+    -- Intentionally unreachable until the numbers pass lands. The clearing half
+    -- goes through noteMaterialGone so it can only ever use the aimed filter.
+    SoilLogger.debug("[MaterialDown] validation sweep armed at ratio %.2f",
+        MaterialDown.PLACEHOLDER_PRESENCE_RATIO)
+end
+
+-- =========================================================
+-- Publication (v1's whole wire contract)
+-- =========================================================
+
+--- Band descriptor for an exact day count.
+function MaterialDown.bandForDays(days)
+    for _, band in ipairs(MaterialDown.BANDS) do
+        if days >= band.floor then return band.name end
+    end
+    return MaterialDown.BANDS[#MaterialDown.BANDS].name
+end
+
+--- DAYS-DOWN at a world position, server-computed, with the two named neutrals.
+---
+--- This is the entire published surface in v1. Water-days and unknown-days arrive
+--- with the sibling member; the object band arrives with the bale member.
+---@return table result  { status, days, band } - days/band only when status == OK
+function MaterialDown:getDaysDownAt(worldX, worldZ)
+    local R = MaterialDown.RESULT
+    if not self:isArmed() then return { status = R.UNAVAILABLE } end
+
+    local raw = self.valueMaps:readRawAtWorld(MaterialDown.LAYER_KEY, worldX, worldZ)
+    if raw == nil then return { status = R.UNAVAILABLE } end
+    if raw <= RAW_NO_RECORD then return { status = R.NO_RECORD } end
+    if raw >= RAW_CEILING then return { status = R.CEILING } end
+
+    local days = raw - RAW_BORN   -- raw 1 is born today = 0 full days down
+    return { status = R.OK, days = days, band = MaterialDown.bandForDays(days) }
+end
+
+-- =========================================================
+-- Object ledger MECHANISM (no rows in v1)
+-- =========================================================
+-- Built here, consumed by the bale member later. Keyed on an OPAQUE OWNER TOKEN so
+-- this system never needs to understand what the owner is, and enumerate-not-list
+-- so no caller can take a reference to the live table and mutate it behind us.
+
+function MaterialDown:setObjectRecord(token, record)
+    if token == nil then return false end
+    self.objects[tostring(token)] = record
+    return true
+end
+
+function MaterialDown:getObjectRecord(token)
+    if token == nil then return nil end
+    return self.objects[tostring(token)]
+end
+
+function MaterialDown:enumerateObjects(fn)
+    if type(fn) ~= "function" then return 0 end
+    local n = 0
+    for token, record in pairs(self.objects) do
+        fn(token, record)
+        n = n + 1
+    end
+    return n
+end
+
+-- =========================================================
+-- Persistence (StateLedger sidecar; merge-never-replace)
+-- =========================================================
+
+function MaterialDown:serialize()
+    local objects = {}
+    for token, record in pairs(self.objects) do objects[token] = record end
+    return {
+        schema                = 1,
+        ageAppliedThroughDay  = self.ageAppliedThroughDay,
+        objects               = objects,
+    }
+end
+
+--- MERGE, never replace.
+---
+--- StateLedger OMITS a block when serialize fails and cannot distinguish an omitted
+--- block from a brand-new save (it decides resume-vs-defaults purely on data ~= nil).
+--- A replace-on-nil would therefore wipe the watermark after ONE bad save, and a
+--- lost watermark means the next tick re-ages the entire map.
+function MaterialDown:deserialize(data)
+    if type(data) ~= "table" then return false end
+
+    if type(data.ageAppliedThroughDay) == "number" then
+        -- Keep the FURTHEST-ON watermark. Going backwards would re-age the map.
+        if self.ageAppliedThroughDay == nil or data.ageAppliedThroughDay > self.ageAppliedThroughDay then
+            self.ageAppliedThroughDay = data.ageAppliedThroughDay
+        end
+    end
+
+    if type(data.objects) == "table" then
+        for token, record in pairs(data.objects) do
+            if self.objects[token] == nil then self.objects[token] = record end
+        end
+    end
+    return true
+end
+
+SoilLogger.info("MaterialDown (SF-43) loaded")

--- a/src/MaterialDown.lua
+++ b/src/MaterialDown.lua
@@ -43,6 +43,30 @@ local RAW_NO_RECORD = 0
 local RAW_BORN      = 1
 local RAW_CEILING   = 255   -- SoilValueMaps.RAW_MAX; asserted against it at arm()
 
+-- [SF-45] THE TRACKED MATERIAL SET - the configuration that gates birth-by-
+-- observation. Engine fill-type NAMES, verified at source.
+--
+-- The layers themselves are material-blind by design, which is the whole point:
+-- adding a second crop to this programme costs ONE ENTRY here plus whatever numbers
+-- its own reader needs, and birth, ageing, condition, movement inheritance and the
+-- collector's refusal-honest read then cover it automatically. STRAW is that
+-- receipt - it joined for one line.
+--
+-- Any straw-specific MACHINERY (as opposed to a row) re-opens governance by
+-- definition. If you find yourself adding a branch here, stop.
+MaterialDown.TRACKED_MATERIALS = {
+    GRASS_WINDROW    = true,   -- cut grass, the foundation's first material
+    DRYGRASS_WINDROW = true,   -- hay: the cured form of that same swath
+    STRAW            = true,   -- [SF-45] the second crop, and its entire build
+}
+
+---@param fillTypeName string|nil  engine fill-type name
+---@return boolean tracked
+function MaterialDown.isTrackedMaterial(fillTypeName)
+    if fillTypeName == nil then return false end
+    return MaterialDown.TRACKED_MATERIALS[tostring(fillTypeName):upper()] == true
+end
+
 -- Land type under observed material. All four AGE IDENTICALLY in v1 - material
 -- lying out is weather, not soil simulation, which is exactly why sim-disabled
 -- ground still counts. The branch exists because the consuming members
@@ -263,9 +287,20 @@ end
 ---
 --- A machine we failed to observe leaves an UNRECORDED patch, which is a gap in
 --- knowledge, not a defect - the read refuses on raw 0 rather than guessing.
+--- [SF-45] `fillTypeName` gates the write against the tracked set. Passing a
+--- material that is not tracked REFUSES: chaff behind a combine is not a swath, and
+--- recording it would age something no member will ever read.
+---
+--- nil means the caller made no claim about the material, which is allowed and
+--- records. The observation hook always knows its fill type and will always pass
+--- one, so the gate bites where it matters; nil exists for callers that genuinely
+--- only know "material is here" and for the bench.
 ---@return boolean recorded
-function MaterialDown:noteMaterialAt(verts, fieldId)
+function MaterialDown:noteMaterialAt(verts, fieldId, fillTypeName)
     if not self:isArmed() or not verts or #verts < 3 then return false end
+    if fillTypeName ~= nil and not MaterialDown.isTrackedMaterial(fillTypeName) then
+        return false
+    end
     local landType = self:resolveLandType(fieldId)
     local ok = self.valueMaps:setPolygonWhere(
         MaterialDown.LAYER_KEY, verts, RAW_BORN, RAW_NO_RECORD, RAW_NO_RECORD)
@@ -296,10 +331,13 @@ end
 ---     pixel ever had, which is why readAverageOfPolygon is forbidden here.
 ---   * A source area with no record at all births today, correctly.
 ---@return boolean recorded
-function MaterialDown:noteMaterialMoved(srcVerts, dstVerts, fieldId)
+function MaterialDown:noteMaterialMoved(srcVerts, dstVerts, fieldId, fillTypeName)
     if not self:isArmed() or not dstVerts or #dstVerts < 3 then return false end
+    if fillTypeName ~= nil and not MaterialDown.isTrackedMaterial(fillTypeName) then
+        return false
+    end
     if not srcVerts or #srcVerts < 3 then
-        return self:noteMaterialAt(dstVerts, fieldId)
+        return self:noteMaterialAt(dstVerts, fieldId, fillTypeName)
     end
 
     local vm = self.valueMaps

--- a/src/MaterialDown.lua
+++ b/src/MaterialDown.lua
@@ -200,6 +200,39 @@ function MaterialDown:_standDown(why)
     SoilLogger.warning("[MaterialDown] STANDING DOWN for this session: %s", tostring(why))
 end
 
+--- THE VERTEX SHAPE GATE, and it sits here rather than at the store on purpose.
+---
+--- Standing down is for a store that cannot do the work. It is NOT for a caller that
+--- asked badly, and those two used to be the same event: every refused aimed write
+--- assumed "polygon ops unavailable" and killed the layer for the session. So one
+--- caller passing a flat {x1,z1,...} array instead of {{x=,z=},...} cost the whole
+--- system, because indexing a number raises inside the store's pcall and the store
+--- read that as an engine verdict.
+---
+--- Checking the shape BEFORE the call keeps both behaviours honest: rubbish never
+--- reaches the store, and a refusal that comes back from a well-formed call really is
+--- the fabrication fence firing, which must still stand the system down.
+---@return boolean valid
+function MaterialDown._isValidPolygon(verts)
+    if type(verts) ~= "table" or #verts < 3 then return false end
+    for i = 1, #verts do
+        local v = verts[i]
+        if type(v) ~= "table" or type(v.x) ~= "number" or type(v.z) ~= "number" then
+            return false
+        end
+    end
+    return true
+end
+
+--- Refuse a malformed polygon loudly, without disarming anything.
+---@return boolean false, always
+function MaterialDown:_refuseShape(where)
+    SoilLogger.warning(
+        "[MaterialDown] %s got a malformed polygon (expected {{x=,z=},...}) and refused it. " ..
+        "The layer stays armed: this is a caller bug, not a store failure.", tostring(where))
+    return false
+end
+
 -- =========================================================
 -- The tick (Time Guard, day cadence)
 -- =========================================================
@@ -297,7 +330,10 @@ end
 --- only know "material is here" and for the bench.
 ---@return boolean recorded
 function MaterialDown:noteMaterialAt(verts, fieldId, fillTypeName)
-    if not self:isArmed() or not verts or #verts < 3 then return false end
+    if not self:isArmed() then return false end
+    if not MaterialDown._isValidPolygon(verts) then
+        return self:_refuseShape("noteMaterialAt")
+    end
     if fillTypeName ~= nil and not MaterialDown.isTrackedMaterial(fillTypeName) then
         return false
     end
@@ -332,11 +368,15 @@ end
 ---   * A source area with no record at all births today, correctly.
 ---@return boolean recorded
 function MaterialDown:noteMaterialMoved(srcVerts, dstVerts, fieldId, fillTypeName)
-    if not self:isArmed() or not dstVerts or #dstVerts < 3 then return false end
+    if not self:isArmed() then return false end
+    if not MaterialDown._isValidPolygon(dstVerts) then
+        return self:_refuseShape("noteMaterialMoved (destination)")
+    end
     if fillTypeName ~= nil and not MaterialDown.isTrackedMaterial(fillTypeName) then
         return false
     end
-    if not srcVerts or #srcVerts < 3 then
+    if not MaterialDown._isValidPolygon(srcVerts) then
+        -- No usable source area: a birth, correctly, not a laundering path.
         return self:noteMaterialAt(dstVerts, fieldId, fillTypeName)
     end
 
@@ -360,7 +400,7 @@ function MaterialDown:noteMaterialMoved(srcVerts, dstVerts, fieldId, fillTypeNam
                 local present = vm:hasAnyInBand(MaterialDown.LAYER_KEY, srcVerts, bandLowRaw, bandHighRaw)
                 if present == nil then
                     self:_standDown("the band probe was refused by the store (polygon ops unavailable)")
-                    return false
+        return false
                 end
                 if present then inheritRaw = bandLowRaw end
             end
@@ -390,7 +430,10 @@ end
 --- which costs a few wasted drying calls but never loses a record - the forgiving
 --- direction.
 function MaterialDown:noteMaterialGone(verts, fieldId)
-    if not self:isArmed() or not verts or #verts < 3 then return false end
+    if not self:isArmed() then return false end
+    if not MaterialDown._isValidPolygon(verts) then
+        return self:_refuseShape("noteMaterialGone")
+    end
     local ok = self.valueMaps:clearPolygonWhere(
         MaterialDown.LAYER_KEY, verts, RAW_BORN, RAW_CEILING)
     if not ok then

--- a/src/MaterialDown.lua
+++ b/src/MaterialDown.lua
@@ -102,6 +102,12 @@ function MaterialDown.new()
     -- Object ledger MECHANISM (built here, consumed by the bale member later).
     -- Keyed on an OPAQUE OWNER TOKEN; enumerate-not-list. NO rows in v1.
     self.objects   = {}
+    -- [SF-49] Fields currently carrying a record, as a set. The sibling's drying
+    -- pass needs per-field geometry (soil class is a per-field property), and
+    -- probing every field on the map once a day to find the two that have a swath
+    -- on them is the wrong shape. Maintained by the same calls that write the layer,
+    -- so it costs nothing extra and cannot drift from the writes it mirrors.
+    self.activeFields = {}
     self.stoodDown = false   -- true once a fence refused; the layer is inert
     return self
 end
@@ -267,6 +273,7 @@ function MaterialDown:noteMaterialAt(verts, fieldId)
         self:_standDown("the aimed write was refused by the store (polygon ops unavailable)")
         return false
     end
+    self:markFieldActive(fieldId)
     return true, landType
 end
 
@@ -331,6 +338,7 @@ function MaterialDown:noteMaterialMoved(srcVerts, dstVerts, fieldId)
         self:_standDown("the aimed write was refused by the store (polygon ops unavailable)")
         return false
     end
+    self:markFieldActive(fieldId)
     return true
 end
 
@@ -339,7 +347,11 @@ end
 --- raw 0 lets BIRTH re-date the pixel as today, which launders age in the one
 --- direction the design forbids.
 ---@return boolean cleared
-function MaterialDown:noteMaterialGone(verts)
+--- `fieldId` is optional and only drops the field from the active set; pass it when
+--- the caller knows the field is now empty. Omitting it leaves the field active,
+--- which costs a few wasted drying calls but never loses a record - the forgiving
+--- direction.
+function MaterialDown:noteMaterialGone(verts, fieldId)
     if not self:isArmed() or not verts or #verts < 3 then return false end
     local ok = self.valueMaps:clearPolygonWhere(
         MaterialDown.LAYER_KEY, verts, RAW_BORN, RAW_CEILING)
@@ -347,6 +359,7 @@ function MaterialDown:noteMaterialGone(verts)
         self:_standDown("the filtered clear was refused by the store (polygon ops unavailable)")
         return false
     end
+    self:markFieldClear(fieldId)
     return true
 end
 
@@ -409,6 +422,28 @@ end
 -- this system never needs to understand what the owner is, and enumerate-not-list
 -- so no caller can take a reference to the live table and mutate it behind us.
 
+--- [SF-49] Iterate the fields that currently carry a record. Enumerate-not-list so
+--- no caller can take a reference to the live set and mutate it behind us.
+function MaterialDown:enumerateActiveFields(fn)
+    if type(fn) ~= "function" then return 0 end
+    local n = 0
+    for fieldId in pairs(self.activeFields) do
+        fn(fieldId)
+        n = n + 1
+    end
+    return n
+end
+
+function MaterialDown:markFieldActive(fieldId)
+    if fieldId == nil then return end
+    self.activeFields[fieldId] = true
+end
+
+function MaterialDown:markFieldClear(fieldId)
+    if fieldId == nil then return end
+    self.activeFields[fieldId] = nil
+end
+
 function MaterialDown:setObjectRecord(token, record)
     if token == nil then return false end
     self.objects[tostring(token)] = record
@@ -437,10 +472,13 @@ end
 function MaterialDown:serialize()
     local objects = {}
     for token, record in pairs(self.objects) do objects[token] = record end
+    local active = {}
+    for fieldId in pairs(self.activeFields) do active[#active + 1] = fieldId end
     return {
         schema                = 1,
         ageAppliedThroughDay  = self.ageAppliedThroughDay,
         objects               = objects,
+        activeFields          = active,
     }
 end
 
@@ -463,6 +501,14 @@ function MaterialDown:deserialize(data)
     if type(data.objects) == "table" then
         for token, record in pairs(data.objects) do
             if self.objects[token] == nil then self.objects[token] = record end
+        end
+    end
+
+    -- Merge, never replace: a field the running session already knows carries
+    -- material stays active even if the saved set predates it.
+    if type(data.activeFields) == "table" then
+        for _, fieldId in ipairs(data.activeFields) do
+            self.activeFields[fieldId] = true
         end
     end
     return true

--- a/src/MaterialDown.lua
+++ b/src/MaterialDown.lua
@@ -493,6 +493,27 @@ function MaterialDown:getObjectRecord(token)
     return self.objects[tostring(token)]
 end
 
+--- CREATE, the shape SF-46 specified as the mechanism's first consumer.
+---
+--- The difference from setObjectRecord is the whole point of having both: create
+--- REFUSES an existing token. An owner minting a token it believes is fresh must not
+--- be able to overwrite a row it cannot see, because the ledger is enumerate-not-list
+--- and a silent clobber there is unobservable until the save is already wrong.
+function MaterialDown:createObjectRecord(token, record)
+    if token == nil or record == nil then return false end
+    local key = tostring(token)
+    if self.objects[key] ~= nil then return false end
+    self.objects[key] = record
+    return true
+end
+
+function MaterialDown:removeObjectRecord(token)
+    if token == nil then return false end
+    if self.objects[tostring(token)] == nil then return false end
+    self.objects[tostring(token)] = nil
+    return true
+end
+
 function MaterialDown:enumerateObjects(fn)
     if type(fn) ~= "function" then return 0 end
     local n = 0

--- a/src/MaterialWetness.lua
+++ b/src/MaterialWetness.lua
@@ -29,6 +29,12 @@ MaterialWetness.LAYER_KEY = "materialWetness"
 -- Encoding, mirroring the layer def. Asserted against the store at arm().
 local PCT_MIN, PCT_MAX = 0, 100
 local RAW_FLOOR        = 32   -- every real reading sits at or above this
+
+-- Exported for the members, which have to exclude the sentinel band on their own
+-- calls. It was file-local, so `MaterialWetness.RAW_FLOOR` in a member read nil and
+-- the band floor silently became 0 - the sentinel band INCLUDED, which is exactly the
+-- read trap SF-49's own comments warn about. One assignment closes it.
+MaterialWetness.RAW_FLOOR = RAW_FLOOR
 local SENTINEL_RAW     = 24   -- inside the reserved 16-31 band = REFUSAL
 
 -- Drying phase table. RULED 2026-07-31: points of moisture lost per day, wet basis,

--- a/src/MaterialWetness.lua
+++ b/src/MaterialWetness.lua
@@ -1,0 +1,791 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - WHAT THE SKY DID (SF-49)
+-- =========================================================
+-- Six days down in a dry spell is fit to bale; six days with three showers through
+-- it is ruined. The sibling (MATERIAL DOWN) answers how LONG. This one answers
+-- what CONDITION.
+--
+-- A per-cell MATERIAL WETNESS layer (percent moisture, wet basis) written once a
+-- day by a three-phase drying pass under a humidity-and-temperature ceiling, wetted
+-- by rain and by irrigation, plus a small per-day WATER RECORD so a spoil rule can
+-- ask "how many of the last six days brought water".
+--
+-- THE NAMING FENCE (hard): this mod already ships `advanceWetness` driving
+-- COMPACTION from rain, and SeasonalCropStress owns SOIL moisture. Three wetness
+-- quantities now exist. Every key and getter here carries MATERIAL, or a future
+-- builder will conflate them. `advanceWetness` is NEVER touched from this file.
+--
+-- SERVER ONLY, like the sibling. Publishes bands; draws nothing.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class MaterialWetness
+MaterialWetness = {}
+local MaterialWetness_mt = Class(MaterialWetness)
+
+MaterialWetness.LAYER_KEY = "materialWetness"
+
+-- Encoding, mirroring the layer def. Asserted against the store at arm().
+local PCT_MIN, PCT_MAX = 0, 100
+local RAW_FLOOR        = 32   -- every real reading sits at or above this
+local SENTINEL_RAW     = 24   -- inside the reserved 16-31 band = REFUSAL
+
+-- Drying phase table. RULED 2026-07-31: points of moisture lost per day, wet basis,
+-- walking the published 3-to-5-day cure at day grain. Drying is MULTIPLICATIVE but
+-- the engine write is ADDITIVE, which is exactly why this is a banded pass rather
+-- than one call: each band gets its own subtraction.
+MaterialWetness.PHASES = {
+    { name = "rapid",        pctLow = 60, pctHigh = 100, dropPerDay = 25 },
+    { name = "transitional", pctLow = 40, pctHigh = 60,  dropPerDay = 18 },
+    { name = "bound",        pctLow = 0,  pctHigh = 40,  dropPerDay = 6  },
+}
+
+-- Soil classes from SeasonalCropStress's shipped SOIL_PARAMS (verified at source
+-- 2026-07-31: sandy 1.40 / loamy 1.00 / clay 0.70). The call count is a FUNCTION of
+-- the shipped class count, not a constant - a fourth class makes twelve.
+MaterialWetness.SOIL_EVAP = { sandy = 1.40, loamy = 1.00, clay = 0.70 }
+MaterialWetness.DEFAULT_SOIL_CLASS = "loamy"
+
+-- Composite weather multiplier. RULED 2026-07-31: endpoints 1.3 / 1.0 / 0.45, the
+-- agreed ~3x spread between sun-with-dry-soil and cloud-with-wet-soil, lerped over
+-- cloud cover and standing soil moisture together. ONE multiplier, deliberately:
+-- the literature does not support separate coefficients for the two inputs.
+MaterialWetness.WEATHER_MULT = { high = 1.30, mid = 1.00, low = 0.45 }
+
+-- Rain setback. RULED 2026-07-31: +15 points per FULL rain day, scaled by the day's
+-- rain fraction. Labelled heuristic - no literature mapping exists for this one.
+MaterialWetness.RAIN_SETBACK_PER_DAY = 15
+
+-- How many days of water verdicts the record keeps. A spoil rule asks about the
+-- last six; the ring is sized well past that so a member can widen without a
+-- migration, and bounded so a long save cannot grow it without limit.
+MaterialWetness.WATER_RECORD_DAYS = 30
+
+-- =========================================================
+-- EMC ceiling table
+-- =========================================================
+-- Material cannot dry below its equilibrium moisture content for the current
+-- humidity and temperature. Bilinearly interpolated, CLAMPED at the table edges,
+-- NEVER extrapolated.
+--
+-- *** THESE NUMBERS ARE PLACEHOLDERS AND MUST BE RECONCILED BEFORE SHIP. ***
+-- The brief fixes the ceiling table as literature-derived (Purdue NRAES-5) and
+-- carries it in the workspace SDS, which is not in this repo. The MECHANISM below
+-- is what the brief specifies in detail and is what the tests pin; the table is one
+-- swap away. These values are plausible hay EMC figures and are NOT the ruled ones.
+--
+-- The table is indexed in FAHRENHEIT. The engine reports CELSIUS (confirmed from
+-- the LUADOC: USE_FAHRENHEIT is a display setting and the unit texts list celsius
+-- first; WeatherGuard's own SEASON_TEMP of {12,22,10,2} is Celsius too). The bridge
+-- is therefore a real conversion and it happens at EXACTLY ONE SITE below - a
+-- Celsius value read as Fahrenheit lands in the wrong row and nothing complains.
+MaterialWetness.EMC_TEMPS_F = { 40, 60, 80, 100 }
+MaterialWetness.EMC_RH_PCT  = { 20, 40, 60, 80, 90 }
+MaterialWetness.EMC_TABLE = {
+    { 7.5, 10.8, 14.2, 19.5, 24.0 },   -- 40 F
+    { 6.8, 10.0, 13.3, 18.4, 22.7 },   -- 60 F
+    { 6.2,  9.3, 12.5, 17.4, 21.5 },   -- 80 F
+    { 5.7,  8.7, 11.8, 16.5, 20.4 },   -- 100 F
+}
+MaterialWetness.EMC_TABLE_IS_PLACEHOLDER = true
+
+-- THE UNIT BRIDGE. One site, on purpose.
+function MaterialWetness.celsiusToFahrenheit(c)
+    return (tonumber(c) or 0) * 9 / 5 + 32
+end
+
+-- Position of `v` within a sorted axis: index of the lower node and the 0-1
+-- fraction toward the next. Clamped at both edges, so a value off the end of the
+-- table pins to the edge row rather than extrapolating past published data.
+local function axisPosition(axis, v)
+    if v <= axis[1] then return 1, 0 end
+    local n = #axis
+    if v >= axis[n] then return n - 1, 1 end
+    for i = 1, n - 1 do
+        if v <= axis[i + 1] then
+            local span = axis[i + 1] - axis[i]
+            return i, (span > 0) and ((v - axis[i]) / span) or 0
+        end
+    end
+    return n - 1, 1
+end
+
+--- EMC (percent, wet basis) for a humidity and a temperature IN CELSIUS.
+--- The conversion to the table's Fahrenheit basis happens here and nowhere else.
+function MaterialWetness.emcFor(humidityPct, temperatureC)
+    local rh = math.max(0, math.min(100, tonumber(humidityPct) or 0))
+    local tF = MaterialWetness.celsiusToFahrenheit(temperatureC)
+
+    local ti, tfrac = axisPosition(MaterialWetness.EMC_TEMPS_F, tF)
+    local hi, hfrac = axisPosition(MaterialWetness.EMC_RH_PCT,  rh)
+
+    local t0, t1 = MaterialWetness.EMC_TABLE[ti], MaterialWetness.EMC_TABLE[ti + 1]
+    local a = t0[hi] + (t0[hi + 1] - t0[hi]) * hfrac
+    local b = t1[hi] + (t1[hi + 1] - t1[hi]) * hfrac
+    return a + (b - a) * tfrac
+end
+
+-- =========================================================
+-- Encoding helpers
+-- =========================================================
+-- ENCODE THE BOUNDS BEFORE THEY REACH THE FILTER. Passing percentages straight
+-- through would put the phase boundaries at roughly 23 and 15 percent instead of 60
+-- and 40, and every call-count test would still pass while the curve was wrong.
+
+--- percent (wet basis) -> raw, using the layer's own linear encoding.
+--- 60 pct is raw 153, 40 pct is raw 103.
+function MaterialWetness.pctToRaw(pct)
+    local span = SoilValueMaps.RAW_SPAN
+    local clamped = math.max(PCT_MIN, math.min(PCT_MAX, tonumber(pct) or 0))
+    local raw = SoilValueMaps.RAW_MIN + math.floor((clamped - PCT_MIN) / (PCT_MAX - PCT_MIN) * span + 0.5)
+    if raw < RAW_FLOOR then raw = RAW_FLOOR end
+    return raw
+end
+
+--- raw -> percent, or nil for the two non-values (no record, and the refusal band).
+function MaterialWetness.rawToPct(raw)
+    if raw == nil or raw <= 0 then return nil end
+    if raw < RAW_FLOOR then return nil end   -- inside the reserved sentinel band
+    local span = SoilValueMaps.RAW_SPAN
+    return PCT_MIN + (raw - SoilValueMaps.RAW_MIN) / span * (PCT_MAX - PCT_MIN)
+end
+
+--- Points of moisture expressed as raw steps (a delta, so no floor applies).
+function MaterialWetness.pointsToRawDelta(points)
+    local span = SoilValueMaps.RAW_SPAN
+    return math.floor((tonumber(points) or 0) / (PCT_MAX - PCT_MIN) * span + 0.5)
+end
+
+MaterialWetness.RESULT = {
+    OK          = "ok",
+    REFUSAL     = "refusal",       -- the sentinel, or a quantity we cannot trust
+    NO_MATERIAL = "noMaterial",
+    UNAVAILABLE = "unavailable",
+}
+
+-- Condition bands the members read. Names, not numbers, so a later balance pass
+-- moves the edges without touching a consumer.
+MaterialWetness.BANDS = {
+    { name = "soaked", floor = 60 },
+    { name = "damp",   floor = 40 },
+    { name = "curing", floor = 25 },
+    { name = "fit",    floor = 0  },
+}
+
+-- =========================================================
+-- Construction
+-- =========================================================
+
+function MaterialWetness.new()
+    local self = setmetatable({}, MaterialWetness_mt)
+    self.armed        = false
+    self.stoodDown    = false
+    self.valueMaps    = nil
+    self.materialDown = nil
+    self.soilSystem   = nil
+    self.appliedThroughDay = nil
+    -- Water Record: day number -> { water = bool, source = string, derived = bool }.
+    -- Verdicts are PERSISTED, never recomputed: the climate roll reads the current
+    -- season and weather mode, so an unfrozen past day would change its own answer.
+    self.waterRecord  = {}
+    self.recordDays   = {}   -- ordered day numbers, oldest first (the ring)
+    -- Shelter shape cache, invalidated on the placeable lifecycle.
+    self.shelterDirty = true
+    self.shelterCache = {}
+    return self
+end
+
+function MaterialWetness:isArmed()
+    return self.armed and not self.stoodDown
+end
+
+function MaterialWetness:_standDown(why)
+    if self.stoodDown then return end
+    self.stoodDown = true
+    SoilLogger.warning("[MaterialWetness] STANDING DOWN for this session: %s", tostring(why))
+end
+
+--- Bind-time self-check, same shape and same reason as the sibling's.
+function MaterialWetness:arm(valueMaps, materialDown, soilSystem)
+    self.armed = false
+    if g_server == nil then return false end
+    if valueMaps == nil or not valueMaps.available then
+        SoilLogger.warning("[MaterialWetness] value maps unavailable - WHAT THE SKY DID stands down")
+        return false
+    end
+    if valueMaps.applyRawDeltaToPolygonBand == nil then
+        SoilLogger.warning(
+            "[MaterialWetness] the SoilValueMaps in scope lacks the SF-49 banded delta - this is the " ..
+            "community-fork collision. WHAT THE SKY DID stands down.")
+        return false
+    end
+    if valueMaps:getLayerEntry(MaterialWetness.LAYER_KEY) == nil then
+        SoilLogger.warning("[MaterialWetness] layer '%s' did not resolve - stands down", MaterialWetness.LAYER_KEY)
+        return false
+    end
+    if materialDown == nil then
+        SoilLogger.warning("[MaterialWetness] the sibling (MATERIAL DOWN) is absent - stands down")
+        return false
+    end
+
+    self.valueMaps    = valueMaps
+    self.materialDown = materialDown
+    self.soilSystem   = soilSystem
+    self.armed        = true
+    self.stoodDown    = false
+    if MaterialWetness.EMC_TABLE_IS_PLACEHOLDER then
+        SoilLogger.warning(
+            "[MaterialWetness] the EMC ceiling table is PLACEHOLDER data pending the ruled NRAES-5 " ..
+            "figures; the drying floor is approximate until it is swapped")
+    end
+    SoilLogger.info("[OK] MaterialWetness armed (server-only)")
+    return true
+end
+
+-- =========================================================
+-- Sky and soil reads (all pull-only, neutral when absent)
+-- =========================================================
+
+local function weatherGuard()
+    return (g_currentMission ~= nil and g_currentMission.weatherGuard) or nil
+end
+
+local function cropStress()
+    return (g_currentMission ~= nil and g_currentMission.cropStressManager) or nil
+end
+
+--- Current sky. nil means we do not know, and the accrual HOLDS rather than
+--- inventing one: no WeatherGuard is not the same as a clear dry day.
+function MaterialWetness:readSky()
+    local wg = weatherGuard()
+    if wg == nil or wg.getCurrentSky == nil then return nil end
+    local ok, sky = pcall(function() return wg:getCurrentSky() end)
+    if not ok then return nil end
+    return sky
+end
+
+--- Rain for TODAY only. getEffectiveRain floors its argument at zero, so asking it
+--- about yesterday silently answers about today; never ask it about the past.
+function MaterialWetness:readRainToday()
+    local wg = weatherGuard()
+    if wg == nil or wg.getEffectiveRain == nil then return nil end
+    local ok, rain = pcall(function() return wg:getEffectiveRain(0) end)
+    if not ok then return nil end
+    -- getEffectiveRain returns an identical zero-table on ten error paths and on two
+    -- honest dry rolls, so a zero is treated as a dry day and ignorance is read from
+    -- getCurrentSky's humidityDefaulted flag instead.
+    return rain
+end
+
+--- Climate for a season. NORMALISED TO 1-BASED AT THE CALL SITE: getClimate rejects
+--- anything outside 1-4, and SeasonalCropStress normalises the OTHER way for its own
+--- tables, so feeding SCS's spring in here would give a permanently dry spring.
+function MaterialWetness:readClimate(season1Based)
+    local wg = weatherGuard()
+    if wg == nil or wg.getClimate == nil then return nil end
+    local s = tonumber(season1Based)
+    if s == nil or s < 1 or s > 4 then return nil end
+    local ok, climate = pcall(function() return wg:getClimate(s) end)
+    if not ok then return nil end
+    return climate
+end
+
+function MaterialWetness:currentSeason1Based()
+    local env = g_currentMission and g_currentMission.environment
+    if env == nil then return nil end
+    -- Engine basis, used as-is. Season.SPRING is 1 and WeatherGuard indexes its own
+    -- 1-based tables with this same value.
+    return env.currentSeason
+end
+
+--- Which season a PAST day belonged to.
+---
+--- A sleep across a season turn must not charge every skipped day to the season the
+--- player woke up in: waking in autumn after sleeping through summer would price a
+--- fortnight of summer drying at autumn's rain fraction.
+---
+--- Period-aligned approximation: it steps back whole seasons and does not know how
+--- far into the current period today sits, so a day within one period of a season
+--- boundary can be attributed to the neighbouring season. That error is bounded by
+--- one period and always in the right direction of magnitude; the exact form needs a
+--- day-in-period accessor and is a refinement, not a correction.
+---@return number|nil season1Based
+function MaterialWetness:seasonForDay(dayNumber)
+    local env = g_currentMission and g_currentMission.environment
+    if env == nil then return nil end
+    local currentSeason = env.currentSeason
+    if currentSeason == nil then return nil end
+
+    local current = tonumber(env.currentMonotonicDay) or dayNumber
+    local daysPerPeriod = tonumber(env.daysPerPeriod) or 0
+    if daysPerPeriod <= 0 then return currentSeason end
+
+    local daysPerSeason = daysPerPeriod * 3   -- three periods to a season
+    local back = math.max(0, current - (tonumber(dayNumber) or current))
+    local seasonsBack = math.floor(back / daysPerSeason)
+    -- 1-based with wraparound: stepping back from spring lands in winter.
+    return ((currentSeason - 1 - seasonsBack) % 4) + 1
+end
+
+--- Standing SOIL moisture (0-1) as a drying DRAG. Read through the facade, never
+--- the subsystem, and never confused with material wetness: wet ground is not wet hay.
+function MaterialWetness:readSoilMoisture(fieldId)
+    local cs = cropStress()
+    if cs == nil or cs.getMoisture == nil then return nil end
+    local ok, m = pcall(function() return cs:getMoisture(fieldId) end)
+    if not ok then return nil end
+    return m
+end
+
+--- Soil class for a field, from SCS. Defaults to loamy (multiplier 1.0) when absent,
+--- which is the neutral choice rather than a fast or slow one.
+function MaterialWetness:soilClassFor(fieldId)
+    local cs = cropStress()
+    if cs == nil or cs.getFieldSoilType == nil then return MaterialWetness.DEFAULT_SOIL_CLASS end
+    local ok, t = pcall(function() return cs:getFieldSoilType(fieldId) end)
+    if not ok or t == nil or MaterialWetness.SOIL_EVAP[t] == nil then
+        return MaterialWetness.DEFAULT_SOIL_CLASS
+    end
+    return t
+end
+
+--- The composite weather multiplier: ONE number over cloud cover and soil moisture.
+--- Clear sky over dry ground dries fastest; overcast over wet ground slowest.
+function MaterialWetness.weatherMultiplier(cloudCoverage, soilMoisture)
+    local W = MaterialWetness.WEATHER_MULT
+    local cloud = math.max(0, math.min(1, tonumber(cloudCoverage) or 0.5))
+    local wet   = math.max(0, math.min(1, tonumber(soilMoisture)  or 0.5))
+    -- 0 = the drying-friendly end (clear, dry), 1 = the drying-hostile end.
+    local hostility = (cloud + wet) * 0.5
+    if hostility <= 0.5 then
+        local f = hostility / 0.5
+        return W.high + (W.mid - W.high) * f
+    end
+    local f = (hostility - 0.5) / 0.5
+    return W.mid + (W.low - W.mid) * f
+end
+
+-- =========================================================
+-- Shelter
+-- =========================================================
+-- The wetting call receives a shape with roofs subtracted. The engine query is a
+-- POINT predicate, so it BUILDS the shape rather than filtering the write.
+--
+-- NEUTRAL MEANS IT WETS. Claiming shelter we cannot verify is the lie that matters:
+-- a swath wrongly marked dry survives a storm that should have ruined it.
+
+function MaterialWetness:invalidateShelterCache()
+    self.shelterDirty = true
+    self.shelterCache = {}
+end
+
+--- Is this position under cover? nil when the mask is unavailable, which the caller
+--- must treat as "not sheltered".
+function MaterialWetness.isSheltered(worldX, worldZ)
+    local mission = g_currentMission
+    if mission == nil or mission.indoorMask == nil
+       or mission.indoorMask.getIsIndoorAtWorldPosition == nil then
+        return nil
+    end
+    local ok, indoor = pcall(function()
+        return mission.indoorMask:getIsIndoorAtWorldPosition(worldX, worldZ)
+    end)
+    if not ok then return nil end
+    return indoor == true
+end
+
+-- =========================================================
+-- The daily accrual: DRY, then WET, then RECORD
+-- =========================================================
+
+--- One Time Guard accrual, day cadence, registered at the priority the sibling
+--- reserved so this settles AFTER the age tick: time exists before the day's
+--- weather is applied to it.
+---
+--- ctx.proration is ignored (firstPeriodPolicy is "skip", so no partial first
+--- period is ever settled; the scheduler's silent default would have been "prorate",
+--- which would retroactively wet or dry material that predates the layer).
+function MaterialWetness:onConditionAccrual(ctx)
+    if not self:isArmed() then return end
+    local day = ctx and tonumber(ctx.monotonicDay)
+    if day == nil then return end
+    if self.appliedThroughDay ~= nil and day <= self.appliedThroughDay then return end
+
+    local boundaries = math.floor(tonumber(ctx.boundariesCrossed) or 1)
+    if boundaries < 1 then boundaries = 1 end
+
+    -- The placeable added/removed hook for the shelter cache is a bounced confirm
+    -- (there is no in-house precedent - SCS ships three placeables with no lifecycle
+    -- handling at all). Until it lands, invalidate once per settle so a demolished
+    -- shed's footprint stays dry for at most ONE day rather than forever. That is
+    -- the failure the brief names, bounded rather than left open, and the eventual
+    -- hook simply makes the bound tighter.
+    self:invalidateShelterCache()
+
+    -- CATCH-UP. Skipped days are identifiable from the persisted cursor. Walk them
+    -- oldest-first so each day's verdict is recorded in order.
+    local firstDay = day - boundaries + 1
+    for d = firstDay, day do
+        local isToday = (d == day)
+        self:settleOneDay(d, isToday)
+    end
+
+    self.appliedThroughDay = day
+end
+
+--- Settle a single day. `isToday` selects the live sky; a skipped day is
+--- CLIMATE-DERIVED and says so, the same honesty as humidityDefaulted.
+function MaterialWetness:settleOneDay(dayNumber, isToday)
+    local sky, rain, derived = nil, nil, false
+
+    if isToday then
+        sky  = self:readSky()
+        rain = self:readRainToday()
+    end
+
+    if sky == nil then
+        -- No live sky: fall back to this day's OWN season's climate. A sleep across
+        -- a season turn must not charge every skipped day to the waking season.
+        derived = true
+        -- EACH day to ITS OWN season, never all of them to the waking one.
+        local climate = self:readClimate(self:seasonForDay(dayNumber))
+        if climate == nil then
+            -- No WeatherGuard at all: the accrual HOLDS. No invented sky.
+            SoilLogger.debug("[MaterialWetness] day %s: no sky and no climate - holding", tostring(dayNumber))
+            return
+        end
+        sky = {
+            humidity      = 0.65,
+            temperature   = climate.meanTemp,
+            cloudCoverage = 0.5,
+        }
+        rain = { rainScale = climate.rainDayFraction or 0, isRaining = (climate.rainDayFraction or 0) > 0.5 }
+    end
+
+    self:dryPass(sky)
+    local watered, source = self:wetPass(rain)
+    self:recordDay(dayNumber, watered, source, derived)
+end
+
+--- DRY. Three bands by current value, each with its own subtraction, one filtered
+--- call per band per field. The phase bounds are ENCODED before they reach the
+--- filter, and the pass never aims below the EMC ceiling.
+function MaterialWetness:dryPass(sky)
+    if not self:isArmed() then return 0 end
+    local md = self.materialDown
+    if md == nil or md.enumerateActiveFields == nil then return 0 end
+
+    local humidity = sky and sky.humidity or 0.65
+    if humidity <= 1 then humidity = humidity * 100 end   -- accept 0-1 or 0-100
+    local emcPct  = MaterialWetness.emcFor(humidity, sky and sky.temperature or 15)
+    local emcRaw  = MaterialWetness.pctToRaw(emcPct)
+
+    local calls = 0
+    md:enumerateActiveFields(function(fieldId)
+        local verts = self:fieldVerts(fieldId)
+        if verts == nil then return end
+
+        local soilClass = self:soilClassFor(fieldId)
+        local evap      = MaterialWetness.SOIL_EVAP[soilClass] or 1.0
+        local moisture  = self:readSoilMoisture(fieldId)
+        local weather   = MaterialWetness.weatherMultiplier(sky and sky.cloudCoverage, moisture)
+
+        for _, phase in ipairs(MaterialWetness.PHASES) do
+            local points   = phase.dropPerDay * evap * weather
+            local rawDelta = MaterialWetness.pointsToRawDelta(points)
+            if rawDelta > 0 then
+                -- Bounds encoded FIRST. Raw, not percent.
+                local bandLow  = math.max(MaterialWetness.pctToRaw(phase.pctLow), emcRaw)
+                local bandHigh = MaterialWetness.pctToRaw(phase.pctHigh)
+                local applied = self.valueMaps:applyRawDeltaToPolygonBand(
+                    MaterialWetness.LAYER_KEY, verts, -rawDelta, bandLow, bandHigh,
+                    -- Floor at the EMC ceiling, never at the raw minimum: without
+                    -- this a bound-water step walks a low pixel down into the
+                    -- reserved sentinel band, where it stops being a value and
+                    -- starts reading as a REFUSAL.
+                    { floorTo = math.max(emcRaw, RAW_FLOOR) })
+                if applied == nil then
+                    self:_standDown("the banded delta was refused by the store")
+                    return
+                end
+                calls = calls + 1
+            end
+        end
+    end)
+    return calls
+end
+
+--- WET. Rain across the area, then irrigation per running system. The shelter shape
+--- is subtracted from the wetting call, never used to filter it.
+---@return boolean watered, string source
+function MaterialWetness:wetPass(rain)
+    if not self:isArmed() then return false, "none" end
+
+    local watered, source = false, "none"
+    local fraction = 0
+    if rain ~= nil then
+        fraction = math.max(0, math.min(1, tonumber(rain.rainScale) or 0))
+    end
+
+    if fraction > 0 then
+        local points   = MaterialWetness.RAIN_SETBACK_PER_DAY * fraction
+        local rawDelta = MaterialWetness.pointsToRawDelta(points)
+        if rawDelta > 0 then
+            local md = self.materialDown
+            if md ~= nil and md.enumerateActiveFields ~= nil then
+                md:enumerateActiveFields(function(fieldId)
+                    local verts = self:wettableVerts(fieldId)
+                    if verts == nil then return end
+                    self.valueMaps:applyRawDeltaToPolygonBand(
+                        MaterialWetness.LAYER_KEY, verts, rawDelta, RAW_FLOOR, SoilValueMaps.RAW_MAX)
+                end)
+            end
+            watered, source = true, "rain"
+        end
+    end
+
+    -- IRRIGATION. Gated on the SeasonalCropStress facade extension (getIrrigationSystems
+    -- gaining x/z/radius plus the arrival notice), which is on the ledger and NOT
+    -- built - verified at source 2026-07-31. Until it lands there is no irrigation
+    -- term at all, which is the neutral-when-absent behaviour, not a silent zero.
+    --
+    -- When it does land: one call per RUNNING system over the pivot's real circle at
+    -- rain rate, coefficient 1.0, driven by ARRIVAL NOTICES accumulated per day and
+    -- never by a sampled isActive flag (SCS activation is hourly and ephemeral, so a
+    -- re-fired activation during their load is not an arrival). Irrigation has NO
+    -- catch-up by ruling: skipped days receive none.
+    if self:irrigationAvailable() then
+        SoilLogger.debug("[MaterialWetness] irrigation facade present but the arrival contract is unbuilt")
+    end
+
+    return watered, source
+end
+
+--- True only when the SCS facade carries the geometry this system needs. Checking
+--- the SHAPE rather than the mod's presence, so the term switches itself on the day
+--- the extension ships instead of needing a code change here.
+function MaterialWetness:irrigationAvailable()
+    local cs = cropStress()
+    if cs == nil or cs.getIrrigationSystems == nil then return false end
+    local ok, systems = pcall(function() return cs:getIrrigationSystems() end)
+    if not ok or type(systems) ~= "table" then return false end
+    local first = systems[1]
+    return first ~= nil and first.x ~= nil and first.z ~= nil and first.radius ~= nil
+end
+
+--- RECORD. One verdict per day: did water arrive, from any source. PERSISTED, never
+--- recomputed - the climate roll reads the current season and weather mode, so an
+--- unfrozen past day would quietly change its own answer.
+function MaterialWetness:recordDay(dayNumber, watered, source, derived)
+    if dayNumber == nil then return end
+    if self.waterRecord[dayNumber] ~= nil then return end   -- frozen once written
+
+    self.waterRecord[dayNumber] = {
+        water   = watered == true,
+        source  = source or "none",
+        derived = derived == true,
+    }
+    self.recordDays[#self.recordDays + 1] = dayNumber
+
+    while #self.recordDays > MaterialWetness.WATER_RECORD_DAYS do
+        local oldest = table.remove(self.recordDays, 1)
+        self.waterRecord[oldest] = nil
+    end
+end
+
+--- How many of the last `days` days brought water. The question a spoil rule asks.
+---@return number count, number known  known < days means the record does not reach back that far
+function MaterialWetness:waterDaysInLast(days, throughDay)
+    local n = math.max(1, math.floor(tonumber(days) or 6))
+    local last = tonumber(throughDay) or self.appliedThroughDay
+    if last == nil then return 0, 0 end
+    local count, known = 0, 0
+    for d = last - n + 1, last do
+        local rec = self.waterRecord[d]
+        if rec ~= nil then
+            known = known + 1
+            if rec.water then count = count + 1 end
+        end
+    end
+    return count, known
+end
+
+-- =========================================================
+-- Geometry helpers
+-- =========================================================
+
+function MaterialWetness:fieldVerts(fieldId)
+    local ss = self.soilSystem
+    if ss == nil or ss._getFieldPolyVerts == nil then return nil end
+    local field = ss.fieldData and ss.fieldData[fieldId]
+    local ok, verts = pcall(function() return ss:_getFieldPolyVerts(fieldId, field) end)
+    if not ok or verts == nil or #verts < 3 then return nil end
+    return verts
+end
+
+--- The wetting geometry: the field with sheltered ground subtracted.
+---
+--- v1 subtracts shelter at the WHOLE-FIELD grain: if the field's own sample points
+--- read as indoor the field is skipped, otherwise it wets in full. That is the
+--- honest half of the rule (unverifiable shelter WETS) without pretending to a
+--- sub-field cut-out the point predicate cannot cheaply build. A finer shape is a
+--- refinement, not a correction, and the cache below is already keyed for it.
+function MaterialWetness:wettableVerts(fieldId)
+    local verts = self:fieldVerts(fieldId)
+    if verts == nil then return nil end
+
+    if self.shelterDirty then
+        self.shelterCache = {}
+        self.shelterDirty = false
+    end
+    local cached = self.shelterCache[fieldId]
+    if cached ~= nil then
+        if cached == false then return nil end
+        return verts
+    end
+
+    local sheltered = 0
+    local sampled   = 0
+    for _, v in ipairs(verts) do
+        local indoor = MaterialWetness.isSheltered(v.x, v.z)
+        if indoor ~= nil then
+            sampled = sampled + 1
+            if indoor then sheltered = sheltered + 1 end
+        end
+    end
+    -- Neutral means it WETS: no samples, or a partial reading, and the rain lands.
+    local allSheltered = (sampled > 0 and sheltered == sampled)
+    self.shelterCache[fieldId] = not allSheltered
+    if allSheltered then return nil end
+    return verts
+end
+
+-- =========================================================
+-- The read the members call
+-- =========================================================
+
+function MaterialWetness.bandForPct(pct)
+    for _, band in ipairs(MaterialWetness.BANDS) do
+        if pct >= band.floor then return band.name end
+    end
+    return MaterialWetness.BANDS[#MaterialWetness.BANDS].name
+end
+
+--- Banded condition over a work area, taking the COLLECTED QUANTITY IN LITRES as a
+--- NON-OPTIONAL parameter (the engine hands it back from tipToGroundAroundLine and
+--- every base-game consumer keeps that return).
+---
+--- RULES, each a refusal path rather than a number:
+---   * nil, zero or negative quantity returns the REFUSAL state, never a value.
+---   * any refusing cell in the set makes the WHOLE answer a refusal.
+---   * NEVER built on readAverageOfPolygon. Its written-pixels filter would sum the
+---     sentinel raw into a confident average - and the sentinel decodes to roughly
+---     nine percent, bone-dry - pulling a mixed pickup toward FIT. The filter here
+---     EXCLUDES the sentinel band using the same band parameter the new store method
+---     takes, which is why that method has two uses rather than one.
+---
+--- The two windrow fill types are INSEPARABLE at pickup, so a mixed load is the
+--- NORMAL case and a mass-weighted integral is the only honest answer.
+---@return table { status, pct, band }
+function MaterialWetness:readCondition(verts, litres)
+    local R = MaterialWetness.RESULT
+    if not self:isArmed() then return { status = R.UNAVAILABLE } end
+    if verts == nil or #verts < 3 then return { status = R.UNAVAILABLE } end
+
+    local q = tonumber(litres)
+    if q == nil or q <= 0 then return { status = R.REFUSAL } end
+
+    local vm = self.valueMaps
+    -- Any pixel in the reserved sentinel band makes the whole answer a refusal:
+    -- refusal propagates, it does not average away.
+    local refusing = vm:hasAnyInBand(MaterialWetness.LAYER_KEY, verts, 1, RAW_FLOOR - 1)
+    if refusing == nil then return { status = R.UNAVAILABLE } end
+    if refusing then return { status = R.REFUSAL } end
+
+    local present = vm:hasAnyInBand(MaterialWetness.LAYER_KEY, verts, RAW_FLOOR, SoilValueMaps.RAW_MAX)
+    if present == nil then return { status = R.UNAVAILABLE } end
+    if not present then return { status = R.NO_MATERIAL } end
+
+    -- Mass-weighted mean over the cells that actually carry material. The sentinel
+    -- band is excluded by the filter, so nothing bone-dry-looking can enter the sum.
+    local avg = vm:readAverageRawInBand(MaterialWetness.LAYER_KEY, verts, RAW_FLOOR, SoilValueMaps.RAW_MAX)
+    if avg == nil then return { status = R.UNAVAILABLE } end
+
+    local pct = MaterialWetness.rawToPct(avg)
+    if pct == nil then return { status = R.REFUSAL } end
+    return { status = R.OK, pct = pct, band = MaterialWetness.bandForPct(pct) }
+end
+
+--- MOWER / TEDDER INTERACTION. A mower dropping over existing material is a
+--- MOVEMENT, not a birth: the engine picks hay up and re-drops it as grass, and its
+--- own source comment says so. Without this rule a second cut re-dates AND re-wets a
+--- nearly-ready swath, which is the same laundering the sibling's age rule closes.
+function MaterialWetness:noteMaterialMoved(srcVerts, dstVerts)
+    if not self:isArmed() then return false end
+    if dstVerts == nil or #dstVerts < 3 then return false end
+    if srcVerts == nil or #srcVerts < 3 then return false end
+
+    local vm = self.valueMaps
+    -- Inherit the WETTEST band present in the source, walking down from soaked. The
+    -- wet direction is the conservative one here: calling moved material drier than
+    -- its source is what would let a rake dry a swath for free.
+    for _, band in ipairs(MaterialWetness.BANDS) do
+        local low = MaterialWetness.pctToRaw(band.floor)
+        local present = vm:hasAnyInBand(MaterialWetness.LAYER_KEY, srcVerts, low, SoilValueMaps.RAW_MAX)
+        if present == nil then return false end
+        if present then
+            return vm:setPolygonWhere(MaterialWetness.LAYER_KEY, dstVerts, low, 0, 0)
+        end
+    end
+    return false
+end
+
+-- =========================================================
+-- Persistence (the MaterialWaterBook sidecar; merge-never-replace)
+-- =========================================================
+
+function MaterialWetness:serialize()
+    local days = {}
+    for _, d in ipairs(self.recordDays) do
+        local rec = self.waterRecord[d]
+        if rec ~= nil then
+            days[#days + 1] = { day = d, water = rec.water, source = rec.source, derived = rec.derived }
+        end
+    end
+    return { schema = 1, appliedThroughDay = self.appliedThroughDay, days = days }
+end
+
+--- MERGE, never replace, for the same reason as the sibling: StateLedger omits a
+--- block when serialize fails and cannot tell that from a brand-new save.
+--- A recorded verdict is never overwritten - it was frozen for a reason.
+function MaterialWetness:deserialize(data)
+    if type(data) ~= "table" then return false end
+
+    if type(data.appliedThroughDay) == "number" then
+        if self.appliedThroughDay == nil or data.appliedThroughDay > self.appliedThroughDay then
+            self.appliedThroughDay = data.appliedThroughDay
+        end
+    end
+
+    if type(data.days) == "table" then
+        for _, rec in ipairs(data.days) do
+            if rec.day ~= nil and self.waterRecord[rec.day] == nil then
+                self.waterRecord[rec.day] = {
+                    water   = rec.water == true,
+                    source  = rec.source or "none",
+                    derived = rec.derived == true,
+                }
+                self.recordDays[#self.recordDays + 1] = rec.day
+            end
+        end
+        table.sort(self.recordDays)
+        while #self.recordDays > MaterialWetness.WATER_RECORD_DAYS do
+            local oldest = table.remove(self.recordDays, 1)
+            self.waterRecord[oldest] = nil
+        end
+    end
+    return true
+end
+
+SoilLogger.info("MaterialWetness (SF-49) loaded")

--- a/src/MaterialWetness.lua
+++ b/src/MaterialWetness.lua
@@ -174,6 +174,57 @@ MaterialWetness.BANDS = {
 }
 
 -- =========================================================
+-- Spoil counts (SF-45): a READER parameter, never a layer one
+-- =========================================================
+-- How many separate RAIN-DAYS ruin this material. The counts live HERE, in the
+-- reader, because the layer is material-blind and the collector is the thing that
+-- knows what fill type it just picked up. Putting the count in a layer would make
+-- every future material a store change instead of a table row - which is exactly
+-- the cost the foundation was built to avoid.
+--
+-- RULED 2026-07-31. Straw gets one day more than hay because its value is
+-- STRUCTURAL, not nutritive: a wetting that ruins feed still leaves usable bedding.
+MaterialWetness.SPOIL_RAIN_DAYS = {
+    GRASS_WINDROW    = 3,
+    DRYGRASS_WINDROW = 3,
+    STRAW            = 4,
+}
+
+---@return number|nil rainDays  nil = this material has no spoil rule
+function MaterialWetness.spoilRainDaysFor(fillTypeName)
+    if fillTypeName == nil then return nil end
+    return MaterialWetness.SPOIL_RAIN_DAYS[tostring(fillTypeName):upper()]
+end
+
+--- THE GOING-OFF VERDICT, derived at READ time from the Water Record.
+---
+--- `windowDays` is how far back to look. The hay member passes the material's own
+--- DAYS DOWN, so the question actually asked is "how many rain-days since this was
+--- cut", not "in some fixed recent window". Defaults to the record's full span.
+---
+--- REFUSAL HONESTY: when the record does not reach back across the whole window we
+--- report `known` short of `window` rather than answering from a partial history. A
+--- confident "not spoiled" built on three remembered days out of eight is a lie.
+---@return table { status, spoiled, waterDays, needed, known, window }
+function MaterialWetness:goingOffVerdict(fillTypeName, windowDays, throughDay)
+    local R = MaterialWetness.RESULT
+    local needed = MaterialWetness.spoilRainDaysFor(fillTypeName)
+    if needed == nil then return { status = R.REFUSAL } end
+
+    local window = math.max(1, math.floor(tonumber(windowDays) or MaterialWetness.WATER_RECORD_DAYS))
+    local waterDays, known = self:waterDaysInLast(window, throughDay)
+
+    return {
+        status    = (known >= window) and R.OK or R.REFUSAL,
+        spoiled   = waterDays >= needed,
+        waterDays = waterDays,
+        needed    = needed,
+        known     = known,
+        window    = window,
+    }
+end
+
+-- =========================================================
 -- Construction
 -- =========================================================
 

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1259,6 +1259,14 @@ function SoilFertilityManager:saveSoilData()
     if self.soilSystem.valueMaps then
         self.soilSystem.valueMaps:saveToSavegame(savegamePath)
     end
+
+    -- [SF-43] MATERIAL DOWN's watermark + object sidecar. The age LAYER itself
+    -- persists natively as one of the .grle files just written; only the small
+    -- sidecar needs a home. No-ops when StateLedger is present (the ledger owns the
+    -- state then, so nothing writes it twice).
+    if SoilMaterialDownBridge and self.soilSystem.materialDown then
+        SoilMaterialDownBridge.saveFallback(self.soilSystem.materialDown)
+    end
 end
 
 --- Load soil data from XML file

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -14,6 +14,26 @@ local SoilFertilitySystem_mt = Class(SoilFertilitySystem)
 
 local COVERAGE_MILESTONES = { 0.10, 0.25, 0.50, 0.75, 1.0 }
 
+-- CD-9: Mode of Action → FRAC group mapping for resistance tracking.
+-- Physical fungicides only (generic FUNGICIDE has no MOA).
+-- SULFUR and COPPER_HYDROXIDE are natural/bio (lower max resistance).
+local MODE_FOR_FILLTYPE = {
+    PROPICONAZOLE      = "3",   -- FRAC 3  (triazole)
+    TEBUCONAZOLE       = "3",   -- FRAC 3  (triazole)
+    AZOXYSTROBIN       = "11",  -- FRAC 11 (strobilurin)
+    BOSCALID           = "7",   -- FRAC 7  (SDHI)
+    MANCOZEB           = "M3",  -- FRAC M3 (dithiocarbamate)
+    METALAXYL          = "4",   -- FRAC 4  (phenylamide)
+    SULFUR             = "M2",  -- FRAC M2 (inorganic, natural)
+    COPPER_HYDROXIDE   = "M1",  -- FRAC M1 (inorganic, natural)
+}
+
+-- Set of natural/bio fungicide names (lower max resistance).
+local NATURAL_FUNGICIDE_NAMES = {
+    SULFUR = true,
+    COPPER_HYDROXIDE = true,
+}
+
 -- Resolve a 1-5 setting index to its TUNING LUT value.
 -- Falls back to the index-3 value (the baseline) if the LUT is missing.
 local function getTuningMult(settings, settingId, lutKey)
@@ -21,6 +41,31 @@ local function getTuningMult(settings, settingId, lutKey)
     local lut = SoilConstants.TUNING and SoilConstants.TUNING[lutKey]
     if lut then return lut[idx] or lut[3] or 1.0 end
     return 1.0
+end
+
+--- Invalidate cached polygon vertices for a field when farmland ownership or
+--- geometry may have changed (F61). Forces the next coverage calculation to
+--- re-resolve from the live g_fieldManager rather than using stale cached data.
+---@param field table   self.fieldData[fieldId]
+local function invalidatePolyVerts(field)
+    if field then
+        field._polyVerts = nil
+    end
+end
+
+-- CD-9: Lookup the FRAC group for a fungicide fill type name.
+-- Returns nil for generic FUNGICIDE (no MOA assigned).
+---@param fillTypeName string
+---@return string|nil
+function SoilFertilitySystem.getModeForFillType(fillTypeName)
+    return MODE_FOR_FILLTYPE[fillTypeName]
+end
+
+-- CD-9: True when the fill type is a natural/bio fungicide (lower max resistance).
+---@param fillTypeName string
+---@return boolean
+function SoilFertilitySystem.isNaturalFungicide(fillTypeName)
+    return NATURAL_FUNGICIDE_NAMES[fillTypeName] == true
 end
 
 function SoilFertilitySystem.new(settings)
@@ -741,9 +786,10 @@ function SoilFertilitySystem:onFieldOwnershipChanged(fieldId, farmlandId, farmId
         return
     end
 
-    -- Field acquired - ensure data entry exists, then add to active set.
+    -- F61: invalidate cached poly verts so coverage re-resolves the polygon at next use
     local field = self:getOrCreateField(fieldId, true)
     if field then
+        invalidatePolyVerts(field)
         self:_addToActiveSet(fieldId)
         SoilLogger.debug("[PERF-P1] Field %d acquired by farm %d - added to active set", fieldId, farmId)
     end
@@ -820,6 +866,17 @@ function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType)
         field.weedPressure = math.max(0, field.weedPressure - weedReduction)
         if factor > 0.01 then
             field.herbicideDaysLeft = 0
+        end
+        changed = true
+    end
+
+    -- CD-9: new crop planted → 50% resistance decay (partial reset).
+    -- Resistance never fully resets on planting; the half-life means a resistant
+    -- field stays somewhat resistant going into the new season.
+    if field.resistance then
+        for mode, val in pairs(field.resistance) do
+            field.resistance[mode] = val * 0.5
+            if field.resistance[mode] < 0.01 then field.resistance[mode] = 0 end
         end
         changed = true
     end
@@ -2895,6 +2952,7 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
         activeDiseaseSeverity = 1.0,-- cached yield-severity multiplier for activeDisease
         diseaseDiscovered = false,  -- discovery gate: an active infection stays UNKNOWN in every scout report until deliberately scouted (or revealed by a future dog / ProStaff report)
         lastFungicide = nil,        -- last chemical applied (for resistance / UI flavor)
+        resistance = {},            -- CD-9: { [mode] = score 0..max } per-MOA resistance scores
         dryDayCount = 0,
         nutrientBuffer = {},  -- Tracks [fillTypeIndex] = litersApplied (reset daily)
         zoneData = {},        -- Sparse {cellKey → {N,P,K,pH,OM}} for per-area overlay
@@ -3850,6 +3908,20 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
             -- Route through _applyCompactionDecay so the recovery sticks: shaving
             -- field.compaction alone was wiped by the next per-cell rewrite.
             self:_applyCompactionDecay(field, cp.NATURAL_DECAY_PER_DAY * timeFactor * tunComp)
+        end
+    end
+
+    -- ── CD-9: Per-MOA resistance daily decay ────────────────────────────────
+    -- Each unused month decays resistance scores by 15% (RESISTANCE_DECAY_MONTHLY).
+    -- Calendar-normalized: the per-day multiplier is DECAY^(1/daysPerPeriod) so the
+    -- monthly decay is identical on 1-day and 28-day months.
+    if SoilConstants.RESISTANCE and field.resistance then
+        local decayPerDay = SoilConstants.RESISTANCE.DECAY_MONTHLY ^ (1 / daysPerMonth)
+        for mode, val in pairs(field.resistance) do
+            if val > 0 then
+                field.resistance[mode] = val * decayPerDay
+                if field.resistance[mode] < 0.01 then field.resistance[mode] = 0 end
+            end
         end
     end
 
@@ -5559,6 +5631,24 @@ function SoilFertilitySystem:onFungicideAppliedDirect(fieldId, effectiveness, li
         end
     end
 
+    -- CD-9: Per-MOA resistance build and effectiveness reduction
+    local mode = self.getModeForFillType(chemId)
+    if mode then
+        local isNatural = self.isNaturalFungicide(chemId)
+        local maxRes = isNatural and SoilConstants.RESISTANCE.MAX_NATURAL or SoilConstants.RESISTANCE.MAX_SYNTHETIC
+        local isOrganic = field.organic ~= nil
+            and (field.organic.state == SoilConstants.ORGANIC.STATE_TRANSITION
+                 or field.organic.state == SoilConstants.ORGANIC.STATE_CERTIFIED)
+        if not (isOrganic and not isNatural) then
+            field.resistance[mode] = math.min(maxRes, (field.resistance[mode] or 0)
+                + SoilConstants.RESISTANCE.BUILD_PER_APPLICATION * maxRes)
+        end
+        local resistanceScore = field.resistance[mode] or 0
+        if resistanceScore > 0 then
+            effectiveness = (effectiveness or 1.0) * (1 - resistanceScore / maxRes)
+        end
+    end
+
     -- Confirm field area on first application (mirrors onInsecticideAppliedDirect / applyFertilizer)
     local _isNewSession = not next(field.sessionCoverageCells or {})
     if not field._farmlandAreaConfirmed or _isNewSession then
@@ -6145,6 +6235,16 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             setXMLString(xmlFile, fieldKey .. "#activeDisease", field.activeDisease or "")
             setXMLInt(xmlFile, fieldKey .. "#diseaseDiscovered", field.diseaseDiscovered and 1 or 0)
             setXMLString(xmlFile, fieldKey .. "#lastFungicide", field.lastFungicide or "")
+            -- CD-9: Serialize per-MOA resistance as comma-separated mode:score pairs
+            if field.resistance then
+                local parts = {}
+                for mode, val in pairs(field.resistance) do
+                    if val > 0 then parts[#parts + 1] = mode .. ":" .. val end
+                end
+                if #parts > 0 then
+                    setXMLString(xmlFile, fieldKey .. "#resistance", table.concat(parts, ","))
+                end
+            end
             setXMLInt(xmlFile, fieldKey .. "#dryDayCount", field.dryDayCount or 0)
             setXMLInt(xmlFile, fieldKey .. "#burnDaysLeft", field.burnDaysLeft or 0)
             setXMLInt(xmlFile, fieldKey .. "#lastAlertSeason", field.lastAlertSeason or 0)
@@ -6260,6 +6360,18 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             activeDiseaseSeverity = 1.0,
             diseaseDiscovered = (getXMLInt(xmlFile, fieldKey .. "#diseaseDiscovered") or 0) == 1,
             lastFungicide = getXMLString(xmlFile, fieldKey .. "#lastFungicide"),
+            -- CD-9: Deserialize per-MOA resistance from comma-separated mode:score pairs
+            resistance = (function()
+                local rt = {}
+                local raw = getXMLString(xmlFile, fieldKey .. "#resistance")
+                if raw then
+                    for part in raw:gmatch("([^,]+)") do
+                        local mode, score = part:match("^(.+):([%d.]+)$")
+                        if mode and score then rt[mode] = tonumber(score) or 0 end
+                    end
+                end
+                return rt
+            end)(),
             dryDayCount = getXMLInt(xmlFile, fieldKey .. "#dryDayCount") or 0,
             burnDaysLeft = getXMLInt(xmlFile, fieldKey .. "#burnDaysLeft") or 0,
             amendBurnPenalty = getXMLFloat(xmlFile, fieldKey .. "#amendBurnPenalty") or nil,
@@ -6457,6 +6569,14 @@ function SoilFertilitySystem:getSoilStateTable()
                 insecticideAppliedDay = self.insecticideAppliedDay[fieldId] or 0,
                 fungicideAppliedDay   = self.fungicideAppliedDay[fieldId] or 0,
             }
+            -- CD-9: Per-MOA resistance scores (saved only when populated).
+            if field.resistance and next(field.resistance) then
+                local rt = {}
+                for mode, val in pairs(field.resistance) do
+                    if val > 0 then rt[mode] = val end
+                end
+                if next(rt) then e.resistance = rt end
+            end
             -- Frozen yield only while a freeze is live (matches XML save).
             if field.frozenYieldModifier and field.frozenYieldFruitType then
                 e.frozenYieldModifier  = field.frozenYieldModifier
@@ -6535,6 +6655,7 @@ function SoilFertilitySystem:applySoilStateTable(data)
                 activeDiseaseSeverity = 1.0,
                 diseaseDiscovered     = e.diseaseDiscovered or false,
                 lastFungicide         = e.lastFungicide,
+                resistance = (function() local rt = {}; if e.resistance and type(e.resistance) == "table" then for k, v in pairs(e.resistance) do rt[k] = v end end; return rt end)(),
                 dryDayCount           = e.dryDayCount or 0,
                 burnDaysLeft          = e.burnDaysLeft or 0,
                 amendBurnPenalty      = e.amendBurnPenalty,

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -92,6 +92,9 @@ function SoilFertilitySystem.new(settings)
     -- REFINED: engine bit-vector value maps (~2 m/px, PF-style). Replaces the
     -- 10-40 m zoneData cell grid as the per-pixel truth for N/P/K/pH/OM/compaction.
     self.valueMaps    = SoilValueMaps    and SoilValueMaps.new()    or nil
+    -- [SF-43] MATERIAL DOWN. Created here beside the store it rides on; armed only
+    -- after the store initializes, because arming asserts its layer keys resolved.
+    self.materialDown = MaterialDown     and MaterialDown.new()     or nil
 
     -- Per-day flag table for fertilizer application notifications (fieldId → game day last shown)
     -- Prevents notification spam since the sprayer hook fires every frame while active.
@@ -191,6 +194,15 @@ function SoilFertilitySystem:initialize()
         local savegameDir = g_currentMission and g_currentMission.missionInfo
                             and g_currentMission.missionInfo.savegameDirectory
         self.valueMaps:initialize(savegameDir)
+    end
+
+    -- [SF-43] BIND-TIME SELF-CHECK. Must run AFTER every candidate has loaded and
+    -- AFTER SoilValueMaps:initialize: the community fork declares the same
+    -- SoilValueMaps global with byte-identical filenames and none of our defs, and
+    -- every store method returns early SILENTLY on an unknown key. Without this the
+    -- system would look healthy while recording nothing at all.
+    if self.materialDown then
+        self.materialDown:arm(self.valueMaps)
     end
 
     -- Scan fields using real FieldManager (now runs with layerSystem ready)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -6186,6 +6186,11 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         burnDaysLeft = field.burnDaysLeft or 0,
         amendBurnPenalty = field.amendBurnPenalty or 0,  -- pending lime/OM-on-crop burn (0-1); explains a low yield
         amendBurnRisk = self:isAmendmentBurnRisk(liveFruitTypeIndex, liveGrowthState),  -- (#684) true → liming/manuring NOW would scorch the crop
+        -- [SF50-C1] Growth state of the live crop, additive for the harvester panel's
+        -- yield estimate. nil when no live fruit is detected (bare/cut field), which the
+        -- consumer must read as honest absence, never as a substituted state. Already
+        -- computed above for amendBurnRisk; this only stops throwing it away.
+        growthState = liveGrowthState,
         nutrientBuffer          = field.nutrientBuffer or {},
         coverageFraction        = field.coverageFraction or 0,
         sessionCoverageFraction = field.sessionCoverageFraction or 0,

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -97,6 +97,9 @@ function SoilFertilitySystem.new(settings)
     self.materialDown = MaterialDown     and MaterialDown.new()     or nil
     -- [SF-49] WHAT THE SKY DID. Rides the sibling's machinery; armed after it.
     self.materialWetness = MaterialWetness and MaterialWetness.new() or nil
+    -- [SF-44] THE HAY BET. The settle-pass member that reads condition and
+    -- applies grass-to-hay conversion (once the bounced confirm lands).
+    self.hayBet = HayBet and HayBet.new() or nil
 
     -- Per-day flag table for fertilizer application notifications (fieldId → game day last shown)
     -- Prevents notification spam since the sprayer hook fires every frame while active.
@@ -210,6 +213,10 @@ function SoilFertilitySystem:initialize()
     -- merely present, and refuses to arm if it is not.
     if self.materialWetness then
         self.materialWetness:arm(self.valueMaps, self.materialDown, self)
+    end
+    -- [SF-44] Armed after the condition layer: depends on both sibling systems.
+    if self.hayBet then
+        self.hayBet:arm(self.materialDown, self.materialWetness)
     end
 
     -- Scan fields using real FieldManager (now runs with layerSystem ready)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -100,6 +100,9 @@ function SoilFertilitySystem.new(settings)
     -- [SF-44] THE HAY BET. The settle-pass member that reads condition and
     -- applies grass-to-hay conversion (once the bounced confirm lands).
     self.hayBet = HayBet and HayBet.new() or nil
+    -- [SF-46] THE YARD LADDER. Per-bale condition tracking on the shelter
+    -- ladder, ending in condemnation.
+    self.yardLadder = YardLadder and YardLadder.new() or nil
 
     -- Per-day flag table for fertilizer application notifications (fieldId → game day last shown)
     -- Prevents notification spam since the sprayer hook fires every frame while active.
@@ -217,6 +220,10 @@ function SoilFertilitySystem:initialize()
     -- [SF-44] Armed after the condition layer: depends on both sibling systems.
     if self.hayBet then
         self.hayBet:arm(self.materialDown, self.materialWetness)
+    end
+    -- [SF-46] Armed after HayBet; depends on all three sibling systems.
+    if self.yardLadder then
+        self.yardLadder:arm(self.materialDown, self.materialWetness, self.hayBet)
     end
 
     -- Scan fields using real FieldManager (now runs with layerSystem ready)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -95,6 +95,8 @@ function SoilFertilitySystem.new(settings)
     -- [SF-43] MATERIAL DOWN. Created here beside the store it rides on; armed only
     -- after the store initializes, because arming asserts its layer keys resolved.
     self.materialDown = MaterialDown     and MaterialDown.new()     or nil
+    -- [SF-49] WHAT THE SKY DID. Rides the sibling's machinery; armed after it.
+    self.materialWetness = MaterialWetness and MaterialWetness.new() or nil
 
     -- Per-day flag table for fertilizer application notifications (fieldId → game day last shown)
     -- Prevents notification spam since the sprayer hook fires every frame while active.
@@ -203,6 +205,11 @@ function SoilFertilitySystem:initialize()
     -- system would look healthy while recording nothing at all.
     if self.materialDown then
         self.materialDown:arm(self.valueMaps)
+    end
+    -- [SF-49] Armed after the sibling: it depends on that system being live, not
+    -- merely present, and refuses to arm if it is not.
+    if self.materialWetness then
+        self.materialWetness:arm(self.valueMaps, self.materialDown, self)
     end
 
     -- Scan fields using real FieldManager (now runs with layerSystem ready)

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -278,8 +278,10 @@ end
 --- Pure yield-modifier calculation - the SINGLE source of truth for both the
 --- applied harvest reduction (computeYieldModifier) and the monitor's forecast
 --- (getFieldInfo.yieldEfficiency). Reads explicit N/P/K so callers control the
---- nutrient source; BOTH call sites pass FIELD-AVERAGE values, so the number the
---- monitor shows always equals the grain the combine actually receives.
+--- nutrient source; BOTH call sites pass FIELD-AVERAGE values, so OUR share of the
+--- reduction is identical on the applied and displayed paths. The monitor then
+--- additionally folds in SeasonalCropStress's upstream cut (SCS-002) before showing
+--- a number, because that cut reaches the same grain without passing through here.
 --- Read-only: never mutates field state. The amendment-burn one-shot is consumed
 --- by the real harvest path (computeYieldModifier), not here, so the display can
 --- evaluate it as often as it likes without clearing it.
@@ -431,6 +433,32 @@ function SoilFertilitySystem:_omYieldModifier(field)
     end
 end
 
+--- SCS-002 read: SeasonalCropStress's drought-stress yield keep-factor for a field.
+---
+--- SCS reduces yield on its OWN hook, UPSTREAM of ours: Cutter.processCutterArea
+--- scales spec.workAreaParameters.lastMultiplierArea, which the combine later turns
+--- into the fill delta our hopper hook modifies. The two therefore MULTIPLY, and a
+--- forecast that reports only our own modifier overstates the grain the player
+--- actually receives on any stressed field whenever SCS is installed.
+---
+--- DISPLAY USE ONLY. computeYieldModifier must never include this: SCS applies its
+--- own cut itself, and HarvestContractUnderwrite divides out exactly the value the
+--- hopper hook applied. Folding it into the applied path would double-charge the
+--- player and break the contract top-up in the same stroke.
+---
+--- Pull-only, pcall-guarded, neutral when absent - mirrors the SCS-001 moisture read
+--- in _applyRainLeaching. The function-type guard also keeps us neutral against an
+--- OLDER SCS that predates the getter, so the two mods version-skew safely.
+---@param fieldId number
+---@return number keep  Multiplier in [0,1]; 1.0 when SCS contributes no reduction
+function SoilFertilitySystem:_scsYieldKeepFactor(fieldId)
+    local csMgr = g_currentMission and g_currentMission.cropStressManager
+    if not csMgr or type(csMgr.getYieldKeepFactor) ~= "function" then return 1.0 end
+    local ok, keep = pcall(csMgr.getYieldKeepFactor, csMgr, fieldId)
+    if ok and type(keep) == "number" and keep >= 0.0 and keep <= 1.0 then return keep end
+    return 1.0
+end
+
 --- Forage yield modifier for windrow-drop mowers (#696). Forage crops are gated out of
 --- _yieldModifierFromNutrients via NON_CROP_NAMES (correct - no yield % score for hay), so
 --- the mower path needs its own nutrient read. Uses the "tolerant" tier (matching
@@ -484,10 +512,12 @@ function SoilFertilitySystem:computeYieldModifier(fieldId, fruitTypeIndex)
     local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
     local cropName  = fruitDesc and (fruitDesc.name or "") or ""
 
-    -- Single source of truth: the applied reduction is driven by FIELD-AVERAGE
-    -- nutrients. getFieldInfo()'s monitor forecast calls this same helper with the
-    -- same field-average values, so the displayed "Yield eff." always equals the
-    -- grain the hopper actually receives.
+    -- Single source of truth for OUR reduction: driven by FIELD-AVERAGE nutrients.
+    -- getFieldInfo()'s monitor forecast calls this same helper with the same
+    -- field-average values, so SF's own share of the cut is identical on both paths.
+    -- The monitor additionally multiplies in SeasonalCropStress's keep-factor
+    -- (SCS-002) - deliberately NOT done here, because SCS applies that cut itself
+    -- upstream and HarvestContractUnderwrite inverts exactly what we return.
     local modifier = self:_yieldModifierFromNutrients(
         field, cropName, field.nitrogen, field.phosphorus, field.potassium, fieldId)
 
@@ -4303,8 +4333,9 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
 
     -- Refresh the field-uniform yield value painted into the soilYield layer.
     -- getFieldInfo returns the SAME field-average yield % shown on the Soil Monitor
-    -- and applied by the combine hook, so the map layer can never disagree with the
-    -- grain you harvest. No managed crop (fallow/grass) → 0 (renders empty).
+    -- (our modifier, plus any upstream ecosystem cut it folds in - see SCS-002), so
+    -- the map layer can never disagree with the monitor or with the grain you
+    -- harvest. No managed crop (fallow/grass) → 0 (renders empty).
     do
         local yinfo = self:getFieldInfo(fieldId)
         field.yieldEfficiency = (yinfo and yinfo.yieldEfficiency) or 0
@@ -6052,7 +6083,9 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
     local cropLowerInfo = cropName and string.lower(cropName) or ""
     local isNonCropField = nonCrops[cropLowerInfo]
 
-    -- Yield efficiency forecast - MUST equal the grain the combine actually receives.
+    -- Yield efficiency forecast - MUST equal the grain the combine actually receives,
+    -- which means OUR modifier AND any upstream reduction another ecosystem mod applies
+    -- to the same grain (currently SeasonalCropStress; folded in below as SCS-002).
     -- The applied reduction (computeYieldModifier) is driven by FIELD-AVERAGE nutrients
     -- and frozen for the duration of a harvest pass, so this forecast does the same:
     --   * during an active harvest of this crop -> return the frozen applied value, so
@@ -6076,6 +6109,11 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
             local avgK = field.potassium  or SoilConstants.FIELD_DEFAULTS.potassium
             mod = self:_yieldModifierFromNutrients(field, cropName, avgN, avgP, avgK, nil)
         end
+        -- SCS-002: fold in SeasonalCropStress's own upstream drought cut so the number
+        -- the player reads is the COMBINED reduction, not just our share of it. Applies
+        -- to the frozen branch too - SCS's cut runs live during the pass regardless of
+        -- our freeze. Exactly 1.0 (byte-identical to before) when SCS is absent.
+        mod = mod * self:_scsYieldKeepFactor(fieldId)
         yieldEfficiency = math.floor(mod * 100 + 0.5)
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -5458,7 +5458,26 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
     if not overlayOnly then
         -- Mark this field as geometrically tracked so trackSprayerCoverage's guard knows
         -- the cell-dedup path is actually updating coverage fractions (#753).
-        field._geometricCoverageOwner = true
+        --
+        -- F61 (VWW half of #650): claim ownership ONLY once at least one cell has
+        -- actually been accepted. Claiming unconditionally is what freezes coverage on a
+        -- multi-field farmland: _getFieldPolyVerts resolves the FIRST field polygon on the
+        -- farmland, so on the OTHER field every boom-cell centre fails _isPointInPoly and
+        -- nothing accrues -- yet the flag was still set, and the guard at :5226 then locked
+        -- out the liter fallback for the rest of the session. Coverage and Pass% sat at 0%
+        -- and the 80% PROTECTION_THRESHOLD never opened, which is the reported symptom.
+        --
+        -- Gating on the cell set makes the degradation correct instead: no accepted cells
+        -- means the geometric path is not tracking anything, so the liter fallback stays
+        -- available exactly as it does for a non-VWW implement. When the polygon IS right
+        -- the first accepted cell claims ownership on the same call as before, so the
+        -- healthy path is unchanged and there is still no double-count.
+        --
+        -- next() is O(1) and sessionCoverageCells is already cleared at every site that
+        -- clears _geometricCoverageOwner, so this needs no new state to keep in sync.
+        if next(field.sessionCoverageCells) ~= nil then
+            field._geometricCoverageOwner = true
+        end
         field.coverageFraction        = math.min(1.0, (field.coveredAreaHa  or 0) / areaInHa)
         field.sessionCoverageFraction = math.min(1.0, (field.sessionCoverageHa or 0) / areaInHa)
 

--- a/src/YardLadder.lua
+++ b/src/YardLadder.lua
@@ -439,6 +439,14 @@ function YardLadder:onLadderPass(ctx)
     -- one that cannot condemn a yard on evidence we do not have.
     local wetDays, dryDays = self:_splitSpan(boundaries, day)
 
+    -- THE PASS SAYS IT RAN, and it has to. Every day pass in this family was silent:
+    -- the age tick, the condition accrual and this one all did their work and printed
+    -- nothing. So when two bales survived a skipped year there was no way to tell
+    -- "the pass never fired" from "it fired and the span was wrong" from "the days
+    -- never advanced". One line ends that ambiguity for good.
+    SoilLogger.debug("[YardLadder] pass: day=%d boundaries=%d wet=%d dry=%d rows=%d",
+        day, boundaries, wetDays, dryDays, #due)
+
     for _, item in ipairs(due) do
         local ok, err = pcall(function()
             self:_processRow(item.token, item.row, day, wetDays, dryDays)
@@ -502,7 +510,11 @@ function YardLadder:_processRow(token, row, day, wetDays, dryDays)
     -- makes, and the honest one, since a bale that had moved would have failed dwell.
     local rate = (wetDays or 0) * R.WET_OUTDOOR + (dryDays or 0) * R.DRY_OUTDOOR
     local shelter = self:_shelterMultiplier(x, z)
-    row.condition = (row.condition or 0) + rate * shelter
+    local before = row.condition or 0
+    row.condition = before + rate * shelter
+
+    SoilLogger.debug("[YardLadder] %s: %.1f -> %.1f (+%.1f, shelter x%.2f)",
+        token, before, row.condition, rate * shelter, shelter)
 
     if row.condition >= R.CONDEMN_AT then
         self:_condemn(token, row, live)

--- a/src/YardLadder.lua
+++ b/src/YardLadder.lua
@@ -59,10 +59,56 @@ YardLadder.RATES = {
     DWELL_EPSILON   = 0.5,   -- metres, the stationary test
 }
 
--- The birth stub, indexed by the ENGINE'S OWN 1-based season (Season.SPRING is 1,
--- the same basis MaterialWetness:currentSeason1Based reads). Percent wetness, not
--- ladder units. Deleted when the hay member's ground read covers every birth.
-YardLadder.SEASONAL_BIRTH = { 65, 55, 70, 75 }
+-- THE BIRTH AXIS, RULED BY ARISSANI 2026-07-30. This is the mapping the first cut
+-- guessed at and this member refused to invent.
+--
+-- A bale made from FIT material is born at ZERO. The penalty is for how far ABOVE the
+-- safe-baling line the material was WHEN IT WAS BALED, which is the actual mistake a
+-- real farmer makes and the entire reason a fit line exists.
+--
+--   condition = max(0, wetnessPct - FIT_PCT) x PER_POINT_ABOVE_FIT
+--
+-- ONE POINT ABOVE THE LINE COSTS ONE WET-DAY EQUIVALENT, so the handicap is expressed
+-- in terms of the wet rate rather than as a second free-standing number: if the ladder
+-- is ever retuned the handicap follows it, which is what "wet-day equivalent" means.
+--
+-- Walking it against the ruled ladder, which is how the dial was set:
+--   baled at 20 -> 0    a full wet week to going off
+--   baled at 25 -> 30   going off inside two wet days
+--   baled at 27 -> 42   born already going off
+--   baled at 30 -> 60   condemned inside a week
+--
+-- Deliberately unforgiving: hay baled at 27 percent moulds within a week in a real
+-- yard, and a gentler curve would say baling wet costs almost nothing, which is false.
+-- Flagged as a DIAL rather than a derivation. If it plays too harsh it is one number.
+--
+-- The fit line itself is agronomy-fixed rather than taste: the published safe-baling
+-- line is 18 to 20 and 20 is the generous edge of safe. Read from the hay member so
+-- there is one fit line in the mod, not two.
+YardLadder.FIT_PCT_FALLBACK = 20
+
+function YardLadder.fitPct()
+    if HayBet ~= nil and type(HayBet.FIT_PCT) == "number" then return HayBet.FIT_PCT end
+    return YardLadder.FIT_PCT_FALLBACK
+end
+
+--- The ruled birth mapping. Wetness percent in, ladder units out.
+---
+--- A NIL WETNESS IS NOT A ZERO WETNESS, BUT IT IS A ZERO CONDITION. A bale we have no
+--- record for (bought, pre-existing on an upgraded save, or otherwise never watched)
+--- opens at zero, because a bale we cannot vouch for is not pre-condemned on a guess.
+--- That is this family's refusal-honesty rule pointed at its own birth event, and it
+--- is why the old seasonal table is gone: those four numbers were a WETNESS estimate
+--- and were never a condition.
+---@param wetnessPct number|nil
+---@return number condition
+function YardLadder.birthCondition(wetnessPct)
+    local pct = tonumber(wetnessPct)
+    if pct == nil then return 0 end
+    local over = pct - YardLadder.fitPct()
+    if over <= 0 then return 0 end
+    return over * YardLadder.RATES.WET_OUTDOOR
+end
 
 -- Condition bands. Names, not numbers, so a balance pass moves the edges without
 -- touching a consumer. Mirrors the sibling's BANDS convention.
@@ -214,14 +260,13 @@ function YardLadder:onBaleCreated(nodeId, bale, fillTypeName, fillLevel, farmId,
             tostring(farmId), tostring(fillTypeName), tostring(capacity), stranded)
     end
 
-    local wetnessPct, isStub = self:_birthWetness(nodeId, fillLevel)
+    local wetnessPct = self:_birthWetness(nodeId, fillLevel)
     local token = self:_mintToken()
 
     -- DATA ONLY. Nothing here may be a live reference or a scenegraph handle.
     local row = {
-        condition       = 0,          -- ladder units; see the birth-axis note at the top
-        birthWetnessPct = wetnessPct,
-        birthStub       = isStub,
+        condition       = YardLadder.birthCondition(wetnessPct),
+        birthWetnessPct = wetnessPct,   -- published in its own right, never the ladder
         farmId          = farmId or 0,
         fillTypeName    = fillTypeName or "UNKNOWN",
         capacity        = capacity or 0,
@@ -231,9 +276,9 @@ function YardLadder:onBaleCreated(nodeId, bale, fillTypeName, fillLevel, farmId,
     if not md:createObjectRecord(token, row) then return end
     self:_attach(token, nodeId, bale)
 
-    SoilLogger.debug("[YardLadder] birth %s node=%s farm=%s fill=%s cap=%s wetness=%.1f%s",
+    SoilLogger.debug("[YardLadder] birth %s node=%s farm=%s fill=%s cap=%s wetness=%s condition=%.1f",
         token, tostring(nodeId), tostring(farmId), tostring(fillTypeName), tostring(capacity),
-        wetnessPct or -1, isStub and " (stub)" or "")
+        wetnessPct ~= nil and string.format("%.1f", wetnessPct) or "unknown", row.condition)
 
     self:publishWetnessAtBaling(token, fillTypeName, wetnessPct)
 end
@@ -287,7 +332,7 @@ end
 
 --- The birth read. Ground band when the hay member and the sky member are both live,
 --- the seasonal stub otherwise.
----@return number|nil wetnessPct, boolean isStub
+---@return number|nil wetnessPct  nil means NO RECORD, which is not a wetness of zero
 function YardLadder:_birthWetness(nodeId, fillLevel)
     local mw = self.materialWetness
     if mw ~= nil and mw:isArmed()
@@ -306,14 +351,15 @@ function YardLadder:_birthWetness(nodeId, fillLevel)
             }
             local c = mw:readCondition(verts, fillLevel)
             if c ~= nil and c.status == MaterialWetness.RESULT.OK then
-                return c.pct, false
+                return c.pct
             end
-            -- REFUSAL PROPAGATES. A refused read is not a zero and not a default: it
-            -- falls through to the stub, which is a stated starting value rather than
-            -- an invented reading.
+            -- REFUSAL PROPAGATES, and now it propagates all the way out as NIL.
         end
     end
-    return self:_seasonalBirthWetness(), true
+    -- NO RECORD. Not a wetness of zero, not a seasonal guess: unknown. The caller
+    -- opens such a bale at zero condition, per the ruling, because a bale we cannot
+    -- vouch for must not be pre-condemned on an estimate.
+    return nil
 end
 
 --- Today, for stamping a birth. The accrual's ctx.monotonicDay is the authority on
@@ -326,14 +372,11 @@ function YardLadder:_today()
     return tonumber(day) or 0
 end
 
-function YardLadder:_seasonalBirthWetness()
-    local env = g_currentMission and g_currentMission.environment
-    local season = env and env.currentSeason
-    if type(season) == "number" and YardLadder.SEASONAL_BIRTH[season] ~= nil then
-        return YardLadder.SEASONAL_BIRTH[season]
-    end
-    return nil
-end
+-- The seasonal birth stub (spring 65 / summer 55 / autumn 70 / winter 75) is DELETED,
+-- not disabled. Its brief said "deleted when the hay member lands", the hay member has
+-- landed, and the birth-axis ruling settled what it was standing in for: those four
+-- numbers were a WETNESS estimate and were never a condition. A bale with no record
+-- opens at zero.
 
 -- =========================================================
 -- Death

--- a/src/YardLadder.lua
+++ b/src/YardLadder.lua
@@ -1,0 +1,562 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - THE YARD LADDER (SF-46)
+-- =========================================================
+-- An unwrapped bale left out goes off. Condition, never a fill
+-- bleed: this member holds a per-bale CONDITION record in the
+-- delivered object ledger, accrues it on a shelter ladder once
+-- per day, pauses it under wrap, reads it as bands into the feed
+-- chain, and ends it in ONE server-authoritative condemnation
+-- event.
+--
+-- The condemnation write (fillLevel 0 then delete) is the ONLY
+-- write this member makes to a bale's fill state.
+--
+-- SERVER ONLY. Rows ride MaterialDown's object-ledger mechanism
+-- (StateLedger table, OPAQUE OWNER TOKEN, enumerate-not-list).
+--
+-- TWO THINGS THE BRIEF ASSUMED AND THE ENGINE DOES NOT PROVIDE,
+-- both honoured in their honest half rather than faked:
+--
+--   1. THE ENCLOSED TIER. The ruled ladder has three rungs
+--      (outdoors 1.0, roof 0.15x, enclosed 0). The engine's
+--      shelter predicate is BINARY: indoorMask has INDOOR and
+--      OUTDOOR and nothing between (verified against the LUADOC;
+--      no three-state predicate exists anywhere in the reference).
+--      So v1 ships TWO rungs and an unverifiable enclosure is
+--      charged the ROOF rate, never zero. That is the same
+--      direction the sibling's rule takes when shelter cannot be
+--      proven: unverifiable cover does not earn the benefit. A
+--      free rung would stop a yard's condition dead on evidence
+--      the engine never gave us.
+--
+--   2. THE BIRTH AXIS. The birth read returns a WETNESS PERCENT.
+--      The ladder accrues CONDITION UNITS. The brief never states
+--      the mapping between them, and they cannot be the same
+--      number: the ruled horizons (going-off about a wet week at
+--      40 units, condemned about 2.5 wet weeks at 100) only hold
+--      if condition starts at zero, whereas the seasonal stub
+--      would open a winter bale at 75, already past going-off and
+--      four wet days from condemnation. So birth wetness is
+--      RECORDED and PUBLISHED as its own quantity and does not
+--      seed the ladder. Picking the curve that joins them is a
+--      design call, not an implementation one; it is on the
+--      ledger for Arissani.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class YardLadder
+YardLadder = {}
+local YardLadder_mt = Class(YardLadder)
+
+-- Ruled numbers (SF-46 brief, NUMBERS ADDENDUM 2026-07-31).
+YardLadder.RATES = {
+    WET_OUTDOOR     = 6,     -- condition units per wet outdoor day
+    DRY_OUTDOOR     = 1,     -- condition units per dry outdoor day
+    ROOF_MULTIPLIER = 0.15,  -- open roof, corrected from the 0.4 placeholder
+    GOING_OFF_AT    = 40,    -- units: the going-off band opens
+    CONDEMN_AT      = 100,   -- units: terminal
+    DWELL_EPSILON   = 0.5,   -- metres, the stationary test
+}
+
+-- The birth stub, indexed by the ENGINE'S OWN 1-based season (Season.SPRING is 1,
+-- the same basis MaterialWetness:currentSeason1Based reads). Percent wetness, not
+-- ladder units. Deleted when the hay member's ground read covers every birth.
+YardLadder.SEASONAL_BIRTH = { 65, 55, 70, 75 }
+
+-- Condition bands. Names, not numbers, so a balance pass moves the edges without
+-- touching a consumer. Mirrors the sibling's BANDS convention.
+YardLadder.BAND = {
+    FRESH     = "fresh",
+    GOING_OFF = "goingOff",
+    CONDEMNED = "condemned",
+}
+
+local TOKEN_PREFIX = "yl_"
+
+-- =========================================================
+-- Construction
+-- =========================================================
+
+function YardLadder.new()
+    local self = setmetatable({}, YardLadder_mt)
+    self.materialDown    = nil
+    self.materialWetness = nil
+    self.hayBet          = nil
+    self.armed           = false
+
+    -- TRANSIENT STATE, owned here and NEVER placed in a ledger record.
+    -- MaterialDown:serialize copies records wholesale into the StateLedger table, so
+    -- a live Bale reference parked on a record would be handed to the serializer. The
+    -- record carries data; everything that cannot survive a save lives in this table.
+    self._live    = {}   -- token -> { nodeId, bale, lastPosX, lastPosZ, lastCheckDay }
+    self._byNode  = {}   -- nodeId -> token
+    self._nextId  = 1
+    self._orphanReported = false
+    return self
+end
+
+---@param materialDown    MaterialDown
+---@param materialWetness MaterialWetness|nil
+---@param hayBet          HayBet|nil
+function YardLadder:arm(materialDown, materialWetness, hayBet)
+    self.armed = false
+    if materialDown == nil or not materialDown:isArmed() then
+        SoilLogger.info("[YardLadder] MaterialDown not armed - standing down")
+        return false
+    end
+    self.materialDown    = materialDown
+    self.materialWetness = materialWetness  -- may be nil (SF-49 absent)
+    self.hayBet          = hayBet           -- may be nil (SF-44 absent)
+    self.armed           = true
+
+    -- The token counter must clear every token already in the ledger, or a reload
+    -- would mint a token that collides with a surviving row.
+    self:_seedTokenCounter()
+
+    local R = YardLadder.RATES
+    SoilLogger.info("[OK] YardLadder armed (wet=%d/d dry=%d/d roof=x%.2f goingOff=%d condemn=%d)",
+        R.WET_OUTDOOR, R.DRY_OUTDOOR, R.ROOF_MULTIPLIER, R.GOING_OFF_AT, R.CONDEMN_AT)
+
+    -- The optional boot-time RealisticWeather presence line (Arissani's, TAKEN in the
+    -- brief's status line). RW rots bales too; when a player reports a vanished bale
+    -- this line plus our one condemnation line is how the two are told apart.
+    if g_modIsLoaded ~= nil and g_modIsLoaded["FS25_RealisticWeather"] then
+        SoilLogger.info("[YardLadder] RealisticWeather present: it deletes bales too, so read the CONDEMN line before attributing one to us")
+    end
+    return true
+end
+
+function YardLadder:isArmed()
+    return self.armed
+end
+
+--- Walk the surviving rows so a fresh token can never collide with a loaded one.
+function YardLadder:_seedTokenCounter()
+    local highest = 0
+    self.materialDown:enumerateObjects(function(token)
+        local n = YardLadder._tokenSerial(token)
+        if n ~= nil and n > highest then highest = n end
+    end)
+    self._nextId = highest + 1
+end
+
+-- =========================================================
+-- Tokens
+-- =========================================================
+-- OPAQUE and MINTED, never derived from the bale.
+--
+-- The obvious key is the bale's nodeId, and it is wrong: scenegraph node ids are not
+-- stable across a save and reload. A nodeId token would orphan every row the moment
+-- the game restarted, hand each reloaded bale a fresh condition, and leave the dead
+-- rows in the savegame forever. The token is minted here and the nodeId lives in the
+-- transient index instead.
+
+function YardLadder._tokenSerial(token)
+    if type(token) ~= "string" then return nil end
+    if token:sub(1, #TOKEN_PREFIX) ~= TOKEN_PREFIX then return nil end
+    return tonumber(token:sub(#TOKEN_PREFIX + 1))
+end
+
+function YardLadder._isOurToken(token)
+    return YardLadder._tokenSerial(token) ~= nil
+end
+
+function YardLadder:_mintToken()
+    local token = TOKEN_PREFIX .. tostring(self._nextId)
+    self._nextId = self._nextId + 1
+    return token
+end
+
+-- =========================================================
+-- Birth, and the re-attach that shares its door
+-- =========================================================
+
+--- A bale entered the world. Either it is one of ours coming back (reload, or
+--- PlaceableObjectStorage handing it out again) or it is new.
+---
+--- THE RE-ATTACH IS NOT STORAGE-SPECIFIC ON PURPOSE. The brief scopes the heuristic to
+--- PlaceableObjectStorage, but storage is only one of the two doors a known bale comes
+--- back through; a savegame reload is the other, and it is the common one. Both arrive
+--- here as "a bale appeared and may already have a row", so both take the same path.
+---@param nodeId       number   bale scenegraph node
+---@param bale         table    live bale object
+---@param fillTypeName string
+---@param fillLevel    number   litres, the newborn bale's own
+---@param farmId       number
+---@param capacity     number
+function YardLadder:onBaleCreated(nodeId, bale, fillTypeName, fillLevel, farmId, capacity)
+    if not self:isArmed() then return end
+    if g_server == nil then return end
+    if nodeId == nil then return end
+    local md = self.materialDown
+    if md == nil then return end
+
+    -- Same node twice (a double register, or our own hook re-entered) is a no-op.
+    if self._byNode[nodeId] ~= nil then return end
+
+    local existing = self:_findUnattachedMatch(farmId, fillTypeName, capacity)
+    if existing ~= nil then
+        self:_attach(existing, nodeId, bale)
+        local row = md:getObjectRecord(existing)
+        SoilLogger.debug("[YardLadder] re-attached %s to node %s (condition %.1f)",
+            existing, tostring(nodeId), (row and row.condition) or 0)
+        return
+    end
+
+    -- No candidate. ACCEPT AND LOG, never silently fresh: if there were unattached
+    -- rows and none matched, the bale keeps its fresh row but the mismatch is said out
+    -- loud, because that is the line that tells us the heuristic key is too narrow.
+    local stranded = self:_countUnattached()
+    if stranded > 0 and not self._orphanReported then
+        self._orphanReported = true
+        SoilLogger.info("[YardLadder] no row matched an arriving bale (farm=%s fill=%s cap=%s); %d row(s) still unattached, accepting as new",
+            tostring(farmId), tostring(fillTypeName), tostring(capacity), stranded)
+    end
+
+    local wetnessPct, isStub = self:_birthWetness(nodeId, fillLevel)
+    local token = self:_mintToken()
+
+    -- DATA ONLY. Nothing here may be a live reference or a scenegraph handle.
+    local row = {
+        condition       = 0,          -- ladder units; see the birth-axis note at the top
+        birthWetnessPct = wetnessPct,
+        birthStub       = isStub,
+        farmId          = farmId or 0,
+        fillTypeName    = fillTypeName or "UNKNOWN",
+        capacity        = capacity or 0,
+        bornDay         = self:_today(),
+    }
+
+    if not md:createObjectRecord(token, row) then return end
+    self:_attach(token, nodeId, bale)
+
+    SoilLogger.debug("[YardLadder] birth %s node=%s farm=%s fill=%s cap=%s wetness=%.1f%s",
+        token, tostring(nodeId), tostring(farmId), tostring(fillTypeName), tostring(capacity),
+        wetnessPct or -1, isStub and " (stub)" or "")
+
+    self:publishWetnessAtBaling(token, fillTypeName, wetnessPct)
+end
+
+--- Heuristic key: farm + fill type + capacity, oldest row first so the choice is
+--- deterministic. Rows sharing all three are interchangeable except for condition, so
+--- picking among them cannot be wrong in any way a player could observe.
+function YardLadder:_findUnattachedMatch(farmId, fillTypeName, capacity)
+    local best, bestBorn = nil, nil
+    self.materialDown:enumerateObjects(function(token, row)
+        if not YardLadder._isOurToken(token) then return end
+        if self._live[token] ~= nil then return end
+        if type(row) ~= "table" then return end
+        if row.farmId ~= (farmId or 0) then return end
+        if row.fillTypeName ~= (fillTypeName or "UNKNOWN") then return end
+        if math.abs((row.capacity or 0) - (capacity or 0)) > 1 then return end
+        local born = row.bornDay or 0
+        if bestBorn == nil or born < bestBorn then
+            best, bestBorn = token, born
+        end
+    end)
+    return best
+end
+
+function YardLadder:_countUnattached()
+    local n = 0
+    self.materialDown:enumerateObjects(function(token)
+        if YardLadder._isOurToken(token) and self._live[token] == nil then n = n + 1 end
+    end)
+    return n
+end
+
+function YardLadder:_attach(token, nodeId, bale)
+    self._live[token] = {
+        nodeId       = nodeId,
+        bale         = bale,
+        lastPosX     = nil,
+        lastPosZ     = nil,
+        lastCheckDay = nil,
+    }
+    self._byNode[nodeId] = token
+end
+
+function YardLadder:_detach(token)
+    local live = self._live[token]
+    if live ~= nil and live.nodeId ~= nil then
+        self._byNode[live.nodeId] = nil
+    end
+    self._live[token] = nil
+end
+
+--- The birth read. Ground band when the hay member and the sky member are both live,
+--- the seasonal stub otherwise.
+---@return number|nil wetnessPct, boolean isStub
+function YardLadder:_birthWetness(nodeId, fillLevel)
+    local mw = self.materialWetness
+    if mw ~= nil and mw:isArmed()
+       and self.hayBet ~= nil and self.hayBet:isArmed()
+       and entityExists ~= nil and entityExists(nodeId) then
+        local ok, x, _, z = pcall(getWorldTranslation, nodeId)
+        if ok and x ~= nil then
+            -- A one-metre square under the bale. LITRES IS NON-OPTIONAL and the
+            -- newborn bale's own fill level is the quantity the brief names; a nil or
+            -- zero here is a caller bug and readCondition correctly refuses it.
+            local verts = {
+                { x = x - 0.5, z = z - 0.5 },
+                { x = x + 0.5, z = z - 0.5 },
+                { x = x + 0.5, z = z + 0.5 },
+                { x = x - 0.5, z = z + 0.5 },
+            }
+            local c = mw:readCondition(verts, fillLevel)
+            if c ~= nil and c.status == MaterialWetness.RESULT.OK then
+                return c.pct, false
+            end
+            -- REFUSAL PROPAGATES. A refused read is not a zero and not a default: it
+            -- falls through to the stub, which is a stated starting value rather than
+            -- an invented reading.
+        end
+    end
+    return self:_seasonalBirthWetness(), true
+end
+
+--- Today, for stamping a birth. The accrual's ctx.monotonicDay is the authority on
+--- the pass itself; this is only for rows born between passes, so it reads the same
+--- basis the engine exposes as a FIELD (currentMonotonicDay). There is no documented
+--- getDay() method and this member does not invent one.
+function YardLadder:_today()
+    local env = g_currentMission and g_currentMission.environment
+    local day = env and env.currentMonotonicDay
+    return tonumber(day) or 0
+end
+
+function YardLadder:_seasonalBirthWetness()
+    local env = g_currentMission and g_currentMission.environment
+    local season = env and env.currentSeason
+    if type(season) == "number" and YardLadder.SEASONAL_BIRTH[season] ~= nil then
+        return YardLadder.SEASONAL_BIRTH[season]
+    end
+    return nil
+end
+
+-- =========================================================
+-- Death
+-- =========================================================
+
+--- A bale left the world: sold, fed out, mixed, condemned by us, condemned by
+--- RealisticWeather, or taken by the engine's bale cap. One door for all of them.
+function YardLadder:onBaleRemoved(nodeId)
+    if not self:isArmed() then return end
+    if g_server == nil then return end
+    if nodeId == nil then return end
+    local token = self._byNode[nodeId]
+    if token == nil then return end
+    self:_detach(token)
+    if self.materialDown ~= nil then
+        self.materialDown:removeObjectRecord(token)
+    end
+end
+
+-- =========================================================
+-- The daily ladder pass
+-- =========================================================
+
+--- One Time Guard accrual, day cadence, on the everything-else slot (never the age
+--- tick). Enumerates OUR rows and only ours. Cost is linear in ledger rows and makes
+--- no engine pass at all, so it does not move the family's measured millisecond bill.
+function YardLadder:onLadderPass(ctx)
+    if not self:isArmed() then return end
+    if g_server == nil then return end
+    local md = self.materialDown
+    if md == nil then return end
+
+    local day = ctx and tonumber(ctx.monotonicDay)
+    if day == nil then return end
+
+    -- Collected first: condemnation mutates the ledger, and mutating a table while
+    -- pairs() walks it is undefined in Lua 5.1.
+    local due = {}
+    md:enumerateObjects(function(token, row)
+        if YardLadder._isOurToken(token) and type(row) == "table" then
+            due[#due + 1] = { token = token, row = row }
+        end
+    end)
+
+    local wet = self:_isDayWet(day)
+    for _, item in ipairs(due) do
+        local ok, err = pcall(function() self:_processRow(item.token, item.row, day, wet) end)
+        if not ok then
+            SoilLogger.warning("[YardLadder] row %s failed its pass: %s", item.token, tostring(err))
+        end
+    end
+end
+
+function YardLadder:_processRow(token, row, day, dayIsWet)
+    local live = self._live[token]
+
+    -- Unattached: the row survived a save but no bale has claimed it back yet. It
+    -- cannot be located, so it cannot accrue. It is NOT deleted either, because the
+    -- bale may still be inside a PlaceableObjectStorage waiting to be handed out.
+    if live == nil then return end
+
+    -- The node may have gone without our delete hook seeing it. entityExists is the
+    -- documented guard; getWorldTranslation on a dead node is not safe to call.
+    if entityExists == nil or not entityExists(live.nodeId) then
+        self:onBaleRemoved(live.nodeId)
+        return
+    end
+
+    -- WRAP IS ABSOLUTE ARMOUR IN V1 (ratification call b, resolved 2026-07-31). While
+    -- the engine's own fermentation clock runs, ours does not: one clock per bale.
+    if self:_isFermenting(live.bale) then return end
+
+    local ok, x, _, z = pcall(getWorldTranslation, live.nodeId)
+    if not ok or x == nil then return end
+
+    -- DWELL AT DAY GRAIN. A bale that moved since yesterday's sample was in transit
+    -- and accrues nothing, so a hauled load is never charged for the trip. A parked
+    -- trailer is stationary and does accrue, which is the case the rule is for.
+    local moved = false
+    if live.lastPosX ~= nil and live.lastCheckDay ~= nil and live.lastCheckDay ~= day then
+        local dx, dz = x - live.lastPosX, z - live.lastPosZ
+        local eps = YardLadder.RATES.DWELL_EPSILON
+        moved = (dx * dx + dz * dz) > (eps * eps)
+    end
+
+    live.lastPosX, live.lastPosZ, live.lastCheckDay = x, z, day
+    if moved then return end
+
+    local R = YardLadder.RATES
+    local rate = dayIsWet and R.WET_OUTDOOR or R.DRY_OUTDOOR
+    local shelter = self:_shelterMultiplier(x, z)
+    row.condition = (row.condition or 0) + rate * shelter
+
+    if row.condition >= R.CONDEMN_AT then
+        self:_condemn(token, row, live)
+    end
+end
+
+--- Outdoors full rate, under cover the roof rate. See the enclosed-tier note at the
+--- top of the file: the engine's predicate is binary, so there is no third rung to
+--- read, and cover we cannot verify is charged rather than exempted.
+function YardLadder:_shelterMultiplier(x, z)
+    if MaterialWetness == nil or MaterialWetness.isSheltered == nil then return 1.0 end
+    local sheltered = MaterialWetness.isSheltered(x, z)
+    -- nil means the mask is unavailable, and the invariant is neutral-when-absent:
+    -- no mask reads as outdoors.
+    if sheltered == true then return YardLadder.RATES.ROOF_MULTIPLIER end
+    return 1.0
+end
+
+--- Was this day a wet one? The sky member's Water Record is the only source; there is
+--- no documented per-day rainfall getter on Environment and this member does not
+--- invent one.
+---
+--- known == 0 means the record does not reach back to that day. That is a refusal, and
+--- a refusal is not a wet day: it takes the DRY rate, which is the neutral-when-absent
+--- direction and cannot condemn a yard on missing evidence.
+function YardLadder:_isDayWet(day)
+    local mw = self.materialWetness
+    if mw == nil or not mw:isArmed() then return false end
+    local ok, count, known = pcall(mw.waterDaysInLast, mw, 1, day)
+    if not ok or known == nil or known < 1 then return false end
+    return (count or 0) > 0
+end
+
+function YardLadder:_isFermenting(bale)
+    if bale == nil then return false end
+    local bm = g_currentMission and g_currentMission.baleManager
+    if bm == nil or bm.getFermentationTime == nil then return false end
+    local ok, t = pcall(bm.getFermentationTime, bm, bale)
+    return ok and t ~= nil
+end
+
+-- =========================================================
+-- Condemnation
+-- =========================================================
+
+--- ONE server-authoritative event, ONE attributable log line. RealisticWeather deletes
+--- bales as well, so this line is the only way a player report naming a vanished bale
+--- can be told apart from theirs. It stays at info level for that reason.
+function YardLadder:_condemn(token, row, live)
+    SoilLogger.info("[YardLadder] CONDEMN %s: farm=%s fill=%s cap=%s condition=%.1f (SoilFertilizer removed this bale)",
+        token, tostring(row.farmId), tostring(row.fillTypeName), tostring(row.capacity), row.condition or 0)
+
+    local bale = live and live.bale
+
+    -- The row dies first so the delete hook cannot re-enter and act on a live row.
+    self:_detach(token)
+    self.materialDown:removeObjectRecord(token)
+
+    if bale == nil or bale.delete == nil then
+        -- Reached terminal condition with no object to act on. Say so rather than
+        -- leaving a silently immortal bale behind: the row is gone, the bale is not.
+        SoilLogger.warning("[YardLadder] %s hit terminal condition with no live bale reference - row dropped, bale left in world", token)
+        return
+    end
+
+    -- MixerWagon.md:896/:898 idiom: empty it, then delete it.
+    pcall(function()
+        if bale.setFillLevel ~= nil then bale:setFillLevel(0) end
+        bale:delete()
+    end)
+end
+
+-- =========================================================
+-- The read: bands, never a raw number
+-- =========================================================
+
+--- The feed chain's read. Bands are the contract; the unit count behind them is ours.
+---@return string|nil band, number|nil condition
+function YardLadder:getConditionBand(token)
+    if not self:isArmed() or self.materialDown == nil then return nil end
+    local row = self.materialDown:getObjectRecord(token)
+    if type(row) ~= "table" then return nil end
+    local c = row.condition or 0
+    local R = YardLadder.RATES
+    if c >= R.CONDEMN_AT then return YardLadder.BAND.CONDEMNED, c end
+    if c >= R.GOING_OFF_AT then return YardLadder.BAND.GOING_OFF, c end
+    return YardLadder.BAND.FRESH, c
+end
+
+--- The same read addressed by the thing a caller actually holds: a bale node.
+function YardLadder:getConditionBandForNode(nodeId)
+    local token = self._byNode[nodeId]
+    if token == nil then return nil end
+    return self:getConditionBand(token)
+end
+
+-- =========================================================
+-- Publications
+-- =========================================================
+-- PUBLISH ONLY. DairyCore is the sole writer of Feed Provenance and this member never
+-- writes it. The input-spec rider on this brief carries both of these onto the Feed
+-- Provenance brief; until that lands there is no consumer, so the publication is a
+-- message-centre emit plus a line, and the shape is what the rider will bind to.
+
+YardLadder.MESSAGE_WETNESS_AT_BALING = "SoilFertilizer_YardLadder_wetnessAtBaling"
+YardLadder.MESSAGE_CONDITION_AT_FEED = "SoilFertilizer_YardLadder_conditionAtFeed"
+
+function YardLadder:publishWetnessAtBaling(token, fillTypeName, wetnessPct)
+    if wetnessPct == nil then return end
+    SoilLogger.debug("[YardLadder] publish wetness-at-baling: %s fill=%s wetness=%.1f",
+        tostring(token), tostring(fillTypeName), wetnessPct)
+    if g_messageCenter ~= nil and g_messageCenter.publish ~= nil then
+        pcall(function()
+            g_messageCenter:publish(YardLadder.MESSAGE_WETNESS_AT_BALING, token, fillTypeName, wetnessPct)
+        end)
+    end
+end
+
+--- Called at feeding by the feed chain. Publishes the BAND, not the unit count.
+function YardLadder:publishConditionAtFeed(nodeId)
+    local band, condition = self:getConditionBandForNode(nodeId)
+    if band == nil then return nil end
+    SoilLogger.debug("[YardLadder] publish condition-at-feed: node=%s band=%s condition=%.1f",
+        tostring(nodeId), band, condition or 0)
+    if g_messageCenter ~= nil and g_messageCenter.publish ~= nil then
+        pcall(function()
+            g_messageCenter:publish(YardLadder.MESSAGE_CONDITION_AT_FEED, nodeId, band, condition)
+        end)
+    end
+    return band
+end
+
+---- End of file
+SoilLogger.info("YardLadder (SF-46) loaded")

--- a/src/YardLadder.lua
+++ b/src/YardLadder.lua
@@ -412,6 +412,17 @@ function YardLadder:onLadderPass(ctx)
     local day = ctx and tonumber(ctx.monotonicDay)
     if day == nil then return end
 
+    -- HOW MANY DAYS ACTUALLY PASSED, not how many settles fired.
+    --
+    -- A tablet time-skip crosses months in one settle. Both siblings already read
+    -- this: MaterialDown ages the layer by the full span and MaterialWetness applies
+    -- the whole weather window. This member did not, so it charged ONE day per skip
+    -- no matter how long the skip was, and a bale left in a yard survived a simulated
+    -- year at a cost of one dry day. Observed in game 2026-07-31: two bales outdoors
+    -- across roughly a year, still there, untouched.
+    local boundaries = math.floor(tonumber(ctx.boundariesCrossed) or 1)
+    if boundaries < 1 then boundaries = 1 end
+
     -- Collected first: condemnation mutates the ledger, and mutating a table while
     -- pairs() walks it is undefined in Lua 5.1.
     local due = {}
@@ -421,16 +432,35 @@ function YardLadder:onLadderPass(ctx)
         end
     end)
 
-    local wet = self:_isDayWet(day)
+    -- Split the crossed span into wet and dry days ONCE, from the Water Record, rather
+    -- than asking per bale. `waterDaysInLast` returns how many of the last N days
+    -- brought water and how many of those N it actually has a record for; days it
+    -- cannot reach count as DRY, which is the neutral-when-absent direction and is the
+    -- one that cannot condemn a yard on evidence we do not have.
+    local wetDays, dryDays = self:_splitSpan(boundaries, day)
+
     for _, item in ipairs(due) do
-        local ok, err = pcall(function() self:_processRow(item.token, item.row, day, wet) end)
+        local ok, err = pcall(function()
+            self:_processRow(item.token, item.row, day, wetDays, dryDays)
+        end)
         if not ok then
             SoilLogger.warning("[YardLadder] row %s failed its pass: %s", item.token, tostring(err))
         end
     end
 end
 
-function YardLadder:_processRow(token, row, day, dayIsWet)
+--- How many of the `span` days ending at `throughDay` were wet, and how many dry.
+---@return number wetDays, number dryDays
+function YardLadder:_splitSpan(span, throughDay)
+    local mw = self.materialWetness
+    if mw == nil or not mw:isArmed() then return 0, span end
+    local ok, count = pcall(mw.waterDaysInLast, mw, span, throughDay)
+    if not ok or type(count) ~= "number" then return 0, span end
+    if count > span then count = span end
+    return count, span - count
+end
+
+function YardLadder:_processRow(token, row, day, wetDays, dryDays)
     local live = self._live[token]
 
     -- Unattached: the row survived a save but no bale has claimed it back yet. It
@@ -466,7 +496,11 @@ function YardLadder:_processRow(token, row, day, dayIsWet)
     if moved then return end
 
     local R = YardLadder.RATES
-    local rate = dayIsWet and R.WET_OUTDOOR or R.DRY_OUTDOOR
+    -- The whole crossed span at once. SHELTER IS SAMPLED ONCE, HERE, and applied to
+    -- the span: we know where the bale is now and have no record of where it stood on
+    -- each skipped day. That is the same assumption the dwell check above already
+    -- makes, and the honest one, since a bale that had moved would have failed dwell.
+    local rate = (wetDays or 0) * R.WET_OUTDOOR + (dryDays or 0) * R.DRY_OUTDOOR
     local shelter = self:_shelterMultiplier(x, z)
     row.condition = (row.condition or 0) + rate * shelter
 
@@ -485,21 +519,6 @@ function YardLadder:_shelterMultiplier(x, z)
     -- no mask reads as outdoors.
     if sheltered == true then return YardLadder.RATES.ROOF_MULTIPLIER end
     return 1.0
-end
-
---- Was this day a wet one? The sky member's Water Record is the only source; there is
---- no documented per-day rainfall getter on Environment and this member does not
---- invent one.
----
---- known == 0 means the record does not reach back to that day. That is a refusal, and
---- a refusal is not a wet day: it takes the DRY rate, which is the neutral-when-absent
---- direction and cannot condemn a yard on missing evidence.
-function YardLadder:_isDayWet(day)
-    local mw = self.materialWetness
-    if mw == nil or not mw:isArmed() then return false end
-    local ok, count, known = pcall(mw.waterDaysInLast, mw, 1, day)
-    if not ok or known == nil or known < 1 then return false end
-    return (count or 0) > 0
 end
 
 function YardLadder:_isFermenting(bale)

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -1740,10 +1740,26 @@ SoilConstants.SEE_AND_SPRAY = {
 -- ========================================
 -- Per-section rate multiplier derived from the nutrient deficit at each section's soil cell.
 -- The manual rate setting acts as a ceiling; variable rate cannot exceed it.
+-- CD-9: Per-MOA disease resistance tuning values
+-- RESISTANCE_BUILD_PER_APPLICATION: fractional immunity gained per full-rate pass of one MOA
+-- RESISTANCE_DECAY_MONTHLY: multiplier applied per unused month (calendar-normalized)
+-- HYBRID_THRESHOLD: resistance level at which ≥2 modes triggers hybrid onset
+-- RESISTANCE_MAX_SYNTHETIC: ceiling for synthetic MOA scores (10 = 100% immunity)
+-- RESISTANCE_MAX_NATURAL: ceiling for natural/bio MOA scores (5 = 50% immunity)
+SoilConstants.RESISTANCE = {
+    BUILD_PER_APPLICATION = 0.05,
+    DECAY_MONTHLY         = 0.85,
+    HYBRID_THRESHOLD      = 0.7,
+    MAX_SYNTHETIC         = 10,
+    MAX_NATURAL           = 5,
+}
+
 SoilConstants.VARIABLE_RATE = {
     NUTRIENT_TARGET = 70,     -- "well stocked" level - same as Smart Sensor NUTRIENT_TARGET
     MIN_RATE        = 0.30,   -- minimum multiplier (field at or above target → light top-up pass)
     MAX_RATE        = 1.50,   -- maximum multiplier (completely depleted cell)
+    PH_OPTIMAL      = 6.5,   -- optimal pH target (reuse NUTRIENT_LIMITS.PH_OPTIMAL)
+    PH_CURVE_FLOOR  = 5.0,   -- max rate at pH <= floor (reuse NUTRIENT_LIMITS.PH_MIN)
 }
 
 -- ========================================

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -2868,7 +2868,14 @@ function HookManager:installTedderHook()
         local maxX = math.max(xs, xw, xh, x4)
         local minZ = math.min(zs, zw, zh, z4)
         local maxZ = math.max(zs, zw, zh, z4)
-        return { minX, minZ, maxX, minZ, maxX, maxZ, minX, maxZ }
+        -- {x=,z=} objects, the store contract. See buildWorkAreaPolygon at the top of
+        -- this file for what a flat array costs.
+        return {
+            { x = minX, z = minZ },
+            { x = maxX, z = minZ },
+            { x = maxX, z = maxZ },
+            { x = minX, z = maxZ },
+        }
     end
 
     --- Create a delegating wrapper for one tedder instance.

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1477,6 +1477,7 @@ function HookManager:installVariableRateHook()
     local kFerts   = {}   -- K-only (POTASH, etc.)
     local npkFerts = {}   -- multi-nutrient (all N/P/K fertilizers)
     local omFerts  = {}   -- OM-primary (compost, manure, digestate - target organic matter)
+    local limeFerts = {}  -- pH-raising products (LIME, LIQUIDLIME)
 
     local profs = SoilConstants.FERTILIZER_PROFILES
     local omPrimarySet = SoilConstants.SPRAYER_RATE and SoilConstants.SPRAYER_RATE.OM_PRIMARY_PRODUCTS
@@ -1493,6 +1494,9 @@ function HookManager:installVariableRateHook()
             end
             if omPrimarySet and omPrimarySet[name] then
                 omFerts[name] = true
+            end
+            if prof.pH and prof.pH > 0 then
+                limeFerts[name] = true
             end
         end
     end
@@ -1547,15 +1551,16 @@ function HookManager:installVariableRateHook()
             if ft and ssNames[ft.name] then
                 return
             end
-            if not ft or (not npkFerts[ft.name] and not omFerts[ft.name]) then
+            if not ft or (not npkFerts[ft.name] and not omFerts[ft.name] and not limeFerts[ft.name]) then
                 sensorMgr:clearSectionRates(vehicleId)
                 return
             end
 
-            local isN   = nFerts[ft.name]  == true
-            local isP   = pFerts[ft.name]  == true
-            local isK   = kFerts[ft.name]  == true
-            local isOM  = omFerts[ft.name] == true
+            local isN    = nFerts[ft.name]   == true
+            local isP    = pFerts[ft.name]   == true
+            local isK    = kFerts[ft.name]   == true
+            local isOM   = omFerts[ft.name]  == true
+            local isLime = limeFerts[ft.name] == true
 
             -- Manual rate ceiling
             local rm = sfm.sprayerRateManager
@@ -1608,6 +1613,11 @@ function HookManager:installVariableRateHook()
                                 nutrientVal = readAt("phosphorus") or fd.phosphorus or target
                             elseif isK then
                                 nutrientVal = readAt("potassium") or fd.potassium or target
+                            elseif isLime then
+                                local cellPH = readAt("pH") or fd.pH
+                                local deficit = math.max(0, vrCfg.PH_OPTIMAL - cellPH) / (vrCfg.PH_OPTIMAL - vrCfg.PH_CURVE_FLOOR)
+                                if deficit > 1 then deficit = 1 end
+                                rate = vrCfg.MIN_RATE + deficit * (vrCfg.MAX_RATE - vrCfg.MIN_RATE)
                             else
                                 -- Complex NPK: use worst (lowest) of the three
                                 local n = readAt("nitrogen")   or fd.nitrogen   or target
@@ -1616,8 +1626,10 @@ function HookManager:installVariableRateHook()
                                 nutrientVal = math.min(n, p, k)
                             end
 
-                            local deficit = math.max(0, effTarget - nutrientVal) / effTarget
-                            rate = vrCfg.MIN_RATE + deficit * (vrCfg.MAX_RATE - vrCfg.MIN_RATE)
+                            if not isLime then
+                                local deficit = math.max(0, effTarget - nutrientVal) / effTarget
+                                rate = vrCfg.MIN_RATE + deficit * (vrCfg.MAX_RATE - vrCfg.MIN_RATE)
+                            end
                         end
                     end
 
@@ -2963,6 +2975,15 @@ function HookManager:installSprayerAreaHook()
                 local _hasCropProt = herbEffectiveness or pestEffectiveness or diseaseEffectiveness
                 local _useLitCov = (not isFertilizer) or (isFertilizer and _hasCropProt)
                 if g_SoilFertilityManager.soilSystem then
+                    local _vwwEarly = self.spec_variableWorkWidth
+                    local _hasVWWEarly = _vwwEarly and _vwwEarly.sections and #_vwwEarly.sections > 0
+                    -- F61: for non-VWW implements using liter-based coverage, clear stale
+                    -- _geometricCoverageOwner so a previous VWW session's guard does not
+                    -- block the liter path (line 5123 in trackSprayerCoverage).
+                    if not _hasVWWEarly and g_SoilFertilityManager.soilSystem.fieldData
+                       and g_SoilFertilityManager.soilSystem.fieldData[fieldId] then
+                        g_SoilFertilityManager.soilSystem.fieldData[fieldId]._geometricCoverageOwner = nil
+                    end
                     g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, _useLitCov)
                 end
 
@@ -3269,6 +3290,11 @@ function HookManager:installSprayerAreaHook()
                         -- protection products already did so in the trackSprayerCoverage call
                         -- above (updateFractions = not isFertilizer), so don't double-count.
                         if liters > 0 and isFertilizer then
+                            -- F61: clear stale geometric owner flag so the liter-based fallback
+                            -- is not blocked by a previous VWW session's guard (line 5123).
+                            if soilSys.fieldData and soilSys.fieldData[fieldId] then
+                                soilSys.fieldData[fieldId]._geometricCoverageOwner = nil
+                            end
                             soilSys:trackSprayerCoverage(fieldId, liters, fillType.name, true)
                         end
                     end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -211,6 +211,13 @@ function HookManager:installAll(soilSystem)
     local tedderOk = self:installTedderHook()
     if tedderOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
+    -- Bale birth and death hooks (SF-46 "THE YARD LADDER"): per-bale condition rows
+    local baleBirthOk = self:installBaleBirthHook()
+    if baleBirthOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    local baleDeleteOk = self:installBaleDeleteHook()
+    if baleDeleteOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
     -- Fertilizer application hook (covers ALL sprayers + spreaders via Sprayer specialization)
     local sprayerAreaOk = self:installSprayerAreaHook()
     if sprayerAreaOk then successCount = successCount + 1 else failCount = failCount + 1 end
@@ -2916,6 +2923,118 @@ function HookManager:installTedderHook()
     end
 
     SoilLogger.info("[OK] Tedder hook installed (instance-level, %d existing tedders patched)", patchedCount)
+    return true
+end
+
+-- =========================================================
+-- HOOK 1f: Bale birth and death (SF-46 "THE YARD LADDER")
+-- =========================================================
+-- Two hooks on Bale's own lifecycle, both on methods the LUADOC shows BaleManager
+-- calling on bale instances (Bale:register at BaleManager.md:154, Bale:delete inherited
+-- and shown at PackedBale.md:36).
+--
+-- CLASS-LEVEL ASSIGNMENT IS CORRECT HERE, and it is worth saying why, because the
+-- opposite is true two hooks up. The tedder hook must go on at instance level because
+-- SpecializationUtil.registerFunction copies the function pointer into each vehicle
+-- type's table, so a later class assignment patches a table nobody reads. A Bale is an
+-- Object, not a Vehicle: it has no specializations and instances resolve through the
+-- class table by metatable, so patching the class is what instances actually see.
+
+--- Resolve the yard ladder, or nil when it is not available to take an event.
+local function getArmedYardLadder()
+    local sfm = g_SoilFertilityManager
+    if sfm == nil or sfm.soilSystem == nil then return nil end
+    if sfm.settings == nil or not sfm.settings.enabled then return nil end
+    local yl = sfm.soilSystem.yardLadder
+    if yl == nil or not yl:isArmed() then return nil end
+    return yl
+end
+
+--- Hooks Bale.register for the yard ladder's per-bale condition rows. Catches every
+--- door a bale enters the world through: baler spawn, packed-bale unpacking, console
+--- creation, PlaceableObjectStorage retrieval, and savegame load.
+---@return boolean success
+function HookManager:installBaleBirthHook()
+    if Bale == nil or type(Bale.register) ~= "function" then
+        SoilLogger.warning("[BaleBirth] Bale.register not available - yard ladder birth hook skipped")
+        return false
+    end
+
+    local origRegister = Bale.register
+    Bale.register = function(baleSelf, ...)
+        -- DELEGATE FIRST, always. The bale must be fully registered before we read a
+        -- thing off it, and our failure must never be able to stop a bale existing.
+        local results = { origRegister(baleSelf, ...) }
+
+        local yl = getArmedYardLadder()
+        if yl ~= nil then
+            pcall(function()
+                local nodeId = baleSelf.nodeId
+                if nodeId == nil then return end
+
+                local ftName = "UNKNOWN"
+                if baleSelf.getFillType ~= nil and g_fillTypeManager ~= nil then
+                    local ftIdx = baleSelf:getFillType()
+                    if ftIdx ~= nil and ftIdx > 0 then
+                        local ft = g_fillTypeManager:getFillTypeByIndex(ftIdx)
+                        if ft ~= nil then ftName = ft.name end
+                    end
+                end
+
+                local fillLevel = 0
+                if baleSelf.getFillLevel ~= nil then
+                    fillLevel = baleSelf:getFillLevel() or 0
+                end
+
+                -- Capacity is a REAL getter (PackedBale.md:207), and it matters: it is
+                -- one third of the re-attach heuristic key, so a fill-level stand-in
+                -- would make the key drift every time a bale was partly used.
+                local capacity = fillLevel
+                if baleSelf.getCapacity ~= nil then
+                    capacity = baleSelf:getCapacity() or fillLevel
+                end
+
+                local farmId = 0
+                if baleSelf.getOwnerFarmId ~= nil then
+                    farmId = baleSelf:getOwnerFarmId() or 0
+                end
+
+                yl:onBaleCreated(nodeId, baleSelf, ftName, fillLevel, farmId, capacity)
+            end)
+        end
+
+        return unpack(results)
+    end
+
+    SoilLogger.info("[OK] Bale birth hook installed (Bale.register)")
+    return true
+end
+
+--- Hooks Bale.delete so a row dies with its bale. ONE door for every way a bale
+--- leaves: sale, feeding out, mixing, our own condemnation, RealisticWeather's
+--- deletion, and the engine bale cap. The brief lists those separately and notes the
+--- cap's internals are unexamined; hooking the single exit means we never had to
+--- examine them.
+---@return boolean success
+function HookManager:installBaleDeleteHook()
+    if Bale == nil or type(Bale.delete) ~= "function" then
+        SoilLogger.warning("[BaleDeath] Bale.delete not available - yard ladder rows will rely on the entityExists sweep")
+        return false
+    end
+
+    local origDelete = Bale.delete
+    Bale.delete = function(baleSelf, ...)
+        -- Read the node BEFORE delegating: after the base call the node is gone.
+        local yl = getArmedYardLadder()
+        if yl ~= nil then
+            pcall(function()
+                if baleSelf.nodeId ~= nil then yl:onBaleRemoved(baleSelf.nodeId) end
+            end)
+        end
+        return origDelete(baleSelf, ...)
+    end
+
+    SoilLogger.info("[OK] Bale delete hook installed (Bale.delete)")
     return true
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -29,9 +29,18 @@ end
 --- Overestimates slightly (may include non-cut area at swath edges), but the
 --- RAW_NO_RECORD filter in setPolygonWhere makes it safe: unrecorded pixels
 --- get born, already-recorded pixels are untouched.
+--- THE VERTEX SHAPE IS THE CONTRACT, and it is {x=,z=} objects, NOT a flat array.
+--- Everything downstream reads `v.x` and `v.z`: setPolygonRegion at
+--- SoilValueMaps.lua:527, isPointInPoly, and the field polygons
+--- SoilFertilitySystem:_getFieldPolyVerts builds. A flat {x1,z1,...} array does not
+--- merely fail to write, it INDEXES A NUMBER inside setPolygonRegion's pcall, and
+--- that handler treats any failure as "the engine has no polygon ops" and latches
+--- hasPolygonOps=false on the SHARED store for the rest of the session. One mown
+--- verge would have taken the age layer, the wetness layer and the yard ladder down
+--- together, with a single warning line to show for it.
 ---@param vehicle table  the vehicle (Mower, Combine, etc.)
 ---@param areaType number  WorkAreaType constant (e.g. WorkAreaType.MOWER)
----@return table|nil  flat vertex array {x1,z1, x2,z2, ...} or nil
+---@return table|nil  vertex array {{x=,z=}, ...} or nil
 local function buildWorkAreaPolygon(vehicle, areaType)
     local ok, workAreas = pcall(function()
         return vehicle:getTypedWorkAreas(areaType)
@@ -60,7 +69,12 @@ local function buildWorkAreaPolygon(vehicle, areaType)
         end
     end
     if minX == nil then return nil end
-    return { minX, minZ, maxX, minZ, maxX, maxZ, minX, maxZ }
+    return {
+        { x = minX, z = minZ },
+        { x = maxX, z = minZ },
+        { x = maxX, z = maxZ },
+        { x = minX, z = maxZ },
+    }
 end
 
 --- Resolve the windrow fill type name from a fruit type index.
@@ -2333,7 +2347,7 @@ function HookManager:installHarvestHook()
                 end)
 
                 -- [MATERIAL DOWN BIRTH] Record straw deposition when the combine
-                -- is in swath mode. Runs regardless of nutrientCycles — the straw
+                -- is in swath mode. Runs regardless of nutrientCycles - the straw
                 -- birth gate is `md:isArmed()`, not a settings toggle.
                 if detectedFieldId and detectedFieldId > 0 then
                     pcall(function()
@@ -2667,11 +2681,11 @@ function HookManager:installMowerHook()
                     if waPoly then
                         -- Polygon centre for field lookup (avoids header-vs-tractor offset)
                         local cx, cz = 0, 0
-                        for i = 1, #waPoly, 2 do
-                            cx = cx + waPoly[i]
-                            cz = cz + waPoly[i + 1]
+                        for _, v in ipairs(waPoly) do
+                            cx = cx + v.x
+                            cz = cz + v.z
                         end
-                        local n = #waPoly / 2
+                        local n = #waPoly
                         cx, cz = cx / n, cz / n
 
                         local fieldId = hookMgrRef:getFieldIdAtWorldPosition(cx, cz)
@@ -2689,7 +2703,7 @@ function HookManager:installMowerHook()
                 end
             end
 
-            -- [NUTRIENT CYCLES] Existing nutrient depletion — gated on setting
+            -- [NUTRIENT CYCLES] Existing nutrient depletion - gated on setting
             if not g_SoilFertilityManager.settings.nutrientCycles then return end
 
             local success, errorMsg = pcall(function()
@@ -2817,12 +2831,12 @@ function HookManager:installMowerYieldHook()
 end
 
 -- =========================================================
--- HOOK 1e: Tedder (hay drying acceleration — SF-44 "THE HAY BET")
+-- HOOK 1e: Tedder (hay drying acceleration - SF-44 "THE HAY BET")
 -- =========================================================
 --- Instance-level delegating wrapper on Tedder.processTedderArea.
 --- Applies the hay bet's one-time drying delta and enqueues a
 --- corrective pass at end of frame. Never a class-level assignment
---- (the brief rules it explicitly) — each existing tedder instance
+--- (the brief rules it explicitly) - each existing tedder instance
 --- is patched at install time, and VehicleSystem.addVehicle is
 --- hooked to catch new spawns.
 ---@return boolean success
@@ -2866,7 +2880,7 @@ function HookManager:installTedderHook()
             local results = { realFn(tedderSelf, workArea, dt) }
 
             -- HAY BET: apply drying delta + enqueue correction
-            -- Server only — no client-side material logic
+            -- Server only - no client-side material logic
             if not tedderSelf.isServer then
                 return unpack(results)
             end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -18,6 +18,61 @@ function HookManager.new()
     return self
 end
 
+-- =========================================================
+-- Material birth geometry helpers
+-- =========================================================
+-- [SF-43/SF-44] These build polygon vertices from vehicle work areas for the
+-- birth observation hook. Called from the mower and combine hooks below.
+
+--- Build a bounding-box polygon from a vehicle's typed work areas. The polygon
+--- is the axis-aligned bounding rectangle of ALL work areas of the given type.
+--- Overestimates slightly (may include non-cut area at swath edges), but the
+--- RAW_NO_RECORD filter in setPolygonWhere makes it safe: unrecorded pixels
+--- get born, already-recorded pixels are untouched.
+---@param vehicle table  the vehicle (Mower, Combine, etc.)
+---@param areaType number  WorkAreaType constant (e.g. WorkAreaType.MOWER)
+---@return table|nil  flat vertex array {x1,z1, x2,z2, ...} or nil
+local function buildWorkAreaPolygon(vehicle, areaType)
+    local ok, workAreas = pcall(function()
+        return vehicle:getTypedWorkAreas(areaType)
+    end)
+    if not ok or not workAreas or #workAreas == 0 then return nil end
+
+    local minX, maxX, minZ, maxZ
+    for _, wa in ipairs(workAreas) do
+        if wa.start and wa.width and wa.height then
+            local xs, _, zs = getWorldTranslation(wa.start)
+            local xw, _, zw = getWorldTranslation(wa.width)
+            local xh, _, zh = getWorldTranslation(wa.height)
+            if xs and xw and xh then
+                -- Fourth corner of the parallelogram: width + height - start
+                local x4 = xw + xh - xs
+                local z4 = zw + zh - zs
+                for _, xv in ipairs({ xs, xw, xh, x4 }) do
+                    if minX == nil or xv < minX then minX = xv end
+                    if maxX == nil or xv > maxX then maxX = xv end
+                end
+                for _, zv in ipairs({ zs, zw, zh, z4 }) do
+                    if minZ == nil or zv < minZ then minZ = zv end
+                    if maxZ == nil or zv > maxZ then maxZ = zv end
+                end
+            end
+        end
+    end
+    if minX == nil then return nil end
+    return { minX, minZ, maxX, minZ, maxX, maxZ, minX, maxZ }
+end
+
+--- Resolve the windrow fill type name from a fruit type index.
+--- FS25 windrow fill types follow the pattern FRUITNAME_WINDROW.
+---@param fruitTypeIndex number
+---@return string|nil
+local function fruitTypeToWindrowName(fruitTypeIndex)
+    local ft = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    if not ft or not ft.name then return nil end
+    return tostring(ft.name):upper() .. "_WINDROW"
+end
+
 --- Helper to get field ID from world coordinates
 ---@param x number World X coordinate
 ---@param z number World Z coordinate
@@ -151,6 +206,10 @@ function HookManager:installAll(soilSystem)
     -- Mower yield hook (#696): windrow output scales with soil nutrients via conversionFactor
     local mowerYieldOk = self:installMowerYieldHook()
     if mowerYieldOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    -- Tedder hook (SF-44 "THE HAY BET"): hay drying acceleration + corrective queue
+    local tedderOk = self:installTedderHook()
+    if tedderOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
     -- Fertilizer application hook (covers ALL sprayers + spreaders via Sprayer specialization)
     local sprayerAreaOk = self:installSprayerAreaHook()
@@ -2184,11 +2243,14 @@ function HookManager:installHarvestHook()
             -- The crop is deposited on the ground rather than collected in the hopper.
             -- We still deplete nutrients (the soil grew the biomass regardless of collection method);
             -- updateFieldNutrients handles the liters=0 case via area-based estimation.
+            -- Field detection for nutrient depletion + straw birth.
+            -- NOTE: straw birth does NOT gate on nutrientCycles: a player who turns
+            -- nutrient cycling off should still get straw that remembers when it was
+            -- cut (Arissani ruling 2026-07-30). The birth uses the same detection.
             if combineSelf.isServer
                 and g_SoilFertilityManager
                 and g_SoilFertilityManager.soilSystem
                 and g_SoilFertilityManager.settings.enabled
-                and g_SoilFertilityManager.settings.nutrientCycles
                 and inputFruitType and inputFruitType > 0
                 and area and area > 0
             then
@@ -2263,14 +2325,39 @@ function HookManager:installHarvestHook()
                         fieldId, inputFruitType, area)
                 end)
 
+                -- [MATERIAL DOWN BIRTH] Record straw deposition when the combine
+                -- is in swath mode. Runs regardless of nutrientCycles — the straw
+                -- birth gate is `md:isArmed()`, not a settings toggle.
+                if detectedFieldId and detectedFieldId > 0 then
+                    pcall(function()
+                        local md = g_SoilFertilityManager.soilSystem.materialDown
+                        if not md or not md:isArmed() then return end
+
+                        -- Only record straw when the combine is depositing a swath
+                        local isSwath = false
+                        if combineSelf.getIsSwathActive then
+                            isSwath = combineSelf:getIsSwathActive()
+                        end
+                        if not isSwath then return end
+                        if not strawRatio or strawRatio <= 0 then return end
+
+                        -- Build polygon from the header's cutter work areas
+                        local waPoly = buildWorkAreaPolygon(combineSelf, WorkAreaType.CUTTER)
+                        if not waPoly then return end
+
+                        md:noteMaterialAt(waPoly, detectedFieldId, "STRAW")
+                        SoilLogger.debug("[HarvestHook] straw birth: field %d, area=%.1fm2",
+                            detectedFieldId, area or 0)
+                    end)
+                end
+
                 if not ok then
                     SoilLogger.error("Harvest hook (field detection) failed: %s", tostring(errMsg))
                 end
             else
-                SoilLogger.debug("Harvest hook: skipped (isServer=%s enabled=%s nutrientCycles=%s fruit=%s area=%s)",
+                SoilLogger.debug("Harvest hook: skipped (isServer=%s enabled=%s fruit=%s area=%s)",
                     tostring(combineSelf.isServer),
                     tostring(g_SoilFertilityManager and g_SoilFertilityManager.settings.enabled),
-                    tostring(g_SoilFertilityManager and g_SoilFertilityManager.settings.nutrientCycles),
                     tostring(inputFruitType), tostring(area))
             end
 
@@ -2546,8 +2633,7 @@ function HookManager:installMowerHook()
             if not mowerSelf.isServer then return end
             if not g_SoilFertilityManager
                or not g_SoilFertilityManager.soilSystem
-               or not g_SoilFertilityManager.settings.enabled
-               or not g_SoilFertilityManager.settings.nutrientCycles then
+               or not g_SoilFertilityManager.settings.enabled then
                 return
             end
 
@@ -2561,8 +2647,43 @@ function HookManager:installMowerHook()
             if area <= 0 then return end
 
             local fruitType = spec.workAreaParameters.lastInputFruitType
-
             if not fruitType or fruitType <= 0 then return end
+
+            -- [MATERIAL DOWN BIRTH] Record cut grass on the age layer. Runs regardless
+            -- of nutrientCycles: a player who turns nutrient cycling off should still
+            -- get hay that remembers when it was cut (Arissani ruling 2026-07-30).
+            -- The TRACKED_MATERIALS gate filters non-tracked crops automatically.
+            do
+                local md = g_SoilFertilityManager.soilSystem.materialDown
+                if md and md:isArmed() then
+                    local waPoly = buildWorkAreaPolygon(mowerSelf, WorkAreaType.MOWER)
+                    if waPoly then
+                        -- Polygon centre for field lookup (avoids header-vs-tractor offset)
+                        local cx, cz = 0, 0
+                        for i = 1, #waPoly, 2 do
+                            cx = cx + waPoly[i]
+                            cz = cz + waPoly[i + 1]
+                        end
+                        local n = #waPoly / 2
+                        cx, cz = cx / n, cz / n
+
+                        local fieldId = hookMgrRef:getFieldIdAtWorldPosition(cx, cz)
+                        if fieldId and fieldId > 0 then
+                            local fillTypeName = fruitTypeToWindrowName(fruitType)
+                            if fillTypeName then
+                                local ok = pcall(md.noteMaterialAt, md, waPoly, fieldId, fillTypeName)
+                                if ok then
+                                    SoilLogger.debug("[MowerHook] material birth: field %d, %s",
+                                        fieldId, fillTypeName)
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+
+            -- [NUTRIENT CYCLES] Existing nutrient depletion — gated on setting
+            if not g_SoilFertilityManager.settings.nutrientCycles then return end
 
             local success, errorMsg = pcall(function()
                 local x, _, z = getWorldTranslation(mowerSelf.rootNode)
@@ -2590,7 +2711,7 @@ function HookManager:installMowerHook()
     )
 
     self:register(Mower, "onEndWorkAreaProcessing", original, "Mower.onEndWorkAreaProcessing")
-    SoilLogger.info("[OK] Mower hook installed (Mower.onEndWorkAreaProcessing) - forage crop nutrient tracking active")
+    SoilLogger.info("[OK] Mower hook installed (Mower.onEndWorkAreaProcessing) - forage crop + material birth active")
     return true
 end
 
@@ -2685,6 +2806,116 @@ function HookManager:installMowerYieldHook()
     self:register(Mower, "onEndWorkAreaProcessing", origEnd, "Mower.onEndWorkAreaProcessing (forage yield restore)")
 
     SoilLogger.info("[OK] Mower yield hook installed - windrow forage output now scales with soil nutrients")
+    return true
+end
+
+-- =========================================================
+-- HOOK 1e: Tedder (hay drying acceleration — SF-44 "THE HAY BET")
+-- =========================================================
+--- Instance-level delegating wrapper on Tedder.processTedderArea.
+--- Applies the hay bet's one-time drying delta and enqueues a
+--- corrective pass at end of frame. Never a class-level assignment
+--- (the brief rules it explicitly) — each existing tedder instance
+--- is patched at install time, and VehicleSystem.addVehicle is
+--- hooked to catch new spawns.
+---@return boolean success
+function HookManager:installTedderHook()
+    if not Tedder or type(Tedder.processTedderArea) ~= "function" then
+        SoilLogger.warning("[TedderHook] Tedder.processTedderArea not available - skipping")
+        return false
+    end
+
+    local hookMgrRef = self
+
+    --- Build a bounding-box polygon from a single work area's
+    --- start/width/height nodes. Returns {minX,minZ, maxX,minZ,
+    --- maxX,maxZ, minX,maxZ} or nil.
+    local function singleWAPoly(workArea)
+        if not workArea
+           or not workArea.start
+           or not workArea.width
+           or not workArea.height then
+            return nil
+        end
+        local xs, _, zs = getWorldTranslation(workArea.start)
+        local xw, _, zw = getWorldTranslation(workArea.width)
+        local xh, _, zh = getWorldTranslation(workArea.height)
+        if not xs or not xw or not xh then return nil end
+        local x4 = xw + xh - xs
+        local z4 = zw + zh - zs
+        local minX = math.min(xs, xw, xh, x4)
+        local maxX = math.max(xs, xw, xh, x4)
+        local minZ = math.min(zs, zw, zh, z4)
+        local maxZ = math.max(zs, zw, zh, z4)
+        return { minX, minZ, maxX, minZ, maxX, maxZ, minX, maxZ }
+    end
+
+    --- Create a delegating wrapper for one tedder instance.
+    --- DELEGATES fully (superFunc first), then applies the
+    --- hay bet's drying delta and enqueues the correction pass.
+    local function makeWrapper(realFn)
+        return function(tedderSelf, workArea, dt)
+            -- DELEGATE fully: original processTedderArea first
+            local results = { realFn(tedderSelf, workArea, dt) }
+
+            -- HAY BET: apply drying delta + enqueue correction
+            -- Server only — no client-side material logic
+            if not tedderSelf.isServer then
+                return unpack(results)
+            end
+            if not g_SoilFertilityManager
+               or not g_SoilFertilityManager.soilSystem
+               or not g_SoilFertilityManager.settings.enabled then
+                return unpack(results)
+            end
+
+            local hayBet = g_SoilFertilityManager.soilSystem.hayBet
+            if not hayBet or not hayBet:isArmed() then
+                return unpack(results)
+            end
+
+            local poly = singleWAPoly(workArea)
+            if not poly then return unpack(results) end
+
+            local ok = pcall(function()
+                hayBet:applyTedderDelta(poly)
+                hayBet:enqueueCorrection(poly)
+            end)
+            if not ok then
+                SoilLogger.warning("[TedderHook] hay bet apply failed for work area")
+            end
+
+            return unpack(results)
+        end
+    end
+
+    -- PATCH existing tedder instances (placed on map at load)
+    local patchedCount = 0
+    local vs = g_currentMission and g_currentMission.vehicleSystem
+    if vs and vs.vehicles then
+        for _, vehicle in pairs(vs.vehicles) do
+            if vehicle.spec_tedder
+               and type(vehicle.processTedderArea) == "function" then
+                vehicle.processTedderArea = makeWrapper(vehicle.processTedderArea)
+                patchedCount = patchedCount + 1
+            end
+        end
+    end
+
+    -- HOOK VehicleSystem.addVehicle to patch future tedder spawns
+    if vs and type(vs.addVehicle) == "function" then
+        local origAdd = vs.addVehicle
+        vs.addVehicle = function(self, vehicle, ...)
+            if vehicle
+               and vehicle.spec_tedder
+               and type(vehicle.processTedderArea) == "function" then
+                vehicle.processTedderArea = makeWrapper(vehicle.processTedderArea)
+            end
+            return origAdd(self, vehicle, ...)
+        end
+    end
+
+    SoilLogger.info("[OK] Tedder hook installed (instance-level, %d existing tedders patched)", patchedCount)
     return true
 end
 

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -77,6 +77,37 @@ local function buildWorkAreaPolygon(vehicle, areaType)
     }
 end
 
+--- Bounding box of ONE work area, as {x=,z=} vertices.
+---
+--- Same contract as buildWorkAreaPolygon above and for the same reasons; the
+--- difference is only that this takes a work area the engine already handed us rather
+--- than asking a vehicle for its typed set. Used by the tedder hook and the combine
+--- swath hook, both of which receive their work area as an argument.
+---@param workArea table
+---@return table|nil  {{x=,z=}, ...} or nil
+local function buildSingleWorkAreaPolygon(workArea)
+    if not workArea or not workArea.start or not workArea.width or not workArea.height then
+        return nil
+    end
+    local xs, _, zs = getWorldTranslation(workArea.start)
+    local xw, _, zw = getWorldTranslation(workArea.width)
+    local xh, _, zh = getWorldTranslation(workArea.height)
+    if not xs or not xw or not xh then return nil end
+
+    -- Fourth corner of the parallelogram: width + height - start.
+    local x4, z4 = xw + xh - xs, zw + zh - zs
+    local minX = math.min(xs, xw, xh, x4)
+    local maxX = math.max(xs, xw, xh, x4)
+    local minZ = math.min(zs, zw, zh, z4)
+    local maxZ = math.max(zs, zw, zh, z4)
+    return {
+        { x = minX, z = minZ },
+        { x = maxX, z = minZ },
+        { x = maxX, z = maxZ },
+        { x = minX, z = maxZ },
+    }
+end
+
 --- Resolve the windrow fill type name from a fruit type index.
 --- FS25 windrow fill types follow the pattern FRUITNAME_WINDROW.
 ---@param fruitTypeIndex number
@@ -224,6 +255,10 @@ function HookManager:installAll(soilSystem)
     -- Tedder hook (SF-44 "THE HAY BET"): hay drying acceleration + corrective queue
     local tedderOk = self:installTedderHook()
     if tedderOk then successCount = successCount + 1 else failCount = failCount + 1 end
+
+    -- Combine swath hook (SF-43/SF-45): straw birth on the age layer
+    local swathOk = self:installCombineSwathHook()
+    if swathOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
     -- Bale birth and death hooks (SF-46 "THE YARD LADDER"): per-bale condition rows
     local baleBirthOk = self:installBaleBirthHook()
@@ -2346,31 +2381,22 @@ function HookManager:installHarvestHook()
                         fieldId, inputFruitType, area)
                 end)
 
-                -- [MATERIAL DOWN BIRTH] Record straw deposition when the combine
-                -- is in swath mode. Runs regardless of nutrientCycles - the straw
-                -- birth gate is `md:isArmed()`, not a settings toggle.
-                if detectedFieldId and detectedFieldId > 0 then
-                    pcall(function()
-                        local md = g_SoilFertilityManager.soilSystem.materialDown
-                        if not md or not md:isArmed() then return end
-
-                        -- Only record straw when the combine is depositing a swath
-                        local isSwath = false
-                        if combineSelf.getIsSwathActive then
-                            isSwath = combineSelf:getIsSwathActive()
-                        end
-                        if not isSwath then return end
-                        if not strawRatio or strawRatio <= 0 then return end
-
-                        -- Build polygon from the header's cutter work areas
-                        local waPoly = buildWorkAreaPolygon(combineSelf, WorkAreaType.CUTTER)
-                        if not waPoly then return end
-
-                        md:noteMaterialAt(waPoly, detectedFieldId, "STRAW")
-                        SoilLogger.debug("[HarvestHook] straw birth: field %d, area=%.1fm2",
-                            detectedFieldId, area or 0)
-                    end)
-                end
+                -- STRAW BIRTH DOES NOT LIVE HERE ANY MORE. It used to, and it could
+                -- never have fired, for two independent reasons:
+                --
+                --   1. It gated on `combineSelf:getIsSwathActive()`. THAT METHOD DOES
+                --      NOT EXIST, in the LUADOC, in lua-scripting, or in AI-reference.
+                --      The `if combineSelf.getIsSwathActive` guard around it was
+                --      therefore always false, the flag stayed false, and the block
+                --      returned every single time whatever the player had set.
+                --   2. It asked the COMBINE for `WorkAreaType.CUTTER` work areas. Those
+                --      belong to the cutter, a separate attached vehicle
+                --      (Cutter.md:483); a combine owns COMBINESWATH and COMBINECHOPPER
+                --      (Combine.md:1407). So the polygon would have been nil anyway.
+                --
+                -- Confirmed dead by a live harvest: the hook logged its field line
+                -- hundreds of times over a full wheat field and produced zero births.
+                -- See installCombineSwathHook for where this belongs.
 
                 if not ok then
                     SoilLogger.error("Harvest hook (field detection) failed: %s", tostring(errMsg))
@@ -2692,9 +2718,22 @@ function HookManager:installMowerHook()
                         if fieldId and fieldId > 0 then
                             local fillTypeName = fruitTypeToWindrowName(fruitType)
                             if fillTypeName then
-                                local ok = pcall(md.noteMaterialAt, md, waPoly, fieldId, fillTypeName)
-                                if ok then
+                                -- REPORT THE RESULT, NOT THE PCALL STATUS. pcall returns
+                                -- true whenever the call RAN, so the old line announced
+                                -- "material birth" for materials noteMaterialAt had just
+                                -- refused. Mowing a meadow printed a birth per work area
+                                -- per frame for a material that is not in the tracked set
+                                -- and was never recorded. A diagnostic that cannot say no
+                                -- is worse than none, because it is trusted.
+                                local ok, recorded = pcall(md.noteMaterialAt, md, waPoly, fieldId, fillTypeName)
+                                if not ok then
+                                    SoilLogger.warning("[MowerHook] material birth raised: field %d, %s",
+                                        fieldId, fillTypeName)
+                                elseif recorded then
                                     SoilLogger.debug("[MowerHook] material birth: field %d, %s",
+                                        fieldId, fillTypeName)
+                                else
+                                    SoilLogger.debug("[MowerHook] no record (not a tracked material): field %d, %s",
                                         fieldId, fillTypeName)
                                 end
                             end
@@ -2944,6 +2983,134 @@ function HookManager:installTedderHook()
     end
 
     SoilLogger.info("[OK] Tedder hook installed (instance-level, %d existing tedders patched)", patchedCount)
+    return true
+end
+
+-- =========================================================
+-- HOOK 1e2: Combine swath (STRAW BIRTH, SF-43 / SF-45)
+-- =========================================================
+-- `Combine:processCombineSwathArea(workArea)` is the function that actually lays a
+-- swath, and hooking it is what makes straw birth self-gating: it is only ever in the
+-- call path when the combine is dropping material, so there is no swath flag to read
+-- and no phantom method to guess at. That is the same shape the mower hook has for
+-- grass, which is the one birth path that has always worked.
+--
+-- INSTANCE LEVEL, and this is the trap-3 case rather than the Bale case below.
+-- `SpecializationUtil.registerFunction(vehicleType, "processCombineSwathArea", ...)`
+-- at Combine.md:2823 copies the pointer into each vehicle type's table at
+-- registration, so assigning `Combine.processCombineSwathArea` here would patch a
+-- table nobody reads and the hook would silently never run.
+--
+-- THE RETURN VALUE IS THE EVIDENCE. The engine returns dropped litres
+-- (Combine.md:2692-2714), so a birth is recorded only when material actually landed.
+-- No litres, no record: that is a stronger gate than any flag, because it is the
+-- outcome rather than an intention.
+---@return boolean success
+function HookManager:installCombineSwathHook()
+    if not Combine or type(Combine.processCombineSwathArea) ~= "function" then
+        SoilLogger.warning("[SwathHook] Combine.processCombineSwathArea not available - straw birth skipped")
+        return false
+    end
+
+    local hookMgrRef = self
+
+    --- The dropped material's own fill type, resolved exactly the way the engine
+    --- resolves it at Combine.md:2703-2706: fruit type from the drop fill type, then
+    --- that fruit's windrow fill type. Never hardcoded to STRAW, so the tracked-material
+    --- set stays the single place that decides what is recorded.
+    local function windrowFillTypeName(combineSelf)
+        local spec = combineSelf.spec_combine
+        local params = spec and spec.workAreaParameters
+        local dropFillType = params and params.dropFillType
+        if dropFillType == nil or g_fruitTypeManager == nil then return nil end
+
+        local fruitDesc = g_fruitTypeManager:getFruitTypeByFillTypeIndex(dropFillType)
+        if fruitDesc == nil or fruitDesc.index == nil then return nil end
+
+        local windrowIdx = g_fruitTypeManager:getWindrowFillTypeIndexByFruitTypeIndex(fruitDesc.index)
+        if windrowIdx == nil or g_fillTypeManager == nil then return nil end
+
+        local ft = g_fillTypeManager:getFillTypeByIndex(windrowIdx)
+        return ft and ft.name or nil
+    end
+
+    local function makeWrapper(realFn)
+        return function(combineSelf, workArea, ...)
+            -- DELEGATE FIRST, always, and forward every return: the engine's own
+            -- caller reads the dropped-litres value.
+            local results = { realFn(combineSelf, workArea, ...) }
+
+            if not combineSelf.isServer then return unpack(results) end
+
+            -- Nothing landed on the ground, so there is nothing to remember.
+            local droppedLiters = results[1]
+            if type(droppedLiters) ~= "number" or droppedLiters <= 0 then
+                return unpack(results)
+            end
+
+            if not g_SoilFertilityManager
+               or not g_SoilFertilityManager.soilSystem
+               or not g_SoilFertilityManager.settings
+               or not g_SoilFertilityManager.settings.enabled then
+                return unpack(results)
+            end
+
+            -- Birth is NOT gated on nutrientCycles: a player who turns nutrient
+            -- cycling off should still get straw that remembers when it was cut
+            -- (Arissani ruling 2026-07-30).
+            local md = g_SoilFertilityManager.soilSystem.materialDown
+            if not md or not md:isArmed() then return unpack(results) end
+
+            pcall(function()
+                local poly = buildSingleWorkAreaPolygon(workArea)
+                if not poly then return end
+
+                local cx, cz = 0, 0
+                for _, v in ipairs(poly) do cx, cz = cx + v.x, cz + v.z end
+                cx, cz = cx / #poly, cz / #poly
+
+                local fieldId = hookMgrRef:getFieldIdAtWorldPosition(cx, cz)
+                if not fieldId or fieldId <= 0 then return end
+
+                -- nil name is allowed through: noteMaterialAt records it as an
+                -- unnamed material rather than refusing, because the caller made no
+                -- claim to check. A NAMED but untracked material is refused there.
+                local name = windrowFillTypeName(combineSelf)
+                if md:noteMaterialAt(poly, fieldId, name) then
+                    SoilLogger.debug("[SwathHook] straw birth: field %d, %s, %.1fL dropped",
+                        fieldId, tostring(name), droppedLiters)
+                end
+            end)
+
+            return unpack(results)
+        end
+    end
+
+    -- Patch combines already in the world.
+    local patchedCount = 0
+    local vs = g_currentMission and g_currentMission.vehicleSystem
+    if vs and vs.vehicles then
+        for _, vehicle in pairs(vs.vehicles) do
+            if vehicle.spec_combine and type(vehicle.processCombineSwathArea) == "function" then
+                vehicle.processCombineSwathArea = makeWrapper(vehicle.processCombineSwathArea)
+                patchedCount = patchedCount + 1
+            end
+        end
+    end
+
+    -- And any that spawn later, the same way the tedder and harvest hooks do.
+    if vs and type(vs.addVehicle) == "function" then
+        local origAdd = vs.addVehicle
+        vs.addVehicle = function(self, vehicle, ...)
+            if vehicle and vehicle.spec_combine
+               and type(vehicle.processCombineSwathArea) == "function" then
+                vehicle.processCombineSwathArea = makeWrapper(vehicle.processCombineSwathArea)
+            end
+            return origAdd(self, vehicle, ...)
+        end
+    end
+
+    SoilLogger.info("[OK] Combine swath hook installed (instance-level, %d existing combines patched)", patchedCount)
     return true
 end
 

--- a/src/integrations/SoilMaterialDownBridge.lua
+++ b/src/integrations/SoilMaterialDownBridge.lua
@@ -106,12 +106,53 @@ function SoilMaterialDownBridge.registerAccruals(materialDown)
     return true
 end
 
+SoilMaterialDownBridge.ACCRUAL_CONDITION = "SoilFertilizer_MaterialWetness_condition"
+
+--- [SF-49] The condition accrual, registered into the slot the sibling reserved so
+--- it settles AFTER the age tick. The ordering is the point: a day's age must be
+--- settled before that day's weather is applied to it, or the two members disagree
+--- about what day it is.
+---
+--- firstPeriodPolicy = "skip" for the same stated reason as the sibling's pair - the
+--- scheduler's silent default is "prorate", which would retroactively wet or dry
+--- material that predates the layer.
+---@return boolean registered
+function SoilMaterialDownBridge.registerConditionAccrual(materialWetness)
+    if materialWetness == nil then return false end
+    if g_server == nil then return false end
+
+    local tg = getTimeGuard()
+    if tg == nil or tg.registerAccrual == nil then
+        SoilLogger.info("[MaterialWetness] Time Guard not detected - condition never accrues")
+        return false
+    end
+
+    local okReg = false
+    local ok, err = pcall(function()
+        okReg = tg:registerAccrual(SoilMaterialDownBridge.ACCRUAL_CONDITION, {
+            cadence           = "day",
+            flowClass         = "calendar",
+            firstPeriodPolicy = "skip",
+            priority          = SoilMaterialDownBridge.PRIORITY.CONDITION_ACCRUAL,
+            onSettle          = function(ctx) materialWetness:onConditionAccrual(ctx) end,
+        })
+    end)
+    if not ok or not okReg then
+        SoilLogger.warning("[MaterialWetness] Time Guard registration failed: %s", tostring(err))
+        return false
+    end
+    SoilLogger.info("[OK] MaterialWetness registered its condition accrual (skip, prio %d)",
+        SoilMaterialDownBridge.PRIORITY.CONDITION_ACCRUAL)
+    return true
+end
+
 function SoilMaterialDownBridge.unregisterAccruals()
     local tg = getTimeGuard()
     if tg == nil or tg.unregisterAccrual == nil then return end
     pcall(function()
         tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_AGE)
         tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_MAINTENANCE)
+        tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_CONDITION)
     end)
     SoilMaterialDownBridge.timeGuardActive = false
 end
@@ -177,6 +218,44 @@ function SoilMaterialDownBridge.registerLedger(materialDown)
     SoilMaterialDownBridge.ledgerActive = true
     SoilLogger.info("[OK] MaterialDown registered with StateLedger as '%s'",
         SoilMaterialDownBridge.MODULE_ID)
+    return true
+end
+
+-- [SF-49] The Water Record's own ledger module. ONE NOUN, PINNED: this string is a
+-- persistence key, so a later rename orphans every saved verdict.
+SoilMaterialDownBridge.WATER_MODULE_ID = "SoilFertilizer_MaterialWaterBook"
+SoilMaterialDownBridge.waterLedgerActive = false
+
+--- Register the Water Record sidecar. Merge-never-replace on the far side, for the
+--- same reason as the sibling's: an omitted block is indistinguishable from a new
+--- save, and a replace-on-nil would erase frozen verdicts that cannot be recomputed
+--- (the climate roll reads the CURRENT season, so a past day would change its answer).
+function SoilMaterialDownBridge.registerWaterLedger(materialWetness)
+    SoilMaterialDownBridge.waterLedgerActive = false
+    if materialWetness == nil then return false end
+    if g_server == nil then return false end
+
+    local ledger = getLedger()
+    if ledger == nil or ledger.registerModule == nil then
+        SoilLogger.info("[MaterialWetness] StateLedger not detected - the Water Record is session-only")
+        return false
+    end
+
+    local ok, err = pcall(function()
+        ledger:registerModule(SoilMaterialDownBridge.WATER_MODULE_ID, {
+            serialize   = function() return materialWetness:serialize() end,
+            deserialize = function(data)
+                if data ~= nil then materialWetness:deserialize(data) end
+            end,
+        })
+    end)
+    if not ok then
+        SoilLogger.warning("[MaterialWetness] StateLedger registration failed: %s", tostring(err))
+        return false
+    end
+    SoilMaterialDownBridge.waterLedgerActive = true
+    SoilLogger.info("[OK] MaterialWetness registered with StateLedger as '%s'",
+        SoilMaterialDownBridge.WATER_MODULE_ID)
     return true
 end
 

--- a/src/integrations/SoilMaterialDownBridge.lua
+++ b/src/integrations/SoilMaterialDownBridge.lua
@@ -153,8 +153,52 @@ function SoilMaterialDownBridge.unregisterAccruals()
         tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_AGE)
         tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_MAINTENANCE)
         tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_CONDITION)
+        if SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER then
+            tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER)
+        end
     end)
     SoilMaterialDownBridge.timeGuardActive = false
+end
+
+-- =========================================================
+-- Hay Member (SF-44 — THE HAY BET)
+-- =========================================================
+
+SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER = "SoilFertilizer_HayBet_resolution"
+
+--- Register the hay member resolution on the MEMBER_RESOLUTION
+--- slot (priority 10, before the age tick). Called once per game
+--- day to run the settle pass — read condition, decide spoil, and
+--- (when the conversion confirm lands) convert grass to hay.
+---@param hayBet HayBet|nil
+---@return boolean registered
+function SoilMaterialDownBridge.registerHayMember(hayBet)
+    if hayBet == nil or not hayBet:isArmed() then return false end
+    if g_server == nil then return false end
+
+    local tg = getTimeGuard()
+    if tg == nil or tg.registerAccrual == nil then
+        SoilLogger.info("[HayBet] Time Guard not detected - settle pass never fires")
+        return false
+    end
+
+    local okReg = false
+    local ok, err = pcall(function()
+        okReg = tg:registerAccrual(SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER, {
+            cadence           = "day",
+            flowClass         = "calendar",
+            firstPeriodPolicy = "skip",
+            priority          = SoilMaterialDownBridge.PRIORITY.MEMBER_RESOLUTION,
+            onSettle          = function(ctx) hayBet:onSettle(ctx) end,
+        })
+    end)
+    if not ok or not okReg then
+        SoilLogger.warning("[HayBet] Time Guard registration failed: %s", tostring(err))
+        return false
+    end
+
+    SoilLogger.info("[OK] HayBet registered its day settle (prio %d)", SoilMaterialDownBridge.PRIORITY.MEMBER_RESOLUTION)
+    return true
 end
 
 -- =========================================================

--- a/src/integrations/SoilMaterialDownBridge.lua
+++ b/src/integrations/SoilMaterialDownBridge.lua
@@ -164,14 +164,14 @@ function SoilMaterialDownBridge.unregisterAccruals()
 end
 
 -- =========================================================
--- Hay Member (SF-44 — THE HAY BET)
+-- Hay Member (SF-44 - THE HAY BET)
 -- =========================================================
 
 SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER = "SoilFertilizer_HayBet_resolution"
 
 --- Register the hay member resolution on the MEMBER_RESOLUTION
 --- slot (priority 10, before the age tick). Called once per game
---- day to run the settle pass — read condition, decide spoil, and
+--- day to run the settle pass - read condition, decide spoil, and
 --- (when the conversion confirm lands) convert grass to hay.
 ---@param hayBet HayBet|nil
 ---@return boolean registered
@@ -205,7 +205,7 @@ function SoilMaterialDownBridge.registerHayMember(hayBet)
 end
 
 -- =========================================================
--- Yard Ladder (SF-46 — THE YARD LADDER)
+-- Yard Ladder (SF-46 - THE YARD LADDER)
 -- =========================================================
 
 SoilMaterialDownBridge.ACCRUAL_LADDER = "SoilFertilizer_YardLadder_pass"

--- a/src/integrations/SoilMaterialDownBridge.lua
+++ b/src/integrations/SoilMaterialDownBridge.lua
@@ -1,0 +1,227 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - MATERIAL DOWN bridges (SF-43)
+-- =========================================================
+-- Two optional-mod bridges for the MATERIAL DOWN system, kept together because
+-- they are the system's only outside contact:
+--
+--   1. TIME GUARD - two day-cadence accruals. SoilFertilizer had NO Time Guard
+--      integration before this brief, so this is new plumbing, not a contract
+--      change on their side.
+--   2. STATE LEDGER - the watermark + object sidecar, delegate-when-present with
+--      an own-XML fallback.
+--
+-- Both are strictly delegate-when-present. Neither mod is a hard dependency.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+SoilMaterialDownBridge = {}
+
+-- =========================================================
+-- Time Guard
+-- =========================================================
+
+SoilMaterialDownBridge.ACCRUAL_AGE         = "SoilFertilizer_MaterialDown_age"
+SoilMaterialDownBridge.ACCRUAL_MAINTENANCE = "SoilFertilizer_MaterialDown_maintenance"
+
+-- Settle order for the WHOLE ground-material package, fixed here so the sibling
+-- member registers into a known sequence instead of negotiating one later:
+--
+--   10  member conversion / spoil resolution   (no registrant in v1; the slot exists)
+--   20  THIS mod's age tick                    <- time exists before the day's weather
+--   30  the sibling's condition accrual (dry, wet, record)
+--   40  publication / maintenance
+--
+-- The ordering is the point: a day's age must be settled BEFORE the sibling applies
+-- that day's weather to it, or the two members disagree about what day it is.
+SoilMaterialDownBridge.PRIORITY = {
+    MEMBER_RESOLUTION = 10,
+    AGE_TICK          = 20,
+    CONDITION_ACCRUAL = 30,   -- reserved for the sibling; nothing registers it here
+    PUBLICATION       = 40,
+}
+
+SoilMaterialDownBridge.timeGuardActive = false
+
+local function getTimeGuard()
+    return (g_currentMission ~= nil and g_currentMission.timeGuard) or nil
+end
+
+--- Register the two accruals. Server only: the layer does not exist elsewhere.
+---
+--- firstPeriodPolicy = "skip" on BOTH, stated explicitly because the scheduler's
+--- SILENT default is "prorate", which would retroactively settle the partial period
+--- the mod happened to load in - ageing material that predates the layer entirely.
+--- Both onSettle bodies ignore ctx.proration, which is meaningless for a +1 raw add.
+---@return boolean registered
+function SoilMaterialDownBridge.registerAccruals(materialDown)
+    SoilMaterialDownBridge.timeGuardActive = false
+    if materialDown == nil then return false end
+    if g_server == nil then return false end
+
+    local tg = getTimeGuard()
+    if tg == nil or tg.registerAccrual == nil then
+        -- Neutral when absent, and deliberately NOT papered over with a private
+        -- day counter: a second clock beside Time Guard's is the same class of
+        -- mistake as a private sky. Records are still born and still read; they
+        -- simply do not age until Time Guard is present.
+        SoilLogger.info(
+            "[MaterialDown] Time Guard not detected - material ages nowhere. Records are still " ..
+            "created and read; no private clock is minted to fill the gap.")
+        return false
+    end
+
+    local okAge = false
+    local okMaint = false
+    local ok, err = pcall(function()
+        okAge = tg:registerAccrual(SoilMaterialDownBridge.ACCRUAL_AGE, {
+            cadence           = "day",
+            flowClass         = "calendar",
+            firstPeriodPolicy = "skip",
+            priority          = SoilMaterialDownBridge.PRIORITY.AGE_TICK,
+            onSettle          = function(ctx) materialDown:onAgeTick(ctx) end,
+        })
+        okMaint = tg:registerAccrual(SoilMaterialDownBridge.ACCRUAL_MAINTENANCE, {
+            cadence           = "day",
+            flowClass         = "calendar",
+            firstPeriodPolicy = "skip",
+            priority          = SoilMaterialDownBridge.PRIORITY.PUBLICATION,
+            onSettle          = function(ctx) materialDown:onMaintenanceTick(ctx) end,
+        })
+    end)
+
+    if not ok then
+        SoilLogger.warning("[MaterialDown] Time Guard registration failed: %s", tostring(err))
+        return false
+    end
+    if not (okAge and okMaint) then
+        SoilLogger.warning("[MaterialDown] Time Guard rejected an accrual (age=%s maintenance=%s)",
+            tostring(okAge), tostring(okMaint))
+        return false
+    end
+
+    SoilMaterialDownBridge.timeGuardActive = true
+    SoilLogger.info("[OK] MaterialDown registered two day accruals with Time Guard (skip, prio %d/%d)",
+        SoilMaterialDownBridge.PRIORITY.AGE_TICK, SoilMaterialDownBridge.PRIORITY.PUBLICATION)
+    return true
+end
+
+function SoilMaterialDownBridge.unregisterAccruals()
+    local tg = getTimeGuard()
+    if tg == nil or tg.unregisterAccrual == nil then return end
+    pcall(function()
+        tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_AGE)
+        tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_MAINTENANCE)
+    end)
+    SoilMaterialDownBridge.timeGuardActive = false
+end
+
+-- =========================================================
+-- State Ledger sidecar
+-- =========================================================
+
+SoilMaterialDownBridge.MODULE_ID  = "SoilFertilizer_MaterialDown"
+SoilMaterialDownBridge.XML_FILE   = "sfMaterialDown.xml"
+SoilMaterialDownBridge.ledgerActive = false
+
+local function getLedger()
+    return (g_currentMission ~= nil and g_currentMission.stateLedger) or nil
+end
+
+local function xmlPath()
+    if g_currentMission == nil or g_currentMission.missionInfo == nil
+       or g_currentMission.missionInfo.savegameDirectory == nil then
+        return nil
+    end
+    return g_currentMission.missionInfo.savegameDirectory .. "/" .. SoilMaterialDownBridge.XML_FILE
+end
+
+--- Register the sidecar with StateLedger when present.
+---
+--- deserialize MERGES, never replaces. StateLedger OMITS a block when serialize
+--- fails and cannot tell an omitted block from a brand-new save (it chooses
+--- resume-vs-defaults purely on data ~= nil). A replace-on-nil would wipe the
+--- watermark after ONE bad save, and a lost watermark re-ages the entire map on the
+--- next tick. MaterialDown:deserialize keeps the furthest-on watermark for the same
+--- reason, so the merge is enforced on both sides of this boundary.
+function SoilMaterialDownBridge.registerLedger(materialDown)
+    SoilMaterialDownBridge.ledgerActive = false
+    if materialDown == nil then return false end
+    if g_server == nil then return false end
+
+    local ledger = getLedger()
+    if ledger == nil or ledger.registerModule == nil then
+        SoilLogger.info("[MaterialDown] StateLedger not detected - using %s",
+            SoilMaterialDownBridge.XML_FILE)
+        return false
+    end
+
+    local ok, err = pcall(function()
+        ledger:registerModule(SoilMaterialDownBridge.MODULE_ID, {
+            serialize = function()
+                return materialDown:serialize()
+            end,
+            deserialize = function(data)
+                -- nil on a brand-new save AND on an omitted block: merge handles both.
+                if data ~= nil then materialDown:deserialize(data) end
+            end,
+        })
+    end)
+
+    if not ok then
+        SoilLogger.warning("[MaterialDown] StateLedger registration failed: %s (using %s)",
+            tostring(err), SoilMaterialDownBridge.XML_FILE)
+        return false
+    end
+
+    SoilMaterialDownBridge.ledgerActive = true
+    SoilLogger.info("[OK] MaterialDown registered with StateLedger as '%s'",
+        SoilMaterialDownBridge.MODULE_ID)
+    return true
+end
+
+--- Own-XML fallback save. Runs only when StateLedger is absent; the ledger owns the
+--- state when present so nothing writes it twice.
+function SoilMaterialDownBridge.saveFallback(materialDown)
+    if materialDown == nil or SoilMaterialDownBridge.ledgerActive then return end
+    if g_server == nil then return end
+    local path = xmlPath()
+    if path == nil or createXMLFile == nil then return end
+
+    local state = materialDown:serialize()
+    local ok, err = pcall(function()
+        local xmlFile = createXMLFile("sfMaterialDown", path, "materialDown")
+        if xmlFile == nil then return end
+        setXMLInt(xmlFile, "materialDown#schema", state.schema or 1)
+        if state.ageAppliedThroughDay ~= nil then
+            setXMLInt(xmlFile, "materialDown#ageAppliedThroughDay", state.ageAppliedThroughDay)
+        end
+        saveXMLFile(xmlFile)
+        delete(xmlFile)
+    end)
+    if not ok then
+        SoilLogger.warning("[MaterialDown] fallback save failed: %s", tostring(err))
+    end
+end
+
+--- Own-XML fallback load. Also MERGES (through MaterialDown:deserialize), so a
+--- missing or unreadable file leaves whatever the ledger already delivered intact.
+function SoilMaterialDownBridge.loadFallback(materialDown)
+    if materialDown == nil or SoilMaterialDownBridge.ledgerActive then return end
+    if g_server == nil then return end
+    local path = xmlPath()
+    if path == nil or loadXMLFile == nil or fileExists == nil or not fileExists(path) then return end
+
+    local ok, err = pcall(function()
+        local xmlFile = loadXMLFile("sfMaterialDown", path)
+        if xmlFile == nil then return end
+        local day = getXMLInt(xmlFile, "materialDown#ageAppliedThroughDay")
+        delete(xmlFile)
+        if day ~= nil then
+            materialDown:deserialize({ ageAppliedThroughDay = day })
+        end
+    end)
+    if not ok then
+        SoilLogger.warning("[MaterialDown] fallback load failed: %s", tostring(err))
+    end
+end

--- a/src/integrations/SoilMaterialDownBridge.lua
+++ b/src/integrations/SoilMaterialDownBridge.lua
@@ -27,10 +27,10 @@ SoilMaterialDownBridge.ACCRUAL_MAINTENANCE = "SoilFertilizer_MaterialDown_mainte
 -- Settle order for the WHOLE ground-material package, fixed here so the sibling
 -- member registers into a known sequence instead of negotiating one later:
 --
---   10  member conversion / spoil resolution   (no registrant in v1; the slot exists)
+--   10  member conversion / spoil resolution   (SF-44 HayBet)
 --   20  THIS mod's age tick                    <- time exists before the day's weather
 --   30  the sibling's condition accrual (dry, wet, record)
---   40  publication / maintenance
+--   40  publication / maintenance              (SF-46's ladder pass rides this slot)
 --
 -- The ordering is the point: a day's age must be settled BEFORE the sibling applies
 -- that day's weather to it, or the two members disagree about what day it is.
@@ -38,7 +38,7 @@ SoilMaterialDownBridge.PRIORITY = {
     MEMBER_RESOLUTION = 10,
     AGE_TICK          = 20,
     CONDITION_ACCRUAL = 30,   -- reserved for the sibling; nothing registers it here
-    PUBLICATION       = 40,
+    PUBLICATION       = 40,   -- maintenance, and SF-46's ladder pass
 }
 
 SoilMaterialDownBridge.timeGuardActive = false
@@ -156,6 +156,9 @@ function SoilMaterialDownBridge.unregisterAccruals()
         if SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER then
             tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_HAY_MEMBER)
         end
+        if SoilMaterialDownBridge.ACCRUAL_LADDER then
+            tg:unregisterAccrual(SoilMaterialDownBridge.ACCRUAL_LADDER)
+        end
     end)
     SoilMaterialDownBridge.timeGuardActive = false
 end
@@ -198,6 +201,51 @@ function SoilMaterialDownBridge.registerHayMember(hayBet)
     end
 
     SoilLogger.info("[OK] HayBet registered its day settle (prio %d)", SoilMaterialDownBridge.PRIORITY.MEMBER_RESOLUTION)
+    return true
+end
+
+-- =========================================================
+-- Yard Ladder (SF-46 — THE YARD LADDER)
+-- =========================================================
+
+SoilMaterialDownBridge.ACCRUAL_LADDER = "SoilFertilizer_YardLadder_pass"
+
+--- Register the yard ladder's daily pass on the PUBLICATION slot
+--- (priority 40), the everything-else day accrual the brief names.
+--- Never the one-call age tick: this pass is linear in ledger rows
+--- and makes no engine pass, so it has no business sharing a slot
+--- with the whole-layer walk.
+---
+--- Accruals are keyed by NAME, so riding the same priority as the
+--- maintenance accrual is a shared slot, not a collision.
+---@param yardLadder YardLadder|nil
+---@return boolean registered
+function SoilMaterialDownBridge.registerLadderPass(yardLadder)
+    if yardLadder == nil or not yardLadder:isArmed() then return false end
+    if g_server == nil then return false end
+
+    local tg = getTimeGuard()
+    if tg == nil or tg.registerAccrual == nil then
+        SoilLogger.info("[YardLadder] Time Guard not detected - ladder pass never fires")
+        return false
+    end
+
+    local okReg = false
+    local ok, err = pcall(function()
+        okReg = tg:registerAccrual(SoilMaterialDownBridge.ACCRUAL_LADDER, {
+            cadence           = "day",
+            flowClass         = "calendar",
+            firstPeriodPolicy = "skip",
+            priority          = SoilMaterialDownBridge.PRIORITY.PUBLICATION,
+            onSettle          = function(ctx) yardLadder:onLadderPass(ctx) end,
+        })
+    end)
+    if not ok or not okReg then
+        SoilLogger.warning("[YardLadder] Time Guard registration failed: %s", tostring(err))
+        return false
+    end
+
+    SoilLogger.info("[OK] YardLadder registered its daily pass (prio %d)", SoilMaterialDownBridge.PRIORITY.PUBLICATION)
     return true
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -57,6 +57,7 @@ source(modDirectory .. "src/FieldSentry.lua")
 source(modDirectory .. "src/MaterialDown.lua")
 source(modDirectory .. "src/MaterialWetness.lua")
 source(modDirectory .. "src/HayBet.lua")
+source(modDirectory .. "src/YardLadder.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 -- Harvest contract underwrite (#741 / SF-29): tops base-game harvest contracts up to the
 -- vanilla-expected completion at delivery, so degraded neighbour fields can complete. Reads
@@ -212,6 +213,11 @@ local function loadedMission(mission, node)
         local hayBet = sfm and sfm.soilSystem and sfm.soilSystem.hayBet
         if hayBet then
             SoilMaterialDownBridge.registerHayMember(hayBet)
+        end
+        -- [SF-46] THE YARD LADDER: bale condition ladder pass, priority 40.
+        local yardLadder = sfm and sfm.soilSystem and sfm.soilSystem.yardLadder
+        if yardLadder then
+            SoilMaterialDownBridge.registerLadderPass(yardLadder)
         end
     end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -56,6 +56,7 @@ source(modDirectory .. "src/SoilSensorManager.lua")
 source(modDirectory .. "src/FieldSentry.lua")
 source(modDirectory .. "src/MaterialDown.lua")
 source(modDirectory .. "src/MaterialWetness.lua")
+source(modDirectory .. "src/HayBet.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 -- Harvest contract underwrite (#741 / SF-29): tops base-game harvest contracts up to the
 -- vanilla-expected completion at delivery, so degraded neighbour fields can complete. Reads
@@ -206,6 +207,11 @@ local function loadedMission(mission, node)
         if mw then
             SoilMaterialDownBridge.registerWaterLedger(mw)
             SoilMaterialDownBridge.registerConditionAccrual(mw)
+        end
+        -- [SF-44] THE HAY BET: settle pass member, priority 10 (before age tick).
+        local hayBet = sfm and sfm.soilSystem and sfm.soilSystem.hayBet
+        if hayBet then
+            SoilMaterialDownBridge.registerHayMember(hayBet)
         end
     end
 
@@ -598,6 +604,11 @@ FSBaseMission.delete = Utils.prependedFunction(FSBaseMission.delete, unload)
 FSBaseMission.update = Utils.appendedFunction(FSBaseMission.update, function(mission, dt)
     if sfm then
         sfm:update(dt)
+        -- [SF-44] Drain the tedder's correction queue at end of frame
+        local hayBet = sfm.soilSystem and sfm.soilSystem.hayBet
+        if hayBet then
+            hayBet:onUpdate()
+        end
         if sfm.sprayerInfoPanel then
             sfm.sprayerInfoPanel:update(dt)
         end

--- a/src/main.lua
+++ b/src/main.lua
@@ -54,6 +54,7 @@ source(modDirectory .. "src/SoilSensorManager.lua")
 -- FieldSentry backend gate (#651): must load before SoilFertilitySystem so its
 -- daily loop can consult FieldSentry_API. Backend only - no UI, no equation changes.
 source(modDirectory .. "src/FieldSentry.lua")
+source(modDirectory .. "src/MaterialDown.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 -- Harvest contract underwrite (#741 / SF-29): tops base-game harvest contracts up to the
 -- vanilla-expected completion at delivery, so degraded neighbour fields can complete. Reads
@@ -100,6 +101,7 @@ source(modDirectory .. "src/integrations/SectionControlIntegration.lua")
 source(modDirectory .. "src/integrations/PrecisionFarmingBridge.lua")
 source(modDirectory .. "src/integrations/SoilSettingsHubBridge.lua")
 source(modDirectory .. "src/integrations/SoilStateLedgerBridge.lua")
+source(modDirectory .. "src/integrations/SoilMaterialDownBridge.lua")
 source(modDirectory .. "src/integrations/SoilMasterHUDBridge.lua")
 source(modDirectory .. "src/integrations/SoilNetworkSyncBridge.lua")
 
@@ -184,6 +186,20 @@ local function loadedMission(mission, node)
     -- runs loadSoilData.
     if SoilStateLedgerBridge then
         SoilStateLedgerBridge.register(sfm)
+    end
+
+    -- [SF-43] MATERIAL DOWN's own two bridges. Registered here, alongside the ledger
+    -- above, so the sidecar's deserialize has fired before anything reads a
+    -- watermark, and so Time Guard has published its g_currentMission handle.
+    -- Both no-op when their mod is absent; the system stays inert rather than
+    -- minting a private clock or a second copy of the state.
+    if SoilMaterialDownBridge then
+        local md = sfm and sfm.soilSystem and sfm.soilSystem.materialDown
+        if md then
+            SoilMaterialDownBridge.registerLedger(md)
+            SoilMaterialDownBridge.loadFallback(md)
+            SoilMaterialDownBridge.registerAccruals(md)
+        end
     end
 
     -- FS25_MasterHUD: when present it drives our whole HUD draw stack through its

--- a/src/main.lua
+++ b/src/main.lua
@@ -55,6 +55,7 @@ source(modDirectory .. "src/SoilSensorManager.lua")
 -- daily loop can consult FieldSentry_API. Backend only - no UI, no equation changes.
 source(modDirectory .. "src/FieldSentry.lua")
 source(modDirectory .. "src/MaterialDown.lua")
+source(modDirectory .. "src/MaterialWetness.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 -- Harvest contract underwrite (#741 / SF-29): tops base-game harvest contracts up to the
 -- vanilla-expected completion at delivery, so degraded neighbour fields can complete. Reads
@@ -199,6 +200,12 @@ local function loadedMission(mission, node)
             SoilMaterialDownBridge.registerLedger(md)
             SoilMaterialDownBridge.loadFallback(md)
             SoilMaterialDownBridge.registerAccruals(md)
+        end
+        -- [SF-49] The condition half registers into the slot the sibling reserved.
+        local mw = sfm and sfm.soilSystem and sfm.soilSystem.materialWetness
+        if mw then
+            SoilMaterialDownBridge.registerWaterLedger(mw)
+            SoilMaterialDownBridge.registerConditionAccrual(mw)
         end
     end
 

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -84,6 +84,23 @@ SoilValueMaps.LAYER_DEFS = {
     -- executeSet(0) - which is total data loss, not churn. One flag cannot be
     -- half-set, so the coupling is structural rather than a convention to remember.
     { key = "materialAge",     file = "sfSoilMap_MA.grle",  minVal = 0,   maxVal = 254, serverOnly = true },
+    -- WHAT THE SKY DID (SF-49): material moisture, PERCENT WET BASIS, the condition
+    -- half of the ground-material foundation. Appends onto the machinery the sibling
+    -- built with no further contract change, exactly as its brief predicted.
+    --
+    -- Encoding is the ordinary linear one (60 pct -> raw 153, 40 pct -> raw 103).
+    -- The REFUSAL state reuses the store's OWN shipped sentinel pattern rather than a
+    -- parallel mechanism: unknownRaw lands in the reserved 16-31 band and rawFloor 32
+    -- keeps every real reading above it, so nothing can decode a refusal as a value.
+    -- Consequence worth knowing: readings below ~12.2 pct clamp to raw 32. Hay EMC
+    -- floors sit around there anyway, and the drying pass never aims below its EMC
+    -- ceiling, so the clamp is not reachable in practice - but it is real.
+    --
+    -- NAMING FENCE: this mod already ships advanceWetness driving COMPACTION from
+    -- rain, and SCS owns SOIL moisture. Three wetness quantities now exist, so every
+    -- key and getter here carries MATERIAL. advanceWetness is never touched.
+    { key = "materialWetness", file = "sfSoilMap_MW.grle",  minVal = 0,   maxVal = 100,
+      rawFloor = 32, unknownRaw = SoilValueMaps.UNKNOWN_RAW, serverOnly = true },
 }
 
 local NUM_CHANNELS = 8      -- bits per pixel
@@ -708,6 +725,37 @@ end
 -- delta's SIGN purely as an overflow guard (:583/:585); that is not a band a
 -- caller can choose.
 
+-- Shared band arithmetic for the two aimed-delta methods below.
+--
+-- INVARIANT (SF-49 #6): the engine-safety window is INTERSECTED with the caller's
+-- band, NEVER replaced. A caller band lying wholly outside the safe window is a
+-- NO-OP on both sides - not a clamp, not a wrap. Silently widening a caller's band
+-- back to the safe window would let a drying pass touch pixels the phase table
+-- deliberately excluded.
+--
+-- Returns addLow, addHigh (nil = no add) and edgeLow, edgeHigh (nil = no edge
+-- pass). The edge pass carries the pixels the add's guard had to exclude: they
+-- saturate at the top for a positive delta and floor at the bottom for a negative
+-- one, so a long step cannot leave a permanently frozen band at either end.
+local function aimedWindows(rawDelta, rawLow, rawHigh)
+    local addLow, addHigh, edgeLow, edgeHigh
+    if rawDelta > 0 then
+        addLow   = rawLow
+        addHigh  = math.min(rawHigh, RAW_MAX - rawDelta)
+        edgeLow  = math.max(rawLow,  RAW_MAX - rawDelta + 1)
+        edgeHigh = rawHigh
+    else
+        local mag = -rawDelta
+        addLow   = math.max(rawLow, RAW_MIN + mag)
+        addHigh  = rawHigh
+        edgeLow  = rawLow
+        edgeHigh = math.min(rawHigh, RAW_MIN + mag - 1)
+    end
+    if addLow  > addHigh  then addLow,  addHigh  = nil, nil end
+    if edgeLow > edgeHigh then edgeLow, edgeHigh = nil, nil end
+    return addLow, addHigh, edgeLow, edgeHigh
+end
+
 --- [SF-43 ask 1] Add `rawDelta` to every pixel of a layer whose CURRENT raw value
 --- lies inside the caller-aimed band [rawLow, rawHigh], then saturate the pixels
 --- the add's guard window had to exclude.
@@ -754,12 +802,13 @@ function SoilValueMaps:applyRawDeltaToLayer(key, rawDelta, rawLow, rawHigh)
             DensityCoordType.POINT_POINT_POINT)
     end
 
-    -- Pass 1: the add. The upper bound stops short of RAW_MAX - rawDelta so no
-    -- pixel can overflow past the ceiling and wrap into the raw-0 no-data sentinel.
-    local addHigh = math.min(rawHigh, RAW_MAX - rawDelta)
-    if addHigh >= rawLow then
+    local addLow, addHigh, satLow, satHigh = aimedWindows(rawDelta, rawLow, rawHigh)
+
+    -- Pass 1: the add. Its window stops short of RAW_MAX - rawDelta so no pixel can
+    -- overflow past the ceiling and wrap into the raw-0 no-data sentinel.
+    if addLow then
         coverWholeMap()
-        filter:setValueCompareParams(DensityValueCompareType.BETWEEN, rawLow, addHigh)
+        filter:setValueCompareParams(DensityValueCompareType.BETWEEN, addLow, addHigh)
         local ok, err = pcall(function() m:executeAdd(rawDelta, filter) end)
         if not ok then
             self.hasExecuteAdd = false
@@ -776,14 +825,87 @@ function SoilValueMaps:applyRawDeltaToLayer(key, rawDelta, rawLow, rawHigh)
     -- window on this tick and on every tick after it, forever.
     -- At rawDelta 1 (the ordinary daily tick) this window is empty by construction,
     -- so the normal path really is ONE engine call.
-    local satLow  = math.max(rawLow,  RAW_MAX - rawDelta + 1)
-    local satHigh = math.min(rawHigh, RAW_MAX - 1)
-    if satLow <= satHigh then
+    if satLow then
         coverWholeMap()
         filter:setValueCompareParams(DensityValueCompareType.BETWEEN, satLow, satHigh)
         local okSat, errSat = pcall(function() m:executeSet(RAW_MAX, filter) end)
         if not okSat then
             SoilLogger.warning("SoilValueMaps: saturating pass failed on '%s' (%s)", key, tostring(errSat))
+        end
+    end
+
+    return rawDelta
+end
+
+--- [SF-49, the one new store ask] Apply `rawDelta` to the pixels of `verts` whose
+--- CURRENT raw lies in the caller-aimed band [rawLow, rawHigh]. The polygon sibling
+--- of applyRawDeltaToLayer, and the first method here that accepts a NEGATIVE delta
+--- under a caller band - which is what a multiplicative drying curve needs, since
+--- the engine write is additive and the curve is therefore a banded pass.
+---
+--- `opts.floorTo` / `opts.saturateTo` set where the edge pass parks the pixels the
+--- add's guard had to exclude. The floor matters for a layer with a reserved
+--- sentinel band: without it a drying step walks a low pixel straight down into the
+--- sentinel, where it stops being a value and starts reading as a REFUSAL.
+---
+--- Same fabrication fence as its sibling: never falls back to the block-walk.
+---@return number|nil rawApplied  nil = REFUSED, stand the layer down
+function SoilValueMaps:applyRawDeltaToPolygonBand(key, verts, rawDelta, rawLow, rawHigh, opts)
+    if not self.available or not verts or #verts < 3 then return nil end
+    local entry = self.layers[key]
+    if not entry then return nil end
+
+    rawDelta = math.floor(tonumber(rawDelta) or 0)
+    if rawDelta == 0 then return 0 end
+    if rawDelta >  RAW_SPAN - 1 then rawDelta =  RAW_SPAN - 1 end
+    if rawDelta < -(RAW_SPAN - 1) then rawDelta = -(RAW_SPAN - 1) end
+
+    rawLow  = math.max(RAW_MIN, math.floor(tonumber(rawLow)  or RAW_MIN))
+    rawHigh = math.min(RAW_MAX, math.floor(tonumber(rawHigh) or RAW_MAX))
+    if rawLow > rawHigh then return 0 end
+
+    if not self.hasExecuteAdd then
+        SoilLogger.warning(
+            "SoilValueMaps: executeAdd unavailable - REFUSING the banded delta on '%s'. The block-walk " ..
+            "fallback would flatten the banded curve to a block average, so this layer stands down.", key)
+        return nil
+    end
+
+    opts = opts or {}
+    local edgeValue = (rawDelta > 0)
+        and math.min(RAW_MAX, math.floor(tonumber(opts.saturateTo) or RAW_MAX))
+        or  math.max(RAW_MIN, math.floor(tonumber(opts.floorTo)    or RAW_MIN))
+
+    local m      = entry.modifier
+    local filter = entry.filter
+    local addLow, addHigh, edgeLow, edgeHigh = aimedWindows(rawDelta, rawLow, rawHigh)
+
+    -- A caller band wholly outside the safe window is a NO-OP on both sides.
+    if addLow == nil and edgeLow == nil then return 0 end
+
+    if not setPolygonRegion(self, m, verts) then
+        SoilLogger.warning(
+            "SoilValueMaps: polygon ops unavailable - REFUSING the banded delta on '%s'. The block-walk " ..
+            "scales with area and degrades the banded curve to a block average.", key)
+        return nil
+    end
+
+    if addLow then
+        filter:setValueCompareParams(DensityValueCompareType.BETWEEN, addLow, addHigh)
+        local ok, err = pcall(function() m:executeAdd(rawDelta, filter) end)
+        if not ok then
+            self.hasExecuteAdd = false
+            SoilLogger.warning("SoilValueMaps: executeAdd failed on '%s' (%s) - layer stands down",
+                key, tostring(err))
+            return nil
+        end
+    end
+
+    if edgeLow then
+        filter:setValueCompareParams(DensityValueCompareType.BETWEEN, edgeLow, edgeHigh)
+        local okEdge, errEdge = pcall(function() m:executeSet(edgeValue, filter) end)
+        if not okEdge then
+            SoilLogger.warning("SoilValueMaps: edge pass failed on '%s' (%s)", key, tostring(errEdge))
         end
     end
 
@@ -877,6 +999,58 @@ function SoilValueMaps:hasAnyInBand(key, verts, rawLow, rawHigh)
     end)
     if not ok then return nil end
     return (pixels or 0) > 0
+end
+
+--- [SF-49] Average RAW value over a polygon, counting ONLY pixels inside the
+--- caller's band. The second use of the band parameter the aimed delta introduced.
+---
+--- This exists because readAverageOfPolygon below counts every WRITTEN pixel
+--- (`BETWEEN(RAW_MIN, RAW_MAX)`), which on a layer with a reserved sentinel band
+--- means the sentinel enters the sum as an ordinary number. On the wetness layer the
+--- sentinel decodes to roughly nine percent - bone dry - so a single refusing cell
+--- would quietly pull a mixed pickup toward FIT. The band lets the caller exclude it.
+---
+--- Returns the RAW mean, not a decoded value: the caller owns the meaning of raw on
+--- a layer whose low band is a sentinel rather than a small number.
+---@return number|nil rawAvg, number pixelCount
+function SoilValueMaps:readAverageRawInBand(key, verts, rawLow, rawHigh)
+    if not self.available or not verts or #verts < 3 then return nil, 0 end
+    local entry = self.layers[key]
+    if not entry then return nil, 0 end
+
+    rawLow  = math.max(RAW_MIN, math.floor(tonumber(rawLow)  or RAW_MIN))
+    rawHigh = math.min(RAW_MAX, math.floor(tonumber(rawHigh) or RAW_MAX))
+    if rawLow > rawHigh then return nil, 0 end
+
+    local m      = entry.modifier
+    local filter = entry.filter
+    filter:setValueCompareParams(DensityValueCompareType.BETWEEN, rawLow, rawHigh)
+
+    local sum, pixels = 0, 0
+    if setPolygonRegion(self, m, verts) then
+        local ok, acc, n = pcall(function()
+            local a, cnt, _ = m:executeGet(filter)
+            return a, cnt
+        end)
+        if ok and n and n > 0 then sum, pixels = acc, n end
+    else
+        forEachPolyBlock(verts, 16, function(cx, cz, half)
+            m:setParallelogramWorldCoords(
+                cx - half, cz - half, cx + half, cz - half, cx - half, cz + half,
+                DensityCoordType.POINT_POINT_POINT)
+            local ok, acc, n = pcall(function()
+                local a, cnt, _ = m:executeGet(filter)
+                return a, cnt
+            end)
+            if ok and n and n > 0 then
+                sum = sum + acc
+                pixels = pixels + n
+            end
+        end)
+    end
+
+    if pixels <= 0 then return nil, 0 end
+    return sum / pixels, pixels
 end
 
 --- Average semantic value over a field polygon via engine-side executeGet.

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -69,12 +69,33 @@ SoilValueMaps.LAYER_DEFS = {
     -- rawFloor: conventional encodes to raw 1, which shares DMV colour state 0 with
     -- the raw-0 no-data sentinel, so a conventional field stays untinted (deliberate).
     { key = "organicStatus",   ephemeral = true,            minVal = 0,   maxVal = 2 },
+    -- MATERIAL DOWN (SF-43): how many days cut material has been lying at each
+    -- pixel. minVal 0 / maxVal 254 makes unitsPerRaw EXACTLY 1, so one day is one
+    -- raw step and no quantisation error can ever accumulate. No rawFloor (this
+    -- layer never renders) and no unknownRaw (its refusal is the ceiling, not a
+    -- reserved band):
+    --   raw 0   = no record. Bare ground; never ages into a record.
+    --   raw 1   = born today.
+    --   raw 255 = AT OR PAST THE CEILING. A REFUSAL TO RULE, never a value.
+    -- serverOnly couples asks 4 and 5 into ONE flag on purpose (SF-43 invariant 4:
+    -- they are non-optionally coupled). A sync sentinel without the client-allocation
+    -- opt-out leaves the client allocating, painting and drift-resyncing forever, and
+    -- on THIS layer the resync path calls clearLayer - a whole-map unfiltered
+    -- executeSet(0) - which is total data loss, not churn. One flag cannot be
+    -- half-set, so the coupling is structural rather than a convention to remember.
+    { key = "materialAge",     file = "sfSoilMap_MA.grle",  minVal = 0,   maxVal = 254, serverOnly = true },
 }
 
 local NUM_CHANNELS = 8      -- bits per pixel
 local RAW_MIN      = 1      -- raw 0 is reserved as "no data"
 local RAW_MAX      = 255
 local RAW_SPAN     = RAW_MAX - RAW_MIN   -- 254 usable steps
+
+-- Exposed for the MATERIAL DOWN system (SF-43), which reasons in raw day-steps and
+-- must not re-declare these numbers next to a layer whose unitsPerRaw is exactly 1.
+SoilValueMaps.RAW_MIN  = RAW_MIN
+SoilValueMaps.RAW_MAX  = RAW_MAX
+SoilValueMaps.RAW_SPAN = RAW_SPAN
 
 -- Map resolution: half the terrain size (2 m/px on 2048-4096 m maps, same
 -- as Precision Farming), capped at 4096 px so 16x maps stay at 4 m/px and
@@ -166,10 +187,26 @@ function SoilValueMaps:initialize(savegameDir)
                      math.min(MAX_RESOLUTION, math.floor(self.terrainSize / 2)))
 
     local loadedCount = 0
+    -- [SF-43] Resolution is adopted from the FIRST persisted layer that loads, not
+    -- the last. See the guard below for why that distinction is load-bearing.
+    local resolutionAdopted = false
+    -- [SF-43 ask 5] CLIENT-ALLOCATION OPT-OUT. A serverOnly layer is never created
+    -- on a client at all. Paired non-optionally with the sync opt-out (ask 4): a
+    -- client that allocated this layer would paint it, drift from the server forever
+    -- and request resync after resync, and the resync path calls clearLayer - a
+    -- whole-map UNFILTERED executeSet(0). On an age layer that is not churn, it is
+    -- total data loss. Not allocating is the only way the cycle cannot start.
+    local isServer = (g_server ~= nil)
     for _, def in ipairs(SoilValueMaps.LAYER_DEFS) do
-        local bvm = createBitVectorMap("SFVM_" .. def.key)
+        local skipOnClient = (def.serverOnly == true) and not isServer
+        local bvm = nil
+        if not skipOnClient then
+            bvm = createBitVectorMap("SFVM_" .. def.key)
+        end
         if bvm == nil or bvm == 0 then
-            SoilLogger.warning("SoilValueMaps: createBitVectorMap failed for %s", def.key)
+            if not skipOnClient then
+                SoilLogger.warning("SoilValueMaps: createBitVectorMap failed for %s", def.key)
+            end
         else
             local loaded = false
             if savegameDir and fileExists ~= nil and def.file then
@@ -177,9 +214,25 @@ function SoilValueMaps:initialize(savegameDir)
                 if fileExists(path) then
                     local ok = loadBitVectorMapFromFile(bvm, path, NUM_CHANNELS)
                     if ok then
-                        -- Adopt the persisted resolution (may differ if the cap changed)
+                        -- Adopt the persisted resolution (may differ if the cap changed).
+                        -- [SF-43] FIRST loaded layer only. This was last-wins, which
+                        -- quietly made whichever def sits LAST in LAYER_DEFS the
+                        -- resolution authority for EVERY layer - so appending a new
+                        -- persisted def (materialAge) would have silently reinterpreted
+                        -- the six nutrient layers at whatever size the new file happened
+                        -- to be. A later layer that disagrees is a real inconsistency, so
+                        -- say so and keep the established size rather than adopt it.
                         local w, _ = getBitVectorMapSize(bvm)
-                        if w and w > 0 then self.resolution = w end
+                        if w and w > 0 then
+                            if not resolutionAdopted then
+                                self.resolution   = w
+                                resolutionAdopted = true
+                            elseif w ~= self.resolution then
+                                SoilLogger.warning(
+                                    "SoilValueMaps: %s is %dpx but the store is %dpx - keeping %dpx (that layer may misregister)",
+                                    def.file, w, self.resolution, self.resolution)
+                            end
+                        end
                         loaded = true
                         loadedCount = loadedCount + 1
                     else
@@ -215,8 +268,14 @@ function SoilValueMaps:initialize(savegameDir)
     self.available      = true
     -- Ephemeral layers (no file) never load from save; count them out so a full
     -- restore of the persisted layers still short-circuits the reseed.
+    -- [SF-43] Layers the client deliberately did not allocate are counted out too,
+    -- or a client would never reach loadedFromSave and would reseed every join.
     local persistedCount = 0
-    for _, d in ipairs(SoilValueMaps.LAYER_DEFS) do if d.file then persistedCount = persistedCount + 1 end end
+    for _, d in ipairs(SoilValueMaps.LAYER_DEFS) do
+        if d.file and not ((d.serverOnly == true) and not isServer) then
+            persistedCount = persistedCount + 1
+        end
+    end
     self.loadedFromSave = (loadedCount == persistedCount)
 
     -- Probe executeAdd availability once (used for uniform field deltas)
@@ -352,6 +411,19 @@ function SoilValueMaps:readValueAtWorld(key, worldX, worldZ)
     local px, pz = worldToPixel(self, worldX, worldZ)
     local raw = getBitVectorMapPoint(entry.bvm, px, pz, 0, NUM_CHANNELS)
     return decode(raw, entry.def)
+end
+
+--- [SF-43] RAW (unencoded) value at a world position; nil when unavailable.
+--- The age layer must not round-trip through decode(): raw 0 and raw 255 are
+--- SENTINELS ("no record" and "the ceiling refusal"), not points on a semantic
+--- scale, and decoding them would turn both into ordinary-looking day counts.
+---@return number|nil raw  0..255, or nil when the layer does not exist here
+function SoilValueMaps:readRawAtWorld(key, worldX, worldZ)
+    if not self.available then return nil end
+    local entry = self.layers[key]
+    if not entry then return nil end
+    local px, pz = worldToPixel(self, worldX, worldZ)
+    return getBitVectorMapPoint(entry.bvm, px, pz, 0, NUM_CHANNELS)
 end
 
 --- Write a semantic value into a square of half-size `radius` (meters).
@@ -623,6 +695,188 @@ function SoilValueMaps:applyDeltaToPolygon(key, verts, delta)
         end
     end)
     return applied
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Aimed raw-band operations (SF-43 asks 1 and 2)
+-- ─────────────────────────────────────────────────────────
+-- Everything above works in SEMANTIC units and derives its filter internally.
+-- The two methods below work in RAW units and take the caller's own value band,
+-- which is what a per-pixel day counter needs: it has to say "touch written
+-- records but not bare ground, and not the ceiling either", and no existing
+-- method can be aimed that way. applyDeltaToPolygon sets its filter from the
+-- delta's SIGN purely as an overflow guard (:583/:585); that is not a band a
+-- caller can choose.
+
+--- [SF-43 ask 1] Add `rawDelta` to every pixel of a layer whose CURRENT raw value
+--- lies inside the caller-aimed band [rawLow, rawHigh], then saturate the pixels
+--- the add's guard window had to exclude.
+---
+--- THE FABRICATION FENCE (SF-43 invariant 2, the one non-negotiable): this method
+--- NEVER falls through to the coarse block-walk that applyDeltaToPolygon uses when
+--- executeAdd is missing. That fallback point-samples one block centre and
+--- executeSets the whole 16 m block UNFILTERED, which births records on bare ground
+--- and flattens the raster. On a layer whose whole meaning is "how long has this
+--- exact spot had material on it", that is fabrication. If executeAdd is
+--- unavailable we fail loudly and the caller stands the layer down. Honestly inert
+--- beats quietly inventing.
+---
+---@return number|nil rawApplied  raw steps added; nil = REFUSED, stand the layer down
+function SoilValueMaps:applyRawDeltaToLayer(key, rawDelta, rawLow, rawHigh)
+    if not self.available then return nil end
+    local entry = self.layers[key]
+    if not entry then return nil end
+
+    rawDelta = math.floor(tonumber(rawDelta) or 0)
+    if rawDelta <= 0 then return 0 end
+    -- A sleep longer than the raw span cannot be represented as an add; clamp it
+    -- and let the saturating pass below carry everything the add cannot.
+    if rawDelta > RAW_SPAN - 1 then rawDelta = RAW_SPAN - 1 end
+
+    rawLow  = math.max(RAW_MIN, math.floor(tonumber(rawLow)  or RAW_MIN))
+    rawHigh = math.min(RAW_MAX, math.floor(tonumber(rawHigh) or RAW_MAX))
+    if rawLow > rawHigh then return 0 end
+
+    if not self.hasExecuteAdd then
+        SoilLogger.warning(
+            "SoilValueMaps: executeAdd unavailable - REFUSING the aimed delta on '%s'. The block-walk " ..
+            "fallback would invent records on bare ground, so this layer stands down instead.", key)
+        return nil
+    end
+
+    local m      = entry.modifier
+    local filter = entry.filter
+    local half   = self.terrainSize * 0.5
+
+    local function coverWholeMap()
+        m:setParallelogramWorldCoords(
+            -half, -half, half, -half, -half, half,
+            DensityCoordType.POINT_POINT_POINT)
+    end
+
+    -- Pass 1: the add. The upper bound stops short of RAW_MAX - rawDelta so no
+    -- pixel can overflow past the ceiling and wrap into the raw-0 no-data sentinel.
+    local addHigh = math.min(rawHigh, RAW_MAX - rawDelta)
+    if addHigh >= rawLow then
+        coverWholeMap()
+        filter:setValueCompareParams(DensityValueCompareType.BETWEEN, rawLow, addHigh)
+        local ok, err = pcall(function() m:executeAdd(rawDelta, filter) end)
+        if not ok then
+            self.hasExecuteAdd = false
+            SoilLogger.warning("SoilValueMaps: executeAdd failed on '%s' (%s) - layer stands down",
+                key, tostring(err))
+            return nil
+        end
+    end
+
+    -- Pass 2: the saturating pass. Pixels the add's guard window had to exclude but
+    -- that rawDelta lived ticks WOULD have pushed to the ceiling are set there
+    -- directly. Without this a long sleep leaves a permanently frozen band just
+    -- below the ceiling: at rawDelta 30 a pixel sitting at 230 falls outside the add
+    -- window on this tick and on every tick after it, forever.
+    -- At rawDelta 1 (the ordinary daily tick) this window is empty by construction,
+    -- so the normal path really is ONE engine call.
+    local satLow  = math.max(rawLow,  RAW_MAX - rawDelta + 1)
+    local satHigh = math.min(rawHigh, RAW_MAX - 1)
+    if satLow <= satHigh then
+        coverWholeMap()
+        filter:setValueCompareParams(DensityValueCompareType.BETWEEN, satLow, satHigh)
+        local okSat, errSat = pcall(function() m:executeSet(RAW_MAX, filter) end)
+        if not okSat then
+            SoilLogger.warning("SoilValueMaps: saturating pass failed on '%s' (%s)", key, tostring(errSat))
+        end
+    end
+
+    return rawDelta
+end
+
+--- [SF-43 ask 2] Clear to raw 0 ("no record") ONLY the pixels inside `verts` whose
+--- current raw lies in [rawLow, rawHigh]. The value filter is the entire point: a
+--- record must be cleared where the material genuinely left, never wholesale.
+---
+--- Refuses (rather than approximating) when engine polygon ops are unavailable, for
+--- the same reason ask 1 refuses: the block-walk would clear a 16 m block around
+--- each sample, wiping neighbouring records. On this layer an over-broad clear is
+--- not merely data loss - raw 0 lets BIRTH re-date the pixel as today, which
+--- launders age in the one direction the design forbids.
+---
+---@return boolean cleared  false = REFUSED (nothing was written)
+function SoilValueMaps:clearPolygonWhere(key, verts, rawLow, rawHigh)
+    -- Clearing targets WRITTEN records, so the band floor is RAW_MIN here: raw 0 is
+    -- already "no record" and there is nothing to clear.
+    rawLow = math.max(RAW_MIN, math.floor(tonumber(rawLow) or RAW_MIN))
+    return self:setPolygonWhere(key, verts, 0, rawLow, rawHigh)
+end
+
+--- [SF-43] Set every pixel inside `verts` whose CURRENT raw lies in
+--- [rawLow, rawHigh] to `rawValue`. The aimed-band sibling of paintPolygon.
+---
+--- The band floor may be 0 here, unlike the clear above, because "write only where
+--- there is NO record yet" (band [0,0]) is precisely how BIRTH and MOVEMENT
+--- INHERITANCE stay safe: a pixel that already carries an age is outside the band,
+--- so arriving material can never lower an existing age. The merge rule is the
+--- filter, not a read-compare-write the engine could race.
+---
+--- Refuses rather than approximating when polygon ops are unavailable, for the same
+--- reason ask 1 refuses: the block-walk would paint whole 16 m blocks unfiltered,
+--- inventing records on ground no machine touched.
+---@return boolean written  false = REFUSED (nothing was written)
+function SoilValueMaps:setPolygonWhere(key, verts, rawValue, rawLow, rawHigh)
+    if not self.available or not verts or #verts < 3 then return false end
+    local entry = self.layers[key]
+    if not entry then return false end
+
+    rawValue = math.max(0, math.min(RAW_MAX, math.floor(tonumber(rawValue) or 0)))
+    rawLow   = math.max(0,       math.floor(tonumber(rawLow)  or 0))
+    rawHigh  = math.min(RAW_MAX, math.floor(tonumber(rawHigh) or RAW_MAX))
+    if rawLow > rawHigh then return false end
+
+    local m      = entry.modifier
+    local filter = entry.filter
+    if not setPolygonRegion(self, m, verts) then
+        SoilLogger.warning(
+            "SoilValueMaps: polygon ops unavailable - REFUSING the aimed write on '%s'. A block-walk " ..
+            "would paint unfiltered 16 m blocks and invent records on untouched ground.", key)
+        return false
+    end
+
+    filter:setValueCompareParams(DensityValueCompareType.BETWEEN, rawLow, rawHigh)
+    local ok, err = pcall(function() m:executeSet(rawValue, filter) end)
+    if not ok then
+        SoilLogger.warning("SoilValueMaps: aimed write failed on '%s' (%s)", key, tostring(err))
+        return false
+    end
+    return true
+end
+
+--- [SF-43] Highest raw value present inside `verts` within the band
+--- [rawLow, rawHigh], or nil when the band holds no pixel there.
+---
+--- Used by the movement-inheritance probe, which walks bands DOWNWARD so a
+--- destination inherits the OLDEST record found in the source work area. It exists
+--- because readAverageOfPolygon must never be used for that question: an average
+--- invents an age no pixel actually held.
+---@return boolean|nil present  nil = refused (polygon ops unavailable)
+function SoilValueMaps:hasAnyInBand(key, verts, rawLow, rawHigh)
+    if not self.available or not verts or #verts < 3 then return false end
+    local entry = self.layers[key]
+    if not entry then return false end
+
+    rawLow  = math.max(RAW_MIN, math.floor(tonumber(rawLow)  or RAW_MIN))
+    rawHigh = math.min(RAW_MAX, math.floor(tonumber(rawHigh) or RAW_MAX))
+    if rawLow > rawHigh then return false end
+
+    local m      = entry.modifier
+    local filter = entry.filter
+    if not setPolygonRegion(self, m, verts) then return nil end
+
+    filter:setValueCompareParams(DensityValueCompareType.BETWEEN, rawLow, rawHigh)
+    local ok, _, pixels = pcall(function()
+        local a, cnt, _ = m:executeGet(filter)
+        return a, cnt
+    end)
+    if not ok then return nil end
+    return (pixels or 0) > 0
 end
 
 --- Average semantic value over a field polygon via engine-side executeGet.

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -520,8 +520,29 @@ end
 
 -- Apply a field polygon (array of {x=,z=}) as the modifier region.
 -- Returns true on success, false when polygon ops are unsupported.
+--
+-- A MALFORMED POLYGON IS A CALLER BUG, NOT AN ENGINE CAPABILITY VERDICT, and keeping
+-- those two apart is the whole point of the shape check below. This handler latches
+-- hasPolygonOps=false, and probePolygonSupport never re-probes once _polygonProbed is
+-- set, so anything that trips the latch takes EVERY aimed write in the mod down for
+-- the rest of the session: the age layer, the wetness layer, the yard ladder's reads.
+-- A caller passing a flat {x1,z1,...} array used to do exactly that, because indexing
+-- a number raises inside the pcall and the failure was read as "the engine has no
+-- polygon ops". Rubbish in, refuse the write, leave the capability alone.
 local function setPolygonRegion(self, modifier, verts)
     if not probePolygonSupport(self, modifier) then return false end
+
+    if type(verts) ~= "table" or #verts < 3 then return false end
+    for i = 1, #verts do
+        local v = verts[i]
+        if type(v) ~= "table" or type(v.x) ~= "number" or type(v.z) ~= "number" then
+            SoilLogger.warning(
+                "SoilValueMaps: REFUSING a malformed polygon (vertex %d is not {x=,z=}). " ..
+                "Engine polygon ops are left enabled; this is a caller bug, not a capability limit.", i)
+            return false
+        end
+    end
+
     local ok = pcall(function()
         modifier:clearPolygonPoints()
         for _, v in ipairs(verts) do
@@ -529,6 +550,8 @@ local function setPolygonRegion(self, modifier, verts)
         end
     end)
     if not ok then
+        -- The shape was good and the engine still refused, so this one really is a
+        -- capability verdict and the latch is correct.
         self.hasPolygonOps = false
         return false
     end

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1863,6 +1863,11 @@ function SoilValueMapChunkEvent:run(connection)
     if not vm then return end
     local def = SoilValueMaps.LAYER_DEFS[self.layerIdx]
     if not def then return end
+    -- [SF-43 ask 4] Defence in depth at the one call site that can destroy a layer.
+    -- The server never streams a serverOnly layer, but clearLayer immediately below
+    -- is a whole-map UNFILTERED executeSet(0), so a stray or malformed chunk must
+    -- not be able to reach it. Refuse rather than trust the sender.
+    if def.serverOnly == true then return end
 
     -- First chunk of a layer (gyStart == 0): wipe residual local paint so the
     -- server stream can converge. Without this, state-0 cells used to skip and
@@ -1876,7 +1881,11 @@ function SoilValueMapChunkEvent:run(connection)
     end
 
     if self.isLast then
-        SoilLogger.info("Client: value map sync complete (%d layers)", #SoilValueMaps.LAYER_DEFS)
+        local syncedLayers = 0
+        for _, d in ipairs(SoilValueMaps.LAYER_DEFS) do
+            if d.serverOnly ~= true then syncedLayers = syncedLayers + 1 end
+        end
+        SoilLogger.info("Client: value map sync complete (%d layers)", syncedLayers)
         local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
         if minimapLayer then minimapLayer:markDirty() end
         local mapOverlay = g_SoilFertilityManager and g_SoilFertilityManager.soilMapOverlay
@@ -1913,7 +1922,14 @@ function SoilValueMapChecksumEvent.emptyNew()
     return Event.new(SoilValueMapChecksumEvent_mt)
 end
 
---- checksums: array indexed by layerIdx of { sum = n, nonZero = n }
+--- checksums: DENSE array of { layerIdx = n, sum = n, nonZero = n }.
+---
+--- [SF-43 ask 4] Each entry CARRIES its layerIdx. This used to be a positional
+--- array whose position was read back as the LAYER_DEFS index, which meant skipping
+--- any layer would silently shift every checksum after it onto the wrong layer -
+--- the client would then "detect drift" on a layer that was fine and resync it
+--- forever. Carrying the index is the same shape the row-streaming work list below
+--- already uses, and it is what makes the sync opt-out safe to add at all.
 function SoilValueMapChecksumEvent.new(checksums)
     local self = SoilValueMapChecksumEvent.emptyNew()
     self.checksums = checksums or {}
@@ -1923,6 +1939,7 @@ end
 function SoilValueMapChecksumEvent:writeStream(streamId, connection)
     streamWriteUInt8(streamId, #self.checksums)
     for _, cs in ipairs(self.checksums) do
+        streamWriteUInt8(streamId, cs.layerIdx or 0)
         streamWriteInt32(streamId, cs.sum)
         streamWriteInt32(streamId, cs.nonZero)
     end
@@ -1933,8 +1950,9 @@ function SoilValueMapChecksumEvent:readStream(streamId, connection)
     self.checksums = {}
     for i = 1, count do
         self.checksums[i] = {
-            sum     = streamReadInt32(streamId),
-            nonZero = streamReadInt32(streamId),
+            layerIdx = streamReadUInt8(streamId),
+            sum      = streamReadInt32(streamId),
+            nonZero  = streamReadInt32(streamId),
         }
     end
     self:run(connection)
@@ -1952,8 +1970,13 @@ function SoilValueMapChecksumEvent:run(connection)
     local vm = sfGetValueMaps()
     if not vm then return end
 
-    for layerIdx, cs in ipairs(self.checksums) do
-        local def = SoilValueMaps.LAYER_DEFS[layerIdx]
+    for _, cs in ipairs(self.checksums) do
+        -- [SF-43 ask 4] Index comes from the entry, never from its position.
+        local layerIdx = cs.layerIdx
+        local def = layerIdx and SoilValueMaps.LAYER_DEFS[layerIdx]
+        -- A serverOnly layer was never allocated here, so it has nothing to compare
+        -- and must never be resynced. Defensive: the server does not send one.
+        if def and def.serverOnly == true then def = nil end
         if def then
             local localSum, localNonZero = sfComputeLayerChecksum(vm, def.key)
             local sumDrift = math.abs(localSum - cs.sum)
@@ -2034,7 +2057,9 @@ function SoilNetworkEvents_SendValueMaps(connection, onlyLayerIdx)
     -- Build the (layerIdx, gyStart) work list
     local work = {}
     for layerIdx, def in ipairs(SoilValueMaps.LAYER_DEFS) do
-        if onlyLayerIdx == nil or layerIdx == onlyLayerIdx then
+        -- [SF-43 ask 4] A serverOnly layer is never streamed, not even on an
+        -- explicit single-layer resync request: the client has no such layer.
+        if def.serverOnly ~= true and (onlyLayerIdx == nil or layerIdx == onlyLayerIdx) then
             local gy = 0
             while gy < numRows do
                 work[#work + 1] = { layerIdx = layerIdx, key = def.key, gyStart = gy }
@@ -2053,11 +2078,16 @@ function SoilNetworkEvents_SendValueMaps(connection, onlyLayerIdx)
         return SoilValueMapChunkEvent.new(item.layerIdx, item.gyStart, rows, isLast)
     end
 
+    -- [SF-43 ask 4] SKIP serverOnly layers entirely rather than sending a sentinel:
+    -- sfComputeLayerChecksum walks the whole sync grid, so a sentinel would still
+    -- pay the full cost per unsynced layer for a number nobody may act on.
     local function buildChecksums()
         local checksums = {}
-        for _, def in ipairs(SoilValueMaps.LAYER_DEFS) do
-            local sum, nonZero = sfComputeLayerChecksum(vm, def.key)
-            checksums[#checksums + 1] = { sum = sum, nonZero = nonZero }
+        for layerIdx, def in ipairs(SoilValueMaps.LAYER_DEFS) do
+            if def.serverOnly ~= true then
+                local sum, nonZero = sfComputeLayerChecksum(vm, def.key)
+                checksums[#checksums + 1] = { layerIdx = layerIdx, sum = sum, nonZero = nonZero }
+            end
         end
         return checksums
     end
@@ -2107,10 +2137,15 @@ function SoilNetworkEvents_BroadcastValueMapChecksums()
     if g_server == nil then return end
     local vm = sfGetValueMaps()
     if not vm then return end
+    -- [SF-43 ask 4] The broadcast twin of buildChecksums above: same skip, same
+    -- explicit layerIdx. These two must stay in lockstep - a divergence here is
+    -- exactly the positional bug the carried index was added to make impossible.
     local checksums = {}
-    for _, def in ipairs(SoilValueMaps.LAYER_DEFS) do
-        local sum, nonZero = sfComputeLayerChecksum(vm, def.key)
-        checksums[#checksums + 1] = { sum = sum, nonZero = nonZero }
+    for layerIdx, def in ipairs(SoilValueMaps.LAYER_DEFS) do
+        if def.serverOnly ~= true then
+            local sum, nonZero = sfComputeLayerChecksum(vm, def.key)
+            checksums[#checksums + 1] = { layerIdx = layerIdx, sum = sum, nonZero = nonZero }
+        end
     end
     g_server:broadcastEvent(SoilValueMapChecksumEvent.new(checksums))
 end

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -439,7 +439,10 @@ function SoilSettingsGUI:consoleCommandMaterialBench(fieldIdArg, iterArg)
     out[#out + 1] = string.format("  worst single call: %.3f ms", worst)
     out[#out + 1] = "  NOTE: cost is linear in FIELDS CARRYING MATERIAL, not flat across soil classes."
 
-    SoilLogger.info("%s", table.concat(out, "\n"))
+    -- The console echoes the return value, so log a COMPACT line rather than the
+    -- whole block: printing both put the same nine lines in the log twice.
+    SoilLogger.info("[family gate] field %d @%dpx: ageTick=%.3fms catchUp=%.3fms dryBand=%.3fms probe=%.3fms read=%.3fms",
+        fieldId, vm.resolution, rows[1].ms, rows[2].ms, rows[3].ms, rows[5].ms, rows[6].ms)
     return table.concat(out, "\n")
 end
 

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -71,6 +71,7 @@ function SoilSettingsGUI:registerConsoleCommands()
     addConsoleCommand("SoilAddCrop", "Add a custom crop to the tuning table (seeded from generic defaults): SoilAddCrop <name> (#717)", "consoleCommandAddCrop", self)
     -- REFINED: per-pixel value map debug commands
     addConsoleCommand("SoilVmStats", "REFINED: show per-pixel value map status (resolution, layers)", "consoleCommandVmStats", self)
+    addConsoleCommand("SoilMaterialBench", "SF-43/49 family gate: time ms per engine call for the ground-material passes: SoilMaterialBench [fieldId] [iterations]", "consoleCommandMaterialBench", self)
     addConsoleCommand("SoilVmRead", "REFINED: read value map layers at a position: SoilVmRead [x z] (defaults to player/vehicle position)", "consoleCommandVmRead", self)
     addConsoleCommand("SoilVmPaint", "REFINED: paint a value at a position: SoilVmPaint <layer> <value> [radius] [x z] (layer: nitrogen|phosphorus|potassium|pH|organicMatter|compaction)", "consoleCommandVmPaint", self)
     addConsoleCommand("SoilVmReseed", "REFINED: force-reseed all fields into the value maps from field averages (+noise)", "consoleCommandVmReseed", self)
@@ -319,6 +320,127 @@ function SoilSettingsGUI:consoleCommandVmStats()
     local vm, err = sfGetValueMapsForConsole()
     if not vm then return err end
     return vm:getDebugStats()
+end
+
+--- [SF-43 / SF-49 FAMILY GATE] Measure milliseconds per engine call for the
+--- ground-material passes, against a real field polygon, in-game.
+---
+--- The family gate is "milliseconds per engine call on the largest supported map",
+--- and no member of the package may be declared DONE until that number exists.
+--- Call COUNTS are asserted in the bench; this is the other half.
+---
+--- Non-destructive by construction: it REFUSES on a field that already carries
+--- material records, paints its own pixels, and clears them again afterwards. The
+--- two material layers hold no player data, so its scratch space is its own.
+---
+--- Timing uses getTimeSec() (seconds, float) - the pattern proven in the reference
+--- scripting corpus, `(endTime - startTime) * 1000` for milliseconds.
+function SoilSettingsGUI:consoleCommandMaterialBench(fieldIdArg, iterArg)
+    if g_server == nil then return "Material bench is server-only" end
+    if getTimeSec == nil then return "getTimeSec() unavailable on this build - cannot time" end
+
+    local vm, err = sfGetValueMapsForConsole()
+    if not vm then return err end
+    if vm.applyRawDeltaToPolygonBand == nil then
+        return "This SoilValueMaps has no SF-49 banded delta (community-fork collision?)"
+    end
+
+    local soilSys = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+    if soilSys == nil then return "Soil system not available" end
+
+    -- Resolve the field: explicit id, else the one under the player.
+    local fieldId = tonumber(fieldIdArg)
+    if fieldId == nil and soilSys.soilHUD ~= nil then
+        local ok, cur = pcall(function() return soilSys.soilHUD:detectCurrentFieldId() end)
+        if ok then fieldId = cur end
+    end
+    if fieldId == nil then
+        return "No field: pass one (SoilMaterialBench <fieldId> [iterations]) or stand on a field"
+    end
+
+    local field = soilSys.fieldData and soilSys.fieldData[fieldId]
+    local okV, verts = pcall(function() return soilSys:_getFieldPolyVerts(fieldId, field) end)
+    if not okV or verts == nil or #verts < 3 then
+        return string.format("Field %s has no usable polygon", tostring(fieldId))
+    end
+
+    local AGE, WET = "materialAge", "materialWetness"
+    local RAW_MAX = SoilValueMaps.RAW_MAX
+
+    -- Never clobber real records.
+    local occupied = vm:hasAnyInBand(AGE, verts, 1, RAW_MAX)
+    if occupied == nil then return "Band probe refused (polygon ops unavailable) - cannot bench safely" end
+    if occupied then
+        return string.format("Field %d already carries material records - refusing to bench on it", fieldId)
+    end
+
+    local iterations = math.max(1, math.min(200, math.floor(tonumber(iterArg) or 10)))
+
+    local function timeIt(label, fn)
+        local t0 = getTimeSec()
+        for _ = 1, iterations do fn() end
+        local t1 = getTimeSec()
+        return { label = label, ms = ((t1 - t0) * 1000) / iterations }
+    end
+
+    -- Paint scratch pixels so every pass has real work to do.
+    vm:setPolygonWhere(AGE, verts, 1, 0, 0)
+    vm:setPolygonWhere(WET, verts, 153, 0, 0)   -- ~60 percent, the top phase band
+
+    local rows = {}
+    rows[#rows + 1] = timeIt("age tick (whole-layer +1, the daily call)", function()
+        vm:applyRawDeltaToLayer(AGE, 1, 1, RAW_MAX - 1)
+    end)
+    rows[#rows + 1] = timeIt("age catch-up (+30, add + saturating pass)", function()
+        vm:applyRawDeltaToLayer(AGE, 30, 1, RAW_MAX - 1)
+    end)
+    rows[#rows + 1] = timeIt("drying band (polygon, -64 raw)", function()
+        vm:applyRawDeltaToPolygonBand(WET, verts, -64, 32, RAW_MAX, { floorTo = 32 })
+    end)
+    rows[#rows + 1] = timeIt("rain add (polygon, +38 raw)", function()
+        vm:applyRawDeltaToPolygonBand(WET, verts, 38, 32, RAW_MAX)
+    end)
+    rows[#rows + 1] = timeIt("band probe (inheritance / presence)", function()
+        vm:hasAnyInBand(AGE, verts, 1, RAW_MAX)
+    end)
+    rows[#rows + 1] = timeIt("banded average (the collector's read)", function()
+        vm:readAverageRawInBand(WET, verts, 32, RAW_MAX)
+    end)
+    rows[#rows + 1] = timeIt("aimed write (birth / inheritance)", function()
+        vm:setPolygonWhere(AGE, verts, 1, 0, 0)
+    end)
+
+    -- Put the scratch space back.
+    vm:clearPolygonWhere(AGE, verts, 1, RAW_MAX)
+    vm:clearPolygonWhere(WET, verts, 1, RAW_MAX)
+
+    local out = {
+        string.format("MATERIAL FAMILY GATE - field %d, %d iteration(s), %dpx / %.0fm (%.1f m/px)",
+            fieldId, iterations, vm.resolution, vm.terrainSize, vm.terrainSize / vm.resolution),
+        string.format("  capability: executeAdd=%s polygonOps=%s",
+            tostring(vm.hasExecuteAdd), tostring(vm.hasPolygonOps)),
+    }
+    local worst = 0
+    for _, r in ipairs(rows) do
+        out[#out + 1] = string.format("  %-42s %7.3f ms/call", r.label, r.ms)
+        if r.ms > worst then worst = r.ms end
+    end
+
+    -- The projected daily bill, stating the LINEAR term rather than hiding it.
+    local activeFields = 0
+    local md = soilSys.materialDown
+    if md ~= nil and md.enumerateActiveFields ~= nil then
+        activeFields = md:enumerateActiveFields(function() end)
+    end
+    local perField = 3   -- three drying phase bands
+    out[#out + 1] = string.format(
+        "  daily bill: 1 age tick + 1 rain + (%d phases x %d field(s) with material) = %d call(s)",
+        perField, activeFields, 2 + perField * activeFields)
+    out[#out + 1] = string.format("  worst single call: %.3f ms", worst)
+    out[#out + 1] = "  NOTE: cost is linear in FIELDS CARRYING MATERIAL, not flat across soil classes."
+
+    SoilLogger.info("%s", table.concat(out, "\n"))
+    return table.concat(out, "\n")
 end
 
 function SoilSettingsGUI:consoleCommandVmRead(xArg, zArg)

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -27,22 +27,18 @@ SoilHarvesterPanel.SEG_N   = 10      -- number of segments
 SoilHarvesterPanel.SEG_GAP = 0.0018  -- gap between segments
 SoilHarvesterPanel.PANEL_W = 0.210
 SoilHarvesterPanel.STAT_H  = 0.040   -- stats bar (icons + values) at bottom
+SoilHarvesterPanel.EST_H   = 0.012   -- provenance caption above the stats bar
 
 SoilHarvesterPanel.DEFAULT_X = 0.015625
 SoilHarvesterPanel.DEFAULT_Y = 0.340
 
 SoilHarvesterPanel.WARN_THRESHOLD = 0.85  -- flash warning above this fill ratio
 
--- Base crop yields (t/ha) for the yield estimate cell
-SoilHarvesterPanel.BASE_YIELD = {
-    wheat=8, barley=7, oat=6, rye=6, triticale=7,
-    corn=12, maize=12, sorghum=10,
-    canola=4, rapeseed=4, sunflower=4,
-    soybean=4, beans=4,
-    potato=45, sugarbeet=65, sugarcane=80,
-    cotton=3, tobacco=3,
-    default=8,
-}
+-- [SF-50] The hardcoded BASE_YIELD table was deleted here, deliberately WITHOUT a
+-- fallback. The estimate is now computed from the map's own crop truth (see
+-- computeYieldEstimate below). A stale fallback would be the same defect in disguise:
+-- the table failed silently for its whole life because nothing audited it, whereas a
+-- live read fails as a visible empty cell, which is a bug report within a day.
 
 -- ── Colors ───────────────────────────────────────────────
 SoilHarvesterPanel.C_BG       = {0.05, 0.05, 0.05, 0.82}
@@ -374,6 +370,69 @@ function SoilHarvesterPanel:getCropFillType(combine, tank)
     return nil
 end
 
+-- ── Yield estimate [SF-50] ────────────────────────────────
+-- Estimated t/ha read from the map's own crop truth instead of a hardcoded table:
+--
+--   literPerSqm x yieldScales[growthState] x 10000 m²/ha x massPerLiter x (yieldEff/100)
+--
+-- Every term is an engine descriptor read, so a map that retunes its fruit types retunes
+-- this panel for free and there is nothing left to go stale.
+--
+-- Returns nil when ANY term is missing (unknown fill type, no live growth state, no yield
+-- scale for that state, no mass conversion). The caller then renders the panel's no-data
+-- marker - never a substituted constant.
+--
+-- Units: FillTypeDesc loads `physics#massPerLiter` as `value * 0.001`, so the stored
+-- figure is TONNES per litre (wheat at 0.77 kg/L stores as 0.00077) and the product lands
+-- directly in t/ha with no further scaling.
+SoilHarvesterPanel._estUnitLogged = false
+
+function SoilHarvesterPanel:computeYieldEstimate(cropFT, info)
+    if not cropFT or not info then return nil end
+
+    -- The state of the crop actually standing in the field, never the max-yield state:
+    -- a max read systematically over-promises. nil = no live fruit (bare or fully cut).
+    local growthState = info.growthState
+    if growthState == nil then return nil end
+
+    local fillIdx = cropFT.index
+    if fillIdx == nil then return nil end
+
+    local ok, fruitDesc = pcall(function()
+        return g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByFillTypeIndex(fillIdx)
+    end)
+    if not ok or fruitDesc == nil then return nil end
+
+    local literPerSqm  = fruitDesc.literPerSqm
+    -- yieldScales carries an entry ONLY for harvest-ready growth states, so a standing
+    -- but unripe crop legitimately has no scale. Honest absence, not an error.
+    local scale        = fruitDesc.yieldScales and fruitDesc.yieldScales[growthState]
+    local massPerLiter = cropFT.massPerLiter
+
+    if literPerSqm  == nil or literPerSqm  <= 0 then return nil end
+    if scale        == nil or scale        <= 0 then return nil end
+    if massPerLiter == nil or massPerLiter <= 0 then return nil end
+
+    local yieldEff = info.yieldEfficiency or 100
+    local estTha   = literPerSqm * scale * 10000 * massPerLiter * (yieldEff / 100)
+
+    -- [SF50-C2] Print the raw term set once per session so massPerLiter's unit can be
+    -- confirmed in-game against a known crop. Gated on debugMode so toggling SoilDebug
+    -- on mid-session still produces the line.
+    if not SoilHarvesterPanel._estUnitLogged
+       and g_SoilFertilityManager and g_SoilFertilityManager.settings
+       and g_SoilFertilityManager.settings.debugMode then
+        SoilHarvesterPanel._estUnitLogged = true
+        SoilLogger.debug(
+            "[SoilHarvesterPanel][SF50-C2] fillType=%s literPerSqm=%s growthState=%s " ..
+            "yieldScale=%s massPerLiter=%s yieldEff=%s -> %.2f t/ha",
+            tostring(cropFT.name), tostring(literPerSqm), tostring(growthState),
+            tostring(scale), tostring(massPerLiter), tostring(yieldEff), estTha)
+    end
+
+    return estTha
+end
+
 -- ── Field detection (throttled) ───────────────────────────
 
 function SoilHarvesterPanel:update(dt)
@@ -512,7 +571,11 @@ function SoilHarvesterPanel:draw()
     -- Rows: tank bar + fill text + divider + yield  (+stats bar when active)
     local numContentRows = isActive and 4 or 1
     local statH  = isActive and (SoilHarvesterPanel.STAT_H * sc) or 0
-    local panelH = titleH + pad + numContentRows * rowH + statH + pad
+    -- [SF-50] Reserve a thin band above the stats bar for the estimate's provenance
+    -- caption. The panel is anchored bottom-left, so this grows it upward and leaves
+    -- the saved position untouched.
+    local estH   = isActive and (SoilHarvesterPanel.EST_H * sc) or 0
+    local panelH = titleH + pad + numContentRows * rowH + statH + estH + pad
 
     -- Position
     local panelX, panelBot
@@ -691,13 +754,9 @@ function SoilHarvesterPanel:draw()
         local fieldArea     = (info and info.fieldArea) or 0
         local daysSinceHarv = (info and info.daysSinceHarvest) or 0
 
-        -- Yield estimate: yieldEfficiency * base crop yield (t/ha)
-        local cropName  = info and info.lastCrop
-        local cropKey   = cropName and string.lower(cropName) or "default"
-        local baseYield = SoilHarvesterPanel.BASE_YIELD[cropKey]
-                       or SoilHarvesterPanel.BASE_YIELD.default
-        local yieldEff  = (info and info.yieldEfficiency) or 100
-        local estTha    = baseYield * (yieldEff / 100)
+        -- [SF-50] Yield estimate computed from the map's own crop truth.
+        -- nil means a term was missing; the cell says so rather than inventing a number.
+        local estTha = self:computeYieldEstimate(cropFT, info)
 
         -- ── Cell 1: Wheat icon + estimated t/ha ───────────────
         local cell1X = panelX
@@ -719,10 +778,38 @@ function SoilHarvesterPanel:draw()
         self:drawRect(ic1 - isz*0.28, ic1by + isz*0.44, isz*0.22, isz*0.10, C.C_TITLE_FG, 0.60)
         self:drawRect(ic1 + isz*0.06, ic1by + isz*0.28, isz*0.22, isz*0.10, C.C_TITLE_FG, 0.60)
 
-        local thaStr = string.format("%.1f t/ha", estTha)
+        -- [SF-50] Honest absence: when a term is missing the cell shows the panel's own
+        -- no-data marker (the same "--" the yield-efficiency row uses), never a
+        -- substituted yield number.
+        local thaSz  = 0.0075 * sc
+        local thaY   = sbY + (sbH * 0.35 - thaSz) * 0.5
         setTextAlignment(RenderText.ALIGN_CENTER)
-        setTextColor(unpack(C.C_VALUE))
-        renderText(cell1X + cellW * 0.5, sbY + (sbH * 0.35 - 0.0075*sc) * 0.5, 0.0075*sc, thaStr)
+        if estTha then
+            local okT, fmtT = pcall(function() return g_i18n:getText("sf_hud_tha") end)
+            local thaStr = (okT and fmtT and not fmtT:find("^%$l10n_"))
+                           and string.format(fmtT, estTha)
+                           or  string.format("%.1f t/ha", estTha)
+            setTextColor(unpack(C.C_VALUE))
+            renderText(cell1X + cellW * 0.5, thaY, thaSz, thaStr)
+        else
+            setTextColor(unpack(C.C_DIM))
+            renderText(cell1X + cellW * 0.5, thaY, thaSz, "--")
+        end
+
+        -- ── [SF-50] Provenance caption ────────────────────────
+        -- The t/ha figure is estimated from the map's crop data, not measured from what
+        -- the player actually took off the field. Say so plainly, in their language.
+        -- (sbH is unscaled here while the reserved band is scaled - a pre-existing
+        -- mismatch at userScale ~= 1; max() keeps the caption clear of the bar either way.)
+        local capSz = 0.0062 * sc
+        local okCap, capStr = pcall(function() return g_i18n:getText("sf_hud_yield_est_src") end)
+        if okCap and capStr and not capStr:find("^%$l10n_") then
+            setTextAlignment(RenderText.ALIGN_LEFT)
+            setTextColor(unpack(C.C_DIM))
+            renderText(panelX + pad,
+                       sbY + math.max(sbH, statH) + (estH - capSz) * 0.5,
+                       capSz, capStr)
+        end
 
         -- ── Cell 2: Grain bag icon + session grain (L) ──────────
         local cell2X  = panelX + cellW

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# FS25_SoilFertilizer pre-commit hook.
-# Runs the Lua 5.1 syntax check + FS25 footgun lint whenever a .lua file is staged,
-# so a parse error or sandbox footgun can't land in a commit. Fast (sub-second);
-# the heavier logic tests are left for `bash tools/test/run.sh` / CI.
+# Lua 5.1 syntax (+ repo lint where present) pre-commit gate.
 #
-# Install:  bash tools/test/install-hooks.sh
+# WHY THIS EXISTS: a Lua parse error does not stop FS25 loading the mod. The mod
+# loads, the game runs, and the offending FILE is silently dropped, so one feature
+# is simply absent with nothing but a single compiler line nobody reads. Two such
+# errors sat unnoticed in this suite until 2026-07-30 (FarmTablet's ProStaffApp and
+# WorkplaceTriggers' WTNetworkSyncBridge), each dead in EVERY session since it
+# shipped. Sub-second here beats a deploy plus a multi-minute load, and beats never
+# noticing at all.
+#
+# Install:   bash tools/test/install-hooks.sh
 # Skip once: git commit --no-verify
+# Remove:    rm "$(git rev-parse --git-path hooks)/pre-commit"
 set -e
 
 staged_lua="$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.lua$' || true)"
@@ -15,5 +21,14 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root/tools/test"
 [ -d node_modules ] || npm install --silent
 
-echo "pre-commit: Lua 5.1 syntax + lint…"
-npm run --silent check
+echo "pre-commit: Lua 5.1 syntax (staged)…"
+# Absolute paths, NUL-safe against spaces in the repo path.
+printf '%s\n' "$staged_lua" | while IFS= read -r f; do
+  [ -n "$f" ] && printf '%s\0' "$repo_root/$f"
+done | xargs -0 node ./check-staged.mjs
+
+# Repo-wide lint pass on top, when the repo has one. Non-fatal to keep the gate's
+# job crisp: syntax blocks, style advises.
+if node -e "process.exit(require('./package.json').scripts.lint ? 0 : 1)" 2>/dev/null; then
+  npm run --silent lint || echo "  (lint reported findings; not blocking the commit)"
+fi

--- a/tools/test/check-staged.mjs
+++ b/tools/test/check-staged.mjs
@@ -1,0 +1,37 @@
+// Parse the exact files git is about to commit, with luaparse pinned to Lua 5.1.
+//
+// WHY NOT REUSE tools/test/syntax-check.mjs: its findLuaFiles() defaults to SRC_DIR,
+// so it never sees main.lua at the repo root - the entry point of several mods in this
+// suite. A gate that misses the entry file is worse than no gate, because it grants
+// false confidence. This checks the STAGED set instead, which is by definition exactly
+// what is shipping, wherever it lives in the tree.
+//
+// Lives in tools/test/ (not tools/git-hooks/) because node resolves bare imports from
+// the SCRIPT's directory upward - from tools/git-hooks it never sees tools/test/node_modules.
+// Usage: node check-staged.mjs <abs-path>...
+import { readFileSync } from "node:fs";
+import luaparse from "luaparse";
+
+const files = process.argv.slice(2);
+let bad = 0;
+for (const f of files) {
+  let code;
+  try {
+    code = readFileSync(f, "utf8");
+  } catch {
+    continue; // deleted or moved between staging and now; nothing to parse
+  }
+  try {
+    luaparse.parse(code, { luaVersion: "5.1", comments: false, locations: true });
+  } catch (e) {
+    bad++;
+    console.error(`  \u2717 ${f}\n      ${e.message}`);
+  }
+}
+if (bad > 0) {
+  console.error(`\n  ${bad} staged Lua file(s) will NOT compile in FS25. Commit blocked.`);
+  console.error("  FS25 drops the whole file at load with no useful message, so this");
+  console.error("  would ship as a silently missing feature. Fix, or --no-verify.");
+  process.exit(1);
+}
+console.log(`  \u2713 Lua 5.1 syntax OK - ${files.length} staged file(s)`);

--- a/tools/test/lua/coverage_test.lua
+++ b/tools/test/lua/coverage_test.lua
@@ -152,3 +152,43 @@ do
   end
   T.eq("FERTILIZER_PROFILES: all N/P/K/OM/pH values are numbers", bad, 0)
 end
+
+-- ── F61 (VWW half of #650): ownership is claimed only when a cell is ACCEPTED ──
+-- On a multi-field farmland _getFieldPolyVerts resolves the FIRST field's polygon, so a
+-- VWW sprayer on the OTHER field has every boom cell rejected by the containment test.
+-- markBoomCells used to set _geometricCoverageOwner regardless, which locked out the
+-- liter fallback for the rest of the session and froze Coverage/Pass% at 0%.
+do
+  local sys = newSys({ [1] = { fieldArea = 2.0, sessionCoverageCells = {} } })
+  -- A polygon far from the boom points: every cell centre falls outside it.
+  sys._getFieldPolyVerts = function()
+    return { {x=1000, z=1000}, {x=1010, z=1000}, {x=1010, z=1010}, {x=1000, z=1010} }
+  end
+  sys:markBoomCells(1, { { x = 5, z = 5 }, { x = 15, z = 5 } }, false)
+
+  T.eq("F61: all cells rejected → geometric ownership NOT claimed",
+       sys.fieldData[1]._geometricCoverageOwner, nil)
+  T.near("F61: all cells rejected → no session ha accrued",
+         sys.fieldData[1].sessionCoverageHa or 0, 0)
+
+  -- The liter fallback must still be reachable, exactly as for a non-VWW implement.
+  local rate = SoilConstants.SPRAYER_RATE.BASE_RATES.HERBICIDE.value
+  sys:trackSprayerCoverage(1, rate * 0.5, "HERBICIDE", true)
+  T.near("F61: liter fallback still tracks after a fully-rejected geometric pass",
+         sys.fieldData[1].sessionCoverageFraction, 0.25)
+end
+
+-- The healthy path is unchanged: an accepted cell still claims ownership immediately,
+-- so the #726 double-count guard keeps working on a correctly-resolved polygon.
+do
+  local sys = newSys({ [1] = { fieldArea = 2.0, sessionCoverageCells = {} } })
+  sys._getFieldPolyVerts = function()
+    return { {x=0, z=0}, {x=100, z=0}, {x=100, z=100}, {x=0, z=100} }
+  end
+  sys:markBoomCells(1, { { x = 5, z = 5 }, { x = 15, z = 5 } }, false)
+
+  T.eq("F61: an accepted cell still claims geometric ownership",
+       sys.fieldData[1]._geometricCoverageOwner, true)
+  T.ok("F61: accepted cells accrue session ha",
+       (sys.fieldData[1].sessionCoverageHa or 0) > 0)
+end

--- a/tools/test/lua/material_down_sf43_test.lua
+++ b/tools/test/lua/material_down_sf43_test.lua
@@ -1,0 +1,216 @@
+-- material_down_sf43_test.lua - MATERIAL DOWN (SF-43).
+--
+-- The layer records HOW MANY DAYS cut material has lain at each spot. The one
+-- direction the design forbids is age reading FRESHER than it is, so most of what
+-- is asserted here is a laundering path staying closed:
+--   * the daily tick is ONE engine call and never touches bare ground or the ceiling
+--   * a catch-up saturates the band the add's guard window has to exclude, so a long
+--     sleep cannot leave a permanently frozen strip below the ceiling
+--   * the fabrication fence refuses rather than falling back to the block-walk
+--   * movement inheritance takes the oldest band's FLOOR (a real pixel's age), with
+--     the ceiling probed first so a refusal propagates instead of being averaged
+--   * birth writes only where there is no record, so nothing can lower an age
+--   * the watermark is idempotent and merges forward, never backward
+--
+--!load: src/utils/Logger.lua, src/maps/SoilValueMaps.lua, src/MaterialDown.lua
+
+DensityValueCompareType = DensityValueCompareType or { BETWEEN = 1, EQUAL = 2 }
+DensityCoordType        = DensityCoordType        or { POINT_POINT_POINT = 1 }
+g_server = g_server or {}
+
+-- ── A store with a recording modifier ─────────────────────
+local function makeStore()
+  local calls, band = {}, {}
+  local filter = {
+    setValueCompareParams = function(_, _, low, high) band.low, band.high = low, high end,
+  }
+  local modifier = {
+    setParallelogramWorldCoords  = function() end,
+    clearPolygonPoints           = function() end,
+    addPolygonPointWorldCoords   = function() end,
+    executeAdd = function(_, delta) calls[#calls + 1] = { op = "add", delta = delta, low = band.low, high = band.high } end,
+    executeSet = function(_, value) calls[#calls + 1] = { op = "set", value = value, low = band.low, high = band.high } end,
+    executeGet = function() return 0, 0, 0 end,
+  }
+  local def
+  for _, d in ipairs(SoilValueMaps.LAYER_DEFS) do
+    if d.key == "materialAge" then def = d end
+  end
+  local vm = SoilValueMaps.new()
+  vm.available     = true
+  vm.hasExecuteAdd = true
+  vm.terrainSize   = 2048
+  vm.resolution    = 1024
+  vm.layers        = { materialAge = { bvm = 1, modifier = modifier, filter = filter, def = def } }
+  return vm, calls, def
+end
+
+-- ── 1. The layer definition ───────────────────────────────
+local _, _, def = makeStore()
+T.ok("materialAge def exists", def ~= nil)
+T.eq("minVal 0", def.minVal, 0)
+-- 254 is load-bearing: RAW_SPAN is 254, so unitsPerRaw is exactly 1 and one day is
+-- one raw step with no quantisation error to accumulate over a season.
+T.eq("maxVal 254 makes one raw step exactly one day", def.maxVal, SoilValueMaps.RAW_SPAN)
+T.eq("no rawFloor (this layer never renders)", def.rawFloor, nil)
+T.eq("no unknownRaw (its refusal is the ceiling, not a band)", def.unknownRaw, nil)
+T.eq("serverOnly couples asks 4+5 in one flag", def.serverOnly, true)
+
+-- ── 2. The ordinary daily tick is ONE engine call ─────────
+local vm, calls = makeStore()
+local applied = vm:applyRawDeltaToLayer("materialAge", 1, 1, 254)
+T.eq("tick applies one raw step", applied, 1)
+T.eq("ordinary tick is exactly one engine call", #calls, 1)
+T.eq("that call is an add", calls[1].op, "add")
+T.eq("add delta is 1", calls[1].delta, 1)
+T.eq("guard window excludes raw 0 (bare ground never ages into a record)", calls[1].low, 1)
+T.eq("guard window excludes the ceiling (a saturated pixel stops counting)", calls[1].high, 254)
+
+-- ── 3. Catch-up saturates what the add window must exclude ─
+vm, calls = makeStore()
+vm:applyRawDeltaToLayer("materialAge", 30, 1, 254)
+T.eq("catch-up is two calls, flat in area", #calls, 2)
+T.eq("first is the add", calls[1].op, "add")
+T.eq("add delta is the boundaries crossed", calls[1].delta, 30)
+T.eq("add window stops short so nothing wraps past the ceiling", calls[1].high, 225)
+T.eq("second is the saturating set", calls[2].op, "set")
+T.eq("saturating pass writes the ceiling", calls[2].value, 255)
+-- THE BUG THIS CLOSES: at delta 30 a pixel sitting at 230 is outside the add window
+-- on this tick and on every tick after it. Without pass 2 that band freezes forever.
+T.eq("saturating band starts where the add window ended", calls[2].low, 226)
+T.eq("saturating band stops below the ceiling", calls[2].high, 254)
+
+-- ── 4. An unrepresentable sleep clamps rather than wraps ───
+vm, calls = makeStore()
+vm:applyRawDeltaToLayer("materialAge", 5000, 1, 254)
+T.eq("delta clamps to the raw span", calls[1].delta, SoilValueMaps.RAW_SPAN - 1)
+
+-- ── 5. THE FABRICATION FENCE ──────────────────────────────
+-- The block-walk fallback point-samples a block centre and executeSets the whole
+-- 16 m block UNFILTERED, which births records on bare ground. On an age layer that
+-- is fabrication, so the store must refuse instead. Honestly inert beats inventing.
+vm, calls = makeStore()
+vm.hasExecuteAdd = false
+local refused = vm:applyRawDeltaToLayer("materialAge", 1, 1, 254)
+T.eq("no executeAdd -> REFUSES (nil, not a silent 0)", refused, nil)
+T.eq("and writes nothing at all", #calls, 0)
+
+-- ── 6. Publication bands ──────────────────────────────────
+T.eq("day 0 is fresh",      MaterialDown.bandForDays(0),  "fresh")
+T.eq("day 1 is fresh",      MaterialDown.bandForDays(1),  "fresh")
+T.eq("day 2 is recent",     MaterialDown.bandForDays(2),  "recent")
+T.eq("day 7 is week",       MaterialDown.bandForDays(7),  "week")
+T.eq("day 14 is ageing",    MaterialDown.bandForDays(14), "ageing")
+T.eq("day 60 is veryOld",   MaterialDown.bandForDays(60), "veryOld")
+
+-- ── A MaterialDown on a scriptable fake store ─────────────
+local function makeSystem(present)
+  local writes, probes = {}, {}
+  local rawAt = 0
+  local fake = {
+    available = true,
+    getLayerEntry = function() return {} end,
+    applyRawDeltaToLayer = function(_, _, delta) writes[#writes + 1] = { op = "add", delta = delta }; return delta end,
+    setPolygonWhere = function(_, _, _, value, low, high)
+      writes[#writes + 1] = { op = "set", value = value, low = low, high = high }
+      return true
+    end,
+    clearPolygonWhere = function(_, _, _, low, high)
+      writes[#writes + 1] = { op = "clear", low = low, high = high }
+      return true
+    end,
+    hasAnyInBand = function(_, _, _, low, high)
+      probes[#probes + 1] = { low = low, high = high }
+      for _, r in ipairs(present or {}) do
+        if r >= low and r <= high then return true end
+      end
+      return false
+    end,
+    readRawAtWorld = function() return rawAt end,
+  }
+  local md = MaterialDown.new()
+  md.armed     = true
+  md.valueMaps = fake
+  return md, writes, probes, function(r) rawAt = r end
+end
+
+-- ── 7. Publication: the two named neutrals ────────────────
+local md, _, _, setRaw = makeSystem()
+setRaw(0)
+T.eq("raw 0 is NO RECORD, never day 0", md:getDaysDownAt(0, 0).status, MaterialDown.RESULT.NO_RECORD)
+setRaw(255)
+T.eq("raw 255 is the CEILING refusal, never a value", md:getDaysDownAt(0, 0).status, MaterialDown.RESULT.CEILING)
+setRaw(1)
+local r = md:getDaysDownAt(0, 0)
+T.eq("raw 1 reads OK", r.status, MaterialDown.RESULT.OK)
+T.eq("raw 1 is born today = 0 full days down", r.days, 0)
+setRaw(8)
+r = md:getDaysDownAt(0, 0)
+T.eq("raw 8 is 7 days down", r.days, 7)
+T.eq("and bands as a week", r.band, "week")
+
+-- ── 8. The watermark is idempotent ────────────────────────
+-- The scheduler retries a failed accrual with the SAME boundariesCrossed, so a
+-- throw after the add would otherwise re-add across the whole map.
+local writes
+md, writes = makeSystem()
+md:onAgeTick({ monotonicDay = 10, boundariesCrossed = 1 })
+md:onAgeTick({ monotonicDay = 10, boundariesCrossed = 1 })
+T.eq("the same day settles exactly once", #writes, 1)
+md:onAgeTick({ monotonicDay = 11, boundariesCrossed = 1 })
+T.eq("the next day does settle", #writes, 2)
+md:onAgeTick({ monotonicDay = 9, boundariesCrossed = 1 })
+T.eq("a day going backwards is a no-op", #writes, 2)
+
+-- ── 9. Merge-never-replace on load ────────────────────────
+-- StateLedger omits a block when serialize fails and cannot tell that from a brand
+-- new save, so a replace-on-nil would wipe the watermark after ONE bad save - and a
+-- lost watermark re-ages the entire map on the next tick.
+md = makeSystem()
+md.ageAppliedThroughDay = 40
+md:deserialize({ ageAppliedThroughDay = 12 })
+T.eq("an older saved watermark never moves it backwards", md.ageAppliedThroughDay, 40)
+md:deserialize({ ageAppliedThroughDay = 55 })
+T.eq("a further-on watermark is adopted", md.ageAppliedThroughDay, 55)
+T.eq("a nil block changes nothing", md:deserialize(nil), false)
+T.eq("and leaves the watermark intact", md.ageAppliedThroughDay, 55)
+
+-- ── 10. Movement inheritance: the ceiling propagates ───────
+local probes
+md, writes, probes = makeSystem({ 255, 3 })
+md:noteMaterialMoved({ {x=0,z=0}, {x=1,z=0}, {x=1,z=1} }, { {x=5,z=5}, {x=6,z=5}, {x=6,z=6} })
+T.eq("the ceiling band is probed FIRST", probes[1].low, 255)
+T.eq("a source at the ceiling makes the destination refuse too", writes[1].value, 255)
+
+-- ── 11. Movement inheritance: the oldest band's floor ──────
+-- Raking a week-old row must not make it read fresh. The inherited value is the
+-- oldest present band's FLOOR, which is an age a real pixel in the source held -
+-- never an average, which would invent an age no pixel ever had.
+md, writes = makeSystem({ 15, 2 })
+md:noteMaterialMoved({ {x=0,z=0}, {x=1,z=0}, {x=1,z=1} }, { {x=5,z=5}, {x=6,z=5}, {x=6,z=6} })
+T.eq("inherits the oldest band floor (raw 15 = 14 days)", writes[1].value, 15)
+T.ok("and is never the average of 15 and 2", writes[1].value ~= 8)
+
+-- ── 12. Birth and merge-on-destination ────────────────────
+md, writes = makeSystem({})
+md:noteMaterialAt({ {x=0,z=0}, {x=1,z=0}, {x=1,z=1} }, nil)
+T.eq("birth dates the pixel today", writes[1].value, 1)
+-- The [0,0] band IS the merge rule: a pixel that already carries an age is outside
+-- the filter, so arriving material can never lower an existing age, and there is no
+-- read-compare-write for the engine to race.
+T.eq("birth writes only where there is NO record (low)",  writes[1].low,  0)
+T.eq("birth writes only where there is NO record (high)", writes[1].high, 0)
+
+-- ── 13. Clearing never touches raw 0 ──────────────────────
+-- No periodic wipe exists anywhere in this system: clearing to raw 0 lets birth
+-- re-date the pixel as today, which launders age in the forbidden direction.
+md, writes = makeSystem({})
+md:noteMaterialGone({ {x=0,z=0}, {x=1,z=0}, {x=1,z=1} })
+T.eq("clear targets written records only", writes[1].low, 1)
+T.eq("clear covers up to and including the ceiling", writes[1].high, 255)
+
+-- ── 14. A refused store call stands the system down ───────
+md = makeSystem({})
+md.valueMaps.setPolygonWhere = function() return false end
+md:noteMaterialAt({ {x=0,z=0}, {x=1,z=0}, {x=1,z=1} }, nil)
+T.eq("a refusal makes the system inert for the session", md:isArmed(), false)

--- a/tools/test/lua/material_wetness_sf49_test.lua
+++ b/tools/test/lua/material_wetness_sf49_test.lua
@@ -1,0 +1,234 @@
+-- material_wetness_sf49_test.lua - WHAT THE SKY DID (SF-49).
+--
+-- The sibling answers how LONG material has lain; this one answers what CONDITION
+-- the sky left it in. Most of what is pinned here is a silent-failure path:
+--   * phase bounds ENCODED before they reach the filter - passing percentages raw
+--     puts the boundaries at ~23 and ~15 percent while every call-count test passes
+--   * the overflow guard INTERSECTED with the caller band, never replaced, and the
+--     edge pass never writing outside the band the caller asked for
+--   * a negative delta flooring at the caller's floor, so a drying step cannot walk
+--     a low pixel down into the reserved sentinel band and turn a value into a refusal
+--   * the sentinel excluded from the aggregate read - it decodes to bone-dry and
+--     would pull a mixed pickup toward FIT
+--   * the Celsius-to-Fahrenheit bridge, and an EMC table clamped, never extrapolated
+--   * refusal propagation, and the season basis that silently dries out spring
+--
+--!load: src/utils/Logger.lua, src/maps/SoilValueMaps.lua, src/MaterialDown.lua, src/MaterialWetness.lua
+
+DensityValueCompareType = DensityValueCompareType or { BETWEEN = 1, EQUAL = 2 }
+DensityCoordType        = DensityCoordType        or { POINT_POINT_POINT = 1 }
+g_server = g_server or {}
+
+local POLY = { {x=0,z=0}, {x=10,z=0}, {x=10,z=10}, {x=0,z=10} }
+
+local function makeStore()
+  local calls, band = {}, {}
+  local filter = {
+    setValueCompareParams = function(_, _, low, high) band.low, band.high = low, high end,
+  }
+  local modifier = {
+    setParallelogramWorldCoords = function() end,
+    clearPolygonPoints          = function() end,
+    addPolygonPointWorldCoords  = function() end,
+    executeAdd = function(_, delta) calls[#calls+1] = { op="add", delta=delta, low=band.low, high=band.high } end,
+    executeSet = function(_, value) calls[#calls+1] = { op="set", value=value, low=band.low, high=band.high } end,
+    executeGet = function() return 0, 0, 0 end,
+  }
+  local def
+  for _, d in ipairs(SoilValueMaps.LAYER_DEFS) do
+    if d.key == "materialWetness" then def = d end
+  end
+  local vm = SoilValueMaps.new()
+  vm.available, vm.hasExecuteAdd = true, true
+  vm.terrainSize, vm.resolution  = 2048, 1024
+  vm.layers = { materialWetness = { bvm=1, modifier=modifier, filter=filter, def=def } }
+  return vm, calls, def
+end
+
+-- ── 1. The layer definition and its sentinel ──────────────
+local _, _, def = makeStore()
+T.ok("materialWetness def exists", def ~= nil)
+T.eq("percent wet basis, 0-100", def.maxVal, 100)
+T.eq("serverOnly like its sibling", def.serverOnly, true)
+-- The REFUSAL state reuses the store's OWN shipped sentinel pattern rather than a
+-- parallel mechanism, so nothing can decode a refusal as an ordinary reading.
+T.eq("sentinel reuses the shipped UNKNOWN_RAW", def.unknownRaw, SoilValueMaps.UNKNOWN_RAW)
+T.eq("rawFloor keeps real readings above the sentinel band", def.rawFloor, 32)
+
+-- ── 2. ENCODE THE BOUNDS BEFORE THEY REACH THE FILTER ─────
+-- The exact numbers the brief cites. Getting this wrong puts the phase boundaries
+-- at roughly 23 and 15 percent, and every call-count assertion still passes.
+T.eq("60 percent encodes to raw 153", MaterialWetness.pctToRaw(60), 153)
+T.eq("40 percent encodes to raw 103", MaterialWetness.pctToRaw(40), 103)
+T.eq("100 percent is the top raw",    MaterialWetness.pctToRaw(100), 255)
+T.eq("0 percent floors above the sentinel band", MaterialWetness.pctToRaw(0), 32)
+T.ok("a raw inside the sentinel band is NOT a percentage", MaterialWetness.rawToPct(24) == nil)
+T.ok("raw 0 is not a percentage either", MaterialWetness.rawToPct(0) == nil)
+T.near("raw 153 decodes back to 60 percent", MaterialWetness.rawToPct(153), 60, 0.4)
+
+-- The ruled phase drops, in raw steps.
+T.eq("25 points is 64 raw steps", MaterialWetness.pointsToRawDelta(25), 64)
+T.eq("18 points is 46 raw steps", MaterialWetness.pointsToRawDelta(18), 46)
+T.eq("6 points is 15 raw steps",  MaterialWetness.pointsToRawDelta(6),  15)
+
+-- ── 3. The guard is INTERSECTED, never replaced ───────────
+local vm, calls = makeStore()
+vm:applyRawDeltaToPolygonBand("materialWetness", POLY, 30, 100, 254)
+T.eq("the caller's LOW bound is preserved exactly", calls[1].low, 100)
+-- Silently widening the band back to the safe window would touch pixels the phase
+-- table deliberately excluded.
+T.eq("the HIGH bound shrinks to the safe bound", calls[1].high, 225)
+
+-- ── 4. The edge pass never writes outside the caller band ──
+vm, calls = makeStore()
+vm:applyRawDeltaToPolygonBand("materialWetness", POLY, 30, 100, 240)
+local edge = calls[2]
+T.eq("edge pass exists for an overflowing top", edge.op, "set")
+T.ok("edge low is inside the caller band", edge.low >= 100)
+T.ok("edge high never exceeds the caller band", edge.high <= 240)
+
+-- ── 5. A NEGATIVE delta floors where the caller says ──────
+-- This is the sentinel protection: a bound-water step on a low pixel must park at
+-- the floor, not walk down into the reserved band and become a REFUSAL.
+vm, calls = makeStore()
+vm:applyRawDeltaToPolygonBand("materialWetness", POLY, -50, 32, 255, { floorTo = 40 })
+local addCall, setCall
+for _, c in ipairs(calls) do
+  if c.op == "add" then addCall = c else setCall = c end
+end
+T.eq("the add is a subtraction", addCall.delta, -50)
+T.ok("the add only touches pixels with room to fall", addCall.low >= 51)
+T.eq("everything below that is floored, not wrapped", setCall.value, 40)
+T.ok("and the floor pass stays inside the caller band", setCall.low >= 32)
+
+-- ── 6. A band outside the layer's raw range is a NO-OP ────
+vm, calls = makeStore()
+local applied = vm:applyRawDeltaToPolygonBand("materialWetness", POLY, 10, 300, 400)
+T.eq("out-of-range band writes nothing", #calls, 0)
+T.eq("and reports nothing applied", applied, 0)
+
+-- ── 7. The fabrication fence carries over ─────────────────
+vm, calls = makeStore()
+vm.hasExecuteAdd = false
+T.eq("no executeAdd -> REFUSES", vm:applyRawDeltaToPolygonBand("materialWetness", POLY, 10, 32, 255), nil)
+T.eq("and writes nothing", #calls, 0)
+
+-- ── 8. THE UNIT BRIDGE ────────────────────────────────────
+-- The engine reports Celsius; the EMC table is indexed in Fahrenheit. A Celsius
+-- value read as Fahrenheit lands in the wrong row and nothing complains.
+T.near("0 C is 32 F",   MaterialWetness.celsiusToFahrenheit(0),   32,  1e-9)
+T.near("100 C is 212 F", MaterialWetness.celsiusToFahrenheit(100), 212, 1e-9)
+T.near("20 C is 68 F",  MaterialWetness.celsiusToFahrenheit(20),  68,  1e-9)
+
+-- ── 9. EMC is CLAMPED at the table edges, never extrapolated ─
+local emcCold = MaterialWetness.emcFor(60, -40)   -- far below the table's 40 F row
+local emcHot  = MaterialWetness.emcFor(60, 200)   -- far above its 100 F row
+local emcEdgeLow  = MaterialWetness.emcFor(60, (40 - 32) * 5 / 9)    -- exactly 40 F
+local emcEdgeHigh = MaterialWetness.emcFor(60, (100 - 32) * 5 / 9)   -- exactly 100 F
+T.near("below the table pins to the edge row", emcCold, emcEdgeLow,  1e-6)
+T.near("above the table pins to the edge row", emcHot,  emcEdgeHigh, 1e-6)
+T.ok("humidity below the table pins too", MaterialWetness.emcFor(0, 20) == MaterialWetness.emcFor(20, 20))
+T.ok("higher humidity means a wetter floor",
+     MaterialWetness.emcFor(90, 20) > MaterialWetness.emcFor(20, 20))
+T.ok("warmer air means a drier floor",
+     MaterialWetness.emcFor(60, 5) > MaterialWetness.emcFor(60, 35))
+
+-- ── 10. The composite weather multiplier ──────────────────
+local W = MaterialWetness.WEATHER_MULT
+T.near("clear sky over dry ground dries fastest",
+       MaterialWetness.weatherMultiplier(0, 0), W.high, 1e-9)
+T.near("overcast over saturated ground is slowest",
+       MaterialWetness.weatherMultiplier(1, 1), W.low, 1e-9)
+T.near("the midpoint is neutral", MaterialWetness.weatherMultiplier(0.5, 0.5), W.mid, 1e-9)
+T.ok("the spread is about threefold", W.high / W.low > 2.5 and W.high / W.low < 3.5)
+
+-- ── 11. Condition bands ───────────────────────────────────
+T.eq("70 percent is soaked", MaterialWetness.bandForPct(70), "soaked")
+T.eq("45 percent is damp",   MaterialWetness.bandForPct(45), "damp")
+T.eq("30 percent is curing", MaterialWetness.bandForPct(30), "curing")
+T.eq("15 percent is fit",    MaterialWetness.bandForPct(15), "fit")
+
+-- ── A wetness system on a scriptable fake store ───────────
+local function makeSystem(opts)
+  opts = opts or {}
+  local fake = {
+    available = true,
+    getLayerEntry = function() return {} end,
+    applyRawDeltaToPolygonBand = function() return 1 end,
+    setPolygonWhere = function() return true end,
+    hasAnyInBand = function(_, _, _, low, high)
+      if opts.sentinel and low < 32 then return true end
+      if low >= 32 then return opts.present ~= false end
+      return false
+    end,
+    readAverageRawInBand = function() return opts.avgRaw or 153 end,
+  }
+  local mw = MaterialWetness.new()
+  mw.armed, mw.valueMaps = true, fake
+  return mw
+end
+
+-- ── 12. The read refuses rather than guessing ─────────────
+local mw = makeSystem()
+local R = MaterialWetness.RESULT
+-- Quantity is NON-OPTIONAL: the engine hands it back and every base-game consumer
+-- keeps it, so its absence is a caller bug, not a reason to invent an answer.
+T.eq("nil quantity REFUSES",      mw:readCondition(POLY, nil).status, R.REFUSAL)
+T.eq("zero quantity REFUSES",     mw:readCondition(POLY, 0).status,   R.REFUSAL)
+T.eq("negative quantity REFUSES", mw:readCondition(POLY, -5).status,  R.REFUSAL)
+
+local wet = makeSystem({ avgRaw = 180 })
+local ok = wet:readCondition(POLY, 1200)
+T.eq("a real pickup reads OK", ok.status, R.OK)
+T.near("and reports its percentage", ok.pct, 70.5, 0.5)
+T.eq("banded for the members", ok.band, "soaked")
+
+-- The quantisation edge, pinned deliberately rather than left to be discovered.
+-- 8 bits over 0-100 means one raw step is ~0.394 percent, and encode rounds to the
+-- nearest step: 60 percent encodes to raw 153, which decodes back to 59.84. A value
+-- written AT a band boundary can therefore land one band below it. That is inherent
+-- to the encoding and harmless at these band widths, but it is real.
+T.near("raw 153 decodes just under 60", MaterialWetness.rawToPct(153), 59.84, 0.02)
+T.eq("so a boundary value bands one below", mw:readCondition(POLY, 1200).band, "damp")
+
+-- ── 13. Refusal PROPAGATES; it does not average away ──────
+-- The sentinel decodes to roughly nine percent - bone dry - so summing it into an
+-- average would pull a mixed pickup toward FIT. One refusing cell refuses the lot.
+local refusing = makeSystem({ sentinel = true })
+T.eq("any refusing cell makes the whole answer a refusal",
+     refusing:readCondition(POLY, 1200).status, R.REFUSAL)
+
+local empty = makeSystem({ present = false })
+T.eq("no material is its own answer, not a refusal",
+     empty:readCondition(POLY, 1200).status, R.NO_MATERIAL)
+
+-- ── 14. The Water Record freezes verdicts and stays bounded ─
+mw = makeSystem()
+mw:recordDay(5, true, "rain", false)
+mw:recordDay(5, false, "none", false)   -- a second verdict for the same day
+T.ok("a recorded verdict is FROZEN, never recomputed", mw.waterRecord[5].water == true)
+mw.appliedThroughDay = 5
+local count, known = mw:waterDaysInLast(6)
+T.eq("one wet day in the window", count, 1)
+T.eq("and only one day is actually known", known, 1)
+
+for d = 1, MaterialWetness.WATER_RECORD_DAYS + 20 do mw:recordDay(100 + d, true, "rain", false) end
+T.ok("the ring stays bounded", #mw.recordDays <= MaterialWetness.WATER_RECORD_DAYS)
+
+-- ── 15. Merge-never-replace, same reason as the sibling ───
+mw = makeSystem()
+mw.appliedThroughDay = 40
+mw:deserialize({ appliedThroughDay = 12 })
+T.eq("an older cursor never moves it backwards", mw.appliedThroughDay, 40)
+mw:deserialize({ appliedThroughDay = 55 })
+T.eq("a further-on cursor is adopted", mw.appliedThroughDay, 55)
+T.eq("a nil block changes nothing", mw:deserialize(nil), false)
+
+-- ── 16. THE SEASON BASIS ──────────────────────────────────
+-- getClimate rejects anything outside 1-4, and SeasonalCropStress normalises the
+-- OTHER way for its own tables. Feeding SCS's spring (0) in here would return nil
+-- every time and give a permanently dry spring that nothing would report.
+mw = makeSystem()
+T.ok("season 0 is rejected, not silently used", mw:readClimate(0) == nil)
+T.ok("season 5 is rejected", mw:readClimate(5) == nil)
+T.ok("a non-number season is rejected", mw:readClimate("spring") == nil)

--- a/tools/test/lua/network_events_roundtrip_test.lua
+++ b/tools/test/lua/network_events_roundtrip_test.lua
@@ -241,3 +241,25 @@ do
   T.eq("sentryStatus: reason", d.reason, 5)
   T.eq("sentryStatus: seq", d.seq, 42)
 end
+
+-- ── SoilValueMapChecksumEvent (SF-43 ask 4): each entry CARRIES its layerIdx ──
+-- This was a positional array whose POSITION was read back as the LAYER_DEFS index.
+-- Skipping any layer (the serverOnly opt-out does exactly that) would then shift
+-- every later checksum onto the wrong layer, so a client would "detect drift" on a
+-- healthy layer and resync it forever. The gap below is the whole point: indices 3
+-- and 5 are sent with 4 missing, exactly as a skipped serverOnly layer produces.
+do
+  local sent = {
+    { layerIdx = 3, sum = 1200, nonZero = 340 },
+    { layerIdx = 5, sum = 77,   nonZero = 9   },
+  }
+  local d = rt("vmChecksum", SoilValueMapChecksumEvent.new(sent), SoilValueMapChecksumEvent)
+  T.eq("vmChecksum: entry count survives", #d.checksums, 2)
+  T.eq("vmChecksum: first layerIdx survives the gap", d.checksums[1].layerIdx, 3)
+  T.eq("vmChecksum: first sum",     d.checksums[1].sum,     1200)
+  T.eq("vmChecksum: first nonZero", d.checksums[1].nonZero, 340)
+  -- The assertion that matters: position 2 still says layer 5, not layer 4.
+  T.eq("vmChecksum: a skipped layer does not shift the next one", d.checksums[2].layerIdx, 5)
+  T.eq("vmChecksum: second sum",     d.checksums[2].sum,     77)
+  T.eq("vmChecksum: second nonZero", d.checksums[2].nonZero, 9)
+end

--- a/tools/test/lua/polygon_vertex_contract_test.lua
+++ b/tools/test/lua/polygon_vertex_contract_test.lua
@@ -1,0 +1,150 @@
+-- polygon_vertex_contract_test.lua - the aimed-write vertex contract.
+--
+-- Every aimed write in this mod goes through setPolygonRegion, which reads `v.x` and
+-- `v.z` off each vertex. The contract is therefore {{x=,z=}, ...} and it is not
+-- optional. SF-44's work-area helper returned a FLAT {x1,z1,x2,z2,...} array instead,
+-- and the consequence was not a failed write:
+--
+--   indexing a number raises  ->  the raise is caught by setPolygonRegion's pcall
+--   ->  the handler reads any failure as "the engine has no polygon ops"
+--   ->  hasPolygonOps is latched false on the SHARED store
+--   ->  probePolygonSupport never re-probes, because _polygonProbed is already set
+--   ->  EVERY aimed write in the mod is dead for the rest of the session
+--
+-- So the first mown verge took the age layer, the wetness layer and the yard ladder
+-- down together, and left one warning line behind to explain it. The fix is in two
+-- halves and both are pinned here: the helper returns the right shape, AND a
+-- malformed polygon from any future caller can no longer be mistaken for an engine
+-- capability verdict.
+--
+--!load: src/utils/Logger.lua, src/maps/SoilValueMaps.lua, src/MaterialDown.lua, src/MaterialWetness.lua
+
+DensityValueCompareType = DensityValueCompareType or { BETWEEN = 1, EQUAL = 2 }
+DensityCoordType        = DensityCoordType        or { POINT_POINT_POINT = 1 }
+g_server = g_server or {}
+
+local GOOD = { { x = 0, z = 0 }, { x = 10, z = 0 }, { x = 10, z = 10 }, { x = 0, z = 10 } }
+local FLAT = { 0, 0, 10, 0, 10, 10, 0, 10 }   -- the shape that caused the outage
+
+-- A store with a working engine modifier behind it.
+local function makeStore(opts)
+  opts = opts or {}
+  local points = {}
+  local modifier = {
+    clearPolygonPoints = function() points = {} end,
+    addPolygonPointWorldCoords = function(_, x, z)
+      if opts.engineRaises then error("engine refused") end
+      points[#points + 1] = { x = x, z = z }
+    end,
+    executeSet = function() return true end,
+  }
+  local filter = { setValueCompareParams = function() end }
+  local vm = setmetatable({}, { __index = SoilValueMaps })
+  vm.available = true
+  -- Both keys point at the same modifier: "testLayer" for the direct store
+  -- assertions, MaterialDown.LAYER_KEY for the end-to-end cascade section.
+  local entry = { modifier = modifier, filter = filter }
+  vm.layers = { testLayer = entry, [MaterialDown.LAYER_KEY] = entry }
+  return vm, function() return points end
+end
+
+-- ── 1. The good shape writes ──────────────────────────────
+
+local vm, getPoints = makeStore()
+T.ok("a {x=,z=} polygon writes", vm:setPolygonWhere("testLayer", GOOD, 1, 0, 0))
+T.eq("and every vertex reached the engine", #getPoints(), 4)
+T.eq("in world coords, not indices", getPoints()[2].x, 10)
+
+-- ── 2. The flat shape is REFUSED, and does not latch ──────
+-- This is the assertion that would have caught the outage.
+
+vm = makeStore()
+T.ok("a flat vertex array is refused", not vm:setPolygonWhere("testLayer", FLAT, 1, 0, 0))
+T.ok("and the store does NOT conclude the engine lacks polygon ops", vm.hasPolygonOps ~= false)
+
+-- The proof that it is not a latch: a correct write still lands afterwards.
+T.ok("a good polygon still writes after a malformed one", vm:setPolygonWhere("testLayer", GOOD, 1, 0, 0))
+
+-- Every partial shape a caller might invent is refused the same way.
+vm = makeStore()
+T.ok("vertices missing z are refused",
+     not vm:setPolygonWhere("testLayer", { { x = 1 }, { x = 2 }, { x = 3 } }, 1, 0, 0))
+T.ok("string coordinates are refused",
+     not vm:setPolygonWhere("testLayer", { { x = "1", z = "1" }, { x = 2, z = 2 }, { x = 3, z = 3 } }, 1, 0, 0))
+T.ok("and none of those disabled polygon ops", vm.hasPolygonOps ~= false)
+T.ok("so a good polygon still writes", vm:setPolygonWhere("testLayer", GOOD, 1, 0, 0))
+
+-- ── 3. A REAL engine failure still latches ────────────────
+-- The distinction is the point. Refusing to latch on rubbish must not stop the store
+-- noticing an engine that genuinely cannot do polygon ops.
+
+vm = makeStore({ engineRaises = true })
+T.ok("a well-formed polygon the engine rejects is refused", not vm:setPolygonWhere("testLayer", GOOD, 1, 0, 0))
+T.eq("and THAT does latch, because it is a real capability verdict", vm.hasPolygonOps, false)
+
+-- ── 4. The cascade, end to end through MaterialDown ───────
+-- The outage was never really about one bad write. It was that one bad write stood
+-- the whole system down.
+
+local function makeDown(store)
+  local md = MaterialDown.new()
+  md.armed, md.valueMaps = true, store
+  return md
+end
+
+vm = makeStore()
+local md = makeDown(vm)
+T.ok("a malformed birth polygon does not record", not md:noteMaterialAt(FLAT, 1, "STRAW"))
+T.ok("and MaterialDown does NOT stand down for the session", not md.stoodDown)
+T.ok("so the very next good birth still records", md:noteMaterialAt(GOOD, 1, "STRAW"))
+
+-- The tracked-material gate is unaffected by any of this.
+T.ok("an untracked material still refuses on a good polygon", not md:noteMaterialAt(GOOD, 1, "CHAFF"))
+T.ok("and still does not stand the system down", not md.stoodDown)
+
+-- ── 5. The shape the work-area helper must produce ────────
+-- HookManager's buildWorkAreaPolygon is a local, so this pins the contract it has to
+-- satisfy rather than the function itself: four corners of an axis-aligned box, each
+-- an {x=,z=} table, in an order that encloses area.
+
+local function boxPolygon(minX, minZ, maxX, maxZ)
+  return {
+    { x = minX, z = minZ },
+    { x = maxX, z = minZ },
+    { x = maxX, z = maxZ },
+    { x = minX, z = maxZ },
+  }
+end
+
+local box = boxPolygon(5, 5, 15, 25)
+vm = makeStore()
+T.eq("the work-area shape has four corners", #box, 4)
+T.ok("each corner is a table", type(box[1]) == "table" and type(box[3]) == "table")
+T.ok("each corner carries numeric x and z",
+     type(box[1].x) == "number" and type(box[1].z) == "number")
+T.ok("and the store accepts it", vm:setPolygonWhere("testLayer", box, 1, 0, 0))
+
+-- Corners must not collapse: a zero-area box would write nothing and read as a
+-- successful birth, which is the quiet half of the same failure class.
+T.ok("the box encloses real area", box[1].x ~= box[2].x and box[2].z ~= box[3].z)
+
+-- ── 6. Vertex COUNT guards must count vertices ────────────
+-- The sibling failure. A guard written as `#verts < 6` is right for a flat array of
+-- three points and rejects EVERY {x=,z=} polygon, because a four-corner work area is
+-- length 4. It fails closed and silently: the tedder simply never dries anything.
+
+T.eq("a four-corner polygon has length 4, not 8", #box, 4)
+T.ok("so a `< 6` guard would reject it", #box < 6)
+T.ok("and a `< 3` guard correctly admits it", not (#box < 3))
+
+-- A degenerate two-point area is still refused by the correct guard.
+T.ok("two points is not a polygon", #{ { x = 0, z = 0 }, { x = 1, z = 1 } } < 3)
+
+-- ── 7. The sentinel floor is reachable by members ─────────
+-- MaterialWetness.RAW_FLOOR was file-local, so a member reading it got nil and the
+-- band floor collapsed to 0, quietly INCLUDING the reserved sentinel band in a read
+-- that exists to exclude it.
+
+T.eq("the sentinel floor is exported", type(MaterialWetness.RAW_FLOOR), "number")
+T.ok("and it is above the reserved sentinel band", MaterialWetness.RAW_FLOOR > 24)
+T.ok("a nil floor would have collapsed to zero", (tonumber(nil) or 0) == 0)

--- a/tools/test/lua/straw_down_sf45_test.lua
+++ b/tools/test/lua/straw_down_sf45_test.lua
@@ -1,0 +1,109 @@
+-- straw_down_sf45_test.lua - STRAW DOWN (SF-45).
+--
+-- The shortest brief the ground-material programme will ship, and this is its
+-- receipt. The design ruled that a SECOND crop must cost a configuration row and a
+-- thin rulebook, or the foundation was wrong. So the assertions here are not really
+-- about straw - they are about the foundation holding:
+--
+--   * straw joins the tracked set as ONE ENTRY, and birth/ageing/condition/movement
+--     then cover it with no straw-specific machinery anywhere
+--   * its spoil count lives in the READER, never in a layer, so the same water
+--     history can ruin hay and spare straw
+--
+-- If a future change adds a straw BRANCH rather than a straw ROW, that re-opens
+-- governance by definition - and these tests are where it would first show.
+--
+--!load: src/utils/Logger.lua, src/maps/SoilValueMaps.lua, src/MaterialDown.lua, src/MaterialWetness.lua
+
+DensityValueCompareType = DensityValueCompareType or { BETWEEN = 1, EQUAL = 2 }
+DensityCoordType        = DensityCoordType        or { POINT_POINT_POINT = 1 }
+g_server = g_server or {}
+
+local POLY = { {x=0,z=0}, {x=10,z=0}, {x=10,z=10} }
+
+-- ── 1. Straw is in the tracked set, and it is one row ─────
+T.ok("STRAW is tracked",            MaterialDown.isTrackedMaterial("STRAW"))
+T.ok("cut grass is tracked",        MaterialDown.isTrackedMaterial("GRASS_WINDROW"))
+T.ok("hay is tracked",              MaterialDown.isTrackedMaterial("DRYGRASS_WINDROW"))
+-- Chaff comes off the same combine and is NOT a swath: recording it would age
+-- something no member will ever read.
+T.ok("chaff is not tracked",        not MaterialDown.isTrackedMaterial("CHAFF"))
+T.ok("an unknown fill type is not tracked", not MaterialDown.isTrackedMaterial("SUNFLOWER"))
+T.ok("nil is not tracked",          not MaterialDown.isTrackedMaterial(nil))
+T.ok("the lookup is case-insensitive", MaterialDown.isTrackedMaterial("straw"))
+
+-- ── 2. Birth is gated by the set, not by a straw branch ───
+local function makeDown()
+  local writes = {}
+  local fake = {
+    available = true,
+    getLayerEntry = function() return {} end,
+    setPolygonWhere = function(_, _, _, value) writes[#writes+1] = value; return true end,
+    clearPolygonWhere = function() return true end,
+    hasAnyInBand = function() return false end,
+    readRawAtWorld = function() return 0 end,
+    applyRawDeltaToLayer = function(_, _, d) return d end,
+  }
+  local md = MaterialDown.new()
+  md.armed, md.valueMaps = true, fake
+  return md, writes
+end
+
+local md, writes = makeDown()
+T.ok("straw births", md:noteMaterialAt(POLY, 1, "STRAW"))
+T.eq("and lands as born-today like any other material", writes[1], 1)
+
+md, writes = makeDown()
+T.ok("an untracked material REFUSES", not md:noteMaterialAt(POLY, 1, "CHAFF"))
+T.eq("and writes nothing at all", #writes, 0)
+
+md, writes = makeDown()
+T.ok("an unnamed material still records", md:noteMaterialAt(POLY, 1, nil))
+T.eq("because the caller made no claim to check", #writes, 1)
+
+md, writes = makeDown()
+T.ok("movement is gated the same way", not md:noteMaterialMoved(POLY, POLY, 1, "CHAFF"))
+T.eq("and writes nothing", #writes, 0)
+
+-- The foundation is material-blind: straw took the SAME code path, so there is no
+-- straw-specific write, ageing rule, or inheritance rule to test. That absence is
+-- the point of the brief.
+T.eq("straw needed exactly one set entry", MaterialDown.TRACKED_MATERIALS.STRAW, true)
+
+-- ── 3. The spoil count lives in the READER ────────────────
+T.eq("straw spoils at 4 rain-days", MaterialWetness.spoilRainDaysFor("STRAW"), 4)
+T.eq("hay spoils at 3",             MaterialWetness.spoilRainDaysFor("DRYGRASS_WINDROW"), 3)
+T.eq("cut grass spoils at 3",       MaterialWetness.spoilRainDaysFor("GRASS_WINDROW"), 3)
+T.eq("a material with no rule returns nil", MaterialWetness.spoilRainDaysFor("CHAFF"), nil)
+T.eq("nil returns nil",             MaterialWetness.spoilRainDaysFor(nil), nil)
+
+-- ── 4. THE ASSERTION THAT MATTERS ─────────────────────────
+-- The same weather, read through two materials, must give two verdicts. If this
+-- ever collapses to one answer, the count has drifted into the layer.
+local mw = MaterialWetness.new()
+mw.armed = true
+for d = 1, 6 do
+  -- three wet days out of six
+  mw:recordDay(d, d <= 3, "rain", false)
+end
+mw.appliedThroughDay = 6
+
+local hay   = mw:goingOffVerdict("DRYGRASS_WINDROW", 6)
+local straw = mw:goingOffVerdict("STRAW", 6)
+T.eq("both verdicts are answerable", hay.status, MaterialWetness.RESULT.OK)
+T.eq("three rain-days on the record", hay.waterDays, 3)
+T.ok("three rain-days RUIN hay",      hay.spoiled)
+T.ok("the same three days SPARE straw", not straw.spoiled)
+T.eq("because straw needs a fourth", straw.needed, 4)
+
+mw:recordDay(7, true, "rain", false)
+mw.appliedThroughDay = 7
+T.ok("a fourth wet day takes straw too", mw:goingOffVerdict("STRAW", 7).spoiled)
+
+-- ── 5. Refusal honesty on a short record ──────────────────
+-- A confident "not spoiled" built on three remembered days out of twenty is a lie.
+local short = mw:goingOffVerdict("STRAW", 20)
+T.eq("a window the record cannot cover REFUSES", short.status, MaterialWetness.RESULT.REFUSAL)
+T.ok("and says how far it actually reaches", short.known < short.window)
+T.eq("a material with no spoil rule refuses too",
+     mw:goingOffVerdict("CHAFF", 6).status, MaterialWetness.RESULT.REFUSAL)

--- a/tools/test/lua/yard_ladder_sf46_test.lua
+++ b/tools/test/lua/yard_ladder_sf46_test.lua
@@ -1,0 +1,296 @@
+-- yard_ladder_sf46_test.lua - THE YARD LADDER (SF-46).
+--
+-- The member that holds a per-bale CONDITION row, walks it up a shelter ladder once
+-- per day, and ends it in one condemnation event. These assertions are written the
+-- house way: they pin the failures that would otherwise be SILENT, not the happy path.
+--
+-- Four of them exist because the first cut of this member got them wrong, and every
+-- one of those four would have shipped green under a call-count test:
+--
+--   * THE TOKEN IS NOT THE NODE ID. Scenegraph node ids do not survive a save. A
+--     nodeId token orphans every row on reload, hands each bale a fresh condition,
+--     and leaves the dead rows in the savegame forever. Nothing in game would have
+--     looked wrong for the first hour.
+--   * NO TRANSIENT REACHES THE LEDGER. MaterialDown:serialize copies records
+--     wholesale, so a live Bale reference parked on a row goes to the serializer.
+--   * BIRTH WETNESS IS NOT LADDER UNITS. Seeding condition from the seasonal stub
+--     would open a winter bale at 75 of a 100 ceiling and blow both ruled horizons.
+--   * A REFUSED READ IS NOT A VALUE. It falls to the stub; it never becomes a zero.
+--
+-- The horizon assertions at the end are the balance guard: if someone retunes a rate
+-- without retuning the thresholds, the ruled "about a wet week / about 2.5 wet weeks"
+-- stops being true, and that is the assertion that says so.
+--
+--!load: src/utils/Logger.lua, src/maps/SoilValueMaps.lua, src/MaterialDown.lua, src/MaterialWetness.lua, src/YardLadder.lua
+
+DensityValueCompareType = DensityValueCompareType or { BETWEEN = 1, EQUAL = 2 }
+DensityCoordType        = DensityCoordType        or { POINT_POINT_POINT = 1 }
+g_server = g_server or {}
+function entityExists(_node) return true end
+
+-- ── Fixtures ──────────────────────────────────────────────
+
+local function makeDown()
+  local fake = {
+    available = true,
+    getLayerEntry = function() return {} end,
+    setPolygonWhere = function() return true end,
+    clearPolygonWhere = function() return true end,
+    hasAnyInBand = function() return false end,
+    readRawAtWorld = function() return 0 end,
+    applyRawDeltaToLayer = function(_, _, d) return d end,
+  }
+  local md = MaterialDown.new()
+  md.armed, md.valueMaps = true, fake
+  return md
+end
+
+-- A stand-in sky member. `wetDays` decides the day verdict; `read` decides what the
+-- birth condition read answers.
+local function makeSky(opts)
+  opts = opts or {}
+  return {
+    isArmed = function() return true end,
+    readCondition = function(_self, verts, litres)
+      opts.sawLitres = litres
+      opts.sawVerts  = verts
+      return opts.read or { status = MaterialWetness.RESULT.OK, pct = 30 }
+    end,
+    waterDaysInLast = function(_self, _n, _day)
+      if opts.known == 0 then return 0, 0 end
+      return (opts.wet and 1 or 0), 1
+    end,
+  }
+end
+
+local function makeHay() return { isArmed = function() return true end } end
+
+local function makeLadder(skyOpts)
+  local md  = makeDown()
+  local sky = makeSky(skyOpts)
+  local yl  = YardLadder.new()
+  yl:arm(md, sky, makeHay())
+  return yl, md, sky
+end
+
+-- Outdoors unless a test says otherwise.
+MaterialWetness.isSheltered = function() return false end
+
+-- ── 1. The token is opaque and minted, never the node id ──
+-- The bug this pins: a nodeId-derived token silently orphans every row on reload.
+
+local yl, md = makeLadder()
+yl:onBaleCreated(4242, { getFillLevel = function() return 100 end }, "STRAW", 100, 1, 100)
+
+local seenToken, seenRow
+md:enumerateObjects(function(t, r) seenToken, seenRow = t, r end)
+
+T.ok("a birth creates exactly one row", seenToken ~= nil)
+T.ok("the token does not contain the node id", seenToken:find("4242") == nil)
+T.eq("the token is the minted first serial", seenToken, "yl_1")
+
+-- ── 2. No transient ever reaches the ledger record ────────
+-- MaterialDown:serialize copies records wholesale, so anything on the row is saved.
+
+T.eq("the row holds no live bale reference", seenRow._baleObject, nil)
+T.eq("the row holds no bale reference under any name", seenRow.bale, nil)
+T.eq("the row holds no node id", seenRow.nodeId, nil)
+T.eq("the row holds no sampled position", seenRow.lastPosX, nil)
+for k, v in pairs(seenRow) do
+  T.ok("row field '" .. k .. "' is plain data", type(v) ~= "userdata" and type(v) ~= "function")
+end
+
+-- ── 3. create REFUSES an existing token ───────────────────
+-- set would clobber. The ledger is enumerate-not-list, so a silent clobber is
+-- unobservable until the save is already wrong.
+
+local md2 = makeDown()
+T.ok("create takes a fresh token", md2:createObjectRecord("yl_1", { condition = 5 }))
+T.ok("create refuses a token already present", not md2:createObjectRecord("yl_1", { condition = 9 }))
+T.eq("and the original row is untouched", md2:getObjectRecord("yl_1").condition, 5)
+T.ok("set still overwrites, which is why both exist", md2:setObjectRecord("yl_1", { condition = 9 }))
+
+-- ── 4. Birth wetness is RECORDED, never seeded into units ─
+-- The horizons only hold if condition starts at zero. See the header.
+
+yl, md = makeLadder({ read = { status = MaterialWetness.RESULT.OK, pct = 75 } })
+yl:onBaleCreated(1, { getFillLevel = function() return 100 end }, "DRYGRASS_WINDROW", 100, 1, 100)
+local row = md:getObjectRecord("yl_1")
+T.eq("condition opens at zero", row.condition, 0)
+T.eq("and the wetness read is kept as its own quantity", row.birthWetnessPct, 75)
+T.ok("a ground read is not marked as a stub", not row.birthStub)
+
+-- ── 5. A refused read falls to the stub, never to a value ─
+-- Refusal propagates. It is not a zero and it is not a default reading.
+
+g_currentMission.environment.currentSeason = 4  -- winter, stub 75
+yl, md = makeLadder({ read = { status = MaterialWetness.RESULT.REFUSAL } })
+yl:onBaleCreated(1, { getFillLevel = function() return 100 end }, "STRAW", 100, 1, 100)
+row = md:getObjectRecord("yl_1")
+T.eq("a refusal does not become a wetness of zero", row.birthWetnessPct, 75)
+T.ok("and the row says plainly that it is a stub", row.birthStub)
+T.eq("a refused birth still opens condition at zero", row.condition, 0)
+
+-- ── 6. Litres is passed, and it is the bale's own ─────────
+-- nil, zero or negative returns REFUSAL inside readCondition. Passing the wrong
+-- quantity is a caller bug, so pin what the caller actually hands over.
+
+local skyOpts = { read = { status = MaterialWetness.RESULT.OK, pct = 20 } }
+yl, md = makeLadder(skyOpts)
+yl:onBaleCreated(1, { getFillLevel = function() return 3100 end }, "STRAW", 3100, 1, 4000)
+T.eq("the birth read is given the newborn bale's own fill level", skyOpts.sawLitres, 3100)
+T.ok("and a polygon it can actually read", skyOpts.sawVerts ~= nil and #skyOpts.sawVerts >= 3)
+
+-- ── 7. The re-attach heuristic, and accept-and-log ────────
+-- A reload is the common door a known bale comes back through, not storage.
+
+yl, md = makeLadder()
+yl:onBaleCreated(10, {}, "STRAW", 100, 1, 100)
+md:getObjectRecord("yl_1").condition = 55        -- weathered a while
+
+yl._live, yl._byNode = {}, {}                    -- the reload: transients are gone
+yl:onBaleCreated(999, {}, "STRAW", 100, 1, 100)  -- same farm, fill and capacity
+
+local rowCount = 0
+md:enumerateObjects(function() rowCount = rowCount + 1 end)
+T.eq("a matching bale re-attaches instead of making a second row", rowCount, 1)
+T.eq("and it keeps the condition it had earned", md:getObjectRecord("yl_1").condition, 55)
+T.eq("the new node now addresses the old row", yl._byNode[999], "yl_1")
+
+-- A bale that matches nothing is accepted as new, never silently folded into a row
+-- that is not its own.
+yl:onBaleCreated(1000, {}, "WHEAT", 100, 1, 100)
+rowCount = 0
+md:enumerateObjects(function() rowCount = rowCount + 1 end)
+T.eq("a non-matching bale gets its own row", rowCount, 2)
+
+-- ── 8. The ladder: rates, shelter, dwell, wrap ────────────
+
+local function passOnce(ladder, day)
+  ladder:onLadderPass({ monotonicDay = day })
+end
+
+-- Wet outdoor day: the full ruled rate.
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passOnce(yl, 10)
+T.eq("a wet outdoor day costs the ruled 6", md:getObjectRecord("yl_1").condition, 6)
+
+-- Dry outdoor day: the split the addendum corrected in, so a dry summer cannot
+-- condemn a yard falsely.
+yl, md = makeLadder({ wet = false })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passOnce(yl, 10)
+T.eq("a dry outdoor day costs the ruled 1", md:getObjectRecord("yl_1").condition, 1)
+
+-- Under a roof: the corrected 0.15, not the 0.4 placeholder.
+MaterialWetness.isSheltered = function() return true end
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passOnce(yl, 10)
+T.near("a roof multiplies the wet rate by the ruled 0.15", md:getObjectRecord("yl_1").condition, 0.9, 0.0001)
+
+-- No mask at all reads as outdoors: neutral when absent.
+MaterialWetness.isSheltered = function() return nil end
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passOnce(yl, 10)
+T.eq("an unavailable mask reads as outdoors, not as free shelter", md:getObjectRecord("yl_1").condition, 6)
+MaterialWetness.isSheltered = function() return false end
+
+-- Dwell at day grain: a bale that moved was in transit and is not charged for it.
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passOnce(yl, 10)
+local afterFirst = md:getObjectRecord("yl_1").condition
+getWorldTranslation = function() return 100, 0, 100 end   -- hauled overnight
+passOnce(yl, 11)
+T.eq("a bale that moved since yesterday accrues nothing", md:getObjectRecord("yl_1").condition, afterFirst)
+passOnce(yl, 12)                                          -- parked at the new spot
+T.eq("and a parked trailer starts accruing again", md:getObjectRecord("yl_1").condition, afterFirst + 6)
+getWorldTranslation = function() return 0, 0, 0 end
+
+-- Wrap is absolute armour in v1: one clock per bale, and it is the engine's.
+g_currentMission.baleManager = { getFermentationTime = function() return 5000 end }
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "DRYGRASS_WINDROW", 100, 1, 100)
+passOnce(yl, 10)
+T.eq("a fermenting bale is untouched by the ladder", md:getObjectRecord("yl_1").condition, 0)
+g_currentMission.baleManager = nil
+
+-- A day the Water Record cannot reach is a refusal, and a refusal is not a wet day.
+yl, md = makeLadder({ known = 0 })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passOnce(yl, 10)
+T.eq("an unreachable day takes the dry rate, never the wet one", md:getObjectRecord("yl_1").condition, 1)
+
+-- ── 9. Bands and condemnation ─────────────────────────────
+
+yl, md = makeLadder()
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+row = md:getObjectRecord("yl_1")
+
+row.condition = 39.9
+T.eq("just under the going-off edge is still fresh", (yl:getConditionBand("yl_1")), YardLadder.BAND.FRESH)
+row.condition = 40
+T.eq("the ruled 40 opens the going-off band", (yl:getConditionBand("yl_1")), YardLadder.BAND.GOING_OFF)
+row.condition = 99.9
+T.eq("just under terminal is still only going off", (yl:getConditionBand("yl_1")), YardLadder.BAND.GOING_OFF)
+row.condition = 100
+T.eq("the ruled 100 is terminal", (yl:getConditionBand("yl_1")), YardLadder.BAND.CONDEMNED)
+
+T.eq("the band is reachable by the node a caller actually holds",
+     (yl:getConditionBandForNode(1)), YardLadder.BAND.CONDEMNED)
+
+-- Condemnation is ONE event: empty it, then delete it, and the row dies with it.
+local emptied, deleted = false, false
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {
+  setFillLevel = function(_, v) emptied = (v == 0) end,
+  delete       = function() deleted = true end,
+}, "STRAW", 100, 1, 100)
+md:getObjectRecord("yl_1").condition = 99
+passOnce(yl, 10)
+T.ok("terminal condition empties the bale first", emptied)
+T.ok("then deletes it", deleted)
+T.eq("and the row dies with it", md:getObjectRecord("yl_1"), nil)
+
+-- Terminal with no live reference must not leave a silently immortal bale: the row
+-- goes and the warning is the only trace, which is what makes it findable.
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, nil, "STRAW", 100, 1, 100)
+md:getObjectRecord("yl_1").condition = 99
+passOnce(yl, 10)
+T.eq("a terminal row with no bale reference is still dropped", md:getObjectRecord("yl_1"), nil)
+
+-- A bale leaving by any other door takes its row with it.
+yl, md = makeLadder()
+yl:onBaleCreated(77, {}, "STRAW", 100, 1, 100)
+yl:onBaleRemoved(77)
+T.eq("a removed bale takes its row", md:getObjectRecord("yl_1"), nil)
+T.eq("and its node index entry", yl._byNode[77], nil)
+
+-- ── 10. The ruled horizons still hold ─────────────────────
+-- The balance guard. If a rate moves without the thresholds moving, the addendum's
+-- promise ("going off about a wet week, condemned about 2.5 wet weeks") quietly stops
+-- being true. This is where that shows.
+
+local R = YardLadder.RATES
+local wetDaysToGoingOff = R.GOING_OFF_AT / R.WET_OUTDOOR
+local wetDaysToCondemn  = R.CONDEMN_AT / R.WET_OUTDOOR
+T.near("outdoors, going off lands at about a wet week", wetDaysToGoingOff, 7, 1)
+T.near("and condemnation at about 2.5 wet weeks", wetDaysToCondemn, 17.5, 1.5)
+
+-- The roof rung is the believable shed-year the correction was made for: roughly 7x
+-- kinder than open ground, not the 2.5x the 0.4 placeholder gave.
+T.near("a roof is about 7x kinder than open ground", 1 / R.ROOF_MULTIPLIER, 6.67, 0.5)
+
+-- Dry days are nearly free, which is the half of the correction that stops a dry
+-- summer condemning a yard.
+T.ok("a dry day costs a fraction of a wet one", R.DRY_OUTDOOR * 5 < R.WET_OUTDOOR)
+
+-- The enclosed rung is NOT here on purpose. The engine's shelter predicate is binary
+-- (verified: no three-state predicate exists in the reference), so v1 ships two rungs
+-- and charges unverifiable cover at the roof rate rather than exempting it. If a
+-- three-state predicate ever lands, this is the assertion to come back to.
+T.eq("v1 ships two shelter rungs, outdoors and roof", R.ROOF_MULTIPLIER < 1 and 2 or 0, 2)

--- a/tools/test/lua/yard_ladder_sf46_test.lua
+++ b/tools/test/lua/yard_ladder_sf46_test.lua
@@ -58,9 +58,13 @@ local function makeSky(opts)
       -- sections below measure the ladder rather than the birth handicap.
       return opts.read or { status = MaterialWetness.RESULT.OK, pct = 15 }
     end,
-    waterDaysInLast = function(_self, _n, _day)
+    -- Mirrors the real contract: "how many of the last n days brought water, and how
+    -- many of those n do I have a record for". It must scale with n, or a span test
+    -- silently measures the fixture instead of the code.
+    waterDaysInLast = function(_self, n, _day)
+      n = math.max(1, math.floor(tonumber(n) or 1))
       if opts.known == 0 then return 0, 0 end
-      return (opts.wet and 1 or 0), 1
+      return (opts.wet and n or 0), n
     end,
   }
 end
@@ -259,6 +263,55 @@ yl, md = makeLadder({ known = 0 })
 yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
 passOnce(yl, 10)
 T.eq("an unreachable day takes the dry rate, never the wet one", md:getObjectRecord("yl_1").condition, 1)
+
+-- ── 8b. A time skip charges the SPAN, not one day ─────────
+-- Found in game 2026-07-31: two bales left outdoors across roughly a simulated year
+-- via the tablet, still sitting there. The pass read ctx.monotonicDay and accrued a
+-- single day per settle, so a year-long skip cost one dry day. Both siblings already
+-- read ctx.boundariesCrossed (MaterialDown:264, MaterialWetness:472); this one did
+-- not, and nothing in the suite asked.
+
+local function passSpan(ladder, day, boundaries)
+  ladder:onLadderPass({ monotonicDay = day, boundariesCrossed = boundaries })
+end
+
+-- A hundred dry days is exactly the condemnation threshold at 1/day.
+yl, md = makeLadder({ wet = false })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passSpan(yl, 110, 30)
+T.eq("thirty dry days cost thirty, not one", md:getObjectRecord("yl_1").condition, 30)
+
+-- The wet split comes from the Water Record over the whole span, in one read.
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passSpan(yl, 110, 10)
+T.eq("a ten day span of wet days costs the wet rate throughout",
+     md:getObjectRecord("yl_1").condition, 10 * YardLadder.RATES.WET_OUTDOOR)
+
+-- Days the record cannot reach are DRY, never wet: neutral when absent, and the
+-- direction that cannot condemn a yard on evidence we do not have.
+yl, md = makeLadder({ known = 0 })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+passSpan(yl, 110, 50)
+T.eq("an unreachable span takes the dry rate for every day",
+     md:getObjectRecord("yl_1").condition, 50 * YardLadder.RATES.DRY_OUTDOOR)
+
+-- The headline: a skipped year must actually kill an unsheltered bale.
+local killed = false
+yl, md = makeLadder({ wet = false })
+yl:onBaleCreated(1, { setFillLevel = function() end, delete = function() killed = true end },
+                 "STRAW", 100, 1, 100)
+passSpan(yl, 400, 365)
+T.ok("a bale left outdoors for a skipped year is condemned", killed)
+T.eq("and its row is gone", md:getObjectRecord("yl_1"), nil)
+
+-- A missing or nonsense boundary count degrades to one day rather than zero, so a
+-- scheduler that omits it still ages the yard.
+yl, md = makeLadder({ wet = true })
+yl:onBaleCreated(1, {}, "STRAW", 100, 1, 100)
+yl:onLadderPass({ monotonicDay = 110 })
+T.eq("no boundary count still charges one day",
+     md:getObjectRecord("yl_1").condition, YardLadder.RATES.WET_OUTDOOR)
 
 -- ── 9. Bands and condemnation ─────────────────────────────
 

--- a/tools/test/lua/yard_ladder_sf46_test.lua
+++ b/tools/test/lua/yard_ladder_sf46_test.lua
@@ -54,7 +54,9 @@ local function makeSky(opts)
     readCondition = function(_self, verts, litres)
       opts.sawLitres = litres
       opts.sawVerts  = verts
-      return opts.read or { status = MaterialWetness.RESULT.OK, pct = 30 }
+      -- Default: baled FIT, so a fixture bale opens at zero condition and the ladder
+      -- sections below measure the ladder rather than the birth handicap.
+      return opts.read or { status = MaterialWetness.RESULT.OK, pct = 15 }
     end,
     waterDaysInLast = function(_self, _n, _day)
       if opts.known == 0 then return 0, 0 end
@@ -110,26 +112,60 @@ T.ok("create refuses a token already present", not md2:createObjectRecord("yl_1"
 T.eq("and the original row is untouched", md2:getObjectRecord("yl_1").condition, 5)
 T.ok("set still overwrites, which is why both exist", md2:setObjectRecord("yl_1", { condition = 9 }))
 
--- ── 4. Birth wetness is RECORDED, never seeded into units ─
--- The horizons only hold if condition starts at zero. See the header.
+-- ── 4. THE BIRTH AXIS, ruled by Arissani 2026-07-30 ───────
+-- A bale made from FIT material opens at zero; the penalty is for how far ABOVE the
+-- safe-baling line the material was when it was baled. One point above the line costs
+-- one wet-day equivalent. These four rows are the ruling's own walk, so if the ladder
+-- is retuned without the handicap following it, this is where it shows.
 
-yl, md = makeLadder({ read = { status = MaterialWetness.RESULT.OK, pct = 75 } })
+T.eq("baled at the fit line opens at zero", YardLadder.birthCondition(20), 0)
+T.eq("baled below the line is still zero, never negative", YardLadder.birthCondition(12), 0)
+T.eq("baled at 25 opens at thirty", YardLadder.birthCondition(25), 30)
+T.eq("baled at 27 is born already going off", YardLadder.birthCondition(27), 42)
+T.ok("and 27 really is past the going-off edge", YardLadder.birthCondition(27) >= YardLadder.RATES.GOING_OFF_AT)
+T.eq("baled at 30 opens at sixty", YardLadder.birthCondition(30), 60)
+T.ok("and 30 condemns inside a wet week",
+     YardLadder.birthCondition(30) + 7 * YardLadder.RATES.WET_OUTDOOR >= YardLadder.RATES.CONDEMN_AT)
+T.ok("a bale baled at 25 goes off inside two wet days",
+     YardLadder.birthCondition(25) + 2 * YardLadder.RATES.WET_OUTDOOR >= YardLadder.RATES.GOING_OFF_AT)
+
+-- The handicap is expressed as a wet-day equivalent, so it tracks the wet rate rather
+-- than standing beside it as a second number that can drift.
+T.eq("one point above the line is exactly one wet day",
+     YardLadder.birthCondition(YardLadder.fitPct() + 1), YardLadder.RATES.WET_OUTDOOR)
+
+-- The fit line is agronomy-fixed and there is ONE of them in the mod.
+T.eq("the fit line is 20 percent", YardLadder.fitPct(), 20)
+
+-- End to end through a birth: wetness is recorded in its own right AND drives the
+-- opening condition. Both, not either.
+yl, md = makeLadder({ read = { status = MaterialWetness.RESULT.OK, pct = 25 } })
 yl:onBaleCreated(1, { getFillLevel = function() return 100 end }, "DRYGRASS_WINDROW", 100, 1, 100)
 local row = md:getObjectRecord("yl_1")
-T.eq("condition opens at zero", row.condition, 0)
-T.eq("and the wetness read is kept as its own quantity", row.birthWetnessPct, 75)
-T.ok("a ground read is not marked as a stub", not row.birthStub)
+T.eq("the wetness read is kept as its own quantity", row.birthWetnessPct, 25)
+T.eq("and it opens the ladder at the ruled handicap", row.condition, 30)
 
--- ── 5. A refused read falls to the stub, never to a value ─
--- Refusal propagates. It is not a zero and it is not a default reading.
+-- A bale baled dry is born clean even though its wetness is recorded.
+yl, md = makeLadder({ read = { status = MaterialWetness.RESULT.OK, pct = 14 } })
+yl:onBaleCreated(1, { getFillLevel = function() return 100 end }, "DRYGRASS_WINDROW", 100, 1, 100)
+row = md:getObjectRecord("yl_1")
+T.eq("dry hay records its wetness", row.birthWetnessPct, 14)
+T.eq("and opens at zero", row.condition, 0)
 
-g_currentMission.environment.currentSeason = 4  -- winter, stub 75
+-- ── 5. A bale we cannot vouch for opens at ZERO ───────────
+-- Refusal propagates all the way out as nil. The old seasonal stub (65/55/70/75) was
+-- a WETNESS estimate and was never a condition, so it is deleted rather than disabled:
+-- a bought or pre-existing bale is not pre-condemned on a guess.
+
+g_currentMission.environment.currentSeason = 4   -- winter, the old stub's harshest cell
 yl, md = makeLadder({ read = { status = MaterialWetness.RESULT.REFUSAL } })
 yl:onBaleCreated(1, { getFillLevel = function() return 100 end }, "STRAW", 100, 1, 100)
 row = md:getObjectRecord("yl_1")
-T.eq("a refusal does not become a wetness of zero", row.birthWetnessPct, 75)
-T.ok("and the row says plainly that it is a stub", row.birthStub)
-T.eq("a refused birth still opens condition at zero", row.condition, 0)
+T.eq("an unreadable birth records no wetness at all", row.birthWetnessPct, nil)
+T.eq("and is NOT a wetness of zero either", row.birthWetnessPct, nil)
+T.eq("and opens at zero condition", row.condition, 0)
+T.eq("the seasonal stub is gone, not merely unused", YardLadder.SEASONAL_BIRTH, nil)
+T.eq("an unknown wetness maps to zero condition", YardLadder.birthCondition(nil), 0)
 
 -- ── 6. Litres is passed, and it is the bale's own ─────────
 -- nil, zero or negative returns REFUSAL inside readCondition. Passing the wrong

--- a/tools/test/lua/yield_test.lua
+++ b/tools/test/lua/yield_test.lua
@@ -105,3 +105,44 @@ do
   local m = sys:_yieldModifierFromNutrients({ compaction = 100 }, grassName, thresh, thresh, thresh, nil)
   T.near("yield: grass ignores compaction penalty", m, 1.0)
 end
+
+-- ── SCS-002: SeasonalCropStress keep-factor read ────────────────────────────
+-- _scsYieldKeepFactor is a DISPLAY-path read. It must be perfectly neutral when
+-- SCS is absent (the overwhelmingly common case) and must never let a broken or
+-- version-skewed sibling mod corrupt our forecast.
+do
+  local sys  = newSys()
+  local prev = g_currentMission
+
+  -- No mission at all → neutral.
+  g_currentMission = nil
+  T.near("scs: no mission → 1.0", sys:_scsYieldKeepFactor(1), 1.0)
+
+  -- Mission present, SCS not installed → neutral.
+  g_currentMission = {}
+  T.near("scs: SCS absent → 1.0", sys:_scsYieldKeepFactor(1), 1.0)
+
+  -- OLDER SCS that predates the getter → neutral (version-skew safety).
+  g_currentMission = { cropStressManager = {} }
+  T.near("scs: getter missing → 1.0", sys:_scsYieldKeepFactor(1), 1.0)
+
+  -- Getter throws → pcall swallows it, forecast unaffected.
+  g_currentMission = { cropStressManager = {
+    getYieldKeepFactor = function() error("boom") end } }
+  T.near("scs: getter errors → 1.0", sys:_scsYieldKeepFactor(1), 1.0)
+
+  -- Getter returns a non-number or an out-of-range value → rejected, not trusted.
+  g_currentMission = { cropStressManager = {
+    getYieldKeepFactor = function() return "nope" end } }
+  T.near("scs: non-numeric → 1.0", sys:_scsYieldKeepFactor(1), 1.0)
+  g_currentMission = { cropStressManager = {
+    getYieldKeepFactor = function() return 1.8 end } }
+  T.near("scs: out-of-range → 1.0", sys:_scsYieldKeepFactor(1), 1.0)
+
+  -- A healthy SCS value passes through untouched.
+  g_currentMission = { cropStressManager = {
+    getYieldKeepFactor = function() return 0.82 end } }
+  T.near("scs: valid keep-factor passes through", sys:_scsYieldKeepFactor(1), 0.82)
+
+  g_currentMission = prev
+end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1228,6 +1228,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimado a partir dos dados do mapa" />
 </elements>
 
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1239,5 +1239,8 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="根据地图数据估算" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1239,5 +1239,8 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="根據地圖資料估算" />
 </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1227,6 +1227,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Odhad z dat mapy" />
 </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1179,5 +1179,8 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimeret ud fra kortdata" />
 </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1198,6 +1198,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Geschätzt aus Kartendaten" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1180,6 +1180,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimado a partir de los datos del mapa" />
 </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1242,5 +1242,8 @@
 
     <!-- Harvest contract underwrite (#741) -->
     <e k="sf_underwrite_notify" v="Harvest contract topped up on field %s: degraded soil compensated to the expected yield." />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimated from map data" />
 </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1180,6 +1180,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimado a partir de los datos del mapa" />
 </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1239,5 +1239,8 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="根据地图数据估算" />
 </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1181,6 +1181,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Arvioitu kartan tiedoista" />
 </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1242,5 +1242,8 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimé d'après les données de la carte" />
 </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1200,6 +1200,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Becslés a térkép adatai alapján" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1227,6 +1227,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Diperkirakan dari data peta" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1227,6 +1227,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Stimato dai dati della mappa" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1207,6 +1207,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="マップデータからの推定値" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1208,6 +1208,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="맵 데이터 기반 추정치" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1211,6 +1211,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Geschat op basis van kaartgegevens" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1209,6 +1209,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimert fra kartdata" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1209,6 +1209,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Oszacowano na podstawie danych mapy" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1228,6 +1228,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimado a partir dos dados do mapa" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1228,6 +1228,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Estimat din datele hărții" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1169,6 +1169,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Оценка по данным карты" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1180,6 +1180,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Uppskattat från kartdata" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1181,6 +1181,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Harita verilerinden tahmin edildi" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1180,6 +1180,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Оцінка за даними карти" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1180,6 +1180,9 @@
 <e k="sf_rp_next" v="Next field" />
     
     <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <!-- Harvester panel yield estimate (SF-50) -->
+    <e k="sf_hud_tha" v="%.1f t/ha" />
+    <e k="sf_hud_yield_est_src" v="Ước tính từ dữ liệu bản đồ" />
 </elements>
 
 


### PR DESCRIPTION
Twelve commits when this opened, fifteen now. The bulk is the ground-material programme, built foundations first: the age layer, the wetness layer and the Water Record, then the three members that read them. The last three commits are the fixes that make any of it actually run.

## The programme

| Member | What it adds |
|---|---|
| SF-43 MATERIAL DOWN | The age layer. The ground remembers how long material has lain, with birth, movement inheritance, clearing and a refusal-honest read |
| SF-49 WHAT THE SKY DID | The wetness layer, the three-phase drying pass, the EMC ceiling, the rain add and the Water Record |
| SF-45 STRAW DOWN | The second crop, for one configuration row and no straw branch anywhere |
| SF-44 THE HAY BET | Grass cures by the sky into hay and spoils in the swath |
| SF-46 THE YARD LADDER | Per-bale condition rows, the shelter ladder, and one condemnation event |

Plus `SoilMaterialBench`, the console command that measured the family's per-call millisecond gate in game, and the pre-commit gate that stops a Lua parse error shipping.

## The one a reviewer should read first

`46feb12d` and `742ec253`, because without them **none of the above worked at all.**

The material birth wiring was correct against the ruling, on both hook sites, with the `nutrientCycles` coupling properly broken. It could not function. Three helpers built work-area polygons as flat `{x1,z1,x2,z2,...}` arrays, and every store method reads `v.x` / `v.z`.

That is not a failed write. Indexing a number **raises** inside `setPolygonRegion`'s pcall, and that handler read any failure as "the engine has no polygon ops", latching `hasPolygonOps = false` on the **shared** store. `probePolygonSupport` never re-probes once `_polygonProbed` is set, so the latch held for the session and took every aimed write in the mod with it. `MaterialDown` then stood itself down on the same refusal.

**The first mow or first swath harvest would have silently disarmed all five members.**

Fixed at all three builders, plus three more defects found in the same path:

- `applyTedderDelta` called `applyRawDeltaToLayer`, which walks the whole map. The tedder was drying **every swath in the world** by eight points each time it passed over one of them.
- `applyTedderDelta` and `enqueueCorrection` guarded on `#verts < 6`, correct for a flat array of three points and rejecting **every** `{x=,z=}` polygon, since a four-corner work area is length 4. Failed closed and silent.
- `MaterialWetness.RAW_FLOOR` was file-local, so members read nil and the band floor collapsed to 0, pulling the reserved sentinel band into reads that exist to exclude it.

`setPolygonRegion` now separates a malformed caller polygon from an engine capability verdict, and `MaterialDown` validates shape at its entry points and refuses without disarming. A refusal on a **well-formed** call still stands the system down, which is SF-43's stated intent and is unchanged.

## SF-46 corrections

Five in the first cut, each of which would have shipped green:

- **The token was the bale nodeId.** Node ids do not survive a save, so every row orphaned on reload, every bale got a fresh condition, and dead rows accumulated in the savegame forever.
- **Live Bale references sat on ledger records**, which `MaterialDown:serialize` copies wholesale into the StateLedger table.
- **Birth wetness was seeded into condition units**, which blows both ruled horizons.
- **Three API calls were in no reference**: `environment:getDay()`, `environment:getSeason()`, `getDayRainfall()`.
- **Condemnation only fired with a live bale reference present**, so a reloaded bale lost its row and lived forever.

## Rulings landed since this opened

**The birth axis** (`59b88b45`): a bale made from FIT material opens at zero, and the penalty is for how far above the safe-baling line the material was when baled. `condition = max(0, wetnessPct - 20) x one wet-day equivalent`. Built as a wet-day equivalent rather than the constant 6, so retuning the ladder moves the handicap with it. The seasonal stub is deleted, not disabled: a bale we cannot vouch for opens at zero and records no wetness at all.

**The enclosed shelter rung is still not built.** The engine's shelter predicate is binary and no three-state predicate exists in any reference, so v1 ships two rungs and charges unverifiable cover at the roof rate rather than exempting it.

## Gates

Suite **1127 assertions, 0 failed, across 32 files**. Syntax and lint clean. Built and deployed.

**In-game verification is outstanding for the whole programme.** Every defect above was found by reading and by tests, and the tests passed on code that would have disarmed itself on the first mow. Nothing here has been observed working in a running save.

SF-44 shipped without a test file; that gap is unaddressed in this PR.
