### PR TITLE
feat: CD-10 hybrid family + SF-26 spatial scouting + SF-38 handful read

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@
 
 ## Mid-term (this season)
 - [ ] ProStaff fertilizer discount bridge (silent, pcall-guarded read of `getFertilizerDiscount`) once scheduled. Not built today by decision (Point 8).
-- [ ] Grass drying / rotting (issue #749): feature request for hay drying and bale/loose grass rotting. On ROADMAP as mid-term. Design path: extend SF moisture system (moisture threshold for drying, moisture + time for rotting). See ecosystem ledger 2026-07-26. Needs Arissani design approval before build.
+- [x] Grass drying / rotting (issue #749): shipped as the ground-material family (SF-43 to SF-49, IDs SF-42 superseded). MATERIAL DOWN records how long material lies out, WHAT THE SKY DID carries wetness and the water record, THE HAY BET converts by condition, STRAW DOWN covers the combine swath, THE YARD LADDER handles bale condition. Built on `development` and merged to main in PR #767. Reading surface (SF-48, Wizard lane) still deferred by ruling.
 - [ ] Decide whether `getFieldInfo` should expose FieldSentry state (isSleeping/isMeadow/contractMaskActive) instead of companions reading `g_currentMission.fieldSentry` directly.
 - [ ] Emit a clean disease-at-harvest signal (pathogen id + pressure) for an external diseased-food/mycotoxin model. Data already retained on fieldData at harvest; expose it deliberately.
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,8 @@
 - [ ] None open from the audit. Track new ones from GitHub issues here.
 
 ## Features / enhancements
+- [x] Ground-material family (SF-43 to SF-49, from #749): age layer + object ledger (SF-43), wetness + water record (SF-49), hay conversion + tedder hook (SF-44), straw swath (SF-45), bale condition ladder (SF-46). Merged to main in PR #767. Material birth wired at HookManager.lua:2749 and :3100. Reading surface (SF-48, Wizard) deferred by ruling.
+- [x] CD-9 disease resistance family: F66 per-pass meter fix, CD-11 resistance data contract (four sync paths), CD-12 tank mix (28 blends), F68 durability dial (BUILD_RATE_NATURAL 0.25), saturated-save relief, CD-10 hybrid strains. Merged to main in PR #772. CD-11 readout (Wizard) still pending.
 - [x] Refined per-pixel value-map engine (WizardlyPayload's #736): adopted and folded into development (cd871bd7). Four merge-review fixes landed with it: migration coord fix, skipped-day batch-tail simulation, undiscovered-disease display-map gate, and the SoilMapOverlay semantic review. Per-cell spray now paints the value maps instead of the field average (#735). Our simulation kept on top of the storage engine.
 - [x] Organic certification multiplayer sync (81d7f9d8): state serialized on every field path, fixing the co-op client wipe. Backed by an ephemeral 3-state status-map layer painted at cert changes (a54098f1) and surfaced as map layer 12. Answers the ecosystem organic-cert MP-sync open call.
 - [x] No-till organic-matter dynamics (#738, f0f5aab8): per-tillage oxidation gradient + fenced no-till daily credit; the flat OM_BOOST retired.

--- a/src/HybridStrains.lua
+++ b/src/HybridStrains.lua
@@ -139,15 +139,27 @@ function HybridStrains.isHybrid(diseaseId)
     return def ~= nil and def.requiresModes ~= nil
 end
 
---- The hybrid id a qualifying pair breeds. One row ships today (a flagged substitution --
---- the count is one of Arissani's open feel calls), so every pair maps to it. When more
---- rows land this is the only function that has to learn how to choose between them.
+--- The hybrid id a qualifying pair breeds. ONE resistant complex per crop family (the
+--- 2026-08-01 count ruling): resolve the field's current crop to its family and return
+--- resistant_complex_<family>; with no family, return the default resistant_complex.
+---
+--- THE EXPLICIT LOOKUP REPLACES THE OLD pairs() SCAN, and that replacement is a defect
+--- fix filed as F94. The scan was exact while exactly one row qualified and a coin toss
+--- at seven: Lua guarantees no pairs() iteration order, and two processes can iterate
+--- the same table differently, so a dedicated server and a joining client could pick
+--- DIFFERENT strains from identical data with nothing raised on either side. The lookup
+--- removes the non-determinism by construction and is cheaper than the scan.
+---@param field table
+---@param _m1 string
+---@param _m2 string
 ---@return string|nil
-function HybridStrains.strainForPair(_m1, _m2)
-    for id, def in pairs(SoilConstants.DISEASE_DEFS) do
-        if def.requiresModes ~= nil then return id end
+function HybridStrains.strainForPair(field, _m1, _m2)
+    local crop = field and field.lastCrop
+    if type(crop) == "string" and crop ~= "" then
+        local family = SoilConstants.HYBRID_CROP_FAMILY[string.lower(crop)]
+        if family ~= nil then return "resistant_complex_" .. family end
     end
-    return nil
+    return "resistant_complex"
 end
 
 --- THE PRE-PASS. Returns a hybrid disease id when this field should breed one, else nil.
@@ -164,7 +176,7 @@ function HybridStrains.selectOnset(field, currentDay)
     if HybridStrains.isInCooldown(field, currentDay) then return nil end
     local m1, m2 = HybridStrains.selectPair(field)
     if not m1 then return nil end
-    local id = HybridStrains.strainForPair(m1, m2)
+    local id = HybridStrains.strainForPair(field, m1, m2)
     if not id then return nil end
     return id, m1, m2
 end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -1413,10 +1413,22 @@ SoilConstants.DISEASE_DEFS = {
     -- way. Its presence is also the flag that the factor applies at all; ordinary diseases
     -- carry no requiresModes and nothing about them changes.
     --
-    -- COUNT IS ONE, and that is a flagged substitution: the hybrid count is one of Arissani's
-    -- four open CD-10 feel calls. The brief authorises building the stated default and saying
-    -- so. Adding more rows later is purely additive -- new ids, same mechanism.
-    resistant_complex  = { cat="resistant_complex", sci="Multi-resistant complex",   cool=false, wet=true,  season={1.0,1.1,1.1}, yMin=0.25, yMax=0.45, requiresModes=2 },
+    -- COUNT IS SEVEN (ruled 2026-08-01): one resistant complex per crop family, plus the
+    -- default kept for unfamilied and modded crops. The rows differ ONLY in `sci`, the
+    -- display key, and the yield band; `cat` and `requiresModes` stay IDENTICAL on all
+    -- seven so the ruled control factor and isHybrid hold on every one.
+    --
+    -- The yield band is where families are allowed to differ because that is an agronomic
+    -- statement rather than a dial: a root crop's blight complex genuinely costs more than
+    -- a forage stand's leaf complex. The shipped 0.25 to 0.45 sits in the middle where it
+    -- should; root sits above it and forage below it, per the brief's own example.
+    resistant_complex          = { cat="resistant_complex", sci="Multi-resistant complex",       cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.25, yMax=0.45, requiresModes=2 },
+    resistant_complex_cereal   = { cat="resistant_complex", sci="Multi-resistant cereal complex",  cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.20, yMax=0.40, requiresModes=2 },
+    resistant_complex_maize    = { cat="resistant_complex", sci="Multi-resistant maize complex",   cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.20, yMax=0.40, requiresModes=2 },
+    resistant_complex_oilseed  = { cat="resistant_complex", sci="Multi-resistant oilseed complex", cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.25, yMax=0.45, requiresModes=2 },
+    resistant_complex_root     = { cat="resistant_complex", sci="Multi-resistant root complex",    cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.30, yMax=0.55, requiresModes=2 },
+    resistant_complex_pulse    = { cat="resistant_complex", sci="Multi-resistant pulse complex",   cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.20, yMax=0.40, requiresModes=2 },
+    resistant_complex_forage   = { cat="resistant_complex", sci="Multi-resistant forage complex",  cool=false, wet=true, season={1.0,1.1,1.1}, yMin=0.15, yMax=0.30, requiresModes=2 },
 }
 
 -- Crop → its candidate diseases (lowercased internal fruit name → list of DISEASE_DEFS ids).
@@ -1472,6 +1484,45 @@ SoilConstants.DISEASE_REGISTRY = {
     peanuts     = { "early_leaf_spot", "late_leaf_spot", "peanut_rust", "pod_rot" },
 }
 SoilConstants.DISEASE_REGISTRY_DEFAULT = { "leaf_spot", "rust", "powdery_mildew" }
+
+-- Crop family for the CD-10 hybrid count ruling (2026-08-01): ONE resistant complex per
+-- crop family, the default kept for everything else. The family is the right unit because
+-- resistance breeds in a FIELD, across a rotation, through the disease pool a rotation
+-- shares. Mint and cotton are deliberately absent: a herb and a fibre crop are each their
+-- own world, and they fall to the default rather than to a bucket invented for them.
+-- Lowercase crop key -> family name; every DISEASE_REGISTRY key resolves here or to the
+-- default (the drift test in the CD-10 hybrid-family bench asserts exactly that).
+--
+-- NOTE THE NAME IS HYBRID_CROP_FAMILY, NOT CROP_FAMILY: that name is already a blessed
+-- rotation-planner contract at line ~1698 (getCropFamily, read by DiseaseSystem.rotationMult)
+-- with a DIFFERENT taxonomy (wheat=grain, maize=grain, mint=forage, cotton=other, peanut=root).
+-- The hybrid brief named its table CROP_FAMILY but that slot is taken; a second assignment
+-- of the same name would silently overwrite the rotation planner's table and change how it
+-- scores crop chains. This table carries the hybrid ruling's OWN taxonomy (cereal, maize,
+-- oilseed, root, pulse, forage) and is read only by HybridStrains.strainForPair.
+SoilConstants.HYBRID_CROP_FAMILY = {
+    -- cereal
+    wheat      = "cereal", barley = "cereal", oat = "cereal", rye = "cereal",
+    spelt      = "cereal", triticale = "cereal", greenrye = "cereal",
+    buckwheat  = "cereal", millet = "cereal",
+    -- maize
+    maize      = "maize", sorghum = "maize",
+    -- oilseed
+    canola     = "oilseed", sunflower = "oilseed", mustard = "oilseed",
+    linseed    = "oilseed", flax = "oilseed", poppy = "oilseed",
+    sesame     = "oilseed", safflower = "oilseed",
+    -- root
+    potato     = "root", sugarbeet = "root", taro = "root",
+    -- pulse
+    soybean    = "pulse", pea = "pulse", peas = "pulse", driedpeas = "pulse",
+    chickpea   = "pulse", chickpeas = "pulse", lentil = "pulse", lentils = "pulse",
+    greenbean  = "pulse", bean = "pulse", beans = "pulse", pintobean = "pulse",
+    pintobeans = "pulse", peanut = "pulse", peanuts = "pulse",
+    -- forage
+    alfalfa    = "forage", luzerne = "forage", clover = "forage",
+    whiteclover = "forage", redclover = "forage", grass = "forage",
+    meadow     = "forage", miscanthus = "forage",
+}
 
 -- Effectiveness fallback for any (chemical, category) pair not explicitly listed.
 SoilConstants.DISEASE_DEFAULT_EFFECTIVENESS = 0.25

--- a/tools/test/lua/hybrid_strains_cd10_test.lua
+++ b/tools/test/lua/hybrid_strains_cd10_test.lua
@@ -47,7 +47,8 @@ end
 
 -- ── The hybrid row itself ────────────────────────────────────────────────────────────
 do
-  local id = H.strainForPair("3", "11")
+  local f = newField({ lastCrop = "wheat" })
+  local id = H.strainForPair(f, "3", "11")
   T.ok("a hybrid strain row exists", id ~= nil)
   local def = SoilConstants.DISEASE_DEFS[id]
   T.ok("it carries requiresModes (the control factor's hook)", def.requiresModes == 2)
@@ -230,7 +231,9 @@ end
 
 -- Clearing a hybrid arms the cooldown; clearing an ordinary disease does not.
 do
-  local f = newField({ activeDisease = H.strainForPair("3", "11"), diseasePressure = 0 })
+  local f = newField({ lastCrop = "wheat" })
+  f.activeDisease = H.strainForPair(f, "3", "11")
+  f.diseasePressure = 0
   local sys = newSys(f)
   sys:_updateActiveDisease(1, f, 1, false, 500)
   T.ok("clear: the hybrid name is dropped", f.activeDisease == nil)
@@ -243,7 +246,7 @@ end
 
 -- ── THE RULED CONTROL FACTOR, worked cases ───────────────────────────────────────────
 do
-  local id = H.strainForPair("3", "11")
+  local id = H.strainForPair(newField({ lastCrop = "wheat" }), "3", "11")
   local fresh = newField({ resistance = {} })
   local burned3 = newField({ resistance = { ["3"] = 10 } })
 
@@ -274,7 +277,7 @@ end
 -- And the factor actually reaches the spray path: against a hybrid, a two-mode blend must
 -- out-treat a single jug. That asymmetry IS the reason the factor was ruled.
 do
-  local id = H.strainForPair("3", "11")
+  local id = H.strainForPair(newField({ lastCrop = "wheat" }), "3", "11")
 
   local single = newField({ activeDisease = id, diseasePressure = 80 })
   local sysA = newSys(single)
@@ -297,4 +300,64 @@ do
   T.ok("a two-mode blend does substantially MORE -- the hybrid's whole reason",
        totalB > totalA * 1.5)
   T.near("...and the margin is the ruled factor, 1.0x against 0.5x", totalB / totalA, 2.0, 0.1)
+end
+
+-- ── CD-10 HYBRID FAMILY (2026-08-01 count ruling): one complex per crop family ──────
+do
+  -- BAR 1, the drift test: every DISEASE_REGISTRY key resolves to a family or explicitly
+  -- to the default. Fails the day someone adds a crop and forgets the table.
+  local fam = SoilConstants.HYBRID_CROP_FAMILY
+  local explicitDefault = { mint = true, cotton = true }
+  local total = 0
+  for crop in pairs(SoilConstants.DISEASE_REGISTRY) do
+    total = total + 1
+    T.ok("registry key resolves: " .. crop, fam[crop] ~= nil or explicitDefault[crop] == true)
+  end
+  T.ok("the registry was actually iterated", total > 0)
+
+  -- No invented family: every CROP_FAMILY value is one of the six ruled families.
+  local ruled = { cereal = true, maize = true, oilseed = true, root = true, pulse = true, forage = true }
+  for crop, family in pairs(fam) do
+    T.ok("family is ruled, not invented: " .. crop, ruled[family] == true)
+  end
+
+  -- BAR 2: deterministic. A hundred calls on one field return the same id.
+  local wheat = newField({ lastCrop = "wheat" })
+  local expected = H.strainForPair(wheat, "3", "11")
+  local same = true
+  for _ = 1, 100 do
+    if H.strainForPair(wheat, "3", "11") ~= expected then same = false break end
+  end
+  T.ok("strainForPair is deterministic across 100 calls", same)
+  T.eq("a wheat field breeds the cereal complex", expected, "resistant_complex_cereal")
+  T.eq("a potato field breeds the root complex", H.strainForPair(newField({ lastCrop = "potato" }), "3", "11"), "resistant_complex_root")
+  T.eq("a grass field breeds the forage complex", H.strainForPair(newField({ lastCrop = "grass" }), "3", "11"), "resistant_complex_forage")
+
+  -- BAR 3: an unfamilied crop returns the default, never nil.
+  T.eq("a modded crop falls to the default", H.strainForPair(newField({ lastCrop = "strawberry" }), "3", "11"), "resistant_complex")
+  T.eq("a nil-crop field falls to the default", H.strainForPair(newField({}), "3", "11"), "resistant_complex")
+  T.eq("a nil field falls to the default", H.strainForPair(nil, "3", "11"), "resistant_complex")
+
+  -- BAR 4: all seven ids carry requiresModes = 2 and cat = "resistant_complex".
+  local ids = {
+    "resistant_complex", "resistant_complex_cereal", "resistant_complex_maize",
+    "resistant_complex_oilseed", "resistant_complex_root", "resistant_complex_pulse",
+    "resistant_complex_forage",
+  }
+  for _, id in ipairs(ids) do
+    local def = SoilConstants.DISEASE_DEFS[id]
+    T.ok("row exists: " .. id, def ~= nil)
+    T.eq("requiresModes is 2 on " .. id, def.requiresModes, 2)
+    T.eq("cat is resistant_complex on " .. id, def.cat, "resistant_complex")
+    T.ok("isHybrid recognises " .. id, H.isHybrid(id))
+  end
+
+  -- BAR 5: a field that bred resistant_complex under 2.5 still reads as a hybrid.
+  T.ok("the 2.5 default id still reads as a hybrid", H.isHybrid("resistant_complex"))
+
+  -- The family is reached through the real onset pre-pass.
+  local sys = newSys(newField({ resistance = { ["3"] = 10, ["11"] = 10 }, lastCrop = "wheat" }))
+  local f = sys.fieldData[1]
+  sys:_updateActiveDisease(1, f, 1, false, 100)
+  T.eq("onset on wheat breeds the cereal complex", f.activeDisease, "resistant_complex_cereal")
 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1260,6 +1260,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1271,5 +1271,12 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1271,5 +1271,12 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1259,6 +1259,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1211,5 +1211,12 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1230,6 +1230,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1212,6 +1212,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1274,5 +1274,12 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="Multi-resistant forage complex" />
 </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1212,6 +1212,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1271,5 +1271,12 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1213,6 +1213,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1274,5 +1274,12 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="Complexe multi-résistant" />
+    <e k="sf_dis_resistant_complex_cereal" v="Complexe multi-résistant des céréales" />
+    <e k="sf_dis_resistant_complex_maize" v="Complexe multi-résistant du maïs" />
+    <e k="sf_dis_resistant_complex_oilseed" v="Complexe multi-résistant des oléagineux" />
+    <e k="sf_dis_resistant_complex_root" v="Complexe multi-résistant des racines" />
+    <e k="sf_dis_resistant_complex_pulse" v="Complexe multi-résistant des légumineuses" />
+    <e k="sf_dis_resistant_complex_forage" v="Complexe multi-résistant des fourrages" />
 </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1232,6 +1232,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1259,6 +1259,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1259,6 +1259,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1239,6 +1239,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1240,6 +1240,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1243,6 +1243,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1241,6 +1241,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1241,6 +1241,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1260,6 +1260,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1260,6 +1260,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1201,6 +1201,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1212,6 +1212,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1213,6 +1213,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1212,6 +1212,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1212,6 +1212,13 @@
     <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
     <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
     <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 </elements>
 
 


### PR DESCRIPTION
feat: CD-10 hybrid family + SF-26 spatial scouting + SF-38 handful read

Three builds on `development`, plus the roadmap/todo catch-up, in one PR.

CD-10 hybrid family, one resistant complex per crop family (the 2026-08-01 count ruling):

- Seven strain rows where one shipped: the default `resistant_complex` kept unchanged, plus `resistant_complex_cereal`, `_maize`, `_oilseed`, `_root`, `_pulse`, `_forage`. They differ only in the display name and yield band; `cat` and `requiresModes` stay identical on all seven so the ruled control factor and isHybrid hold on every one.
- `strainForPair(field, m1, m2)` now resolves the field's crop to its family and returns the family strain, falling back to the default for unfamilied and modded crops. The explicit lookup replaces the old `pairs()` scan, which was exact at one row and a coin toss at seven (F94).
- Seven display keys added to all 27 translation files.
- One deliberate departure, stated rather than buried: the brief named the family table `SoilConstants.CROP_FAMILY`, but that name is already a blessed rotation-planner contract with a different taxonomy. Built as `SoilConstants.HYBRID_CROP_FAMILY` so the rotation planner is untouched.

SF-26 spatial scouting walked mask (the ratified brief, built to section 4's test list):

- `SpatialScouting.lua` owns the per-farm, per-field, per-cell walked mask in its own home (LAW 2, never on fieldData). On-foot-only sampling from the server's authoritative player list (LAW 1 + LAW 4). Aging is idempotent and catch-up safe. A knowledge-generation gate keeps pre-re-hide walks from resurrecting (acceptance 4). Serialize/deserialize merges, never replaces.
- `SoilScoutingBridge.lua`: Time Guard day aging (non-money), StateLedger sidecar with own-XML fallback, and a NetworkSync module whose payload carries each entry's own truth (LAW 3: cell, walkDay, sampledTruth, x, z, gen).
- The B2 compose lives at read time in SoilMapOverlay, not in the shared value maps, so each farm's client composes its own walked truth and a different farm's client sees nothing (acceptance 5).

SF-38 the handful read (the frozen Read the Dirt payload contract):

- `HandfulRead.assemble(ctx)` returns one payload for a spot, assembled from getters that all ship, each clause carrying its honest grain (spot/cell/field) and its own gate. Pure assembly, zero writes.
- The material verdict takes the fill type from the caller because the ground-material layers are material-blind on purpose; it refuses honestly when none is supplied. diseaseKnown is cell-grain via the walked mask when a fresh cell exists.
- The clause list rides the payload so the panel (Wizard's brief to follow) iterates it verbatim.

Suite: 2083 assertions, 0 failed across 41 files. Syntax and lint clean.

The in-game acceptance still needs a person with the game: walk an undiscovered field and watch the pattern appear, survive a reload, fade, and the MP farm separation. Nothing built since 2026-07-29 has been observed running in a live game.
