### PR TITLE
feat(ui): Esc RF PDA STABLE chrome freeze (NO-HOST joiner)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.0</version>
+    <version>2.5.0.4</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/main.lua
+++ b/src/main.lua
@@ -103,6 +103,16 @@ source(modDirectory .. "src/ui/SoilMapOverlay.lua")
 source(modDirectory .. "src/ui/SoilMinimapLayer.lua")
 source(modDirectory .. "src/hooks/SoilMapHooks.lua")
 source(modDirectory .. "src/ui/SoilPDAScreen.lua")
+-- RF Esc greenfield (NO-HOST Option B): shared door + Soil module joiner.
+-- Legacy SoilPDAScreen Esc tab stands down when menuRealisticFarming is live.
+source(modDirectory .. "src/ui/RfEscModules.lua")
+source(modDirectory .. "src/ui/SoilTreatmentRates.lua")
+source(modDirectory .. "src/ui/RfPdaSoilPanel.lua")
+source(modDirectory .. "src/ui/RfPdaMenuPage.lua")
+source(modDirectory .. "src/ui/RfEscBootstrap.lua")
+-- DEV: Esc UIDebugger hot-reload (F6 / rfEscReloadGui). Cross-mod singleton install.
+source(modDirectory .. "src/ui/RfEscUiDebugger.lua")
+source(modDirectory .. "src/ui/RfSoilEscJoiner.lua")
 source(modDirectory .. "src/ui/RotationPlannerData.lua")
 source(modDirectory .. "src/ui/SoilFieldDetailDialog.lua")
 source(modDirectory .. "src/ui/RotationPlannerDialog.lua")

--- a/src/ui/RfEscBootstrap.lua
+++ b/src/ui/RfEscBootstrap.lua
@@ -1,0 +1,170 @@
+﻿-- =========================================================
+-- Realistic Farming Esc â€” equal shared chrome bootstrap (NO HOST)
+-- =========================================================
+-- Any joiner may create menuRealisticFarming if absent.
+-- No Soil privilege; no rfPdaHost. Option B equal-bootstrap path.
+-- =========================================================
+
+RfEscBootstrap = {}
+
+local PAGE_NAME = "menuRealisticFarming"
+local CLASS_NAME = "RfPdaMenuPage"
+
+local function _log(level, fmt, ...)
+    local msg = string.format(fmt, ...)
+    if SoilLogger ~= nil and type(SoilLogger[level]) == "function" then
+        SoilLogger[level]("%s", msg)
+    elseif Logging ~= nil and type(Logging[level]) == "function" then
+        Logging[level]("[RfEscBootstrap] " .. msg)
+    else
+        print("[RfEscBootstrap] " .. msg)
+    end
+end
+
+--- Inject frame into InGameMenu (WC/Soil port of addIngameMenuPage).
+local function addIngameMenuPage(frame, pageName, iconPath, uvs, position, predicateFunc, modDir)
+    local targetPosition = 0
+    local inGameMenu = g_gui.screenControllers[InGameMenu]
+    if inGameMenu == nil then
+        _log("warning", "InGameMenu not found")
+        return false
+    end
+    if inGameMenu.pagingElement == nil
+            or inGameMenu.pagingElement.elements == nil
+            or inGameMenu.pagingElement.pages == nil
+            or inGameMenu.pageFrames == nil then
+        _log("warning", "InGameMenu not fully initialized")
+        return false
+    end
+
+    if g_inGameMenu ~= nil and g_inGameMenu.controlIDs ~= nil then
+        g_inGameMenu.controlIDs[pageName] = nil
+    end
+
+    if type(position) == "string" then
+        for i = 1, #g_inGameMenu.pagingElement.elements do
+            local child = g_inGameMenu.pagingElement.elements[i]
+            if child == g_inGameMenu[position] then
+                targetPosition = i + 1
+                break
+            end
+        end
+    elseif type(position) == "number" then
+        targetPosition = position
+    else
+        targetPosition = 1
+    end
+
+    inGameMenu[pageName] = frame
+    inGameMenu.pagingElement:addElement(inGameMenu[pageName])
+    inGameMenu:exposeControlsAsFields(pageName)
+
+    if position ~= nil then
+        for i = #inGameMenu.pagingElement.elements, 1, -1 do
+            local child = inGameMenu.pagingElement.elements[i]
+            if child == inGameMenu[pageName] then
+                table.remove(inGameMenu.pagingElement.elements, i)
+                table.insert(inGameMenu.pagingElement.elements, targetPosition, child)
+                break
+            end
+        end
+        for i = #inGameMenu.pagingElement.pages, 1, -1 do
+            local child = inGameMenu.pagingElement.pages[i]
+            if child.element == inGameMenu[pageName] then
+                table.remove(inGameMenu.pagingElement.pages, i)
+                table.insert(inGameMenu.pagingElement.pages, targetPosition, child)
+                break
+            end
+        end
+    end
+
+    inGameMenu.pagingElement:updateAbsolutePosition()
+    inGameMenu.pagingElement:updatePageMapping()
+    inGameMenu:registerPage(inGameMenu[pageName], nil, predicateFunc)
+
+    local iconFileName = Utils.getFilename(iconPath, modDir)
+    inGameMenu:addPageTab(inGameMenu[pageName], iconFileName, GuiUtils.getUVs(uvs))
+
+    if position ~= nil then
+        for i = 1, #g_inGameMenu.pageFrames do
+            local child = inGameMenu.pageFrames[i]
+            if child == inGameMenu[pageName] then
+                table.remove(inGameMenu.pageFrames, i)
+                table.insert(inGameMenu.pageFrames, targetPosition, child)
+                break
+            end
+        end
+    end
+
+    inGameMenu:rebuildTabList()
+    local page = inGameMenu[pageName]
+    if page ~= nil and page.setVisible ~= nil then
+        pcall(page.setVisible, page, false)
+    end
+    return true
+end
+
+--- Ensure shared Esc door exists. Idempotent: skip create if already present.
+---@param modDir string g_currentModDirectory of the calling joiner
+---@param opts table|nil { profilesXml?, iconPath?, uvs? }
+---@return boolean true if door exists after call
+function RfEscBootstrap.ensureDoor(modDir, opts)
+    if g_client == nil or g_gui == nil or g_inGameMenu == nil or modDir == nil then
+        return false
+    end
+    opts = opts or {}
+
+    local inGameMenu = g_gui.screenControllers[InGameMenu]
+    if inGameMenu == nil
+            or inGameMenu.pagingElement == nil
+            or inGameMenu.pagingElement.elements == nil then
+        return false
+    end
+
+    if g_inGameMenu[PAGE_NAME] ~= nil then
+        return true
+    end
+
+    if RfPdaMenuPage == nil then
+        _log("warning", "RfPdaMenuPage class missing; cannot bootstrap Esc door")
+        return false
+    end
+
+    local profilesXml = opts.profilesXml or (modDir .. "xml/gui/rfEscProfiles.xml")
+    if profilesXml ~= nil then
+        pcall(function()
+            g_gui:loadProfiles(profilesXml)
+        end)
+    end
+
+    local pageController = RfPdaMenuPage.new()
+    local xmlFile = RfPdaMenuPage.getXmlFilename and RfPdaMenuPage.getXmlFilename()
+        or (modDir .. "xml/gui/" .. CLASS_NAME .. ".xml")
+    _log("info", "creating Esc door from %s", tostring(xmlFile))
+    g_gui:loadGui(xmlFile, CLASS_NAME, pageController, true)
+
+    local iconPath = opts.iconPath or RfPdaMenuPage.MENU_ICON_PATH or "textures/ui/menuIcon.dds"
+    local uvs = opts.uvs or { 0, 0, 1024, 1024 }
+    local ok = addIngameMenuPage(
+        pageController,
+        PAGE_NAME,
+        iconPath,
+        uvs,
+        "pageSettings",
+        function() return true end,
+        modDir
+    )
+    if not ok then
+        _log("error", "addIngameMenuPage failed for %s", PAGE_NAME)
+        return false
+    end
+    if pageController.initialize ~= nil then
+        pageController:initialize()
+    end
+    _log("info", "Esc door ready (%s)", PAGE_NAME)
+    return g_inGameMenu[PAGE_NAME] ~= nil
+end
+
+function RfEscBootstrap.getPageName()
+    return PAGE_NAME
+end

--- a/src/ui/RfEscBootstrap.lua
+++ b/src/ui/RfEscBootstrap.lua
@@ -1,4 +1,4 @@
-﻿-- =========================================================
+-- =========================================================
 -- Realistic Farming Esc â€” equal shared chrome bootstrap (NO HOST)
 -- =========================================================
 -- Any joiner may create menuRealisticFarming if absent.

--- a/src/ui/RfEscModules.lua
+++ b/src/ui/RfEscModules.lua
@@ -1,0 +1,155 @@
+-- =========================================================
+-- Realistic Farming Esc — shared module registry (NO HOST)
+-- =========================================================
+-- Law: Ash Office/NOTE-Wizard-Esc-NO-HOST-module-stack-LAW-2026-08-02.md
+-- Published ONLY on g_currentMission.rfEscModules (+ env g_rfEscModules).
+-- Never rfPdaHost / elected Soil owner.
+-- =========================================================
+
+RfEscModules = {}
+local RfEscModules_mt = Class(RfEscModules)
+
+local function _publish(reg)
+    local env = getfenv(0)
+    env.g_rfEscModules = reg
+    if g_currentMission ~= nil then
+        g_currentMission.rfEscModules = reg
+        -- Kill peer-host / Soil-host handles (product law).
+        g_currentMission.rfPdaHost = nil
+    end
+    env.g_rfPdaHost = nil
+end
+
+function RfEscModules.new()
+    local self = setmetatable({}, RfEscModules_mt)
+    self.modules = {}
+    self.activeModuleId = nil
+    self.listeners = {}
+    return self
+end
+
+--- Ensure singleton registry (not a content host).
+---@return table
+function RfEscModules.getOrCreate()
+    local env = getfenv(0)
+    local reg = (g_currentMission and g_currentMission.rfEscModules) or env.g_rfEscModules
+    if reg == nil then
+        reg = RfEscModules.new()
+    end
+    _publish(reg)
+    return reg
+end
+
+---@param listener fun()
+function RfEscModules:addChangeListener(listener)
+    if type(listener) == "function" then
+        table.insert(self.listeners, listener)
+    end
+end
+
+function RfEscModules:_notify()
+    for _, fn in ipairs(self.listeners) do
+        pcall(fn)
+    end
+end
+
+--- Register or replace a module joiner.
+---@param def table { id, title, order, icon?, blurb?, isAvailable, onShow, onHide?, onWageOptionChanged?, onWageReset? }
+function RfEscModules:registerModule(def)
+    if def == nil or def.id == nil or def.id == "" then
+        return false
+    end
+    self.modules[def.id] = {
+        id = def.id,
+        title = def.title or def.id,
+        blurb = def.blurb,
+        order = tonumber(def.order) or 100,
+        icon = def.icon,
+        isAvailable = def.isAvailable or function() return true end,
+        onShow = def.onShow,
+        onHide = def.onHide,
+        onWageOptionChanged = def.onWageOptionChanged,
+        onWageReset = def.onWageReset,
+    }
+    if self.activeModuleId == nil then
+        self.activeModuleId = def.id
+    end
+    self:_notify()
+    return true
+end
+
+-- Compat alias during greenfield migrate (same table, not a host).
+function RfEscModules:registerPanel(def)
+    return self:registerModule(def)
+end
+
+---@param id string
+function RfEscModules:unregisterModule(id)
+    if id == nil then return end
+    local wasActive = self.activeModuleId == id
+    self.modules[id] = nil
+    if wasActive then
+        self.activeModuleId = nil
+        local list = self:getModules()
+        if list[1] ~= nil then
+            self.activeModuleId = list[1].id
+        end
+    end
+    self:_notify()
+end
+
+function RfEscModules:unregisterPanel(id)
+    self:unregisterModule(id)
+end
+
+---@return table[]
+function RfEscModules:getModules()
+    local list = {}
+    for _, def in pairs(self.modules) do
+        local ok, available = pcall(def.isAvailable)
+        if ok and available then
+            table.insert(list, def)
+        end
+    end
+    table.sort(list, function(a, b)
+        if a.order == b.order then
+            return tostring(a.id) < tostring(b.id)
+        end
+        return a.order < b.order
+    end)
+    return list
+end
+
+function RfEscModules:getPanels()
+    return self:getModules()
+end
+
+---@param id string
+function RfEscModules:selectModule(id)
+    if id == nil or self.modules[id] == nil then
+        return false
+    end
+    local ok, available = pcall(self.modules[id].isAvailable)
+    if not (ok and available) then
+        return false
+    end
+    self.activeModuleId = id
+    self:_notify()
+    return true
+end
+
+function RfEscModules:selectPanel(id)
+    return self:selectModule(id)
+end
+
+---@return table|nil
+function RfEscModules:getActiveModule()
+    if self.activeModuleId == nil then
+        return nil
+    end
+    return self.modules[self.activeModuleId]
+end
+
+function RfEscModules:getActivePanel()
+    return self:getActiveModule()
+end

--- a/src/ui/RfEscUiDebugger.lua
+++ b/src/ui/RfEscUiDebugger.lua
@@ -1,0 +1,735 @@
+-- =========================================================
+-- Realistic Farming Esc — UIDebugger hot-reload (DEV ONLY)
+-- =========================================================
+-- Ash GO 2026-08-02: temporary tooling. Not player product path.
+-- Hotkey: F6 (F5 taken by EasyDevControls debug + Market Dynamics MDM).
+-- Hang fence: close InGameMenu before frame delete / loadGui.
+-- CRITICAL 2026-08-02: Giants createFromExistingGui pattern —
+-- delete whole frame controller + root, loadGui into a NEW controller,
+-- then in-place swap InGameMenu page/tab slots (never duplicate seedling).
+-- Does NOT re-run RfEscBootstrap.ensureDoor / module soft-register.
+-- Vera F1 alone/combine still needs full client restart.
+-- Singleton: only one mod installs (prefer Soil; else first).
+-- =========================================================
+
+RfEscUiDebugger = {}
+
+local PAGE_NAME = "menuRealisticFarming"
+local CLASS_NAME = "RfPdaMenuPage"
+local SOIL_MOD_NAME = "FS25_SoilFertilizer"
+local COOLDOWN_MS = 1000
+local _cooldownUntil = 0
+local _listenerInstalled = false
+
+local function _log(level, fmt, ...)
+    local msg = string.format(fmt, ...)
+    if Logging ~= nil and type(Logging[level]) == "function" then
+        Logging[level]("[RfEscUiDebugger] " .. msg)
+    else
+        print("[RfEscUiDebugger] " .. msg)
+    end
+end
+
+local function _normDir(path)
+    if path == nil or path == "" then
+        return nil
+    end
+    local p = tostring(path):gsub("\\", "/"):gsub("/+$", "")
+    return (p .. "/"):lower()
+end
+
+--- True global / mission flag (getfenv(0) is per-mod sandbox — broken for singleton).
+local function _isInstalledGlobally()
+    if _G ~= nil and _G.g_rfEscUiDebuggerInstalled == true then
+        return true
+    end
+    if g_currentMission ~= nil and g_currentMission.rfEscUiDebuggerInstalled == true then
+        return true
+    end
+    return false
+end
+
+local function _markInstalledGlobally()
+    if _G ~= nil then
+        _G.g_rfEscUiDebuggerInstalled = true
+    end
+    if g_currentMission ~= nil then
+        g_currentMission.rfEscUiDebuggerInstalled = true
+    end
+end
+
+local function _getSoilModDirectory()
+    if g_modNameToDirectory ~= nil then
+        local d = g_modNameToDirectory[SOIL_MOD_NAME]
+        if d ~= nil and d ~= "" then
+            return d
+        end
+    end
+    if g_currentModName == SOIL_MOD_NAME and g_currentModDirectory ~= nil then
+        return g_currentModDirectory
+    end
+    if g_modManager ~= nil and type(g_modManager.getModByName) == "function" then
+        local ok, mod = pcall(function()
+            return g_modManager:getModByName(SOIL_MOD_NAME)
+        end)
+        if ok and mod ~= nil and (mod.modDir ~= nil or mod.modDirectory ~= nil) then
+            return mod.modDir or mod.modDirectory
+        end
+    end
+    return nil
+end
+
+local function _getMenu()
+    if g_gui ~= nil and g_gui.screenControllers ~= nil and InGameMenu ~= nil then
+        return g_gui.screenControllers[InGameMenu] or g_inGameMenu
+    end
+    return g_inGameMenu
+end
+
+local function _getPage()
+    local menu = _getMenu()
+    if menu == nil then
+        return nil
+    end
+    return menu[PAGE_NAME] or menu.menuRealisticFarming
+end
+
+--- Prefer Soil shared page XML when Soil is present (one path, not three mod dirs).
+local function _getXmlPath()
+    local soilDir = _getSoilModDirectory()
+    if soilDir ~= nil then
+        return soilDir .. "xml/gui/" .. CLASS_NAME .. ".xml"
+    end
+    if RfPdaMenuPage ~= nil and type(RfPdaMenuPage.getXmlFilename) == "function" then
+        return RfPdaMenuPage.getXmlFilename()
+    end
+    if g_currentModDirectory ~= nil then
+        return g_currentModDirectory .. "xml/gui/" .. CLASS_NAME .. ".xml"
+    end
+    return nil
+end
+
+--- Greenfield SoT is rfEscProfiles.xml; legacy guiProfiles.xml only if present.
+local function _profilesCandidate(dir)
+    if dir == nil or dir == "" then
+        return nil
+    end
+    local preferred = dir .. "xml/gui/rfEscProfiles.xml"
+    local legacy = dir .. "xml/gui/guiProfiles.xml"
+    if fileExists ~= nil then
+        if fileExists(preferred) then
+            return preferred
+        end
+        if fileExists(legacy) then
+            return legacy
+        end
+        return nil
+    end
+    return preferred
+end
+
+local function _getProfilesXml()
+    local fromSoil = _profilesCandidate(_getSoilModDirectory())
+    if fromSoil ~= nil then
+        return fromSoil
+    end
+    return _profilesCandidate(g_currentModDirectory)
+end
+
+local function _captureActiveModuleId()
+    if g_currentMission ~= nil and g_currentMission.rfEscModules ~= nil then
+        return g_currentMission.rfEscModules.activeModuleId
+    end
+    local env = getfenv and getfenv(0) or nil
+    if env ~= nil and env.g_rfEscModules ~= nil then
+        return env.g_rfEscModules.activeModuleId
+    end
+    return nil
+end
+
+local function _restoreActiveModuleId(moduleId)
+    if moduleId == nil or moduleId == "" then
+        return
+    end
+    local reg = nil
+    if g_currentMission ~= nil then
+        reg = g_currentMission.rfEscModules
+    end
+    if reg == nil then
+        local env = getfenv and getfenv(0) or nil
+        if env ~= nil then
+            reg = env.g_rfEscModules
+        end
+    end
+    if reg == nil then
+        return
+    end
+    if type(reg.selectModule) == "function" then
+        pcall(function()
+            reg:selectModule(moduleId)
+        end)
+    elseif type(reg.selectPanel) == "function" then
+        pcall(function()
+            reg:selectPanel(moduleId)
+        end)
+    else
+        reg.activeModuleId = moduleId
+    end
+end
+
+--- Find slot indices for oldPage. Prefer in-place replace (keeps Esc tab).
+local function _findPageSlots(menu, oldPage)
+    local slots = {
+        elementsIdx = nil,
+        pagesIdx = nil,
+        framesIdx = nil,
+        pageTitle = "",
+        pageIdName = nil,
+        pageDisabled = false,
+    }
+    if menu == nil or oldPage == nil then
+        return slots
+    end
+
+    local pe = menu.pagingElement
+    if pe ~= nil and type(pe.elements) == "table" then
+        for i = 1, #pe.elements do
+            if pe.elements[i] == oldPage then
+                slots.elementsIdx = i
+                break
+            end
+        end
+    end
+    if pe ~= nil and type(pe.pages) == "table" then
+        for i = 1, #pe.pages do
+            local page = pe.pages[i]
+            if page ~= nil and page.element == oldPage then
+                slots.pagesIdx = i
+                slots.pageTitle = page.title or ""
+                slots.pageIdName = page.idName
+                slots.pageDisabled = page.disabled == true
+                break
+            end
+        end
+    end
+    if type(menu.pageFrames) == "table" then
+        for i = 1, #menu.pageFrames do
+            if menu.pageFrames[i] == oldPage then
+                slots.framesIdx = i
+                break
+            end
+        end
+    end
+    return slots
+end
+
+--- Detach old controller from paging WITHOUT PagingElement:removeElement
+--- (that path also removePageByElement and would drop the Esc tab slot).
+local function _orphanFromPaging(menu, oldPage, slots)
+    if menu == nil or oldPage == nil then
+        return
+    end
+    local pe = menu.pagingElement
+    if pe ~= nil and type(pe.elements) == "table" and slots.elementsIdx ~= nil then
+        if pe.elements[slots.elementsIdx] == oldPage then
+            table.remove(pe.elements, slots.elementsIdx)
+        else
+            for i = #pe.elements, 1, -1 do
+                if pe.elements[i] == oldPage then
+                    table.remove(pe.elements, i)
+                    break
+                end
+            end
+        end
+    end
+    -- Prevent GuiElement:delete → parent:removeElement → removePageByElement.
+    oldPage.parent = nil
+end
+
+--- Resolve g_gui.frames root for the RF page (name may be CLASS_NAME after loadGui).
+local function _resolveFrameRoot(oldPage)
+    if g_gui == nil or type(g_gui.frames) ~= "table" then
+        return nil, nil
+    end
+    local keys = {}
+    if oldPage ~= nil and oldPage.name ~= nil then
+        keys[#keys + 1] = oldPage.name
+    end
+    keys[#keys + 1] = CLASS_NAME
+    keys[#keys + 1] = "RfPdaMenuPage"
+    for i = 1, #keys do
+        local root = g_gui.frames[keys[i]]
+        if root ~= nil then
+            return root, keys[i]
+        end
+    end
+    return nil, nil
+end
+
+--- Giants InGameMenuAnimalsFrame.createFromExistingGui delete half (pcall-safe).
+local function _deleteOldFrameGiantsWay(oldPage)
+    local frameRoot, frameKey = _resolveFrameRoot(oldPage)
+    local deletedTarget = false
+    local deletedRoot = false
+
+    if frameRoot ~= nil then
+        if frameRoot.target ~= nil and type(frameRoot.target.delete) == "function" then
+            local ok = pcall(function()
+                frameRoot.target:delete()
+            end)
+            deletedTarget = ok
+        end
+        if type(frameRoot.delete) == "function" then
+            local ok = pcall(function()
+                frameRoot:delete()
+            end)
+            deletedRoot = ok
+        end
+        if frameKey ~= nil then
+            g_gui.frames[frameKey] = nil
+        end
+        g_gui.frames[CLASS_NAME] = nil
+        g_gui.frames["RfPdaMenuPage"] = nil
+    end
+
+    -- If frames lookup missed, still delete the old controller (orphaned).
+    if not deletedTarget and oldPage ~= nil and type(oldPage.delete) == "function" then
+        pcall(function()
+            oldPage.parent = nil
+            oldPage:delete()
+        end)
+        deletedTarget = true
+    end
+
+    -- Belt: any leftover children on a surviving oldPage.
+    if oldPage ~= nil and type(oldPage.elements) == "table" and #oldPage.elements > 0 then
+        local children = {}
+        for i = 1, #oldPage.elements do
+            children[#children + 1] = oldPage.elements[i]
+        end
+        for i = 1, #children do
+            local child = children[i]
+            if child ~= nil and type(child.delete) == "function" then
+                pcall(function()
+                    child:delete()
+                end)
+            end
+        end
+    end
+
+    return deletedTarget or deletedRoot
+end
+
+--- Wire newPage into the same paging / pageFrames / pageTabs slots as oldPage.
+local function _inplaceSwapPage(menu, oldPage, newPage, slots, savedTab, savedPredicate)
+    if menu == nil or newPage == nil then
+        return false
+    end
+
+    local pe = menu.pagingElement
+    local elementsIdx = slots.elementsIdx
+    local pagesIdx = slots.pagesIdx
+    local framesIdx = slots.framesIdx
+
+    -- Manual parent insert — do NOT pe:addElement (that appends a second page).
+    if pe ~= nil and type(pe.elements) == "table" then
+        local idx = elementsIdx or (#pe.elements + 1)
+        if idx < 1 then
+            idx = 1
+        end
+        if idx > #pe.elements + 1 then
+            idx = #pe.elements + 1
+        end
+        table.insert(pe.elements, idx, newPage)
+        newPage.parent = pe
+        elementsIdx = idx
+    end
+
+    if pe ~= nil and type(pe.pages) == "table" and pagesIdx ~= nil and pe.pages[pagesIdx] ~= nil then
+        pe.pages[pagesIdx].element = newPage
+        if slots.pageTitle ~= nil then
+            pe.pages[pagesIdx].title = slots.pageTitle
+        end
+        if slots.pageDisabled ~= nil then
+            pe.pages[pagesIdx].disabled = slots.pageDisabled
+        end
+    elseif pe ~= nil and type(pe.pages) == "table" then
+        -- Slot lost somehow: append page entry (last resort; tab already preserved).
+        local page = {
+            id = (pe.getNextID ~= nil and pe:getNextID()) or (#pe.pages + 1),
+            mappingIndex = 0,
+            idName = slots.pageIdName or tostring(newPage),
+            element = newPage,
+            title = slots.pageTitle or "",
+            disabled = slots.pageDisabled == true,
+        }
+        table.insert(pe.pages, page)
+        if pe.idPageHash ~= nil then
+            pe.idPageHash[page.id] = page
+        end
+        pagesIdx = #pe.pages
+    end
+
+    if type(menu.pageFrames) == "table" then
+        if framesIdx ~= nil then
+            menu.pageFrames[framesIdx] = newPage
+        else
+            table.insert(menu.pageFrames, newPage)
+            framesIdx = #menu.pageFrames
+        end
+    end
+
+    -- pageTabs / roots / predicates / typeControllers are keyed by controller ref.
+    if type(menu.pageTabs) == "table" then
+        if oldPage ~= nil then
+            menu.pageTabs[oldPage] = nil
+        end
+        if savedTab ~= nil then
+            local tab = savedTab
+            function tab.onClickCallback()
+                if type(menu.onPageClicked) == "function" then
+                    menu:onPageClicked(menu.activeDetailPage)
+                end
+                if pe ~= nil and type(pe.getPageIdByElement) == "function" and type(pe.getPageMappingIndex) == "function" then
+                    local pageId = pe:getPageIdByElement(newPage)
+                    if pageId ~= nil then
+                        local pageMappingIndex = pe:getPageMappingIndex(pageId)
+                        if menu.currentPage ~= nil and type(menu.currentPage.requestClose) == "function" then
+                            if menu.currentPage:requestClose(tab.onClickCallback) then
+                                if menu.pageSelector ~= nil and type(menu.pageSelector.setState) == "function" then
+                                    menu.pageSelector:setState(pageMappingIndex, true)
+                                end
+                            end
+                        elseif menu.pageSelector ~= nil and type(menu.pageSelector.setState) == "function" then
+                            menu.pageSelector:setState(pageMappingIndex, true)
+                        end
+                    end
+                end
+            end
+            menu.pageTabs[newPage] = tab
+        end
+    end
+
+    if type(menu.pageRoots) == "table" then
+        if oldPage ~= nil then
+            menu.pageRoots[oldPage] = nil
+        end
+        menu.pageRoots[newPage] = (newPage.elements ~= nil and newPage.elements[1]) or nil
+    end
+
+    if type(menu.pageEnablingPredicates) == "table" then
+        if oldPage ~= nil then
+            menu.pageEnablingPredicates[oldPage] = nil
+        end
+        menu.pageEnablingPredicates[newPage] = savedPredicate or function()
+            return true
+        end
+    end
+
+    if type(menu.pageTypeControllers) == "table" and type(newPage.class) == "function" then
+        menu.pageTypeControllers[newPage:class()] = newPage
+    end
+
+    if type(menu.disabledPages) == "table" and oldPage ~= nil then
+        local wasDisabled = menu.disabledPages[oldPage]
+        menu.disabledPages[oldPage] = nil
+        if wasDisabled ~= nil then
+            menu.disabledPages[newPage] = wasDisabled
+        end
+    end
+
+    if menu.currentPage == oldPage then
+        menu.currentPage = newPage
+    end
+
+    menu[PAGE_NAME] = newPage
+    if g_inGameMenu ~= nil then
+        g_inGameMenu[PAGE_NAME] = newPage
+        if type(g_inGameMenu.controlIDs) == "table" then
+            g_inGameMenu.controlIDs[PAGE_NAME] = nil
+        end
+    end
+
+    if type(menu.exposeControlsAsFields) == "function" then
+        pcall(function()
+            menu:exposeControlsAsFields(PAGE_NAME)
+        end)
+    end
+    if pe ~= nil and type(pe.updateAbsolutePosition) == "function" then
+        pcall(function()
+            pe:updateAbsolutePosition()
+        end)
+    end
+    if pe ~= nil and type(pe.updatePageMapping) == "function" then
+        pcall(function()
+            pe:updatePageMapping()
+        end)
+    end
+
+    -- enabledPages / tab list hold old controller refs — rebuild after swap only.
+    if type(menu.rebuildTabList) == "function" then
+        pcall(function()
+            menu:rebuildTabList()
+        end)
+    end
+
+    return elementsIdx ~= nil or pagesIdx ~= nil or framesIdx ~= nil
+end
+
+--- Reload RF Esc page: new controller + Giants frame delete + in-place slot swap.
+--- Hang fence first when InGameMenu is open. Honesty: no ensureDoor re-run.
+---@return boolean
+function RfEscUiDebugger.reloadRfEscPage()
+    if g_client == nil or g_gui == nil then
+        _log("warning", "reload skipped: no client/gui")
+        return false
+    end
+
+    local menu = _getMenu()
+    local oldPage = _getPage()
+    if oldPage == nil then
+        _log("warning", "reload skipped: %s not registered (full restart / ensureDoor needed)", PAGE_NAME)
+        return false
+    end
+
+    local xmlPath = _getXmlPath()
+    if xmlPath == nil then
+        _log("warning", "reload skipped: XML path unknown")
+        return false
+    end
+    if oldPage.xmlFilename == nil then
+        oldPage.xmlFilename = xmlPath
+    end
+
+    local wasInGameMenu = (g_gui.currentGuiName == "InGameMenu")
+    -- Hang fence: never delete while InGameMenu/SmoothList may be drawing.
+    if wasInGameMenu then
+        pcall(function()
+            g_gui:showGui("")
+        end)
+    end
+
+    local activeModuleId = _captureActiveModuleId()
+    local slots = _findPageSlots(menu, oldPage)
+    local savedTab = nil
+    local savedPredicate = nil
+    if menu ~= nil then
+        if type(menu.pageTabs) == "table" then
+            savedTab = menu.pageTabs[oldPage]
+        end
+        if type(menu.pageEnablingPredicates) == "table" then
+            savedPredicate = menu.pageEnablingPredicates[oldPage]
+        end
+    end
+
+    -- Orphan before delete so PagingElement:removeElement cannot drop the page slot.
+    _orphanFromPaging(menu, oldPage, slots)
+    if menu ~= nil then
+        if type(menu.pageTabs) == "table" then
+            menu.pageTabs[oldPage] = nil
+        end
+        if type(menu.pageRoots) == "table" then
+            menu.pageRoots[oldPage] = nil
+        end
+        if type(menu.pageEnablingPredicates) == "table" then
+            menu.pageEnablingPredicates[oldPage] = nil
+        end
+    end
+
+    local newPage = nil
+    local prevReloading = g_gui.currentlyReloading
+    g_gui.currentlyReloading = true
+
+    local ok = false
+    local err = nil
+    local okLoad, loadErr = pcall(function()
+        local profilesXml = _getProfilesXml()
+        if profilesXml ~= nil then
+            local okProf, errProf = pcall(function()
+                g_gui:loadProfiles(profilesXml)
+            end)
+            if okProf then
+                _log("info", "loadProfiles %s", tostring(profilesXml))
+            else
+                _log("warning", "loadProfiles failed (%s): %s", tostring(profilesXml), tostring(errProf))
+            end
+        else
+            _log("warning", "loadProfiles skipped: no rfEscProfiles.xml / guiProfiles.xml")
+        end
+
+        -- Prefer class helper (Animals mirror); fallback inline Giants delete+loadGui.
+        if RfPdaMenuPage ~= nil and type(RfPdaMenuPage.createFromExistingGui) == "function" then
+            newPage = RfPdaMenuPage.createFromExistingGui(oldPage, CLASS_NAME)
+        else
+            _deleteOldFrameGiantsWay(oldPage)
+            newPage = RfPdaMenuPage.new()
+            -- Never leave PAGE_NAME nil during load.
+            if menu ~= nil then
+                menu[PAGE_NAME] = newPage
+            end
+            if g_inGameMenu ~= nil then
+                g_inGameMenu[PAGE_NAME] = newPage
+            end
+            g_gui:loadGui(xmlPath, CLASS_NAME, newPage, true)
+        end
+    end)
+    ok = okLoad
+    err = loadErr
+
+    g_gui.currentlyReloading = prevReloading == true
+
+    if not ok or newPage == nil then
+        _log("error", "frame-replace reload FAILED: %s", tostring(err or "newPage nil"))
+        -- Last-ditch: keep a live controller under PAGE_NAME if possible.
+        if _getPage() == nil and menu ~= nil then
+            local emergency = RfPdaMenuPage ~= nil and RfPdaMenuPage.new() or nil
+            if emergency ~= nil then
+                menu[PAGE_NAME] = emergency
+                if g_inGameMenu ~= nil then
+                    g_inGameMenu[PAGE_NAME] = emergency
+                end
+            end
+        end
+        if wasInGameMenu then
+            pcall(function()
+                g_gui:showGui("InGameMenu")
+            end)
+        end
+        return false
+    end
+
+    _log("info", "tore down old frame; loaded new controller")
+
+    local swapped = _inplaceSwapPage(menu, oldPage, newPage, slots, savedTab, savedPredicate)
+    if not swapped then
+        _log("warning", "slot swap incomplete (elements/pages/pageFrames miss); PAGE_NAME still set")
+    end
+
+    if type(newPage.initialize) == "function" then
+        pcall(function()
+            newPage:initialize()
+        end)
+    end
+    if type(newPage.updateAbsolutePosition) == "function" then
+        pcall(function()
+            newPage:updateAbsolutePosition()
+        end)
+    end
+
+    _restoreActiveModuleId(activeModuleId)
+
+    local function refreshAfterReload()
+        if type(newPage.refreshPanelSelector) == "function" then
+            pcall(function()
+                newPage:refreshPanelSelector(true)
+            end)
+        end
+        if type(newPage.refreshContent) == "function" then
+            pcall(function()
+                newPage:refreshContent(true)
+            end)
+        end
+        if type(newPage._ensureSelectorArrowsVisible) == "function" then
+            pcall(function()
+                newPage:_ensureSelectorArrowsVisible()
+            end)
+        elseif type(newPage._ensureMtoArrowsVisible) == "function" then
+            pcall(function()
+                newPage:_ensureMtoArrowsVisible(newPage.rfPanelSelector)
+            end)
+        end
+    end
+
+    if wasInGameMenu then
+        pcall(function()
+            g_gui:showGui("InGameMenu")
+        end)
+        if menu ~= nil and type(menu.goToPage) == "function" then
+            pcall(function()
+                menu:goToPage(newPage, true)
+            end)
+        end
+        if type(newPage.onFrameOpen) == "function" then
+            pcall(function()
+                newPage:onFrameOpen()
+            end)
+        else
+            refreshAfterReload()
+        end
+    else
+        refreshAfterReload()
+    end
+
+    _log("info", "frame-replace reload OK (%s from %s; slots e=%s p=%s f=%s; module=%s)",
+        CLASS_NAME,
+        tostring(xmlPath),
+        tostring(slots.elementsIdx),
+        tostring(slots.pagesIdx),
+        tostring(slots.framesIdx),
+        tostring(activeModuleId))
+    return true
+end
+
+function RfEscUiDebugger.consoleReload()
+    RfEscUiDebugger.reloadRfEscPage()
+end
+
+local function _onUpdate(_self, dt)
+    if g_client == nil then
+        return
+    end
+    _cooldownUntil = math.max(0, _cooldownUntil - (dt or 0))
+    if _cooldownUntil > 0 then
+        return
+    end
+    if Input == nil or Input.KEY_f6 == nil or Input.isKeyPressed == nil then
+        return
+    end
+    if not Input.isKeyPressed(Input.KEY_f6) then
+        return
+    end
+    -- Dev gate: only when RF Esc door already exists (not a player discovery path).
+    if _getPage() == nil then
+        return
+    end
+    _cooldownUntil = COOLDOWN_MS
+    RfEscUiDebugger.reloadRfEscPage()
+end
+
+function RfEscUiDebugger.install()
+    if g_client == nil then
+        return
+    end
+    -- Cross-mod singleton via true _G / mission (not getfenv sandbox).
+    if _listenerInstalled or _isInstalledGlobally() then
+        return
+    end
+
+    -- Prefer Soil when present so non-Soil mods hard no-op even if they source first.
+    local soilDir = _getSoilModDirectory()
+    local myDir = g_currentModDirectory
+    if soilDir ~= nil and myDir ~= nil and _normDir(soilDir) ~= _normDir(myDir) then
+        return
+    end
+
+    local listener = { update = _onUpdate }
+    addModEventListener(listener)
+    if addConsoleCommand ~= nil then
+        addConsoleCommand("rfEscReloadGui", "Dev: frame-replace reload menuRealisticFarming (hang-fenced; F6)", "consoleReload", RfEscUiDebugger)
+    end
+    _listenerInstalled = true
+    _markInstalledGlobally()
+    local owner = (g_currentModName ~= nil and g_currentModName) or "unknown"
+    _log("info", "installed by %s (F6 / rfEscReloadGui). Dev-only; frame-replace path; not Vera F1 substitute.", tostring(owner))
+end
+
+-- Install when mission finishes (InGameMenu may not exist at source time).
+if Mission00 ~= nil and Utils ~= nil then
+    Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, function()
+        RfEscUiDebugger.install()
+    end)
+end
+-- Also try immediately if already past load (late source / console).
+if g_client ~= nil and g_currentMission ~= nil then
+    RfEscUiDebugger.install()
+end

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1,0 +1,1679 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - RfPdaMenuPage (Esc RF shell)
+-- =========================================================
+-- Phase 1 + F8 + F9 + F10 layout (2026-07-29): RF_PageRoot stretch-fills paging
+-- (not uiInGameMenuFrame 1400x756 mid-band); side 520/548; no page header;
+-- no farm money (Q3 = B). Soil table + TREATMENT PLAN in RfPdaSoilPanel.
+-- Frame debug: SoilRfPdaFrameDebug console toggle (GuiElement.debugEnabled
+-- outlines + short labels; engine also has gsGuiDebug for global UI debug).
+-- Keep: WC inject identity (menuSoilFertilizer), RfPdaHost cycle,
+-- Map lime arrows/dots, GuiElement SmoothList parents, quiet reloads,
+-- blank.png swatches #2A2D28 / #222222, no ownership legend.
+-- Do not: FarmTablet, Phase B Map inject, nil-filename Bitmap bars.
+-- SoilPDAScreen coexists untouched.
+-- =========================================================
+
+local MOD_DIR = g_currentModDirectory
+local MOD_NAME = g_currentModName
+
+-- Soft log when sourced from WC/CS joiners (SoilLogger may be absent).
+if SoilLogger == nil then
+    SoilLogger = {
+        info = function(_, fmt, ...)
+            if Logging and Logging.info then Logging.info("[RfEsc] " .. string.format(fmt or "", ...)) end
+        end,
+        warning = function(_, fmt, ...)
+            if Logging and Logging.warning then Logging.warning("[RfEsc] " .. string.format(fmt or "", ...)) end
+        end,
+        error = function(_, fmt, ...)
+            if Logging and Logging.error then Logging.error("[RfEsc] " .. string.format(fmt or "", ...)) end
+        end,
+    }
+end
+
+---@class RfPdaMenuPage
+RfPdaMenuPage = {}
+RfPdaMenuPage.CLASS_NAME = "RfPdaMenuPage"
+-- NO-HOST: shared Esc door name (not Soil-owned menuSoilFertilizer).
+RfPdaMenuPage.MENU_PAGE_NAME = "menuRealisticFarming"
+RfPdaMenuPage.MENU_ICON_PATH = "textures/ui/menuIcon.dds"
+
+function RfPdaMenuPage.getXmlFilename()
+    return MOD_DIR .. "xml/gui/RfPdaMenuPage.xml"
+end
+
+local RfPdaMenuPage_mt = Class(RfPdaMenuPage, TabbedMenuFrameElement)
+
+local REFRESH_INTERVAL = 2000
+-- Worker Costs Dashboard/Workers: George GREEN-LIGHT 500ms text-only refreshLive.
+local WC_LIVE_REFRESH_INTERVAL = 500
+-- Modules dual-fire FAIL-FIX: ignore duplicate panel id selects within this window.
+local MODULE_SELECT_DEBOUNCE_MS = 120
+
+-- Module-list selection colors (Soil row colors live in RfPdaSoilPanel)
+local COLOR_DIM  = {1.00, 1.00, 1.00, 0.55}
+local COLOR_LIME_BRIGHT = {0.659, 0.878, 0.290, 1.0}
+
+local PANEL_BLURBS = {
+    soilFertilizer = "rf_pda_menu_blurb",
+}
+
+--- Cross-mod Soil panel resolve: bare RfPdaSoilPanel is nil when WC/CS sourced
+--- RfPdaMenuPage last (their env). getfenv(0) is also per-mod; probe Soil
+--- g_modEnvironments + mission soft-detect (suite pattern).
+local _soilPanelResolveLogged = false
+
+local function soilPanelHasRebuild(panel)
+    return panel ~= nil and type(panel.rebuildFieldData) == "function"
+end
+
+local function soilPanelLogResolve(via)
+    if _soilPanelResolveLogged then
+        return
+    end
+    _soilPanelResolveLogged = true
+    local msg = string.format("[RfEsc] RfPdaSoilPanel resolved via %s", via)
+    if Logging ~= nil and type(Logging.info) == "function" then
+        Logging.info("%s", msg)
+    else
+        print(msg)
+    end
+end
+
+local function soilPanel()
+    if soilPanelHasRebuild(RfPdaSoilPanel) then
+        return RfPdaSoilPanel
+    end
+
+    if type(getfenv) == "function" then
+        local env0 = getfenv(0)
+        if soilPanelHasRebuild(env0 and env0.RfPdaSoilPanel) then
+            return env0.RfPdaSoilPanel
+        end
+    end
+
+    if g_modEnvironments ~= nil then
+        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
+            local modEnv = g_modEnvironments[modName]
+            local panel = modEnv and modEnv.RfPdaSoilPanel
+            if soilPanelHasRebuild(panel) then
+                soilPanelLogResolve("g_modEnvironments[" .. modName .. "]")
+                return panel
+            end
+        end
+    end
+
+    if g_currentMission ~= nil and soilPanelHasRebuild(g_currentMission.rfPdaSoilPanel) then
+        soilPanelLogResolve("g_currentMission.rfPdaSoilPanel")
+        return g_currentMission.rfPdaSoilPanel
+    end
+
+    return nil
+end
+
+--- Resolve l10n with English fallback. When CS/WC create the Esc door, MOD_NAME
+--- i18n may lack Soil table keys — also probe Soil modEnv, then g_i18n.
+local function tr(key, fallback)
+    local function tryI18n(i18n)
+        if i18n == nil then
+            return nil
+        end
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if not ok or type(text) ~= "string" or text == "" then
+            return nil
+        end
+        local lower = text:lower()
+        -- Reject unresolved keys (engine often returns "MISSING KEY_NAME").
+        if lower == tostring(key):lower()
+            or text == ("$l10n_" .. key)
+            or lower:find("^missing%s")
+            or lower:find("^missing_")
+        then
+            return nil
+        end
+        return text
+    end
+
+    local tried = {}
+    local function tryMod(name)
+        if name == nil or tried[name] or g_modEnvironments == nil then
+            return nil
+        end
+        tried[name] = true
+        local modEnv = g_modEnvironments[name]
+        return tryI18n(modEnv and modEnv.i18n)
+    end
+
+    local text = tryMod(MOD_NAME)
+        or tryMod("FS25_SoilFertilizer")
+        or tryMod("FS25_SoilFertilizer_Refined")
+        or tryI18n(g_i18n)
+    if text ~= nil then
+        return text
+    end
+    return fallback or key
+end
+
+--- Guest modules bake title at register; never paint engine MISSING chrome.
+--- Modules MTO shows short module names (not door-tab brand watermark).
+local function safePanelTitle(panel)
+    if panel == nil then
+        return ""
+    end
+    local t = panel.title
+    if type(t) == "string" and t ~= "" then
+        local lower = t:lower()
+        if not lower:find("^missing%s") and not lower:find("^missing_") and not lower:find("^%$l10n_")
+            and lower ~= "realistic farming" then
+            return t
+        end
+    end
+    local id = panel.id
+    if id == "soilFertilizer" then
+        return tr("rf_pda_panel_soil", "Soil Fertilizer")
+    elseif id == "workerCosts" then
+        return "Worker Costs"
+    elseif id == "cropStress" then
+        return "Crop Stress"
+    end
+    return id or ""
+end
+
+-- F9 frame-debug targets: id -> short label (colored outline via debugEnabled)
+local FRAME_DEBUG_TARGETS = {
+    { id = "rfPageRoot",          label = "pageRoot" },
+    { id = "rfContentHost",       label = "contentHost" },
+    { id = "rfFilterBox",         label = "sideShell" },
+    { id = "rfMainCol",           label = "mainShell" },
+    { id = "rfPanelContent",      label = "panelContent" },
+    { id = "rfTreatmentStrip",    label = "treatment" },
+    { id = "treatProductsShell",  label = "productsShell" },
+    { id = "treatProdRowsClip",   label = "productsClip" },
+}
+
+function RfPdaMenuPage.new()
+    local self = RfPdaMenuPage:superClass().new(nil, RfPdaMenuPage_mt)
+    self.name = "RfPdaMenuPage"
+    self.className = "RfPdaMenuPage"
+    self.menuButtonInfo = {}
+    self.fieldData = {}
+    self.selectedFieldId = nil
+    self._liveTimer = 0
+    self._wcLiveTimer = 0
+    self.wcSubPageIndex = 1
+    self.wcAboutTabIndex = 1
+    self._panelCache = {}
+    self._lastPanelFingerprint = nil
+    self._hostListenerBound = false
+    self._refreshing = false
+    self._wcWageRefreshing = false
+    self._wcSubnavSeeding = false
+    self._wcSubnavSeeded = false
+    self._lastModuleSelectId = nil
+    self._lastModuleSelectAt = 0
+    self._frameDebug = false
+    self._rfTr = tr
+    return self
+end
+
+--- Giants InGameMenuAnimalsFrame.createFromExistingGui mirror (F6 / UIDebugger).
+--- Caller must orphan this page from InGameMenu.pagingElement first so
+--- GuiElement:delete does not invoke PagingElement:removeElement (slot loss).
+function RfPdaMenuPage.createFromExistingGui(gui, guiName)
+    local newGui = RfPdaMenuPage.new()
+    local name = (gui ~= nil and gui.name) or guiName or RfPdaMenuPage.CLASS_NAME
+    local xmlFilename = (gui ~= nil and gui.xmlFilename) or RfPdaMenuPage.getXmlFilename()
+    local frameRoot = nil
+    if g_gui ~= nil and type(g_gui.frames) == "table" then
+        frameRoot = g_gui.frames[name] or g_gui.frames[RfPdaMenuPage.CLASS_NAME] or g_gui.frames["RfPdaMenuPage"]
+    end
+    if frameRoot ~= nil then
+        if frameRoot.target ~= nil and type(frameRoot.target.delete) == "function" then
+            pcall(function()
+                frameRoot.target:delete()
+            end)
+        end
+        if type(frameRoot.delete) == "function" then
+            pcall(function()
+                frameRoot:delete()
+            end)
+        end
+        if g_gui ~= nil and type(g_gui.frames) == "table" then
+            g_gui.frames[name] = nil
+            g_gui.frames[RfPdaMenuPage.CLASS_NAME] = nil
+            g_gui.frames["RfPdaMenuPage"] = nil
+        end
+    elseif gui ~= nil and type(gui.delete) == "function" then
+        pcall(function()
+            gui.parent = nil
+            gui:delete()
+        end)
+    end
+    g_gui:loadGui(xmlFilename, guiName or RfPdaMenuPage.CLASS_NAME, newGui, true)
+    return newGui
+end
+
+function RfPdaMenuPage:onGuiSetupFinished()
+    RfPdaMenuPage:superClass().onGuiSetupFinished(self)
+
+    self.rfPanelSelector   = self:getDescendantById("rfPanelSelector") or self.rfPanelSelector
+    self.rfPanelDotBox     = self:getDescendantById("rfPanelDotBox") or self.rfPanelDotBox
+    self.rfPanelContent    = self:getDescendantById("rfPanelContent") or self.rfPanelContent
+    self.rfHostPlaceholder = self:getDescendantById("rfHostPlaceholder") or self.rfHostPlaceholder
+    self.rfPageTitle       = self:getDescendantById("rfPageTitle") or self.rfPageTitle
+    self.rfPageBlurb       = self:getDescendantById("rfPageBlurb") or self.rfPageBlurb
+    self.rfDotLegend       = self:getDescendantById("rfDotLegend") or self.rfDotLegend
+    self.rfSuiteHint       = self:getDescendantById("rfSuiteHint") or self.rfSuiteHint
+    self.rfHostTitle       = self:getDescendantById("rfHostTitle") or self.rfHostTitle
+    self.rfHostBlurb       = self:getDescendantById("rfHostBlurb") or self.rfHostBlurb
+    self.rfHostBody        = self:getDescendantById("rfHostBody") or self.rfHostBody
+    self.fieldOverviewList = self:getDescendantById("fieldOverviewList") or self.fieldOverviewList
+    self.csFieldOverviewList = self:getDescendantById("csFieldOverviewList") or self.csFieldOverviewList
+    self.csFieldsEmptyHint = self:getDescendantById("csFieldsEmptyHint") or self.csFieldsEmptyHint
+    self.rfHostTableRegion = self:getDescendantById("rfHostTableRegion") or self.rfHostTableRegion
+    self.csDetailStrip = self:getDescendantById("csDetailStrip") or self.csDetailStrip
+    self.mdGraphRegion = self:getDescendantById("mdGraphRegion") or self.mdGraphRegion
+    self.mdGraphArea = self:getDescendantById("mdGraphArea") or self.mdGraphArea
+    self.mdDetailStrip = self:getDescendantById("mdDetailStrip") or self.mdDetailStrip
+    self.mdMoverSelector = self:getDescendantById("mdMoverSelector") or self.mdMoverSelector
+    self.mdEventsBand = self:getDescendantById("mdEventsBand") or self.mdEventsBand
+    self.mdOpenMarketBtn = self:getDescendantById("mdOpenMarketBtn") or self.mdOpenMarketBtn
+    self.wcGlanceShell = self:getDescendantById("wcGlanceShell") or self.wcGlanceShell
+    self.wcSubnavShell = self:getDescendantById("wcSubnavShell") or self.wcSubnavShell
+    self.wcSubnavSelector = self:getDescendantById("wcSubnavSelector") or self.wcSubnavSelector
+    self.wcSubnavDotBox = self:getDescendantById("wcSubnavDotBox") or self.wcSubnavDotBox
+    -- Dual-arrow FAIL-FIX: live page selector = title-chrome wcTitlePageSelector (not left twin).
+    self.wcTitlePageShell = self:getDescendantById("wcTitlePageShell") or self.wcTitlePageShell
+    self.wcTitlePageSelector = self:getDescendantById("wcTitlePageSelector") or self.wcTitlePageSelector
+    self.wcPageSelector = self:getDescendantById("wcPageSelector") or self.wcPageSelector
+    self.wcSideInfoShell = self:getDescendantById("wcSideInfoShell") or self.wcSideInfoShell
+    self.wcSideInfoBody = self:getDescendantById("wcSideInfoBody") or self.wcSideInfoBody
+    self.wcSideVersion = self:getDescendantById("wcSideVersion") or self.wcSideVersion
+    self.rfSideInfoShell = self:getDescendantById("rfSideInfoShell") or self.rfSideInfoShell
+    self.rfSideInfoBody = self:getDescendantById("rfSideInfoBody") or self.rfSideInfoBody
+    self.rfSideMidSeparator = self:getDescendantById("rfSideMidSeparator") or self.rfSideMidSeparator
+    self.rfModuleListShell = self:getDescendantById("rfModuleListShell") or self.rfModuleListShell
+    self.wcPageShell = self:getDescendantById("wcPageShell") or self.wcPageShell
+    self.wcPageDashboard = self:getDescendantById("wcPageDashboard") or self.wcPageDashboard
+    self.wcPageWages = self:getDescendantById("wcPageWages") or self.wcPageWages
+    self.wcPageWorkers = self:getDescendantById("wcPageWorkers") or self.wcPageWorkers
+    self.wcPageAbout = self:getDescendantById("wcPageAbout") or self.wcPageAbout
+    self.moduleList        = self:getDescendantById("moduleList") or self.moduleList
+    self.fieldsEmptyHint   = self:getDescendantById("fieldsEmptyHint") or self.fieldsEmptyHint
+    self.soilColField = self:getDescendantById("soilColField") or self.soilColField
+    self.soilColArea = self:getDescendantById("soilColArea") or self.soilColArea
+    self.soilColStatus = self:getDescendantById("soilColStatus") or self.soilColStatus
+    self.soilColFert = self:getDescendantById("soilColFert") or self.soilColFert
+    self.soilSectionTreatment = self:getDescendantById("soilSectionTreatment") or self.soilSectionTreatment
+    self.soilTreatProducts = self:getDescendantById("soilTreatProducts") or self.soilTreatProducts
+    self.treatSelectedLabel = self:getDescendantById("treatSelectedLabel") or self.treatSelectedLabel
+    self.treatNextLabel     = self:getDescendantById("treatNextLabel") or self.treatNextLabel
+    self.treatTargetsLabel  = self:getDescendantById("treatTargetsLabel") or self.treatTargetsLabel
+    self.treatTargetsHeading = self:getDescendantById("treatTargetsHeading") or self.treatTargetsHeading
+    self.treatTargetN       = self:getDescendantById("treatTargetN") or self.treatTargetN
+    self.treatTargetP       = self:getDescendantById("treatTargetP") or self.treatTargetP
+    self.treatTargetK       = self:getDescendantById("treatTargetK") or self.treatTargetK
+    self.treatPlanLines     = self:getDescendantById("treatPlanLines") or self.treatPlanLines
+    self.treatProdRows = {}
+    for i = 1, 8 do
+        self.treatProdRows[i] = {
+            row = self:getDescendantById("treatProdRow" .. i),
+            nut = self:getDescendantById("treatProd" .. i .. "Nut"),
+            name = self:getDescendantById("treatProd" .. i .. "Name"),
+            rate = self:getDescendantById("treatProd" .. i .. "Rate"),
+            total = self:getDescendantById("treatProd" .. i .. "Total"),
+        }
+    end
+    self.samplingInfoBox    = self:getDescendantById("samplingInfoBox") or self.samplingInfoBox
+    self.samplingInfoText   = self:getDescendantById("samplingInfoText") or self.samplingInfoText
+    self.samplingInfoFallback = self:getDescendantById("samplingInfoFallback") or self.samplingInfoFallback
+    self.rfSuiteHint        = self:getDescendantById("rfSuiteHint") or self.rfSuiteHint
+    self.rfPageRoot         = self:getDescendantById("rfPageRoot") or self.rfPageRoot
+    self.rfContentHost      = self:getDescendantById("rfContentHost") or self.rfContentHost
+    self.rfFilterBox        = self:getDescendantById("rfFilterBox") or self.rfFilterBox
+    self.rfMainCol          = self:getDescendantById("rfMainCol") or self.rfMainCol
+    self.rfTreatmentStrip   = self:getDescendantById("rfTreatmentStrip") or self.rfTreatmentStrip
+    self.treatProductsShell = self:getDescendantById("treatProductsShell") or self.treatProductsShell
+    self.treatProdRowsClip  = self:getDescendantById("treatProdRowsClip") or self.treatProdRowsClip
+
+    if self.fieldOverviewList then
+        self.fieldOverviewList.dataSource = self
+        self.fieldOverviewList.delegate = self
+    end
+    if self.csFieldOverviewList then
+        self.csFieldOverviewList.dataSource = self
+        self.csFieldOverviewList.delegate = self
+    end
+    self.csFieldData = self.csFieldData or {}
+    if self.moduleList then
+        self.moduleList.dataSource = self
+        self.moduleList.delegate = self
+    end
+end
+
+--- Rebind Soil chrome Text that used $l10n_ at loadGui (fails when CS/WC created the door).
+function RfPdaMenuPage:_applyChromeL10n()
+    local function setEl(el, key, fallback)
+        if el ~= nil and type(el.setText) == "function" then
+            el:setText(tr(key, fallback))
+        end
+    end
+    setEl(self.soilColField, "sf_pda_col_field", "Field")
+    setEl(self.soilColArea, "rf_pda_col_area", "Area")
+    setEl(self.soilColStatus, "sf_pda_col_status", "Status")
+    setEl(self.soilColFert, "rf_pda_col_fert", "Fertilizer")
+    setEl(self.fieldsEmptyHint, "sf_pda_no_fields", "No field data recorded yet.")
+    setEl(self.soilSectionTreatment, "rf_pda_section_treatment", "Treatment")
+    setEl(self.soilTreatProducts, "rf_pda_treat_products", "Products")
+    setEl(self.samplingInfoFallback, "rf_pda_sample_hint", "Soil sample dates appear here when available.")
+end
+
+function RfPdaMenuPage:initialize()
+    RfPdaMenuPage:superClass().initialize(self)
+
+    self.btnBack = {
+        inputAction = InputAction.MENU_BACK,
+        text = g_i18n:getText("button_back")
+    }
+    -- Q/E = vanilla Esc left icon strip only (InGameMenu page prev/next).
+    -- Do NOT bind MENU_PAGE_PREV/NEXT to cyclePanel; modules use MTO L/R arrows.
+    self.btnHelp = {
+        inputAction = InputAction.MENU_EXTRA_1,
+        text = tr("sf_pda_btn_help", "Help"),
+        callback = function()
+            if SoilGuideDialog then
+                SoilGuideDialog.show()
+            elseif SoilHelpDialog then
+                SoilHelpDialog.show()
+            end
+        end
+    }
+
+    self.menuButtonInfo = { self.btnBack, self.btnHelp }
+    self:_applyChromeL10n()
+    self:_bindHostListener()
+end
+
+function RfPdaMenuPage:_bindHostListener()
+    if self._hostListenerBound then return end
+    local host = self:_getHost()
+    if host == nil or type(host.addChangeListener) ~= "function" then
+        return
+    end
+    host:addChangeListener(function()
+        if self.isOpen then
+            -- Quiet: no field SmoothList rebuild on notify; module list only if set changed.
+            self:refreshPanelSelector(false)
+            self:refreshContent(false)
+        end
+    end)
+    self._hostListenerBound = true
+end
+
+function RfPdaMenuPage:onFrameOpen()
+    RfPdaMenuPage:superClass().onFrameOpen(self)
+    self.isOpen = true
+    self._liveTimer = 0
+    self._rfSoilPanelMissingWarned = false
+    self:_bindHostListener()
+    self:_applyChromeL10n()
+    -- F11: lime arrows before and after first refresh (engine may disable on open).
+    self:_ensureSelectorArrowsVisible()
+    self:refreshPanelSelector(true)
+    self:refreshContent(true)
+    self:_ensureSelectorArrowsVisible()
+end
+
+function RfPdaMenuPage:onFrameClose()
+    self.isOpen = false
+    RfPdaMenuPage:superClass().onFrameClose(self)
+end
+
+-- F9: temporary Esc RF PDA frame outlines (GuiElement.debugEnabled + labels).
+-- Engine SoT: GuiElement:draw draws red borders when debugEnabled or g_uiDebugEnabled
+-- (extract GuiElement.lua ~521). Global toggle: console gsGuiDebug.
+-- Suite toggle: SoilRfPdaFrameDebug (labels only our key shells).
+function RfPdaMenuPage:setFrameDebug(enabled)
+    self._frameDebug = enabled == true
+    for _, spec in ipairs(FRAME_DEBUG_TARGETS) do
+        local el = self:getDescendantById(spec.id)
+        if el ~= nil then
+            el.debugEnabled = self._frameDebug
+        end
+    end
+    -- Also outline the TabbedMenuFrameElement (page controller) itself.
+    self.debugEnabled = self._frameDebug
+end
+
+function RfPdaMenuPage:toggleFrameDebug()
+    self:setFrameDebug(not self._frameDebug)
+    return self._frameDebug
+end
+
+function RfPdaMenuPage:draw(clipX1, clipY1, clipX2, clipY2)
+    RfPdaMenuPage:superClass().draw(self, clipX1, clipY1, clipX2, clipY2)
+    -- Market Dynamics Esc glance graph (after chrome). Reuse MDMMarketScreenGraph.draw.
+    do
+        local host = self:_getHost()
+        local active = host and host.getActivePanel and host:getActivePanel()
+        if active ~= nil and active.id == "marketDynamics"
+                and self.mdGraphRegion ~= nil
+                and MDMMarketScreenGraph ~= nil and type(MDMMarketScreenGraph.draw) == "function" then
+            local area = self.mdGraphArea or self.mdGraphRegion
+            if area ~= nil and area.absPosition ~= nil and area.absSize ~= nil then
+                local ft = self.mdSelectedFillType
+                if ft == nil and MdRfPdaGuest ~= nil and type(MdRfPdaGuest.getSelectedFillType) == "function" then
+                    ft = MdRfPdaGuest.getSelectedFillType()
+                end
+                if ft ~= nil then
+                    MDMMarketScreenGraph.draw(ft, area.absPosition[1], area.absPosition[2], area.absSize[1], area.absSize[2])
+                end
+            end
+        end
+    end
+    if not self._frameDebug then
+        return
+    end
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextBold(true)
+    local textSize = 0.012
+    for _, spec in ipairs(FRAME_DEBUG_TARGETS) do
+        local el = self:getDescendantById(spec.id)
+        if el ~= nil and el.absPosition ~= nil and el.absSize ~= nil then
+            local x = el.absPosition[1] + 0.004
+            local y = el.absPosition[2] + el.absSize[2] - textSize - 0.002
+            setTextColor(0.1, 1.0, 0.35, 1)
+            renderText(x, y, textSize, spec.label)
+        end
+    end
+    setTextBold(false)
+    setTextColor(1, 1, 1, 1)
+end
+
+function RfPdaMenuPage:update(dt)
+    RfPdaMenuPage:superClass().update(self, dt)
+    -- Light tick only: never reload SmoothList every 2s (that path + Bitmap parent
+    -- correlated with GuiElement mouseEvent/update stack overflow + emergency GC).
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    local isSoil = active == nil or active.id == "soilFertilizer"
+    local isWc = active ~= nil and active.id == "workerCosts"
+    local isMd = active ~= nil and active.id == "marketDynamics"
+
+    -- Market Dynamics: light text/graph refresh; never SmoothList thrash.
+    if isMd then
+        self._mdLiveTimer = (self._mdLiveTimer or 0) + dt
+        if self._mdLiveTimer >= REFRESH_INTERVAL then
+            self._mdLiveTimer = 0
+            if active ~= nil and type(active.onShow) == "function" then
+                pcall(active.onShow, self.rfHostPlaceholder, true)
+            end
+        end
+        return
+    end
+
+    -- WC Dashboard/Workers: 500ms text-only live refresh (George FULL PORT ACK).
+    if isWc then
+        self._wcLiveTimer = (self._wcLiveTimer or 0) + dt
+        if self._wcLiveTimer >= WC_LIVE_REFRESH_INTERVAL then
+            self._wcLiveTimer = 0
+            if active ~= nil and type(active.onShow) == "function" then
+                pcall(active.onShow, self.rfHostPlaceholder, true)
+            end
+        end
+        return
+    end
+
+    self._liveTimer = (self._liveTimer or 0) + dt
+    if self._liveTimer >= REFRESH_INTERVAL then
+        self._liveTimer = 0
+        -- Phase 1 Q3 = B: no farm money on this Esc page (no balance refresh).
+        if isSoil then
+            local panel = soilPanel()
+            if panel ~= nil then
+                panel.refreshTreatmentPlan(self)
+            end
+        elseif active ~= nil and type(active.onShow) == "function" then
+            -- Light guest glance refresh (text only; no SmoothList thrash).
+            pcall(active.onShow, self.rfHostPlaceholder, true)
+        end
+    end
+end
+
+function RfPdaMenuPage:_getHost()
+    -- Shared module registry only (NO HOST). Never RfPdaHost / rfPdaHost.
+    if RfEscModules ~= nil then
+        return RfEscModules.getOrCreate()
+    end
+    return nil
+end
+
+--- Shared MTO arrow ensure: enable + normalized ~36px hit (never setSize(36,36) literals)
+--- then lime tint. Re-apply every call â€” profile can reset circle buttons to 42.
+function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
+    if sel == nil then
+        return
+    end
+
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false
+    if sel.setCanChangeState then
+        sel:setCanChangeState(true)
+    end
+    if sel.setDisabled then
+        sel:setDisabled(false)
+    end
+
+    -- Extract: GuiUtils.getNormalizedScreenValues(values, default) â€” values = "Wpx Hpx" or array; returns table.
+    -- Never pass bare numbers (GuiUtils.lua #values throws on number).
+    local tw, th = nil, nil
+    if GuiUtils ~= nil and type(GuiUtils.getNormalizedScreenValues) == "function" then
+        local norms = GuiUtils.getNormalizedScreenValues("36px 36px")
+        if type(norms) == "table" then
+            tw, th = norms[1], norms[2]
+        end
+    end
+
+    -- ButtonElement extends TextElement (not Bitmap); tint via GuiOverlay on .overlay.
+    local r, g, b, a = 0.549, 0.776, 0.247, 1
+    for _, btn in ipairs({ sel.leftButtonElement, sel.rightButtonElement }) do
+        if btn ~= nil then
+            if btn.setVisible then btn:setVisible(true) end
+            if btn.setDisabled then btn:setDisabled(false) end
+            -- Size THEN lime (George Plan A). Absolute target â€” do not ratio current size.
+            if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
+                btn:setSize(tw, th)
+            end
+            if btn.overlay ~= nil and GuiOverlay ~= nil and GuiOverlay.setColor then
+                GuiOverlay.setColor(btn.overlay, r, g, b, a)
+            end
+            if type(btn.updateAbsolutePosition) == "function" then
+                btn:updateAbsolutePosition()
+            end
+        end
+    end
+end
+
+--- Keep Map circle arrows enabled + lime on first open (not near-black grey).
+function RfPdaMenuPage:_ensureSelectorArrowsVisible()
+    self:_ensureMtoArrowsVisible(self.rfPanelSelector)
+end
+
+--- Stable id list fingerprint for quiet SmoothList reload decisions.
+function RfPdaMenuPage:_panelSetFingerprint(panels)
+    local parts = {}
+    for i, panel in ipairs(panels or {}) do
+        parts[i] = tostring(panel.id)
+    end
+    return table.concat(parts, "|")
+end
+
+function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
+    if self._refreshing then return end
+    local host = self:_getHost()
+    if host == nil or self.rfPanelSelector == nil then return end
+
+    self._refreshing = true
+    local ok, err = pcall(function()
+        local panels = host:getPanels()
+        local fingerprint = self:_panelSetFingerprint(panels)
+        local setChanged = fingerprint ~= self._lastPanelFingerprint
+        self._lastPanelFingerprint = fingerprint
+        self._panelCache = panels
+
+        local texts = self:_panelTitles(panels)
+        local activeIndex = 1
+        for i, panel in ipairs(panels) do
+            if host.activeModuleId == panel.id then
+                activeIndex = i
+                break
+            end
+        end
+
+        if #texts == 0 then
+            -- Last-resort single label (selector profile keeps textSize ~20px; never RF_PageTitle 74px).
+            texts[1] = "No modules"
+            activeIndex = 1
+        end
+
+        self:_ensureSelectorArrowsVisible()
+        -- setTexts can re-apply profile single-text disable; always follow with force-enable.
+        self.rfPanelSelector:setTexts(texts)
+        if self.rfPanelSelector.setState then
+            -- Modules dual-fire FAIL-FIX (George): forceEvent=true re-enters onClick →
+            -- selectPanel → refreshPanelSelector → setState(true) loop with moduleList.
+            -- Always false while _refreshing so list/MTO sync never raises click.
+            self.rfPanelSelector:setState(activeIndex, false)
+        end
+        -- F11: force lime arrows visible again after setState (engine may disable on open).
+        self:_ensureSelectorArrowsVisible()
+
+        -- Rebuild RoundCorner dots only when count/set changes or forced (onFrameOpen).
+        if forceRebuildDots or setChanged then
+            self:_rebuildDots(#texts)
+        end
+
+        self:_refreshDotLegend(panels, activeIndex)
+        -- Module SmoothList: only when panel set actually changes or forced open.
+        if (forceRebuildDots or setChanged) and self.moduleList then
+            self.moduleList:reloadData()
+        end
+    end)
+    self._refreshing = false
+    if not ok and SoilLogger then
+        SoilLogger.warning("RfPdaMenuPage:refreshPanelSelector failed: %s", tostring(err))
+    end
+end
+
+function RfPdaMenuPage:_refreshDotLegend(panels, activeIndex)
+    if self.rfDotLegend == nil then return end
+    local n = math.max(1, #(panels or {}))
+    local shorts = {}
+    for _, panel in ipairs(panels or {}) do
+        local title = safePanelTitle(panel)
+        if panel.id == "soilFertilizer" then
+            title = tr("rf_pda_module_soil_short", "Soil")
+        end
+        table.insert(shorts, title)
+    end
+    local joined = table.concat(shorts, " Â· ")
+    if joined == "" then
+        joined = tr("rf_pda_module_soil_short", "Soil")
+    end
+    self.rfDotLegend:setText(string.format("%d/%d Â· %s", activeIndex or 1, n, joined))
+end
+
+--- Match SoilMapHooks / Map: grow/shrink from first seed RoundCorner in the BoxLayout.
+function RfPdaMenuPage:_rebuildDots(count)
+    local dotBox = self.rfPanelDotBox
+    if dotBox == nil or dotBox.elements == nil or #dotBox.elements == 0 then
+        return
+    end
+
+    local elements = dotBox.elements
+    local expectedCount = math.max(1, count or 1)
+
+    while #elements < expectedCount do
+        local seed = elements[1]
+        if seed == nil or seed.clone == nil then
+            break
+        end
+        local ok, clone = pcall(function()
+            return seed:clone(dotBox)
+        end)
+        if not ok or clone == nil then
+            break
+        end
+        if FocusManager and FocusManager.loadElementFromCustomValues then
+            pcall(FocusManager.loadElementFromCustomValues, FocusManager, clone)
+        end
+        elements = dotBox.elements
+    end
+
+    while #elements > expectedCount do
+        local last = elements[#elements]
+        if last ~= nil and last.delete then
+            last:delete()
+        end
+        elements = dotBox.elements
+    end
+
+    for i, dot in ipairs(dotBox.elements) do
+        local index = i
+        function dot.getIsSelected()
+            if self.rfPanelSelector == nil or self.rfPanelSelector.getState == nil then
+                return index == 1
+            end
+            return self.rfPanelSelector:getState() == index
+        end
+        if dot.setVisible then
+            dot:setVisible(true)
+        end
+    end
+
+    if dotBox.invalidateLayout then
+        dotBox:invalidateLayout()
+    end
+end
+
+function RfPdaMenuPage:onClickRfPanelSelector()
+    self:_ensureSelectorArrowsVisible()
+    self:_applySelectorState()
+end
+
+--- Debounce duplicate module id selects (MTO ↔ moduleList bounce ~200ms in logs).
+--- @return boolean true when the select should proceed
+function RfPdaMenuPage:_allowModuleSelect(panelId)
+    if panelId == nil then
+        return false
+    end
+    if self._refreshing then
+        return false
+    end
+    local now = g_time or 0
+    if self._lastModuleSelectId == panelId then
+        local elapsed = now - (self._lastModuleSelectAt or 0)
+        if elapsed >= 0 and elapsed < MODULE_SELECT_DEBOUNCE_MS then
+            return false
+        end
+    end
+    self._lastModuleSelectId = panelId
+    self._lastModuleSelectAt = now
+    return true
+end
+
+function RfPdaMenuPage:_restoreBrandToActivePanel()
+    local host = self:_getHost()
+    if host == nil or self.rfPanelSelector == nil or self.rfPanelSelector.setState == nil then
+        return
+    end
+    local panels = self._panelCache or (host.getPanels and host:getPanels()) or {}
+    local idx = 1
+    for i, panel in ipairs(panels) do
+        if panel.id == host.activeModuleId then
+            idx = i
+            break
+        end
+    end
+    -- Click-hit FAIL-FIX: never forceEvent after page click (re-enters Brand onClick / dual-fire).
+    self._refreshing = true
+    pcall(function()
+        self.rfPanelSelector:setState(idx, false)
+    end)
+    self._refreshing = false
+end
+
+function RfPdaMenuPage:_applySelectorState()
+    local host = self:_getHost()
+    if host == nil or self.rfPanelSelector == nil then return end
+    if self._refreshing then
+        return
+    end
+
+    local state = self.rfPanelSelector:getState()
+    local panel = self._panelCache[state]
+    if panel == nil then return end
+
+    if host.activeModuleId ~= panel.id then
+        if not self:_allowModuleSelect(panel.id) then
+            return
+        end
+        -- Host notify refreshes selector + content (quiet lists).
+        host:selectPanel(panel.id)
+        SoilLogger.info("RfPdaMenuPage: selectPanel %s (arrow/selector)", tostring(panel.id))
+    else
+        self:refreshContent(false)
+    end
+end
+
+function RfPdaMenuPage:cyclePanel(delta)
+    local host = self:_getHost()
+    if host == nil then return end
+
+    local panels = host:getPanels()
+    self._panelCache = panels
+    local n = #panels
+    if n <= 0 then return end
+    if n == 1 then
+        -- Stable no-op with one panel; keep arrows visible, no SmoothList rebuild.
+        self:_ensureSelectorArrowsVisible()
+        return
+    end
+
+    local idx = 1
+    for i, panel in ipairs(panels) do
+        if panel.id == host.activeModuleId then
+            idx = i
+            break
+        end
+    end
+
+    local nextIdx = ((idx - 1 + delta) % n) + 1
+    local nextPanel = panels[nextIdx]
+    if nextPanel == nil then return end
+    if not self:_allowModuleSelect(nextPanel.id) then
+        return
+    end
+
+    -- selectPanel notifies → quiet refreshPanelSelector + refreshContent(false)
+    host:selectPanel(nextPanel.id)
+    SoilLogger.info("RfPdaMenuPage: cyclePanel -> %s", tostring(nextPanel.id))
+end
+
+--- Modules MTO texts: module names only (Soil Fertilizer / Worker Costs / Crop Stress).
+--- Door tab owns "Realistic Farming"; never force brand watermark into selector texts.
+function RfPdaMenuPage:_panelTitles(panels)
+    local texts = {}
+    for i, panel in ipairs(panels) do
+        texts[i] = safePanelTitle(panel)
+    end
+    return texts
+end
+
+function RfPdaMenuPage:_refreshPageHeader(active)
+    local isSoil = active == nil or active.id == "soilFertilizer"
+    local isWc = active ~= nil and active.id == "workerCosts"
+    if self.rfPageTitle then
+        if isSoil then
+            self.rfPageTitle:setText(tr("rf_pda_panel_soil", "Soil Fertilizer"))
+        else
+            self.rfPageTitle:setText(safePanelTitle(active))
+        end
+    end
+    if self.rfPageBlurb then
+        if isSoil then
+            self.rfPageBlurb:setText(tr("rf_pda_menu_blurb",
+                "Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields."))
+        elseif isWc then
+            -- Chrome FAIL-FIX: never leave Soil nutrient/treatment copy on Worker Costs.
+            local rawBlurb = active and active.blurb
+            local wcBlurb = "Wage mode, active workers, next settlement estimate. Open Worker Manager for hire and settings."
+            if type(rawBlurb) == "string" and rawBlurb ~= "" then
+                local lower = rawBlurb:lower()
+                if not lower:find("^missing%s") and not lower:find("^missing_") then
+                    wcBlurb = rawBlurb
+                end
+            end
+            self.rfPageBlurb:setText(wcBlurb)
+        elseif active ~= nil and type(active.blurb) == "string" and active.blurb ~= "" then
+            local lower = active.blurb:lower()
+            if not lower:find("^missing%s") and not lower:find("^missing_") then
+                self.rfPageBlurb:setText(active.blurb)
+            else
+                self.rfPageBlurb:setText(tr("rf_pda_host_blurb",
+                    "Quick look at this module. Open Farm Tablet for the full tools."))
+            end
+        else
+            self.rfPageBlurb:setText(tr("rf_pda_host_blurb",
+                "Quick look at this module. Open Farm Tablet for the full tools."))
+        end
+    end
+    -- rfSuiteHint retired: side help paints via rfSideInfoShell / wcSideInfoShell only.
+    if self.rfSuiteHint and self.rfSuiteHint.setText then
+        self.rfSuiteHint:setText("")
+    end
+end
+
+--- Fill Soil/CS left side-info Text (WC body filled by WcRfPdaGuest).
+function RfPdaMenuPage:_refreshSideInfo(activeId)
+    local isSoil = activeId == nil or activeId == "soilFertilizer"
+    local isCs = activeId == "seasonalCropStress"
+    local isWc = activeId == "workerCosts"
+    local isMd = activeId == "marketDynamics"
+    local function setVis(el, visible)
+        if el ~= nil and type(el.setVisible) == "function" then
+            el:setVisible(visible)
+        end
+    end
+    setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
+    setVis(self.wcSideInfoShell, isWc)
+    setVis(self.rfSuiteHint, false)
+    if self.rfSideInfoBody and self.rfSideInfoBody.setText then
+        if isSoil then
+            self.rfSideInfoBody:setText(tr("rf_pda_side_info_soil",
+                "Soil Fertilizer\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).\n\nClick a row. Treatment (below) is the plan for that field:\n- PRODUCT = what to buy (first is preferred; \"or ...\" is an alternate)\n- RATE = amount per area / TOTAL = amount for this field\n- Selected names the field; Next (under it) says what to do first\n\nHow to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.\n\nStart with the weakest Status, open Treatment, follow Next, then the rest of the list."))
+        elseif isCs then
+            self.rfSideInfoBody:setText(tr("rf_pda_side_info_crop_stress",
+                "Crop Stress\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).\n\nClick a row. The strip below names the field, then Next says what to do first:\n- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)\n- High Stress or a sensitive growth window → protect now; stress today cuts harvest later\n- Looking fine → recheck later; worse fields first\n\nIrrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.\n\nIf Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.\n\nStart with Critical Status, follow Next, then work up the list."))
+        elseif isMd then
+            self.rfSideInfoBody:setText(tr("rf_pda_side_info_market_dynamics",
+                "Market Dynamics\n\nThis is a pause market glance, not the full Market desk.\n\nGraph = price path for the crop you pick.\n\nMovers = biggest swings right now. Click one to change the graph.\n\nEvents = world events still driving prices. Empty means nothing active (normal).\n\nBottom strip = facts for the crop you selected.\n\nContracts line = open count only. Full contracts live deeper.\n\nOpen full Market when you need Prices / Events / Contracts admin."))
+        else
+            self.rfSideInfoBody:setText("")
+        end
+    end
+end
+
+--- Show/hide CS table+detail twins and WC subnav/page shells by active guest panel id.
+--- Panel id for Crop Stress guest is seasonalCropStress (not "cropStress").
+function RfPdaMenuPage:_syncHostGuestChrome(activeId)
+    local isSoil = activeId == nil or activeId == "soilFertilizer"
+    local isCs = activeId == "seasonalCropStress"
+    local isWc = activeId == "workerCosts"
+    local isMd = activeId == "marketDynamics"
+    local function setVis(el, visible)
+        if el ~= nil and type(el.setVisible) == "function" then
+            el:setVisible(visible)
+        end
+    end
+    setVis(self.rfHostTableRegion, isCs)
+    setVis(self.csFieldOverviewList, isCs)
+    setVis(self.csDetailStrip, isCs)
+    setVis(self.mdGraphRegion, isMd)
+    setVis(self.mdDetailStrip, isMd)
+    setVis(self.mdMoverSelector, isMd)
+    setVis(self.mdOpenMarketBtn, isMd)
+    if self.mdMoverSelector ~= nil then
+        self.mdMoverSelector.disableButtonsOnSingleText = false
+        self.mdMoverSelector.hideLeftRightButtons = not isMd
+        if type(self.mdMoverSelector.setDisabled) == "function" then
+            self.mdMoverSelector:setDisabled(not isMd)
+        end
+        if isMd and type(self._ensureMtoArrowsVisible) == "function" then
+            self:_ensureMtoArrowsVisible(self.mdMoverSelector)
+        end
+        if isMd and self.mdGraphRegion ~= nil and type(self.mdGraphRegion.updateAbsolutePosition) == "function" then
+            self.mdGraphRegion:updateAbsolutePosition()
+        end
+        if isMd and self.mdGraphArea ~= nil and type(self.mdGraphArea.updateAbsolutePosition) == "function" then
+            self.mdGraphArea:updateAbsolutePosition()
+        end
+    end
+    if not isCs then
+        setVis(self.csFieldsEmptyHint, false)
+    end
+    -- Fresh WC: page MTO lives in sibling wcSubnavShell (NOT rfFilterBox). Brand alone in filter.
+    setVis(self.wcSubnavShell, isWc)
+    setVis(self.wcSubnavSelector, isWc)
+    setVis(self.wcSubnavDotBox, isWc)
+    if self.wcSubnavSelector ~= nil then
+        if isWc then
+            self.wcSubnavSelector.disableButtonsOnSingleText = false
+            self.wcSubnavSelector.hideLeftRightButtons = false
+            if type(self.wcSubnavSelector.setDisabled) == "function" then
+                self.wcSubnavSelector:setDisabled(false)
+            end
+            if type(self.wcSubnavSelector.setCanChangeState) == "function" then
+                self.wcSubnavSelector:setCanChangeState(true)
+            end
+            if self.wcSubnavShell ~= nil and type(self.wcSubnavShell.updateAbsolutePosition) == "function" then
+                self.wcSubnavShell:updateAbsolutePosition()
+            end
+            if type(self.wcSubnavSelector.updateAbsolutePosition) == "function" then
+                self.wcSubnavSelector:updateAbsolutePosition()
+            end
+            if self.rfPanelSelector ~= nil and type(self.rfPanelSelector.updateAbsolutePosition) == "function" then
+                self.rfPanelSelector:updateAbsolutePosition()
+            end
+            if self.wcSubnavDotBox ~= nil and type(self.wcSubnavDotBox.updateAbsolutePosition) == "function" then
+                self.wcSubnavDotBox:updateAbsolutePosition()
+            end
+            self:_ensureWcSubnavArrowsVisible()
+            self:_ensureSelectorArrowsVisible()
+        else
+            self.wcSubnavSelector.hideLeftRightButtons = true
+            if type(self.wcSubnavSelector.setDisabled) == "function" then
+                self.wcSubnavSelector:setDisabled(true)
+            end
+            if type(self.wcSubnavSelector.setCanChangeState) == "function" then
+                self.wcSubnavSelector:setCanChangeState(false)
+            end
+        end
+    end
+    setVis(self.wcTitlePageShell, false)
+    setVis(self.wcTitlePageSelector, false)
+    if self.wcTitlePageSelector ~= nil then
+        self.wcTitlePageSelector.hideLeftRightButtons = true
+        if type(self.wcTitlePageSelector.setDisabled) == "function" then
+            self.wcTitlePageSelector:setDisabled(true)
+        end
+    end
+    setVis(self.wcPageSelector, false)
+    setVis(self.wcSideInfoShell, isWc)
+    setVis(self.wcSideVersion, false)
+    setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
+    -- On WC: hide Brand mid chrome so page sibling band owns that Y; Modules dock stays.
+    setVis(self.rfPanelDotBox, not isWc)
+    setVis(self.rfDotLegend, false)
+    setVis(self.rfSuiteHint, false)
+    setVis(self.rfSideMidSeparator, false)
+    setVis(self.wcPageShell, isWc)
+    setVis(self.wcGlanceShell, false)
+    self:_refreshSideInfo(activeId)
+    -- CS: hide host body so table+detail get room (not isWc alone — body was still on for CS).
+    setVis(self.rfHostBody, not isWc and not isCs and not isMd)
+    -- Keep right hero title/blurb; hide duplicate host title/blurb on WC, MDM and CS.
+    setVis(self.rfHostTitle, not isWc and not isMd and not isCs)
+    setVis(self.rfHostBlurb, not isWc and not isMd and not isCs)
+    if (isWc or isCs or isMd) and self.rfHostBody and self.rfHostBody.setText then
+        self.rfHostBody:setText("")
+    end
+    -- NEVER shrink MODULES dock below workable height (George: >=220).
+    local shell = self.rfModuleListShell
+    if shell ~= nil then
+        if self._rfModuleListShellSizeH == nil then
+            local minW = (shell.size and shell.size[1]) or nil
+            local minH = (shell.size and shell.size[2]) or nil
+            if GuiUtils ~= nil and type(GuiUtils.getNormalizedScreenValues) == "function" then
+                local norms = GuiUtils.getNormalizedScreenValues("504px 220px")
+                if type(norms) == "table" then
+                    minW = norms[1] or minW
+                    minH = norms[2] or minH
+                end
+            end
+            self._rfModuleListShellSizeW = minW or (shell.size and shell.size[1])
+            self._rfModuleListShellSizeH = minH or (shell.size and shell.size[2])
+            if self._rfModuleListShellSizeH == nil then
+                -- Last resort: leave height alone on next setSize skip.
+                self._rfModuleListShellSizeH = shell.size and shell.size[2]
+            end
+        end
+        local targetW = self._rfModuleListShellSizeW
+        local targetH = self._rfModuleListShellSizeH
+        if type(shell.setSize) == "function" and targetW ~= nil and targetH ~= nil then
+            shell:setSize(targetW, targetH)
+        elseif shell.size ~= nil and targetH ~= nil then
+            shell.size[2] = targetH
+        end
+        if shell.updateAbsolutePosition then
+            shell:updateAbsolutePosition()
+        end
+        if shell.setVisible then
+            shell:setVisible(true)
+        end
+    end
+    if isWc and self.wcPageShell ~= nil and self.wcPageShell.updateAbsolutePosition then
+        self.wcPageShell:updateAbsolutePosition()
+    end
+    if not isWc then
+        self._wcSubnavSeeded = false
+        self._wcLastFullPaintPage = nil
+        setVis(self.wcPageDashboard, false)
+        setVis(self.wcPageWages, false)
+        setVis(self.wcPageWorkers, false)
+        setVis(self.wcPageAbout, false)
+    end
+end
+
+--- Active WC page selector = sibling left shell under Brand. Never rfFilterBox; never content-body.
+function RfPdaMenuPage:_wcPageSel()
+    return self.wcSubnavSelector
+end
+
+--- Host-seed WC page labels once on WC enter (never from arrow click; never forceEvent).
+function RfPdaMenuPage:_seedWcSubnavTexts()
+    local sel = self:_wcPageSel()
+    if sel == nil then
+        return
+    end
+    if self._wcSubnavSeeded then
+        return
+    end
+    if sel.setVisible then
+        sel:setVisible(true)
+    end
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false
+    if sel.setCanChangeState then
+        sel:setCanChangeState(true)
+    end
+    if sel.setDisabled then
+        sel:setDisabled(false)
+    end
+    -- Subnav = Dashboard / Wages / Workers only (About retired into wcSideInfoShell).
+    local texts = { "Dashboard", "Wages", "Workers" }
+    self._wcWageRefreshing = true
+    self._wcSubnavSeeding = true
+    if sel.setTexts then
+        sel:setTexts(texts)
+    end
+    local idx = tonumber(self.wcSubPageIndex) or 1
+    if idx < 1 then idx = 1 end
+    if idx > 3 then idx = 3 end
+    self.wcSubPageIndex = idx
+    -- George arrow-crash FAIL-FIX: forceEvent=false — setState(true) re-enters onClick.
+    if sel.setState then
+        sel:setState(idx, false)
+    end
+    self._wcSubnavSeeding = false
+    self._wcWageRefreshing = false
+    self._wcSubnavSeeded = true
+    self:_ensureWcSubnavArrowsVisible()
+    self:_rebuildWcSubnavDots(3)
+    if self.wcSubnavShell ~= nil and self.wcSubnavShell.updateAbsolutePosition then
+        self.wcSubnavShell:updateAbsolutePosition()
+    end
+    if self.rfHostPlaceholder ~= nil and self.rfHostPlaceholder.updateAbsolutePosition then
+        self.rfHostPlaceholder:updateAbsolutePosition()
+    end
+    if sel.updateAbsolutePosition then
+        sel:updateAbsolutePosition()
+    end
+end
+
+--- Contracts page dots under wcSubnavSelector (mirror Brand _rebuildDots; bind to page MTO state).
+function RfPdaMenuPage:_rebuildWcSubnavDots(count)
+    local dotBox = self.wcSubnavDotBox
+    if dotBox == nil or dotBox.elements == nil or #dotBox.elements == 0 then
+        return
+    end
+    if type(dotBox.setVisible) == "function" then
+        dotBox:setVisible(true)
+    end
+
+    local elements = dotBox.elements
+    local expectedCount = math.max(1, count or 1)
+
+    while #elements < expectedCount do
+        local seed = elements[1]
+        if seed == nil or seed.clone == nil then
+            break
+        end
+        local ok, clone = pcall(function()
+            return seed:clone(dotBox)
+        end)
+        if not ok or clone == nil then
+            break
+        end
+        if FocusManager and FocusManager.loadElementFromCustomValues then
+            pcall(FocusManager.loadElementFromCustomValues, FocusManager, clone)
+        end
+        elements = dotBox.elements
+    end
+
+    while #elements > expectedCount do
+        local last = elements[#elements]
+        if last ~= nil and last.delete then
+            last:delete()
+        end
+        elements = dotBox.elements
+    end
+
+    for i, dot in ipairs(dotBox.elements) do
+        local index = i
+        function dot.getIsSelected()
+            local sel = self:_wcPageSel()
+            if sel == nil or sel.getState == nil then
+                return index == 1
+            end
+            return sel:getState() == index
+        end
+        if dot.setVisible then
+            dot:setVisible(true)
+        end
+    end
+
+    if dotBox.invalidateLayout then
+        dotBox:invalidateLayout()
+    end
+    if type(dotBox.updateAbsolutePosition) == "function" then
+        dotBox:updateAbsolutePosition()
+    end
+end
+
+function RfPdaMenuPage:_ensureWcSubnavArrowsVisible()
+    self:_ensureMtoArrowsVisible(self:_wcPageSel())
+end
+
+--- Wage row MTOs + About tab MTO share Brand/page hit laws (normalized setSize then lime).
+function RfPdaMenuPage:_ensureWcWageArrowsVisible()
+    local ids = {
+        "wcOptEnabled", "wcOptCostMode", "wcOptWageLevel",
+        "wcOptNotifications", "wcOptDebugMode", "wcOptMonthlySalary"
+    }
+    for _, id in ipairs(ids) do
+        local sel = self:getDescendantById(id)
+        if sel ~= nil then
+            -- Optional: stop continuous hold from stealing neighboring rows.
+            if sel.registerContinuousInput ~= nil then
+                sel.registerContinuousInput = false
+            end
+            self:_ensureMtoArrowsVisible(sel)
+        end
+    end
+end
+
+function RfPdaMenuPage:_ensureWcAboutArrowsVisible()
+    local sel = self:getDescendantById("wcAboutTabSelector")
+    self:_ensureMtoArrowsVisible(sel)
+end
+
+--- Apply WC secondary page visibility from self.wcSubPageIndex (1..3; About retired).
+function RfPdaMenuPage:_syncWcSubPageVisibility()
+    local idx = tonumber(self.wcSubPageIndex) or 1
+    if idx < 1 then idx = 1 end
+    if idx > 3 then idx = 3 end
+    self.wcSubPageIndex = idx
+    local function setVis(el, visible)
+        if el ~= nil and type(el.setVisible) == "function" then
+            el:setVisible(visible)
+        end
+    end
+    setVis(self.wcPageDashboard, idx == 1)
+    setVis(self.wcPageWages, idx == 2)
+    setVis(self.wcPageWorkers, idx == 3)
+    setVis(self.wcPageAbout, false)
+end
+
+--- Sibling-shell page MTO. Page index only â€” never Brand / selectPanel.
+function RfPdaMenuPage:onClickWcSubnavSelector()
+    if self._wcWageRefreshing or self._wcSubnavSeeding then
+        return
+    end
+    local sel = self:_wcPageSel()
+    if sel == nil or sel.getState == nil then
+        return
+    end
+    if sel ~= self.wcSubnavSelector then
+        return
+    end
+    self:_ensureWcSubnavArrowsVisible()
+    local idx = sel:getState() or 1
+    if idx < 1 then idx = 1 end
+    if idx > 3 then idx = 3 end
+    self.wcSubPageIndex = idx
+    if sel.setState and sel:getState() ~= idx then
+        sel:setState(idx, false)
+    end
+    self:_syncWcSubPageVisibility()
+    if self.wcSubPageIndex == 2 then
+        self:_ensureWcWageArrowsVisible()
+    end
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and active.id == "workerCosts" and type(active.onShow) == "function" then
+        pcall(active.onShow, self.rfHostPlaceholder, true)
+    end
+end
+
+--- Retired title-chrome page MTO (RESTORE): no-op.
+function RfPdaMenuPage:onClickWcTitlePageSelector()
+    return
+end
+
+--- Retired content-body id: no-op.
+function RfPdaMenuPage:onClickWcPageSelector()
+    return
+end
+
+function RfPdaMenuPage:onClickWcAboutTabSelector()
+    if self._wcWageRefreshing or self._wcSubnavSeeding then
+        return
+    end
+    self:_ensureWcAboutArrowsVisible()
+    if self.getDescendantById then
+        local sel = self:getDescendantById("wcAboutTabSelector")
+        if sel ~= nil and sel.getState then
+            self.wcAboutTabIndex = sel:getState() or 1
+        end
+    end
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and active.id == "workerCosts" and type(active.onShow) == "function" then
+        pcall(active.onShow, self.rfHostPlaceholder, true)
+    end
+end
+
+--- Forward wage MultiTextOption clicks to Worker Costs guest (settings:save path).
+function RfPdaMenuPage:onClickWcWageOption()
+    if self._wcWageRefreshing then
+        return
+    end
+    self:_ensureWcWageArrowsVisible()
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and type(active.onWageOptionChanged) == "function" then
+        pcall(active.onWageOptionChanged, self.rfHostPlaceholder)
+    end
+end
+
+function RfPdaMenuPage:onClickWcWageReset()
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and type(active.onWageReset) == "function" then
+        pcall(active.onWageReset, self.rfHostPlaceholder)
+    end
+end
+
+--- @param rebuildLists boolean|nil when true (default), rebuild field SmoothList data
+function RfPdaMenuPage:refreshContent(rebuildLists)
+    if rebuildLists == nil then
+        rebuildLists = true
+    end
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    local panelId = (active ~= nil and active.id) or "soilFertilizer"
+    local isSoil = panelId == "soilFertilizer"
+    -- Hang-fence: one SmoothList reload per panel enter (module switch uses rebuildLists=false).
+    local prevId = self._lastShownPanelId
+    local enteringSoil = isSoil and prevId ~= "soilFertilizer"
+    local enteringCs = panelId == "seasonalCropStress" and prevId ~= "seasonalCropStress"
+    local doSoilListRebuild = rebuildLists or enteringSoil
+    local doCsListRebuild = rebuildLists or enteringCs
+
+    self:_refreshPageHeader(active)
+    self:_applyChromeL10n()
+
+    if self.rfPanelContent and self.rfPanelContent.setVisible then
+        self.rfPanelContent:setVisible(isSoil)
+    end
+    if self.rfHostPlaceholder and self.rfHostPlaceholder.setVisible then
+        self.rfHostPlaceholder:setVisible(not isSoil)
+    end
+
+    if isSoil then
+        self:_syncHostGuestChrome(nil)
+        local panel = soilPanel()
+        if panel == nil then
+            if not self._rfSoilPanelMissingWarned then
+                self._rfSoilPanelMissingWarned = true
+                local msg = "[RfEsc] RfPdaSoilPanel missing — Soil table cannot rebuild (cross-mod env)"
+                if Logging ~= nil and type(Logging.warning) == "function" then
+                    Logging.warning("%s", msg)
+                else
+                    print(msg)
+                end
+            end
+        else
+            -- Always rebuild+reload on Soil show (including enter after non-Soil door create).
+            if doSoilListRebuild then
+                panel.rebuildFieldData(self)
+                if self.selectedFieldId == nil and self.fieldData[1] ~= nil then
+                    self.selectedFieldId = self.fieldData[1].fieldId
+                end
+                panel.reloadFieldList(self)
+            elseif self.fieldData == nil or #self.fieldData == 0 then
+                -- Safety: empty table after soft refresh — force one rebuild.
+                panel.rebuildFieldData(self)
+                if self.selectedFieldId == nil and self.fieldData[1] ~= nil then
+                    self.selectedFieldId = self.fieldData[1].fieldId
+                end
+                panel.reloadFieldList(self)
+            end
+            panel.refreshTreatmentPlan(self)
+        end
+        if active ~= nil and type(active.onShow) == "function" then
+            pcall(active.onShow, self.rfPanelContent)
+        end
+    else
+        self:_syncHostGuestChrome(active and active.id or nil)
+        local skipHostDuplex = active ~= nil and (active.id == "workerCosts" or active.id == "marketDynamics" or active.id == "seasonalCropStress")
+        if self.rfHostTitle and not skipHostDuplex then
+            self.rfHostTitle:setText(safePanelTitle(active))
+        elseif self.rfHostTitle and self.rfHostTitle.setText and skipHostDuplex then
+            self.rfHostTitle:setText("")
+        end
+        if self.rfHostBlurb and not skipHostDuplex then
+            if active ~= nil and type(active.blurb) == "string" and active.blurb ~= "" then
+                local lower = active.blurb:lower()
+                if not lower:find("^missing%s") and not lower:find("^missing_") then
+                    self.rfHostBlurb:setText(active.blurb)
+                else
+                    self.rfHostBlurb:setText(tr("rf_pda_host_blurb",
+                        "Quick look at this module. Open Farm Tablet for the full tools."))
+                end
+            else
+                self.rfHostBlurb:setText(tr("rf_pda_host_blurb",
+                    "Quick look at this module. Open Farm Tablet for the full tools."))
+            end
+        elseif self.rfHostBlurb and self.rfHostBlurb.setText and skipHostDuplex then
+            self.rfHostBlurb:setText("")
+        end
+        if self.rfHostBody and active ~= nil
+            and active.id ~= "workerCosts"
+            and active.id ~= "seasonalCropStress"
+            and active.id ~= "marketDynamics" then
+            self.rfHostBody:setText(tr("rf_pda_host_placeholder",
+                "How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet."))
+        elseif self.rfHostBody and self.rfHostBody.setText
+            and active ~= nil
+            and (active.id == "workerCosts" or active.id == "seasonalCropStress") then
+            self.rfHostBody:setText("")
+        end
+        if active ~= nil and active.id == "workerCosts" then
+            self:_seedWcSubnavTexts()
+            self:_syncWcSubPageVisibility()
+            self:_ensureWcSubnavArrowsVisible()
+            self:_ensureSelectorArrowsVisible()
+            local pageIdx = tonumber(self.wcSubPageIndex) or 1
+            if pageIdx == 2 then
+                self:_ensureWcWageArrowsVisible()
+            end
+        end
+        if active ~= nil and type(active.onShow) == "function" then
+            if active.id == "seasonalCropStress" then
+                -- Full CS field list reload only on enter / rebuildLists (lightOnly otherwise).
+                pcall(active.onShow, self.rfHostPlaceholder, not doCsListRebuild)
+            else
+                pcall(active.onShow, self.rfHostPlaceholder)
+            end
+        end
+        -- Re-assert WC blurb + arrow hits after guest onShow.
+        if active ~= nil and active.id == "workerCosts" then
+            self:_refreshPageHeader(active)
+            self:_ensureWcSubnavArrowsVisible()
+            self:_ensureSelectorArrowsVisible()
+            local pageIdx = tonumber(self.wcSubPageIndex) or 1
+            if pageIdx == 2 then
+                self:_ensureWcWageArrowsVisible()
+            end
+        end
+    end
+
+    self._lastShownPanelId = panelId
+end
+
+function RfPdaMenuPage:getNumberOfItemsInSection(list, section)
+    if list == self.fieldOverviewList then
+        return #self.fieldData
+    end
+    if list == self.csFieldOverviewList then
+        return #(self.csFieldData or {})
+    end
+    if list == self.moduleList then
+        return #self._panelCache
+    end
+    return 0
+end
+
+function RfPdaMenuPage:populateCellForItemInSection(list, section, index, cell)
+    cell.rowDataIndex = index
+    if list == self.fieldOverviewList then
+        local panel = soilPanel()
+        if panel ~= nil then
+            panel.populateFieldRow(self, index, cell)
+        end
+    elseif list == self.csFieldOverviewList then
+        self:_populateCsFieldRow(index, cell)
+    elseif list == self.moduleList then
+        self:_populateModuleRow(index, cell)
+    end
+end
+
+function RfPdaMenuPage:_populateCsFieldRow(index, cell)
+    local entry = (self.csFieldData or {})[index]
+    if entry == nil then return end
+    local idEl = cell:getDescendantByName("csFieldRowId")
+    local cropEl = cell:getDescendantByName("csFieldRowCrop")
+    local moistEl = cell:getDescendantByName("csFieldRowMoisture")
+    local stressEl = cell:getDescendantByName("csFieldRowStress")
+    local irrEl = cell:getDescendantByName("csFieldRowIrrigated")
+    local statusEl = cell:getDescendantByName("csFieldRowStatus")
+    if idEl then idEl:setText(entry.fieldLabel or tostring(entry.fieldId or "")) end
+    if cropEl then cropEl:setText(entry.cropName or "-") end
+    if moistEl then
+        moistEl:setText(entry.moistureText or "-")
+        if entry.moistureColor and moistEl.setTextColor then
+            moistEl:setTextColor(unpack(entry.moistureColor))
+        end
+    end
+    if stressEl then stressEl:setText(entry.stressText or "-") end
+    if irrEl then irrEl:setText(entry.irrigatedText or "-") end
+    if statusEl then
+        statusEl:setText(entry.statusText or "-")
+        if entry.statusColor and statusEl.setTextColor then
+            statusEl:setTextColor(unpack(entry.statusColor))
+        end
+    end
+end
+
+function RfPdaMenuPage:reloadCsFieldList()
+    if self.csFieldOverviewList then
+        self.csFieldOverviewList:reloadData()
+    end
+    if self.csFieldsEmptyHint then
+        self.csFieldsEmptyHint:setVisible(#(self.csFieldData or {}) == 0)
+    end
+end
+
+function RfPdaMenuPage:_populateModuleRow(index, cell)
+    local panel = self._panelCache[index]
+    if panel == nil then return end
+    local titleEl = cell:getDescendantByName("moduleRowTitle")
+    local tagEl = cell:getDescendantByName("moduleRowTag")
+    local short = safePanelTitle(panel)
+    if panel.id == "soilFertilizer" then
+        short = tr("rf_pda_module_soil_short", "Soil")
+    end
+    if titleEl then titleEl:setText(short) end
+    if tagEl then
+        if panel.id == "soilFertilizer" then
+            tagEl:setText(tr("rf_pda_module_tag_host", "open"))
+        else
+            tagEl:setText(tr("rf_pda_module_tag_loaded", "ready"))
+        end
+    end
+    local host = self:_getHost()
+    local selected = host and host.activeModuleId == panel.id
+    if titleEl and titleEl.setTextColor then
+        titleEl:setTextColor(unpack(selected and COLOR_LIME_BRIGHT or COLOR_DIM))
+    end
+end
+
+function RfPdaMenuPage:onListSelectionChanged(list, section, index)
+    if list == self.fieldOverviewList and index ~= nil and index > 0 then
+        local entry = self.fieldData[index]
+        if entry ~= nil then
+            self.selectedFieldId = entry.fieldId
+            local panel = soilPanel()
+            if panel ~= nil then
+                panel.refreshTreatmentPlan(self)
+            end
+        end
+    elseif list == self.csFieldOverviewList and index ~= nil and index > 0 then
+        local entry = (self.csFieldData or {})[index]
+        if entry ~= nil then
+            self.csSelectedIndex = index
+            self.csSelectedFieldId = entry.fieldId
+            self:_refreshGuestDetail()
+        end
+    elseif list == self.moduleList then
+        -- Highlight-only: SmoothList ↑↓ must NOT switch modules.
+        -- Module switch = onClickModuleRow + Modules MTO (_applySelectorState / cyclePanel).
+        return
+    end
+end
+
+--- Text-only guest band refresh on selection (lightOnly contract; no SmoothList reload).
+function RfPdaMenuPage:_refreshGuestDetail()
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and active.id ~= "soilFertilizer" and type(active.onShow) == "function" then
+        pcall(active.onShow, self.rfHostPlaceholder, true)
+    end
+end
+
+local function resolveListRowIndex(element)
+    local el = element
+    local guard = 0
+    while el ~= nil and guard < 8 do
+        if el.rowDataIndex ~= nil then
+            return el.rowDataIndex
+        end
+        el = el.parent
+        guard = guard + 1
+    end
+    return nil
+end
+
+function RfPdaMenuPage:onClickFieldRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then return end
+    local entry = self.fieldData[index]
+    if entry == nil then return end
+    self.selectedFieldId = entry.fieldId
+    SoilLogger.info("RfPdaMenuPage: selected field %s", tostring(entry.fieldId))
+    local panel = soilPanel()
+    if panel ~= nil then
+        panel.refreshTreatmentPlan(self)
+    end
+    if self.fieldOverviewList and self.fieldOverviewList.setSelectedIndex then
+        pcall(function() self.fieldOverviewList:setSelectedIndex(index) end)
+    end
+end
+
+--- Mirror onClickFieldRow for the Crop Stress twin table: select row, refresh band text.
+function RfPdaMenuPage:onClickCsFieldRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then return end
+    local entry = (self.csFieldData or {})[index]
+    if entry == nil then return end
+    self.csSelectedIndex = index
+    self.csSelectedFieldId = entry.fieldId
+    if self.csFieldOverviewList and self.csFieldOverviewList.setSelectedIndex then
+        pcall(function() self.csFieldOverviewList:setSelectedIndex(index) end)
+    end
+    self:_refreshGuestDetail()
+end
+
+function RfPdaMenuPage:onClickModuleRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then return end
+    self:_selectModuleIndex(index)
+end
+
+function RfPdaMenuPage:_selectModuleIndex(index)
+    local host = self:_getHost()
+    local panel = self._panelCache[index]
+    if host == nil or panel == nil then return end
+    if self._refreshing then
+        return
+    end
+    if host.activeModuleId ~= panel.id then
+        if not self:_allowModuleSelect(panel.id) then
+            return
+        end
+        -- Host notify → refreshPanelSelector with forceEvent=false inside _refreshing
+        -- (no MTO onClick bounce back into this path).
+        host:selectPanel(panel.id)
+        SoilLogger.info("RfPdaMenuPage: moduleList -> %s", tostring(panel.id))
+    else
+        self:refreshContent(false)
+    end
+end
+
+function RfPdaMenuPage:getMenuButtonInfo()
+    return self.menuButtonInfo
+end
+
+function RfPdaMenuPage.show()
+    local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
+    if inGameMenu == nil then return end
+    local page = inGameMenu[RfPdaMenuPage.MENU_PAGE_NAME]
+    if page == nil then return end
+    g_gui:showGui("InGameMenu")
+    inGameMenu:goToPage(page)
+end
+
+function RfPdaMenuPage.toggle()
+    if g_gui.currentGuiName == "InGameMenu" then
+        local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
+        if inGameMenu and inGameMenu.currentPage == inGameMenu[RfPdaMenuPage.MENU_PAGE_NAME] then
+            g_gui:changeScreen(nil)
+            return
+        end
+    end
+    RfPdaMenuPage.show()
+end
+
+
+--- Empty bind stubs for frozen MDM chrome nodes under a non-MDM door (partial installs).
+function RfPdaMenuPage:onClickMdSubnavSelector()
+end
+
+function RfPdaMenuPage:onClickMdCommodityRow(element)
+end
+
+function RfPdaMenuPage:onClickMdMoverSelector()
+    if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.onMoverChanged) == "function" then
+        MdRfPdaGuest.onMoverChanged(self.rfHostPlaceholder or self)
+    end
+end
+
+function RfPdaMenuPage:onClickMdOpenMarket()
+    if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.onOpenFullMarket) == "function" then
+        MdRfPdaGuest.onOpenFullMarket()
+    elseif MDMMarketScreen ~= nil and type(MDMMarketScreen.show) == "function" then
+        MDMMarketScreen.show()
+    end
+end

--- a/src/ui/RfPdaSoilPanel.lua
+++ b/src/ui/RfPdaSoilPanel.lua
@@ -1,0 +1,449 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - RfPdaSoilPanel
+-- =========================================================
+-- Phase 0 from-scratch Esc RF rebuild: Soil main-pane logic
+-- extracted from RfPdaMenuPage (table rows + TREATMENT PLAN).
+-- Shell keeps Map chrome / host cycle; this module owns Soil data.
+-- Hang rules: no SmoothList thrash here; shell decides reload timing.
+-- N/P/K/status/fert = colored text only (no nil-filename Bitmaps).
+-- =========================================================
+
+RfPdaSoilPanel = {}
+-- Cross-mod: WC/CS may source RfPdaMenuPage last (their env has no RfPdaSoilPanel).
+-- getfenv(0) is Soil modEnv only — still publish for same-env callers.
+-- Mission soft-detect is the reliable cross-mod bridge (also set in RfSoilEscJoiner).
+if type(getfenv) == "function" then
+    local env0 = getfenv(0)
+    if env0 ~= nil then
+        env0["RfPdaSoilPanel"] = RfPdaSoilPanel
+    end
+end
+if g_currentMission ~= nil then
+    g_currentMission.rfPdaSoilPanel = RfPdaSoilPanel
+end
+
+local COLOR_GOOD = {0.549, 0.776, 0.247, 1.0}
+local COLOR_FAIR = {0.878, 0.627, 0.125, 1.0}
+local COLOR_POOR = {0.788, 0.290, 0.227, 1.0}
+local COLOR_DIM  = {1.00, 1.00, 1.00, 0.55}
+local COLOR_LIME_BRIGHT = {0.659, 0.878, 0.290, 1.0}
+
+local function colorForStatus(status)
+    if status == "Good" or status == "Excellent" then
+        return COLOR_GOOD
+    elseif status == "Fair" or status == "OK" then
+        return COLOR_FAIR
+    end
+    return COLOR_POOR
+end
+
+local function colorForKey(colorKey)
+    if colorKey == "good" or colorKey == "ok" then
+        return COLOR_GOOD
+    elseif colorKey == "fair" or colorKey == "warn" then
+        return COLOR_FAIR
+    elseif colorKey == "poor" or colorKey == "urgent" then
+        return COLOR_POOR
+    end
+    return COLOR_DIM
+end
+
+local function resolveFarmId()
+    local farmId = nil
+    if g_localPlayer ~= nil and g_localPlayer.farmId ~= nil then
+        farmId = g_localPlayer.farmId
+    end
+    if (farmId == nil or farmId == 0) and g_currentMission ~= nil and g_currentMission.getFarmId ~= nil then
+        farmId = g_currentMission:getFarmId()
+    end
+    return farmId
+end
+
+local function appendFieldEntry(page, sfm, fieldId)
+    local ok, info = pcall(function()
+        return sfm.soilSystem:getFieldInfo(fieldId)
+    end)
+    if not ok or info == nil then
+        return
+    end
+    local urgency = 0
+    local urgOk, urgVal = pcall(function()
+        return sfm.soilSystem:getFieldUrgency(fieldId)
+    end)
+    if urgOk and urgVal ~= nil then
+        urgency = urgVal
+    end
+    table.insert(page.fieldData, {
+        fieldId = fieldId,
+        info = info,
+        urgency = urgency or 0,
+    })
+end
+
+local function countFieldDataKeys(fieldData)
+    local n = 0
+    for _ in pairs(fieldData) do
+        n = n + 1
+    end
+    return n
+end
+
+--- Rebuild page.fieldData from SoilFertilitySystem (sorted by fieldId).
+--- Prefer owned fields (Wizard ruling): fieldData keys are farmland ids, so
+--- ownership is g_farmlandManager:getFarmlandOwner(fieldId), same as RfSoilFrame.
+--- If owned filter yields 0 but soilSystem.fieldData has entries, fall back to
+--- all fields with data (farmId mismatch / MP join edge).
+---@param page table RfPdaMenuPage instance
+function RfPdaSoilPanel.rebuildFieldData(page)
+    page.fieldData = {}
+    local sfm = g_SoilFertilityManager
+    if sfm == nil and type(getfenv) == "function" then
+        local env0 = getfenv(0)
+        if env0 ~= nil then
+            sfm = env0.g_SoilFertilityManager
+        end
+    end
+    if sfm == nil or sfm.soilSystem == nil or sfm.soilSystem.fieldData == nil then
+        return
+    end
+
+    local rawCount = countFieldDataKeys(sfm.soilSystem.fieldData)
+    if rawCount == 0 then
+        return
+    end
+
+    local farmId = resolveFarmId()
+    local usedOwnedFilter = false
+    if farmId ~= nil and farmId ~= 0 and g_farmlandManager ~= nil then
+        usedOwnedFilter = true
+        for fieldId, _ in pairs(sfm.soilSystem.fieldData) do
+            local owner = g_farmlandManager:getFarmlandOwner(fieldId)
+            if owner == farmId then
+                appendFieldEntry(page, sfm, fieldId)
+            end
+        end
+    end
+
+    if #page.fieldData == 0 then
+        for fieldId, _ in pairs(sfm.soilSystem.fieldData) do
+            appendFieldEntry(page, sfm, fieldId)
+        end
+        if usedOwnedFilter and #page.fieldData > 0 then
+            local msg = string.format(
+                "RfPdaSoilPanel: owned filter empty; falling back to all fields with soil data (%d)",
+                #page.fieldData
+            )
+            if SoilLogger ~= nil and type(SoilLogger.info) == "function" then
+                SoilLogger.info("%s", msg)
+            elseif Logging ~= nil and type(Logging.info) == "function" then
+                Logging.info("[RfEsc] %s", msg)
+            end
+        end
+    end
+
+    table.sort(page.fieldData, function(a, b)
+        return a.fieldId < b.fieldId
+    end)
+end
+
+function RfPdaSoilPanel.reloadFieldList(page)
+    if page.fieldOverviewList then
+        page.fieldOverviewList:reloadData()
+    end
+    if page.fieldsEmptyHint then
+        local tr = page._rfTr or function(k, fb) return fb or k end
+        if type(page.fieldsEmptyHint.setText) == "function" then
+            page.fieldsEmptyHint:setText(tr("sf_pda_no_fields", "No field data recorded yet."))
+        end
+        page.fieldsEmptyHint:setVisible(#page.fieldData == 0)
+    end
+end
+
+function RfPdaSoilPanel.populateFieldRow(page, index, cell)
+    local entry = page.fieldData[index]
+    if entry == nil or entry.info == nil then return end
+    local info = entry.info
+    local tr = page._rfTr or function(k, fb) return fb or k end
+
+    local idEl     = cell:getDescendantByName("fieldRowId")
+    local areaEl   = cell:getDescendantByName("fieldRowArea")
+    local nEl      = cell:getDescendantByName("fieldRowN")
+    local pEl      = cell:getDescendantByName("fieldRowP")
+    local kEl      = cell:getDescendantByName("fieldRowK")
+    local phEl     = cell:getDescendantByName("fieldRowPH")
+    local statusEl = cell:getDescendantByName("fieldRowStatus")
+    local fertEl   = cell:getDescendantByName("fieldRowFert")
+
+    if idEl then
+        idEl:setText(string.format("Field %s", tostring(entry.fieldId)))
+    end
+
+    if areaEl then
+        local area = info.fieldArea or 0
+        if area > 0 then
+            areaEl:setText(string.format("%.1f", area))
+        else
+            areaEl:setText("-")
+        end
+    end
+
+    local function setNutrientText(el, nutrient)
+        local value = nutrient and nutrient.value or 0
+        local status = nutrient and nutrient.status or "Poor"
+        if el then
+            el:setText(string.format("%d%%", math.floor(value)))
+            el:setTextColor(unpack(colorForStatus(status)))
+        end
+    end
+
+    setNutrientText(nEl, info.nitrogen)
+    setNutrientText(pEl, info.phosphorus)
+    setNutrientText(kEl, info.potassium)
+
+    -- pH: scalar from getFieldInfo (not %); SoilPDAScreen band colors; nil -> "-"
+    if phEl then
+        local phNum = tonumber(info.pH)
+        if phNum == nil then
+            phEl:setText("-")
+            phEl:setTextColor(unpack(COLOR_DIM))
+        else
+            local ph = math.floor((phNum * 10) + 0.5) / 10
+            phEl:setText(string.format("%.1f", ph))
+            -- SoilPDAScreen bands: good 6.5-7.0; fair 6.0-<7.5; else poor
+            if ph >= 6.5 and ph <= 7.0 then
+                phEl:setTextColor(unpack(COLOR_GOOD))
+            elseif ph >= 6.0 and ph < 7.5 then
+                phEl:setTextColor(unpack(COLOR_FAIR))
+            else
+                phEl:setTextColor(unpack(COLOR_POOR))
+            end
+        end
+    end
+
+    local urgent = (entry.urgency or 0) >= 60
+    local okStatus = (entry.urgency or 0) < 25 and not info.needsFertilization
+    if statusEl then
+        if urgent then
+            statusEl:setText(tr("rf_pda_status_urgent", "URGENT"))
+            statusEl:setTextColor(unpack(COLOR_POOR))
+        elseif okStatus then
+            statusEl:setText(tr("rf_pda_status_ok", "OK"))
+            statusEl:setTextColor(unpack(COLOR_GOOD))
+        else
+            statusEl:setText(tr("sf_pda_status_fair", "Fair"))
+            statusEl:setTextColor(unpack(COLOR_FAIR))
+        end
+    end
+
+    if fertEl then
+        if info.needsFertilization then
+            fertEl:setText(tr("rf_pda_fert_chip", "FERT"))
+            fertEl:setTextColor(unpack(COLOR_FAIR))
+        else
+            fertEl:setText("—")
+            fertEl:setTextColor(unpack(COLOR_DIM))
+        end
+    end
+end
+
+function RfPdaSoilPanel.refreshTreatmentPlan(page)
+    local tr = page._rfTr or function(k, fb) return fb or k end
+    local fieldId = page.selectedFieldId
+    local entry = nil
+    for _, e in ipairs(page.fieldData or {}) do
+        if e.fieldId == fieldId then
+            entry = e
+            break
+        end
+    end
+
+    local function clearTargets()
+        if page.treatTargetsHeading then page.treatTargetsHeading:setText("") end
+        if page.treatTargetN then page.treatTargetN:setText("") end
+        if page.treatTargetP then page.treatTargetP:setText("") end
+        if page.treatTargetK then page.treatTargetK:setText("") end
+        if page.treatTargetsLabel then
+            page.treatTargetsLabel:setText("")
+            if page.treatTargetsLabel.setVisible then
+                page.treatTargetsLabel:setVisible(false)
+            end
+        end
+    end
+
+    local function clearProductRows()
+        for i = 1, 8 do
+            local slot = page.treatProdRows and page.treatProdRows[i]
+            if slot and slot.row and slot.row.setVisible then
+                slot.row:setVisible(false)
+            end
+        end
+    end
+
+    local function setProductOk(text, color)
+        clearProductRows()
+        if page.treatPlanLines then
+            page.treatPlanLines:setText(text or "")
+            if page.treatPlanLines.setVisible then
+                page.treatPlanLines:setVisible(text ~= nil and text ~= "")
+            end
+            if color and page.treatPlanLines.setTextColor then
+                page.treatPlanLines:setTextColor(unpack(color))
+            end
+        end
+    end
+
+    local function fillProductRows(rows)
+        clearProductRows()
+        if page.treatPlanLines and page.treatPlanLines.setVisible then
+            page.treatPlanLines:setVisible(false)
+        end
+        local n = math.min(8, #(rows or {}))
+        for i = 1, n do
+            local row = rows[i]
+            local slot = page.treatProdRows and page.treatProdRows[i]
+            if slot and slot.row then
+                if slot.row.setVisible then slot.row:setVisible(true) end
+                if slot.nut then slot.nut:setText(tostring(row.nutrient or "")) end
+                if slot.name then slot.name:setText(tostring(row.product or "")) end
+                if slot.rate then slot.rate:setText(tostring(row.rate or "")) end
+                if slot.total then slot.total:setText(tostring(row.total or "")) end
+                local col = colorForKey(row.colorKey)
+                for _, el in ipairs({ slot.nut, slot.name, slot.rate, slot.total }) do
+                    if el and el.setTextColor then
+                        el:setTextColor(unpack(col))
+                    end
+                end
+            end
+        end
+    end
+
+    local function setSelectedLabel(nextTip)
+        if not page.treatSelectedLabel and not page.treatNextLabel then
+            return
+        end
+        if fieldId == nil then
+            if page.treatSelectedLabel then
+                page.treatSelectedLabel:setText(tr("rf_pda_treatment_none_selected", "Select a field"))
+                if page.treatSelectedLabel.setTextColor then
+                    page.treatSelectedLabel:setTextColor(unpack(COLOR_LIME_BRIGHT))
+                end
+            end
+            if page.treatNextLabel then
+                page.treatNextLabel:setText("")
+                if page.treatNextLabel.setVisible then
+                    page.treatNextLabel:setVisible(false)
+                end
+            end
+            return
+        end
+
+        -- Line 1: Field only
+        if page.treatSelectedLabel then
+            local tpl = tr("rf_pda_treatment_selected", "Selected field: Field %s")
+            local okFmt, formatted = pcall(string.format, tpl, tostring(fieldId))
+            local text = okFmt and formatted or ("Field " .. tostring(fieldId))
+            page.treatSelectedLabel:setText(text)
+            if page.treatSelectedLabel.setTextColor then
+                page.treatSelectedLabel:setTextColor(unpack(COLOR_LIME_BRIGHT))
+            end
+        end
+
+        -- Line 2: Next tip (own Text; wrap via profile textMaxNumLines)
+        if page.treatNextLabel then
+            if nextTip ~= nil and nextTip ~= "" then
+                local tpl = tr("rf_pda_treatment_next", "Next: %s")
+                local okFmt, formatted = pcall(string.format, tpl, nextTip)
+                local text = okFmt and formatted or ("Next: " .. tostring(nextTip))
+                page.treatNextLabel:setText(text)
+                if page.treatNextLabel.setVisible then
+                    page.treatNextLabel:setVisible(true)
+                end
+                if page.treatNextLabel.setTextColor then
+                    page.treatNextLabel:setTextColor(unpack(COLOR_LIME_BRIGHT))
+                end
+            else
+                page.treatNextLabel:setText("")
+                if page.treatNextLabel.setVisible then
+                    page.treatNextLabel:setVisible(false)
+                end
+            end
+        end
+    end
+
+    if entry == nil or entry.info == nil then
+        setSelectedLabel(nil)
+        clearTargets()
+        setProductOk(tr("sf_pda_no_fields", "No field data"), COLOR_DIM)
+        -- F1: never draw empty sampling hint (it overlapped PRODUCTS). Hide both.
+        if page.samplingInfoBox then page.samplingInfoBox:setVisible(false) end
+        if page.samplingInfoFallback then page.samplingInfoFallback:setVisible(false) end
+        return
+    end
+
+    local info = entry.info
+    local thresh = SoilConstants and SoilConstants.STATUS_THRESHOLDS or {}
+    local ct = info.cropTargets
+    local nLo = (ct and ct.N and ct.N.opt) or (thresh.nitrogen and thresh.nitrogen.fair) or 50
+    local nHi = (ct and ct.N and ct.N.opt and math.min(100, ct.N.opt + 20)) or 80
+    local pLo = (ct and ct.P and ct.P.opt) or (thresh.phosphorus and thresh.phosphorus.fair) or 45
+    local pHi = (ct and ct.P and ct.P.opt and math.min(100, ct.P.opt + 20)) or 75
+    local kLo = (ct and ct.K and ct.K.opt) or (thresh.potassium and thresh.potassium.fair) or 40
+    local kHi = (ct and ct.K and ct.K.opt and math.min(100, ct.K.opt + 20)) or 70
+
+    -- F5: separate Text lines (Giants Text often shows literal \n / broken l10n backticks)
+    if page.treatTargetsHeading then
+        page.treatTargetsHeading:setText(tr("rf_pda_treatment_targets_heading", "Target levels"))
+    end
+    if page.treatTargetN then
+        page.treatTargetN:setText(string.format("N %d-%d%%", nLo, nHi))
+    end
+    if page.treatTargetP then
+        page.treatTargetP:setText(string.format("P %d-%d%%", pLo, pHi))
+    end
+    if page.treatTargetK then
+        page.treatTargetK:setText(string.format("K %d-%d%%", kLo, kHi))
+    end
+    if page.treatTargetsLabel and page.treatTargetsLabel.setVisible then
+        page.treatTargetsLabel:setVisible(false)
+    end
+
+    local rows = {}
+    if SoilTreatmentRates and SoilTreatmentRates.buildPlanTableRows then
+        rows = SoilTreatmentRates.buildPlanTableRows(fieldId) or {}
+    end
+
+    local nextTip = nil
+    if #rows > 0 and SoilTreatmentRates and SoilTreatmentRates.buildNextStepLine then
+        nextTip = SoilTreatmentRates.buildNextStepLine(fieldId)
+    end
+    setSelectedLabel(nextTip)
+
+    if #rows == 0 then
+        setProductOk(tr("sf_treat_action_ok", "OK - no treatment needed"), COLOR_GOOD)
+    else
+        fillProductRows(rows)
+    end
+
+    local sampleText = nil
+    if info.lastSampleDate ~= nil or info.nextSampleSuggested ~= nil then
+        local bits = { tr("rf_pda_sample_heading", "Soil sampling") }
+        if info.lastSampleDate then
+            table.insert(bits, tr("rf_pda_sample_dated", "Last sample") .. ": " .. tostring(info.lastSampleDate))
+        end
+        if info.nextSampleSuggested then
+            table.insert(bits, tr("rf_pda_sample_next", "Next suggested") .. ": " .. tostring(info.nextSampleSuggested))
+        end
+        sampleText = table.concat(bits, "\n")
+    end
+
+    -- F1: show sampling only when real dates exist; never show empty fallback over PRODUCTS
+    if page.samplingInfoFallback then
+        page.samplingInfoFallback:setVisible(false)
+    end
+    if page.samplingInfoBox then
+        page.samplingInfoBox:setVisible(sampleText ~= nil)
+    end
+    if page.samplingInfoText and sampleText ~= nil then
+        page.samplingInfoText:setText(sampleText)
+    end
+end

--- a/src/ui/RfSoilEscJoiner.lua
+++ b/src/ui/RfSoilEscJoiner.lua
@@ -1,0 +1,227 @@
+-- =========================================================
+-- RfSoilEscJoiner — Soil module for NO-HOST RF Esc door
+-- =========================================================
+-- Equal Option B: may create menuRealisticFarming when peers absent.
+-- Registers soilFertilizer on g_currentMission.rfEscModules.
+-- Stands down legacy menuSoilFertilizer Esc tab when RF door is live.
+-- =========================================================
+
+RfSoilEscJoiner = {}
+
+local MOD_DIR = g_currentModDirectory
+local MOD_NAME = g_currentModName
+local PANEL_ID = "soilFertilizer"
+local PANEL_ORDER = 10
+
+local _registered = false
+local _legacyStoodDown = false
+
+local function tr(key, fallback)
+    local modEnv = g_modEnvironments and g_modEnvironments[MOD_NAME]
+    local i18n = (modEnv and modEnv.i18n) or g_i18n
+    if i18n then
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            return text
+        end
+    end
+    return fallback or key
+end
+
+local function getRegistry()
+    if RfEscModules ~= nil then
+        return RfEscModules.getOrCreate()
+    end
+    if g_currentMission ~= nil and g_currentMission.rfEscModules ~= nil then
+        return g_currentMission.rfEscModules
+    end
+    return nil
+end
+
+function RfSoilEscJoiner.standDownLegacyEsc()
+    if _legacyStoodDown then
+        return true
+    end
+    if g_gui == nil then
+        return false
+    end
+
+    local inGameMenu = g_gui.screenControllers and g_gui.screenControllers[InGameMenu] or g_inGameMenu
+    if inGameMenu == nil then
+        return false
+    end
+
+    local pageName = (SoilPDAScreen and SoilPDAScreen.MENU_PAGE_NAME) or "menuSoilFertilizer"
+    local screen = inGameMenu[pageName]
+    if screen == nil then
+        _legacyStoodDown = true
+        return true
+    end
+
+    local ok = pcall(function()
+        if inGameMenu.pagingElement ~= nil then
+            local pe = inGameMenu.pagingElement
+            if pe.elements ~= nil then
+                for i = #pe.elements, 1, -1 do
+                    if pe.elements[i] == screen then
+                        table.remove(pe.elements, i)
+                    end
+                end
+            end
+            if pe.pages ~= nil then
+                for i = #pe.pages, 1, -1 do
+                    local pg = pe.pages[i]
+                    if pg ~= nil and pg.element == screen then
+                        table.remove(pe.pages, i)
+                    end
+                end
+            end
+            if type(pe.updateAbsolutePosition) == "function" then
+                pe:updateAbsolutePosition()
+            end
+            if type(pe.updatePageMapping) == "function" then
+                pe:updatePageMapping()
+            end
+        end
+
+        if inGameMenu.pageFrames ~= nil then
+            for i = #inGameMenu.pageFrames, 1, -1 do
+                if inGameMenu.pageFrames[i] == screen then
+                    table.remove(inGameMenu.pageFrames, i)
+                end
+            end
+        end
+
+        if g_inGameMenu ~= nil and g_inGameMenu.controlIDs ~= nil then
+            g_inGameMenu.controlIDs[pageName] = nil
+        end
+
+        inGameMenu[pageName] = nil
+
+        if type(inGameMenu.rebuildTabList) == "function" then
+            inGameMenu:rebuildTabList()
+        end
+        if type(inGameMenu.updatePages) == "function" then
+            inGameMenu:updatePages()
+        end
+    end)
+
+    if ok then
+        _legacyStoodDown = true
+        if SoilLogger ~= nil then
+            SoilLogger.info("RfSoilEscJoiner: stood down legacy Esc %s", pageName)
+        end
+        return true
+    end
+    return false
+end
+
+function RfSoilEscJoiner.tryRegister()
+    if g_client == nil then
+        return false
+    end
+
+    -- Suite soft-detect: publish Soil panel on mission so WC/CS shell can resolve
+    -- across modEnv (bare global + getfenv(0) are Soil-scoped only).
+    if g_currentMission ~= nil and RfPdaSoilPanel ~= nil then
+        g_currentMission.rfPdaSoilPanel = RfPdaSoilPanel
+    end
+
+    -- Always ensureDoor when bootstrap class is sourced; use source-time MOD_DIR only.
+    if RfEscBootstrap ~= nil then
+        if MOD_DIR == nil then
+            if SoilLogger ~= nil then
+                SoilLogger.warning("RfSoilEscJoiner: MOD_DIR nil — cannot ensureDoor (source capture failed)")
+            else
+                print("[SoilFertilizer] RfSoilEscJoiner: WARNING MOD_DIR nil — cannot ensureDoor")
+            end
+        else
+            local doorOk = RfEscBootstrap.ensureDoor(MOD_DIR, {
+                profilesXml = MOD_DIR .. "xml/gui/rfEscProfiles.xml",
+                iconPath = "textures/ui/menuIcon.dds",
+            })
+            if not doorOk then
+                if SoilLogger ~= nil then
+                    SoilLogger.warning("RfSoilEscJoiner: ensureDoor failed (will retry)")
+                else
+                    print("[SoilFertilizer] RfSoilEscJoiner: WARNING ensureDoor failed (will retry)")
+                end
+            end
+        end
+    end
+
+    local reg = getRegistry()
+    if reg == nil or type(reg.registerModule) ~= "function" then
+        return false
+    end
+
+    if not _registered then
+        local ok = reg:registerModule({
+            id = PANEL_ID,
+            title = tr("rf_pda_panel_soil", "Soil Fertilizer"),
+            blurb = tr("rf_pda_menu_blurb", "Field nutrients and treatment glance."),
+            order = PANEL_ORDER,
+            isAvailable = function()
+                return true
+            end,
+            onShow = function(_container)
+                local page = g_inGameMenu and g_inGameMenu.menuRealisticFarming
+                if page ~= nil and RfPdaSoilPanel ~= nil and type(RfPdaSoilPanel.rebuildFieldData) == "function" then
+                    -- Full rebuild only when page asks via refreshContent; light path is treatment refresh.
+                end
+            end,
+            onHide = function() end,
+        })
+        if ok then
+            _registered = true
+            if type(reg.selectModule) == "function" and reg.activeModuleId == nil then
+                reg:selectModule(PANEL_ID)
+            end
+            if SoilLogger ~= nil then
+                SoilLogger.info("RfSoilEscJoiner: registered module %s on rfEscModules", PANEL_ID)
+            end
+        else
+            return false
+        end
+    end
+
+    local doorPresent = g_inGameMenu ~= nil and g_inGameMenu.menuRealisticFarming ~= nil
+    if doorPresent then
+        RfSoilEscJoiner.standDownLegacyEsc()
+    end
+    -- Ready only when module registered AND Esc door actually exists.
+    return _registered and doorPresent
+end
+
+function RfSoilEscJoiner.reset()
+    _registered = false
+    _legacyStoodDown = false
+end
+
+-- Lifecycle: after InGameMenu exists; retry on update until door + module land.
+local _pending = true
+
+local function _onMissionLoaded()
+    _pending = true
+    if RfSoilEscJoiner.tryRegister() then
+        _pending = false
+    end
+end
+
+local function _onUpdate(_mission, _dt)
+    if not _pending then
+        return
+    end
+    if RfSoilEscJoiner.tryRegister() then
+        _pending = false
+    end
+end
+
+local function _onDelete()
+    RfSoilEscJoiner.reset()
+    _pending = true
+end
+
+Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, _onMissionLoaded)
+FSBaseMission.update = Utils.appendedFunction(FSBaseMission.update, _onUpdate)
+FSBaseMission.delete = Utils.appendedFunction(FSBaseMission.delete, _onDelete)

--- a/src/ui/SoilPDAScreen.lua
+++ b/src/ui/SoilPDAScreen.lua
@@ -124,6 +124,21 @@ end
 
 ---@param modDir string
 function SoilPDAScreen.register(modDir)
+    -- Greenfield RF Esc door owns the Esc tab when it actually exists.
+    -- RfEscBootstrap ~= nil only means the class was sourced — NOT that the door is live.
+    if RfEscBootstrap ~= nil and RfSoilEscJoiner ~= nil and type(RfSoilEscJoiner.tryRegister) == "function" then
+        RfSoilEscJoiner.tryRegister()
+    elseif RfEscBootstrap ~= nil and modDir ~= nil then
+        RfEscBootstrap.ensureDoor(modDir, {
+            profilesXml = modDir .. "xml/gui/rfEscProfiles.xml",
+            iconPath = "textures/ui/menuIcon.dds",
+        })
+    end
+    if g_inGameMenu ~= nil and g_inGameMenu.menuRealisticFarming ~= nil then
+        SoilLogger.info("SoilPDAScreen: RF Esc door present — skipping legacy menuSoilFertilizer inject")
+        _pendingRegistration = false
+        return
+    end
     if SoilPDAScreen._performRegistration(modDir) then
         return
     end
@@ -135,6 +150,19 @@ end
 ---@return boolean true if successfully registered
 function SoilPDAScreen._performRegistration(modDir)
     if g_gui == nil or g_inGameMenu == nil then return false end
+
+    if RfEscBootstrap ~= nil and RfSoilEscJoiner ~= nil and type(RfSoilEscJoiner.tryRegister) == "function" then
+        RfSoilEscJoiner.tryRegister()
+    elseif RfEscBootstrap ~= nil and modDir ~= nil then
+        RfEscBootstrap.ensureDoor(modDir, {
+            profilesXml = modDir .. "xml/gui/rfEscProfiles.xml",
+            iconPath = "textures/ui/menuIcon.dds",
+        })
+    end
+    if g_inGameMenu.menuRealisticFarming ~= nil then
+        SoilLogger.info("SoilPDAScreen: RF Esc door present — skipping legacy inject")
+        return true
+    end
 
     if g_inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] ~= nil then
         SoilLogger.info("SoilPDAScreen: already registered, skipping")

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Ativar/desativar impacto sazonal nos nutrientes do solo (impulso primaveril, desaceleração outonal)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efeitos Chuva" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Ativar/desativar impacto chuva no solo (lixiviação nutrientes, alterações pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bônus Aração" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ativar/desativar benefícios aração para fertilidade solo (melhor nitrogênio e matéria orgânica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporação de Resíduos" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Produção" eh="97345487" />
     <e k="sf_hud_estYield" v="Prod. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ideal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Pós-colheita · Fertilizar" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Arrastar: mover   Canto: redimensionar   RMB/Shift+H: pronto" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -339,11 +339,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Toda a simulação do solo roda no servidor. Os clientes recebem os dados e as configurações completas do campo ao entrar, com nova tentativa automática se o servidor ainda estiver carregando. As configurações de exibição do HUD (posição, tema, tamanho) são por jogador e nunca são sincronizadas com o servidor." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Servidores Dedicados" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Servidores dedicados executam a simulação completa sem qualquer sobrecarga de HUD ou GUI - isso é esperado e normal. Use comandos de console (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) para gerenciar e verificar as configurações em um servidor dedicado." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Rotação de Culturas" eh="def2c162" />
@@ -796,7 +796,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1048,7 +1047,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1152,114 +1150,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Não explorado" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimado a partir dos dados do mapa" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1268,11 +1264,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="开启/关闭季节对土壤养分的影响（春季生长加成、秋季生长减缓）" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="降雨影响" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="开启/关闭降雨对土壤的影响（养分流失、酸碱度变化）" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="耕地增益" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="开启/关闭耕地带来的土壤肥力加成（提升氮元素与有机质含量）" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="秸秆还田养分释放" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="产量" eh="97345487" />
     <e k="sf_hud_estYield" v="预估产量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="收割后 · 需施肥改良" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="拖动移动面板｜拖拽角落调整大小｜右键/Shift+H 完成编辑" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H：移动/调整悬浮窗大小" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="检测到模组冲突" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="所有土壤模拟运算在服务器端运行；玩家加入时自动接收完整田地数据与设置，服务器未加载完成会自动重试。悬浮窗位置、配色等个人设置仅本地生效，不同步服务器。" eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="专用服务器" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="专用服务器仅运行模拟运算，无悬浮窗和界面负载属于正常现象。可使用控制台指令（soilStatus、SoilSetDifficulty等）管理和查看模组设置。" eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="轮作机制" eh="def2c162" />
@@ -617,7 +617,7 @@
     <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="自由面板布局" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="允许在编辑模式下独立摆放各类系统面板" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Shift+H 进入编辑模式自由拖动面板，点击面板标题栏减号可折叠面板。" eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -749,11 +749,6 @@
     <e k="sf_cell_sidebar_header" v="采样单元详情" eh="6fc5243e" />
     <e k="sf_cell_coord" v="坐标" eh="99171d3a" />
     <e k="sf_cell_click_hint" v="点击地图任意位置查看该点土壤数据" eh="fc9d240b" />
-    <e k="sf_panel_hdr_smart_systems" v="[EN] Smart Systems" eh="2c27459c" />
-    <e k="sf_nav_smart_systems_label" v="[EN] Smart Systems" eh="2c27459c" />
-    <e k="sf_nav_smart_systems_desc" v="[EN] Configure Smart Sensor, See &amp; Spray and Variable Rate systems" eh="54ce9ec0" />
-    <e k="sf_nav_tuning_label" v="[EN] Constants Tuning Editor" eh="e56a0d6d" />
-    <e k="sf_nav_tuning_desc" v="[EN] Fine-tune simulation constants: depletion rates, stress growth, starting soil values" eh="0f9d6cdd" />
 
     <!-- ======================================================
          SMART SYSTEMS (admin panel section)
@@ -764,20 +759,11 @@
          SMART SENSOR PANEL
          ====================================================== -->
     <e k="sf_sensor_panel_title" v="智能传感器控制面板" eh="33809906" />
-    <e k="sf_sensor_pest" v="[EN] Pest Sensor" eh="81192ad7" />
-    <e k="sf_sensor_disease" v="[EN] Disease Sensor" eh="37955f80" />
-    <e k="sf_sensor_nutrient" v="[EN] Nutrient Sensor" eh="facbd45b" />
-    <e k="sf_sensor_state_on" v="[EN] ON" eh="90651ebe" />
-    <e k="sf_sensor_state_off" v="[EN] OFF" eh="88559a0c" />
 
     <!-- ======================================================
          SEE & SPRAY PANEL
          ====================================================== -->
     <e k="sf_see_spray_panel_title" v="识别精准喷施面板" eh="a7e00bf0" />
-    <e k="sf_see_spray_pest" v="[EN] Pest" eh="8f2aee79" />
-    <e k="sf_see_spray_disease" v="[EN] Disease" eh="e7067a8c" />
-    <e k="sf_see_spray_weed" v="[EN] Weed" eh="2b75024d" />
-    <e k="sf_see_spray_suppressed" v="[EN] All sections suppressed: no pressure detected" eh="858d9549" />
 <e k="sf_see_spray_protected"   v="0%（无胁迫区域）" />
 
     <!-- ======================================================
@@ -809,7 +795,7 @@
     <e k="sf_guide_p1_08" v="磷元素(P)    消耗缓慢，块根类作物消耗更多" eh="651919e6" />
     <e k="sf_guide_p1_09" v="钾元素(K)    块根作物会重度消耗该养分" eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="有机质(OM)   需要多个种植季缓慢累积提升" eh="b235300c" />
-    <e k="sf_guide_p1_11" v="酸碱度(pH)   适宜区间：6.5 – 7.0" eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="土壤状态分级" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="良好（绿色） 养分达到或高于作物最优需求值" eh="a081208f" />
     <e k="sf_guide_p1_14" v="本季度无需施肥管理" eh="58b36ac2" />
@@ -957,13 +943,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="酸碱度调节农资" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="绝大多数作物适宜酸碱度区间：6.5 – 7.0" eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="酸碱度过低（酸性土壤，低于6.5）：" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="酸碱度过高（碱性土壤，高于7.5）：" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="完整中和调节需要1~2个种植季" eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="有机质提升途径" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="粪肥        提升有机质最优选择，同时补充氮元素" eh="99834812" />
     <e k="sf_guide_p4_27" v="堆肥        中等有机质提升，养分均衡温和" eh="d9b0e2f9" />
@@ -1003,9 +989,9 @@
     <e k="sf_guide_p5_22" v="是否每个种植季都需要施肥？" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="氮元素：条件允许建议每季补充" eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="每次收割都会大量消耗土壤氮" eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="磷、钾：通常2~3个种植季追肥一次即可" eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="有机质：长期改良，每年施用一次粪肥即可" eh="78827593" />
-    <e k="sf_guide_p5_27" v="酸碱度：仅数值超出6.5–7.0区间时调节" eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="各类智能传感器系统工作原理？" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="智能传感器会单独关停无改良需求的喷杆分段，" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="无虫害、病害、养分缺口区域自动停喷；识别喷施实时显示单地块胁迫等级；" eh="22de015a" />
@@ -1033,7 +1019,6 @@
     <e k="sf_report_rotation_bonus"   v="轮作增益" />
     <e k="sf_report_rotation_fatigue" v="地力衰减：连作同种作物" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="轮作状态：正常" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="土壤健康：最优" />
     <e k="sf_report_rec_good"         v="良好" />
     <e k="sf_report_rec_fair"         v="一般" />
@@ -1137,140 +1122,114 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
 		<e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
     <e k="sf_nav_crop_tuning_label"       v="Crop Tuning Editor" />
     <e k="sf_nav_crop_tuning_desc"        v="Adjust per-crop N/P/K requirements; add crops via soilCropTuning.xml" />
-    <e k="sf_panel_hdr_smart_sensor_sys" v="[EN] Smart Sensor System" eh="98a0d4b0" />
-    <e k="sf_panel_hdr_see_spray_sys" v="[EN] See &amp; Spray System" eh="c088f9ae" />
-    <e k="sf_panel_hdr_var_rate_sys" v="[EN] Variable Rate System" eh="31d6f5bd" />
-    <e k="sf_smart_sensor_short" v="[EN] Smart Sensor" eh="20c668af" />
-    <e k="sf_smart_sensor_long" v="[EN] Enable or disable the Smart Spray Sensor system" eh="b2eaad7b" />
-    <e k="sf_see_and_spray_short" v="[EN] See &amp; Spray" eh="528cf03f" />
-    <e k="sf_see_and_spray_long" v="[EN] Enable or disable the See &amp; Spray precision spraying system" eh="11dbdf6c" />
-    <e k="sf_variable_rate_short" v="[EN] Variable Rate" eh="ec53a1fc" />
-    <e k="sf_variable_rate_long" v="[EN] Enable or disable Variable Rate Application based on soil deficits" eh="1cd8efb1" />
-    <e k="sf_desc_smartSensorEnabled" v="[EN] Allow players to use Smart Sensor boom-section control based on live soil data" eh="7b26757b" />
-    <e k="sf_desc_seeAndSprayEnabled" v="[EN] Suppress boom sections over areas that do not need spraying" eh="324ceae5" />
-    <e k="sf_config_seeSpray" v="[EN] See &amp; Spray" eh="528cf03f" />
-    <e k="sf_config_seeSprayWeed" v="[EN] See &amp; Spray: Weed" eh="bbdbcf08" />
-    <e k="sf_config_seeSprayPest" v="[EN] See &amp; Spray: Pest" eh="7fd924e4" />
-    <e k="sf_config_seeSprayDisease" v="[EN] See &amp; Spray: Disease" eh="a5e476a8" />
-    <e k="sf_desc_variableRateEnabled" v="[EN] Adjust application rate per section based on soil nutrient deficits" eh="094e5778" />
-    <e k="sf_panel_hdr_field_boundary" v="[EN] Field Boundary Control" eh="d3314e11" />
-    <e k="sf_field_boundary_short" v="[EN] Boundary Control" eh="9322b2c5" />
-    <e k="sf_field_boundary_long" v="[EN] Enable or disable automatic field boundary section control" eh="8901fbcb" />
-    <e k="sf_desc_fieldBoundaryControl" v="[EN] Automatically shuts off boom sections that extend outside field boundaries, preventing off-field product application." eh="8de79d2b" />
-    <e k="sf_panel_hdr_overlap_prev" v="[EN] Overlap Prevention" eh="dbf6d3a1" />
-    <e k="sf_overlap_prev_short" v="[EN] Overlap Prevention" eh="dbf6d3a1" />
-    <e k="sf_overlap_prev_long" v="[EN] Enable or disable density-map-based overlap prevention" eh="c4d0710b" />
-    <e k="sf_desc_overlapPrevention" v="[EN] Automatically shuts off boom sections over ground that is already fully fertilized, preventing wasteful re-application on overlapping swaths." eh="a0a86991" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="未侦察" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="根据地图数据估算" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1279,10 +1238,102 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="啟用/禁用季節對土壤養分的影響（春季生長加速，秋季放緩）" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="降雨效應" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="啟用/禁用降雨對土壤的影響（養分流失、pH 值變化）" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="翻耕獎勵" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="啟用/禁用翻耕對土壤肥力的好處（改善氮和有機質）" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residue Incorporation" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="產量" eh="97345487" />
     <e k="sf_hud_estYield" v="預估產量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-harvest · Fertilize" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="[EN] Shift+H: move/resize" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="所有土壤模擬均在服務器上運行。客戶端在加入時接收完整的田地數據和設置，如果服務器仍在加載中則會自動重試。HUD 顯示設置（位置、主題、大小）是每位玩家獨立的，絕不會同步到服務器。" eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="專用服務器" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="專用服務器運行完整的模擬，沒有任何 HUD 或 GUI 開銷--這是預期且正常的。使用控制台命令（soilStatus、SoilSetDifficulty、SoilShowSettings 等）在專用服務器上管理和驗證設置。" eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="作物輪作" eh="def2c162" />
@@ -617,7 +617,7 @@
     <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -835,7 +835,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -983,13 +983,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1029,9 +1029,9 @@
     <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />
@@ -1059,7 +1059,6 @@
     <e k="sf_report_rotation_bonus"   v="輪作獎勵" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="輪作：正常" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="土壤健康：最佳" />
     <e k="sf_report_rec_good"         v="良好" />
     <e k="sf_report_rec_fair"         v="一般" />
@@ -1163,114 +1162,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="未偵察" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="根據地圖資料估算" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1279,10 +1276,102 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Povolit/zakázat sezónní vliv na půdní živiny (jarní růstový impuls, podzimní zpomalení)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Dešťové efekty" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Povolit/zakázat vliv deště na půdu (vymývání živin, změny pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonus orby" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Povolit/zakázat výhody orby pro úrodnost půdy (zlepšený dusík a organická hmota)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Zapracování posklizňových zbytků" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Výnos" eh="97345487" />
     <e k="sf_hud_estYield" v="Odh. výnos" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimální" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Po sklizni · Hnojit" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Táhnout: přesunout   Roh: změnit velikost   Pravé tlačítko/Shift+H: hotovo" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: přesunout/změnit velikost" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Zjištěna nekompatibilita" eh="89dbfc90" />
@@ -338,22 +338,16 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Veškerá simulace půdy běží na serveru. Klienti při připojení obdrží kompletní data polí a nastavení, s automatickým opakováním, pokud se server stále načítá. Nastavení zobrazení HUD (pozice, motiv, velikost) jsou pro každého hráče zvlášť a nikdy se nesynchronizují se serverem." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedikované servery" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedikované servery běží plnou simulaci bez jakékoli režie HUD nebo GUI - to je očekávané a normální. K nastavení a ověření nastavení na dedikovaném serveru použijte příkazy konzole (soilStatus, SoilSetDifficulty, SoilShowSettings atd.)." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Střídání plodin" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Povolit/zakázat bonus za střídání plodin a únavu z monokultury (sekvence luštěnin obnovují dusík; po sobě jdoucí sezóny stejné plodiny zvyšují vyčerpání)" eh="958b4212" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
-    <e k="sf_report_rotation_ok" v="[EN] OK" eh="e0aa021e" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
-    <e k="sf_report_rec_optimal" v="[EN] Soil Health: Optimal" eh="6ee9d19b" />
-    <e k="sf_report_rec_good" v="[EN] Good" eh="0c6ad70b" />
-    <e k="sf_report_rec_fair" v="[EN] Fair" eh="f7f20cf0" />
-    <e k="sf_report_rec_poor" v="[EN] Poor" eh="0e94d017" />
     <e k="sf_gypsum_title" v="Sádrovec (pH-)" eh="d66da34c" />
     <e k="sf_compost_title" v="Kompost (organický)" eh="c3e2071a" />
     <e k="sf_biosolids_title" v="Biomasa (N+P)" eh="f0c901dc" />
@@ -802,7 +796,6 @@
     <e k="sf_see_spray_disease"     v="Choroby" />
     <e k="sf_see_spray_weed"        v="Plevel" />
     <e k="sf_see_spray_suppressed"  v="Všechny sekce potlačeny: žádný tlak nezjištěn" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="VARIABILNÍ DÁVKA" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. dávka" />
@@ -815,7 +808,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="Volné rozvržení panelů" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Umožnit nezávislé umístění panelů chytrých systémů v režimu úprav" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Přetáhněte každý panel volně pomocí režimu úprav Shift+H. Sbalte panely tlačítkem − v záhlaví." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="da09523b" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="438cd61b" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="ab1d5b05" />
@@ -830,7 +823,7 @@
     <e k="sf_guide_p1_08" v="P   Fosfor         Pomalé vyčerpání. Kořenové plodiny." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Draslík        Kořenové plodiny ho silně vyčerpávají." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organická hmota Buduje se pomalu po mnoho sezón." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Kyselost půdy.  Cílové rozmezí: 6,5 – 7,0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="ÚROVNĚ STAVU" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="DOBRÉ (zelená)  Na nebo nad optimálním cílem plodiny." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -978,13 +971,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="KOREKCE pH" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Cílové rozmezí: 6,5 – 7,0 pro většinu plodin." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH příliš NÍZKÉ (kyselé, pod 6,5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH příliš VYSOKÉ (alkalické, nad 7,5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Počítejte s 1–2 sezónami pro plnou normalizaci." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="ORGANICKÁ HMOTA (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Hnůj          Nejlepší budovatel OM. Také přidává N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Kompost       Střední OM, dobře vyvážený." eh="d9b0e2f9" />
@@ -1024,9 +1017,9 @@
     <e k="sf_guide_p5_22" v="MUSÍM HNOJIT KAŽDOU SEZÓNU?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Dusík: Ano, každou sezónu pokud možno." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P a K: Každé 2–3 sezóny obvykle stačí." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Organická OM: Dlouhodobě. Přidávejte hnůj jednou ročně." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Pouze pokud je mimo rozmezí 6,5–7,0." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="JAK FUNGUJÍ SYSTÉMY CHYTRÝCH SENZORŮ?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Chytrý senzor blokuje jednotlivé sekce ramene, pokud" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="není zjištěna potřeba (žádný škůdce, choroba ani deficit živin" eh="22de015a" />
@@ -1050,8 +1043,6 @@
     <e k="sf_guide_tab_3" v="PRACOVNÍ POSTUP" eh="7337e059" />
     <e k="sf_guide_tab_4" v="PRODUKTY" eh="d71bd8a0" />
     <e k="sf_guide_tab_5" v="ČASTÉ DOTAZY" eh="a922ea47" />
-    <e k="sf_report_fields_tracked" v="[EN] Fields Tracked:" eh="7b1e59b8" />
-    <e k="sf_report_rotation_bonus" v="[EN] Bonus" eh="3c0ee4ba" />
     	<e k="sf_fieldsentry_asleep" v="simulace spí" eh="7d49241b" />
     	<e k="sf_fs_reason_manual" v="ručně" eh="3c78b355" />
     	<e k="sf_fs_reason_npc" v="zakázka NPC" eh="2e1a268b" />
@@ -1151,114 +1142,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Neprozkoumáno" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Odhad z dat mapy" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1267,11 +1256,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktiver/deaktiver sæsonmæssig påvirkning af jordnæringsstoffer (forårsvækst, efterårsstagnation)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktiver/deaktiver regnens påvirkning af jord (næringsstofudvaskning, pH-ændringer)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Pløjebonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktiver/deaktiver pløjningens fordele for jordfrugtbarhed (forbedret kvælstof og organisk materiale)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Indarbejdelse af planterester" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Udbytte" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. udbytte" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Efterhøst - Gød" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Træk: flyt   Hjørne: størrelse   RMB/Shift+H: færdig" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: flyt/størrelse" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Inkompatibilitet opdaget" eh="89dbfc90" />
@@ -326,11 +326,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Al jordsimulering kører på serveren. Klienter modtager fulde markdata og indstillinger ved tilmelding. HUD-visningsindstillinger (position, tema, størrelse) er pr. spiller og synkroniseres aldrig til serveren." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedikerede servere" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedikerede servere kører den fulde simulering uden HUD- eller GUI-overhead. Brug konsolkommandoer (soilStatus, SoilSetDifficulty, SoilShowSettings osv.) til at administrere indstillinger på en dedikeret server." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Sædskifte" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Aktiver/deaktiver sædskiftebonus og monoafgrødetræthed (bælgplantsekvenser genopretter kvælstof; samme afgrøde i på hinanden følgende sæsoner øger udtømning)" eh="958b4212" />
@@ -704,8 +704,6 @@
     <e k="sf_panel_hdr_smart_systems"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_label"      v="Smart Systems" />
     <e k="sf_nav_smart_systems_desc"       v="Opsæt Smart Sensor, præcisionssprøjtningssystemet til variabel dosering" />
-    <e k="sf_nav_tuning_label" v="[EN] Constants Tuning Editor" eh="e56a0d6d" />
-    <e k="sf_nav_tuning_desc" v="[EN] Fine-tune simulation constants: depletion rates, stress growth, starting soil values" eh="0f9d6cdd" />
     <e k="sf_panel_hdr_smart_sensor_sys"   v="Smart Sensor System" />
     <e k="sf_panel_hdr_see_spray_sys"      v="præcisionssprøjtning" />
     <e k="sf_panel_hdr_var_rate_sys"       v="variabelt doseringssystem" />
@@ -742,7 +740,6 @@
     <e k="sf_see_spray_disease"     v="Sygdom" />
     <e k="sf_see_spray_weed"        v="Ukrudt" />
     <e k="sf_see_spray_suppressed"  v="Alle sektioner deaktiveret: intet tryk registreret" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="Variabel dosering" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. dose" />
@@ -757,7 +754,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="Frit panel-layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Tillad at smart systempaneler placeres individuelt i redigeringstilstand" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Træk hvert panel frit med Shift+H redigeringstilstand. Fold paneler sammen med −-knappen i titellinjen." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
     <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
@@ -997,7 +994,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1101,116 +1097,114 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
     <e k="sf_nav_crop_tuning_label"       v="Crop Tuning Editor" />
     <e k="sf_nav_crop_tuning_desc"        v="Adjust per-crop N/P/K requirements; add crops via soilCropTuning.xml" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Ikke udforsket" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimeret ud fra kortdata" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1219,10 +1213,102 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Jahreszeiten beeinflussen den Stickstoffhaushalt deiner Pflanzen. Es werden nun realit├ñtsnah ein Fr├╝hjahrswachstumsschub und ein verlangsamtes Wachstum im Herbst simuliert." eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Auswaschung" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Auswirkungen von Niederschlag auf den Boden ein-/ausschalten (N├ñhrstoffauswaschung, ├änderungen pH-Wert)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="Auswirkung Niederschlag" />
-    <e k="sf_desc_weatherSource" v="Anpassung der Auswirkung von Niederschlag auf den Boden. Standard ├ñndert nichts. Trocken, Normal oder Nass passen die Bodenwerte unabh├ñngig von der Wettervorhersage an und ver├ñndern die Feuchtigkeitswertew f├╝r den Boden." />
-    <e k="sf_ws_long" v="W├ñhlt die klimatischen Bedingungen f├╝r den Zeitraum aus, in denen das Wetter trocken erscheint (Sommer). Hat keinen Einfluss auf das sichtbare Wetter. Diese globale Einstellung ist im Multiplayer nur f├╝r Administratoren zug├ñnglich." />
-    <e k="sf_ws_1" v="Standard" />
-    <e k="sf_ws_2" v="Trocken" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Nass" />
-    <e k="sf_ws_blurb_4" v="Nass: Feuchteres Wetter ├╝ber einen kurzen Zeitraum. Regen beg├╝nstigt eine st├ñrkere Auswaschung und h├Âheren Krankheitsdruck." />
-    <e k="sf_ws_blurb_3" v="Normal: Ausgewogene Regenf├ñlle ├╝ber einen kurzen Zeitraum." />
-    <e k="sf_ws_blurb_2" v="Trocken: Starke Trockenheit ├╝ber einen kurzen Zeitraum. N├ñhrstoffe verbleiben l├ñnger im Boden und Pflanzen ben├Âtigt schneller Wasser." />
-    <e k="sf_ws_blurb_1" v="Standard: Es werden die Werte der Wettervorhersage verwendet. Im Sommer kann Niederschlag gef├╝hlt sehr gering ausfallen." />
-    <e k="sf_ws_world_note" v="Globale Einstellung - Admin-only im multiplayer; ver├ñnder Bodenwerte f├╝r jeden." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Pflugbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Pflugvorteile f├╝r Bodenfruchtbarkeit ein-/ausschalten (verbesserter Stickstoff und organische Substanz)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Ernter├╝ckst├ñnde" eh="f4352cb5" />
@@ -74,7 +74,7 @@
     <e k="sf_rr_short" v="D├╝ngereffizienz" eh="b363b336" />
     <e k="sf_rr_long" v="Wie schnell D├╝nger die N├ñhrstoffe im Boden wiederherstellt (0,25x sehr langsam bis 2,0x sehr schnell)" eh="afe78a6d" />
     <e k="sf_dm_short" v="Klimazone" eh="86eac820" />
-    <e k="sf_dm_long" v="Legt die Feuchtigkeit der Region fest. Bestimmt wie schnell sich Pilzinfektionen ausbreiten und hat einen Einfluss auf die L├ñnge des Zeitraums in denen Fungizide die Pflanze sch├╝tzen." eh="9948c967" />
+    <e k="sf_dm_long" v="[EN] Climate moisture level - controls how quickly fungal diseases build up and how long fungicide protection lasts" eh="23424d05" />
     <e k="sf_dm_1" v="Trocken" eh="cf9aa4a8" />
     <e k="sf_dm_2" v="Gem├ñ├ƒigt" eh="e8328062" />
     <e k="sf_dm_3" v="Feucht" eh="ccb2fc34" />
@@ -224,7 +224,7 @@
     <e k="sf_hud_yield" v="Ertrag" eh="97345487" />
     <e k="sf_hud_estYield" v="gesch├ñtzter Ertrag" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="nach der Ernte: D├╝ngen" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Ziehen: Bewegen   Ecke: Gr├Â├ƒe   Rechtsklick oder Umschalt+H: Beenden" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Umschalt+H: Bearbeitungsmodus" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Inkompatibilit├ñt erkannt" eh="89dbfc90" />
@@ -340,11 +340,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Alle Bodensimulationen laufen auf dem Server. Clients erhalten beim Beitritt vollst├ñndige Felddaten und Einstellungen, mit automatischem Wiederholungsversuch, wenn der Server noch l├ñdt. HUD-Anzeigeeinstellungen (Position, Thema, Gr├Â├ƒe) sind pro Spieler und werden nie mit dem Server synchronisiert." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedizierte Server" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedizierte Server f├╝hren die vollst├ñndige Simulation ohne HUD- oder GUI-Overhead aus - dies ist erwartet und normal. Verwenden Sie Konsolenbefehle (soilStatus, SoilSetDifficulty, SoilShowSettings usw.), um Einstellungen auf einem dedizierten Server zu verwalten und zu ├╝berpr├╝fen." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Kompatibilit├ñt" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Die Realistische B├Âden &amp; D├╝ngung-Mod nutzt angeh├ñngte Funktions-Hooks, sodass es ohne Konflikte parallel zu Courseplay, AutoDrive und den meisten Maschinen-Mods l├ñuft. Wenn ÔÇ×Precision FarmingÔÇ£ in einem Spielstand aktiv ist, erkennt es dies und schaltet sich automatisch aus, sodass sich die beiden Mods niemals um dieselben Felder streiten." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Einstellungen" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="Im Mehrspielermodus k├Ânnen nur Serveradministratoren die Einstellungen ├ñndern. Diese ├änderungen werden ├╝ber das Control Panel oder die Konsole des Hosts vorgenommen und anschlie├ƒend ├╝berpr├╝ft und an alle Clients ├╝bertragen. In den Spielmodi ÔÇ×RealisticÔÇ£ und ÔÇ×HardcoreÔÇ£ sind die Einstellungseditoren und die Schalter f├╝r Herausforderungen gesperrt, sodass niemand die Simulation w├ñhrend des Spiels abschw├ñchen kann." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Fruchtfolge" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Fruchtfolgebonus und Fruchtfolgeprobleme aktivieren/deaktivieren (Leguminosen k├Ânnen durch Stickstoffbindung den Stickstoffvorrat erh├Âhen; wiederholter Anbau derselben Kultur verst├ñrkt den N├ñhrstoffentzug)." eh="958b4212" />
@@ -487,7 +487,7 @@
     <e k="sf_pda_treatment_minor" v="Gering" eh="6fed0c37" />
     <e k="sf_detail_title" v="├£bersicht" eh="03b5acd7" />
     <e k="sf_detail_close" v="Ok" eh="d3d2e617" />
-    <e k="sf_detail_field_label" v="Schlagnummer: " eh="228118ab" />
+    <e k="sf_detail_field_label" v="Schlagnummer:" eh="228118ab" />
     <e k="sf_detail_urgency_label" v="Zustand:" eh="9a83237c" />
     <e k="sf_detail_section_nutrients" v="N├ñhrstoffversorgung" eh="64377acf" />
     <e k="sf_detail_section_pressure" v="Wirtschaftliche Schadschwelle" eh="a73974d0" />
@@ -546,12 +546,12 @@
     <e k="sf_hud_label_ph" v="pH" eh="397dff20" />
     <e k="sf_hud_label_om" v="OS" eh="bfbebc07" />
     <e k="sf_hud_unit_ppm" v="kg/ha" eh="71b18c32" />
-    <e k="sf_hud_coverage" v="Abgedeckte Fl├ñche: %d%% / %d%%" />
-    <e k="sf_hud_pass_coverage" v="Aktueller ├£berfahrt: %d%% (%s)" />
-    <e k="sf_hud_compaction" v="Bodenverdichtung: %d%%" />
-    <e k="sf_hud_yield_eff" v="Ertragspotenzial: %d%%" />
-    <e k="sf_hud_amend_burn" v="Ertragsverlust durch Ver├ñtzung: -%d%%" />
-		<e k="sf_hud_burn_risk" v="Ver├ñtzungsrisiko: erh├Âht" />
+    <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" eh="d407bb6d" />
+    <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" eh="bef3a4f5" />
+    <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
+    <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
+		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
     <e k="sf_sprayer_auto_on" v="Bedarfsgerechte D├╝ngung aktiv" eh="099b5dac" />
     <e k="sf_sprayer_auto_off" v="Bedarfsgerechte D├╝ngung inaktiv [%s]" eh="848cc106" />
@@ -619,7 +619,7 @@
     <e k="sf_desc_fertilizerCosts" v="realistische D├╝ngerpreise" eh="1c197c9f" />
     <e k="sf_desc_showNotifications" v="erhalte Benachrichtigungen ├╝ber den Zustand deiner B├Âden" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="HUD anzeigen" eh="fa8b9224" />
-    <e k="sf_desc_showWorkTrail" v="Zeige kleine Markierungen auf dem Feld, " eh="3a3da614" />
+    <e k="sf_desc_showWorkTrail" v="Zeige kleine Markierungen auf dem Feld," eh="3a3da614" />
 		<e k="sf_desc_showSprayerInfoPanel" v="Zeige das Feldspritzen-HUD wenn du ein entsprechende Maschine benutzt" eh="016b4402" />
 		<e k="sf_desc_showHarvesterPanel" v="Zeige das M├ñhdrescher-HUD wenn du ein entsprechende Maschine benutzt" eh="b16a1726" />
     <e k="sf_desc_hudPosition" v="Ausrichtung" eh="98c8bcea" />
@@ -766,7 +766,6 @@
     <e k="sf_see_spray_disease"     v="Krankheit" />
     <e k="sf_see_spray_weed"        v="Unkraut" />
     <e k="sf_see_spray_suppressed"  v="Alle Sektionen unterdr├╝ckt: kein Druck erkannt" />
-    <e k="sf_see_spray_protected" v="0% (Schutzwirkung)" eh="190bfadc" />
     <!-- PANEL F├£R VARIABLE AUSBRINGMENGE -->
     <e k="sf_var_rate_panel_title" v="SmartRate" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -779,7 +778,7 @@
         <!-- HUD-LAYOUT-ZIEHMODUS-SCHALTFL├äCHE -->
     <e k="sf_independent_panels_short" v="Freies Panel-Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Smart-System-Panels d├╝rfen im Bearbeitungsmodus unabh├ñngig positioniert werden" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Jedes Panel im Bearbeitungsmodus frei ziehen. Panels mit der Schaltfl├ñche - in der Titelleiste einklappen." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="da09523b" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="438cd61b" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="ab1d5b05" />
@@ -794,7 +793,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphor        Verschwindet langsamer. Vermehrt bei Wurzelfr├╝chte." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Kalium          Wurzelfr├╝chte entziehen besonders viel." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OS  Organische Substanz   Baut sich ├╝ber viele Saisons langsam auf." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Bodenreaktion.  Zielbereich: 6.5 - 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="STATUSSTUFEN" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GUT (gr├╝n)  Auf oder ├╝ber dem Optimalwert der Frucht." eh="a081208f" />
     <e k="sf_guide_p1_14" v="Diese Saison ist keine Aktion n├Âtig." eh="58b36ac2" />
@@ -942,13 +941,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH-KORREKTUR" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Zielbereich: 6.5 - 7.0 f├╝r die meisten Kulturen." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH zu NIEDRIG (sauer, unter 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH zu HOCH (alkalisch, ├╝ber 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="F├╝r vollst├ñndige Normalisierung 1-2 Saisons einplanen." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="ORGANISCHE SUBSTANZ (OS)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Mist            Bester OS-Aufbauer. F├╝gt auch N hinzu." eh="99834812" />
     <e k="sf_guide_p4_27" v="Kompost         Mittlere OS-Wirkung, gut ausgewogen." eh="d9b0e2f9" />
@@ -988,9 +987,9 @@
     <e k="sf_guide_p5_22" v="MUSS ICH JEDE SAISON D├£NGEN?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Stickstoff: Ja, m├Âglichst jede Saison." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Er verarmt bei jeder Ernte stark." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P und K: Meist reicht alle 2-3 Saisons." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Organische Substanz: langfristig. Mist einmal pro Jahr zuf├╝hren." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Nur eingreifen, wenn au├ƒerhalb 6.5-7.0." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="WIE FUNKTIONIEREN DIE SMART-SENSOR-SYSTEME?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart-Sensor blockiert einzelne Gest├ñngesektionen, wenn" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="kein Bedarf erkannt wird (kein Sch├ñdlings-, Krankheits- oder N├ñhrstoff-" eh="22de015a" />
@@ -1018,7 +1017,6 @@
     <e k="sf_report_rotation_bonus"   v="Fruchtfolgebonus" />
     <e k="sf_report_rotation_fatigue" v="ungeeignete Vorfrucht" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Fruchtfolge: OK" />
-    <e k="sf_report_rotation_na" v="nicht verf├╝gbar" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Bodengesundheit: Optimal" />
     <e k="sf_report_rec_good"         v="Gut" />
     <e k="sf_report_rec_fair"         v="Mittel" />
@@ -1113,7 +1111,7 @@
     <e k="input_SF_TREATMENT" v="[EN] Open Soil Treatment Panel" eh="a14be056" />
 		<e k="sf_scout_tier_none" v="gesund" eh="741839f3" />
 		<e k="sf_scout_tier_mild" v="vereinzelt" eh="3cc4af7c" />
-		<e k="sf_scout_tier_moderate" v="" eh="vermehrtes Auftreten" />
+		<e k="sf_scout_tier_moderate" v="[EN] moderate" eh="7f0217cd" />
 		<e k="sf_scout_tier_severe" v="gro├ƒfl├ñchig" eh="e709e56a" />
 		<e k="sf_scout_pressure_label" v="Im Bestand befallene Pflanzen" eh="49abd79e" />
 		<e k="sf_scout_budget" v="Preisg├╝nstig" eh="822bead6" />
@@ -1122,114 +1120,112 @@
 		<e k="sf_scout_disabled" v="Krankheiten sind deaktiviert." eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="Erkrankung festlegen" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="Lege die aktuelle Erkrankung des Feldes fest und wie stark der Befall sein soll." eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazol" />
-    <e k="sf_bigBag_propiconazole_name" v="Propiconazol" />
-    <e k="sf_bigBag_propiconazole_function" v="Systemisches Fungizid zur Bek├ñmpfung von Rostpilzen, Mehltau und weiteren Blattkrankheiten." />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Breitbrandfungizid gegen Blattfleckenkrankheiten, Rostpilze und Mehltau." />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Fungizid gegen Botrytis, Sclerotinia und weitere pilzliche Blatt- und St├ñngelkrankheiten." />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Kontaktfungizid mit breitem Wirkungsspektrum gegen Kraut- und Blattkrankheiten." />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Systemisches Fungizid gegen Falschen Mehltau sowie Phytophthora- und Pythium-Arten." />
-    <e k="sf_tebuconazole_title" v="Tebuconazol" />
-    <e k="sf_bigBag_tebuconazole_name" v="Tebuconazol" />
-    <e k="sf_bigBag_tebuconazole_function" v="Systemisches Fungizid gegen Rostpilze, Mehltau, Fusarium und weitere Blattkrankheiten." />
-    <e k="sf_treat_tank_tag" v="F├╝llung" />
-    <e k="sf_treat_physical" v="%s ist ein Spritzmittel - kaufe das Mittel und bringe es mit einer Pflanzenschutzspritze aus." />
-    <e k="sf_sulfur_title" v="Schwefel" />
-    <e k="sf_bigBag_sulfur_name" v="Schwefel" />
-    <e k="sf_bigBag_sulfur_function" v="Kontaktfungizid gegen Echten Mehltau und weitere pilzliche Krankheiten. F├╝r den ├Âkologischen Landbau geeignet." />
-    <e k="sf_copper_hydroxide_title" v="Kupferhydroxid" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="Kupferhydroxid" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Kontaktfungizid gegen pilzliche und bakterielle Krankheiten. F├╝r den ├Âkologischen Landbau geeignet." />
-    <e k="sf_unscouted" v="Nicht erkundet" />
-<e k="sf_map_layer_organic_status" v="Bewirtschaftungsweise" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Bewirtschaftungsweise" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Konventionell" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Umstellungphase" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="├ûkologisch" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Konventionelle Bewirtschaftung." />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="├ûkologische Bewirtschaftung" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unbekannt" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="Keine Daten." />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Auswertung deiner Fruchtfolge" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Fruchtfolgeauswertung " />
+<e k="sf_rp_open" v="Fruchtfolgeauswertung" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Hof-├£bersicht" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="Wenn du als n├ñchstes folgende Kultur anbaust:" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Die selben Informationen wie in der Fruchtfolgebewertung" />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="Baue erst eine Kultur auf dem Feld an, um eine Auswertung deiner Fruchtfolge zu erhalten." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d Felder - Ausgezeichnet %d - In Ordnung %d - Schlecht %d - Unbekannt %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="Keine Felder" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Vorheriges Feld" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="n├ñchstes Feld" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Feld %d  (%d von %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="GeschÔö£├▒tzt aus Kartendaten" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1238,46 +1234,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
-    <e k="sf_map_target_no_data" v="Keine Daten" />
-    <e k="sf_map_limiting" v="Begrenzend" />
-    <e k="sf_map_ph_optimal" v="Optimal" />
-    <e k="sf_map_weed_pressure" v="Unkraut" />
-    <e k="sf_map_tip" v="Hinweis" />
-    <e k="sf_map_balanced" v="Ausgewogen" />
-    <e k="sf_map_ph_apply_lime" v="Kalk ausbringen" />
-    <e k="sf_map_ph_very_acidic" v="Sehr sauer" />
-    <e k="sf_map_herbicide" v="Herbizid" />
-    <e k="sf_map_compaction_urgent" v="dringend Boden auflockern" />
-    <e k="sf_map_ph_none_needed" v="Kein Handlungsbedarf" />
-    <e k="sf_map_not_needed" v="Nicht n├Âtig" />
-    <e k="sf_map_treatment" v="Behandlung" />
-    <e k="sf_map_crop" v="Kultur" />
-    <e k="sf_map_not_applied" v="Nicht ausgebracht" />
-    <e k="sf_map_ph_slightly_acidic" v="Leicht sauer" />
-    <e k="sf_map_compaction_ok" v="Kein Handlungsbedarf" />
-    <e k="sf_map_om_low" v="Niedrig - Mist oder Kompost ausbringen" />
-    <e k="sf_map_disease_pressure" v="Krankheitsbefall" />
-    <e k="sf_map_condition" v="Zustand" />
-    <e k="sf_map_target_none" v="Kein Kultur angebaut" />
-    <e k="sf_map_compaction_recommended" v="Bodenauflockerung empfohlen" />
-    <e k="sf_map_om_fair" v="Stroh / Mist einarbeiten" />
-    <e k="sf_map_ph_apply_lime_urgent" v="Dringend Kalk ausbringen" />
-    <e k="sf_map_insecticide" v="Insektizid" />
-    <e k="sf_map_pest_pressure" v="Sch├ñdlingsbefall" />
-    <e k="sf_map_target" v="Bedarf" />
-    <e k="sf_map_active" v="Aktiv" />
-    <e k="sf_map_ph_severely_over_limed" v="Stark ├╝berkalkt" />
-    <e k="sf_map_fungicide" v="Fungizid" />
-    <e k="sf_map_ph_normalize" v="Normalisierung erlauben" />
-    <e k="sf_map_ph_over_limed" v="├£berkalkt" />
-    <e k="sf_map_gap" v="Differenz" />
-    <e k="sf_map_ph_apply_sulfur" v="Schwefel ausbringen" />
-    <e k="sf_map_om_healthy" v="Gesund - mit Stroh erhalten" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+    <e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+    <e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+    <e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+    <e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+    <e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+    <e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+    <e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+    <e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+    <e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+    <e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+    <e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+    <e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+    <e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+    <e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+    <e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+    <e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+    <e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+    <e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+    <e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+    <e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+    <e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+    <e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+    <e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+    <e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+    <e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+    <e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+    <e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+    <e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+    <e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+    <e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+    <e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+    <e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+    <e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+    <e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activar/desactivar el impacto estacional en los nutrientes del suelo (impulso de crecimiento en primavera, ralentización en otoño)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efectos de la Lluvia" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activar/desactivar el impacto de la lluvia en el suelo (lixiviación de nutrientes, cambios de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonificación por Arado" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activar/desactivar beneficios del arado para la fertilidad del suelo (mejora de nitrógeno y materia orgánica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporación de Residuos" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Rendimiento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Óptimo" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-cosecha · Fertilizar" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB/Shift+H: listo" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -326,11 +326,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Toda simulación ocurre en el servidor. Los clientes reciben datos al unirse. Los ajustes de HUD son locales y nunca se sincronizan al servidor." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Servidores Dedicados" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Ejecutan la simulación completa sin HUD ni GUI. Usa comandos de consola (soilStatus, SoilSetDifficulty, etc.) para gestionar ajustes en un dedicado." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Rotación de Cultivos" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Activar/desactivar bono por rotación y fatiga por monocultivo (leguminosas restauran N; cultivos iguales seguidos aumentan agotamiento)" eh="958b4212" />
@@ -748,7 +748,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1000,7 +999,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1104,114 +1102,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Sin explorar" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimado a partir de los datos del mapa" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1220,11 +1216,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Enable/disable seasonal impact on soil nutrients (spring growth boost, fall slowdown)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Rain Effects" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Enable/disable rain impact on soil (nutrient leaching, pH changes)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Plowing Bonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Enable/disable plowing benefits to soil fertility (improved nitrogen and organic matter)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residue Incorporation" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-harvest ├é┬À Fertilize" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB/Shift+H: done" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="All soil simulation runs on the server. Clients receive full field data and settings on join, with automatic retry if the server is still loading. HUD display settings (position, theme, size) are per-player and are never synced to the server." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedicated Servers" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedicated servers run the full simulation without any HUD or GUI overhead - this is expected and normal. Use console commands (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) to manage and verify settings on a dedicated server." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Crop Rotation" eh="def2c162" />
@@ -617,7 +617,7 @@
     <e k="sf_hud_enter_drag_desc" v="Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -835,7 +835,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="  No action needed this season." eh="58b36ac2" />
@@ -861,7 +861,7 @@
     <e k="sf_guide_p1_34" v="Smart Sensor Blocks sections with no active need." eh="dd267572" />
     <e k="sf_guide_p1_35" v="  Auto per section. Enable in the Admin panel." eh="2b3e6122" />
     <e k="sf_guide_p1_36" v="See &amp; Spray  Live per-cell pressure in the vehicle." eh="cddacb27" />
-    <e k="sf_guide_p1_37" v="  Any sprayer with the See &amp; Spray shop config." eh="88f78e43" />
+    <e k="sf_guide_p1_37" v="  Any sprayer with the See &amp; Spray shop config." eh="49ba39e2" />
     <e k="sf_guide_p1_38" v="Variable Rate Auto-adjusts boom rate from deficits." eh="38a5c159" />
     <e k="sf_guide_p1_39" v="  Key: Toggle Variable Rate (Alt+7). Admin on." eh="3a71a237" />
     <e k="sf_guide_p1_40" v="KEYBINDINGS" eh="07a9ae0d" />
@@ -983,13 +983,13 @@
     <e k="sf_guide_p4_46" v="Treatment (Shift+T) lists what each field" eh="ccc651dc" />
     <e k="sf_guide_p4_47" v="  needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="  Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="  Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1029,9 +1029,9 @@
     <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />
@@ -1166,161 +1166,218 @@
         <e k="sf_multi_tank_short"             v="Multi-Tank Application" />
     <e k="sf_multi_tank_long"              v="Apply fertilizer to multiple tanks at once (front + rear)" />
     <e k="sf_desc_multiTankApplication"   v="When enabled, applying product also fills or drains secondary tanks proportionally" />
-    <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Unscouted" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+    <e k="sf_propiconazole_title" v="Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="-" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" eh="ab1619e3" />
 
     <!-- Harvest contract underwrite (#741) -->
-    <e k="sf_underwrite_notify" v="Harvest contract topped up on field %s: degraded soil compensated to the expected yield." />
+    <e k="sf_underwrite_notify" v="Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimated from map data" />
+    <e k="sf_hud_tha" v="%.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
-    <e k="sf_dis_resistant_complex" v="Multi-resistant complex" />
-    <e k="sf_dis_resistant_complex_cereal" v="Multi-resistant cereal complex" />
-    <e k="sf_dis_resistant_complex_maize" v="Multi-resistant maize complex" />
-    <e k="sf_dis_resistant_complex_oilseed" v="Multi-resistant oilseed complex" />
-    <e k="sf_dis_resistant_complex_root" v="Multi-resistant root complex" />
-    <e k="sf_dis_resistant_complex_pulse" v="Multi-resistant pulse complex" />
-    <e k="sf_dis_resistant_complex_forage" v="Multi-resistant forage complex" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" eh="51ee006b" />
+    <e k="sf_dis_resistant_complex" v="Multi-resistant complex" eh="03eda51d" />
+    <e k="sf_dis_resistant_complex_cereal" v="Multi-resistant cereal complex" eh="710b7f47" />
+    <e k="sf_dis_resistant_complex_maize" v="Multi-resistant maize complex" eh="7e4205c3" />
+    <e k="sf_dis_resistant_complex_oilseed" v="Multi-resistant oilseed complex" eh="09505aa0" />
+    <e k="sf_dis_resistant_complex_root" v="Multi-resistant root complex" eh="e1427e2f" />
+    <e k="sf_dis_resistant_complex_pulse" v="Multi-resistant pulse complex" eh="45fa17e3" />
+    <e k="sf_dis_resistant_complex_forage" v="Multi-resistant forage complex" eh="67b12041" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
-    <e k="sf_map_target_no_data" v="No data" />
-    <e k="sf_map_limiting" v="Limiting" />
-    <e k="sf_map_ph_optimal" v="Optimal" />
-    <e k="sf_map_weed_pressure" v="Weed Pressure" />
-    <e k="sf_map_tip" v="Tip" />
-    <e k="sf_map_balanced" v="Balanced" />
-    <e k="sf_map_ph_apply_lime" v="Apply lime" />
-    <e k="sf_map_ph_very_acidic" v="Very acidic" />
-    <e k="sf_map_herbicide" v="Herbicide" />
-    <e k="sf_map_compaction_urgent" v="Subsoiling urgent" />
-    <e k="sf_map_ph_none_needed" v="None needed" />
-    <e k="sf_map_not_needed" v="Not needed" />
-    <e k="sf_map_treatment" v="Treatment" />
-    <e k="sf_map_crop" v="Crop" />
-    <e k="sf_map_not_applied" v="Not applied" />
-    <e k="sf_map_ph_slightly_acidic" v="Slightly acidic" />
-    <e k="sf_map_compaction_ok" v="No action needed" />
-    <e k="sf_map_om_low" v="Low - add manure or digestate" />
-    <e k="sf_map_disease_pressure" v="Disease Pressure" />
-    <e k="sf_map_condition" v="Condition" />
-    <e k="sf_map_target_none" v="No crop planted" />
-    <e k="sf_map_compaction_recommended" v="Subsoiling recommended" />
-    <e k="sf_map_om_fair" v="Incorporate straw / manure" />
-    <e k="sf_map_ph_apply_lime_urgent" v="Apply lime urgently" />
-    <e k="sf_map_insecticide" v="Insecticide" />
-    <e k="sf_map_pest_pressure" v="Pest Pressure" />
-    <e k="sf_map_target" v="Target" />
-    <e k="sf_map_active" v="Active" />
-    <e k="sf_map_ph_severely_over_limed" v="Severely over-limed" />
-    <e k="sf_map_fungicide" v="Fungicide" />
-    <e k="sf_map_ph_normalize" v="Allow to normalize" />
-    <e k="sf_map_ph_over_limed" v="Over-limed" />
-    <e k="sf_map_gap" v="Gap" />
-    <e k="sf_map_ph_apply_sulfur" v="Apply sulfur" />
-    <e k="sf_map_om_healthy" v="Healthy - maintain with straw" />
+    <e k="sf_experimental_short" v="Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="Release Gate" eh="74d19780" />
+    <e k="sf_map_target_no_data" v="No data" eh="42a7b262" />
+    <e k="sf_map_limiting" v="Limiting" eh="208ee821" />
+    <e k="sf_map_ph_optimal" v="Optimal" eh="cb61fef1" />
+    <e k="sf_map_weed_pressure" v="Weed Pressure" eh="53f8b936" />
+    <e k="sf_map_tip" v="Tip" eh="12ae2a12" />
+    <e k="sf_map_balanced" v="Balanced" eh="c6589f52" />
+    <e k="sf_map_ph_apply_lime" v="Apply lime" eh="5b3983de" />
+    <e k="sf_map_ph_very_acidic" v="Very acidic" eh="5f032f0b" />
+    <e k="sf_map_herbicide" v="Herbicide" eh="1029736e" />
+    <e k="sf_map_compaction_urgent" v="Subsoiling urgent" eh="62a80ea4" />
+    <e k="sf_map_ph_none_needed" v="None needed" eh="a01f2705" />
+    <e k="sf_map_not_needed" v="Not needed" eh="3ec6d6a7" />
+    <e k="sf_map_treatment" v="Treatment" eh="4c4ac06f" />
+    <e k="sf_map_crop" v="Crop" eh="d388632d" />
+    <e k="sf_map_not_applied" v="Not applied" eh="ac612def" />
+    <e k="sf_map_ph_slightly_acidic" v="Slightly acidic" eh="908e5a88" />
+    <e k="sf_map_compaction_ok" v="No action needed" eh="f51a497f" />
+    <e k="sf_map_om_low" v="Low - add manure or digestate" eh="85262077" />
+    <e k="sf_map_disease_pressure" v="Disease Pressure" eh="2b805cc9" />
+    <e k="sf_map_condition" v="Condition" eh="9e2941b3" />
+    <e k="sf_map_target_none" v="No crop planted" eh="101c620c" />
+    <e k="sf_map_compaction_recommended" v="Subsoiling recommended" eh="d01f0d65" />
+    <e k="sf_map_om_fair" v="Incorporate straw / manure" eh="caf68ba7" />
+    <e k="sf_map_ph_apply_lime_urgent" v="Apply lime urgently" eh="b151ae45" />
+    <e k="sf_map_insecticide" v="Insecticide" eh="5650eeef" />
+    <e k="sf_map_pest_pressure" v="Pest Pressure" eh="18a7c2be" />
+    <e k="sf_map_target" v="Target" eh="c41a3189" />
+    <e k="sf_map_active" v="Active" eh="4d3d769b" />
+    <e k="sf_map_ph_severely_over_limed" v="Severely over-limed" eh="23897c47" />
+    <e k="sf_map_fungicide" v="Fungicide" eh="e8512698" />
+    <e k="sf_map_ph_normalize" v="Allow to normalize" eh="9645480a" />
+    <e k="sf_map_ph_over_limed" v="Over-limed" eh="b2a29851" />
+    <e k="sf_map_gap" v="Gap" eh="466b98ca" />
+    <e k="sf_map_ph_apply_sulfur" v="Apply sulfur" eh="73c513b6" />
+    <e k="sf_map_om_healthy" v="Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="Selected field: Field %s" eh="0c01ba54" />
+    <e k="rf_pda_treatment_next" v="Next: %s" eh="6914fabe" />
+    <e k="rf_pda_treatment_selected_next" v="Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="Click a field row for treatment details." eh="ab972960" />
+    <e k="rf_pda_treat_or" v="or %s" eh="a9c3981a" />
+    <e k="rf_pda_treat_method_dry" v="spreader" eh="fc40238b" />
+    <e k="rf_pda_treat_method_liquid" v="sprayer/tank" eh="463b51c3" />
+    <e k="rf_pda_treat_prod_with_how" v="%s · %s" eh="a2dac483" />
+    <e k="rf_pda_treat_next_with_amount" v="%s %s (%s total) · %s" eh="916610f2" />
+    <e k="rf_pda_treat_next_no_amount" v="%s - %s" eh="23afceb9" />
+    <e k="rf_pda_treat_next_why_ph" v="Fix pH before nutrients." eh="f1ba4606" />
+    <e k="rf_pda_treat_next_why_protect" v="Crop pressure first, then soil." eh="ad384268" />
+    <e k="rf_pda_treat_burn_amend" v="Wait: amending now can burn the crop." eh="a521d414" />
+    <e k="rf_pda_treat_next_how_dry" v="buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+    <e k="rf_pda_treat_next_how_liquid" v="buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+    <e k="rf_pda_treat_next_how_lime" v="spread with a dry fertilizer spreader" eh="fcca6b35" />
+    <e k="rf_pda_treat_next_how_liq_lime" v="apply with a sprayer/tank" eh="ccb22a68" />
+    <e k="rf_pda_treat_next_how_gypsum" v="spread with a dry fertilizer spreader" eh="fcca6b35" />
+    <e k="rf_pda_treat_next_how_om" v="spread manure/compost or leave chopped straw" eh="dd5833f9" />
+    <e k="rf_pda_treat_next_how_weed" v="spray (or use a weeder)" eh="b8b43874" />
+    <e k="rf_pda_treat_next_how_pest" v="spray the field" eh="27723cda" />
+    <e k="rf_pda_treat_next_how_disease" v="spray the field" eh="27723cda" />
+    <e k="rf_pda_treat_om_low" v="MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+    <e k="rf_pda_treat_om_fair" v="Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+    <e k="rf_pda_treat_weed" v="HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+    <e k="rf_pda_treat_weed_active" v="Herbicide still active - recheck later" eh="c119bdf0" />
+    <e k="rf_pda_treat_pest" v="INSECTICIDE · sprayer" eh="8cf7f77b" />
+    <e k="rf_pda_treat_pest_active" v="Insecticide still active - recheck later" eh="c1ee2552" />
+    <e k="rf_pda_treat_disease" v="FUNGICIDE · sprayer" eh="47f19736" />
+    <e k="rf_pda_treat_disease_active" v="Fungicide still active - recheck later" eh="8ee03e99" />
+    <e k="rf_pda_side_info_soil" v="Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="2b43079f" />
+    <e k="rf_pda_side_info_crop_stress" v="Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." eh="c9ad5446" />
+    <e k="rf_pda_side_info_market_dynamics" v="Market Dynamics&#10;&#10;This is a pause market glance, not the full Market desk.&#10;&#10;Graph = price path for the crop you pick.&#10;&#10;Movers = biggest swings right now. Click one to change the graph.&#10;&#10;Events = world events still driving prices. Empty means nothing active (normal).&#10;&#10;Bottom strip = facts for the crop you selected.&#10;&#10;Contracts line = open count only. Full contracts live deeper.&#10;&#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activar/desactivar el impacto estacional en los nutrientes del suelo (impulso de crecimiento en primavera, ralentización en otoño)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efectos de lluvia" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activar/desactivar el impacto de la lluvia en el suelo (lixiviación de nutrientes, cambios de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bono por arado" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activar/desactivar beneficios del arado para la fertilidad del suelo (mejora de nitrógeno y materia orgánica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporación de residuos" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Rendimiento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Óptimo" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-cosecha · Fertilizar" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB/Shift+H: listo" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -326,11 +326,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Toda simulación ocurre en el servidor. Los clientes reciben datos al unirse. Los ajustes de HUD son locales y nunca se sincronizan al servidor." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Servidores dedicados" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Ejecutan la simulación completa sin HUD ni GUI. Usa comandos de consola (soilStatus, SoilSetDifficulty, etc.) para gestionar ajustes en un dedicado." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Rotación de cultivos" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Activar/desactivar bono por rotación y fatiga por monocultivo (leguminosas restauran N; cultivos iguales seguidos aumentan agotamiento)" eh="958b4212" />
@@ -748,7 +748,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1000,7 +999,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1104,114 +1102,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Sin explorar" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimado a partir de los datos del mapa" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1220,11 +1216,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="开启/关闭季节对土壤养分的影响（春季生长加成、秋季生长减缓）" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="降雨影响" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="开启/关闭降雨对土壤的影响（养分流失、酸碱度变化）" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="耕地增益" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="开启/关闭耕地带来的土壤肥力加成（提升氮元素与有机质含量）" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residue Incorporation" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="产量" eh="97345487" />
     <e k="sf_hud_estYield" v="预估产量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-harvest · Fertilize" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="[EN] Shift+H: move/resize" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="所有土壤模拟运算在服务器端运行；玩家加入时自动接收完整田地数据与设置，服务器未加载完成会自动重试。悬浮窗位置、配色等个人设置仅本地生效，不同步服务器。" eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="专用服务器" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="专用服务器仅运行模拟运算，无悬浮窗和界面负载属于正常现象。可使用控制台指令（soilStatus、SoilSetDifficulty等）管理和查看模组设置。" eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="轮作机制" eh="def2c162" />
@@ -617,7 +617,7 @@
     <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -835,7 +835,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -983,13 +983,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1029,9 +1029,9 @@
     <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />
@@ -1059,7 +1059,6 @@
     <e k="sf_report_rotation_bonus"   v="轮作增益" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="轮作状态：正常" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="土壤健康：最佳" />
     <e k="sf_report_rec_good"         v="良好" />
     <e k="sf_report_rec_fair"         v="一般" />
@@ -1163,114 +1162,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="未侦察" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="根据地图数据估算" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1279,10 +1276,102 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Ota käyttöön/poista käytöstä vuodenaikojen vaikutus ravinteisiin (keväinen kasvupyrähdys, syksyinen hidastuminen)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Sadevaikutukset" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Ota käyttöön/poista käytöstä sateen vaikutus maaperään (ravinteiden huuhtoutuminen, pH-muutokset)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Kyntöbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ota käyttöön/poista käytöstä kynnön hyödyt maaperän hedelmällisyydelle (parantunut typpi ja orgaaninen aines)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Kasvijätteen muokkaus" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Sato" eh="97345487" />
     <e k="sf_hud_estYield" v="Satoarvio" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimaalinen" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Sadonkorjuun jälkeen · Lannoita" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Veto: siirrä   Kulma: koko   RMB/Shift+H: valmis" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: siirrä/muuta kokoa" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -327,11 +327,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Simulaatio ajetaan palvelimella. Pelaajat saavat tiedot liittyessään. HUD-asetukset ovat pelaajakohtaisia eikä niitä synkronoida." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedikoidut palvelimet" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Palvelin ajaa simulaatiota ilman käyttöliittymää. Käytä konsolikomentoja (soilStatus, SoilSetDifficulty jne.) asetusten hallintaan dedikoidulla palvelimella." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Viljelykierto" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Ota käyttöön/poista käytöstä viljelykiertobonus ja monokulttuurin haitat (palkokasvit palauttavat typpeä; sama kasvi peräkkäin lisää kulutusta)" eh="958b4212" />
@@ -749,7 +749,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1001,7 +1000,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1105,114 +1103,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Kartoittamaton" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Arvioitu kartan tiedoista" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1221,11 +1217,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activer/désactiver l'impact des saisons sur les nutriments du sol (croissance accélérée au printemps, ralentissement en automne)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Effets de la pluie" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activer/désactiver l'impact de la pluie sur le sol (lessivage des nutriments, variations de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonus de labour" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activer/désactiver les effets du labour sur la fertilité du sol (amélioration de l'azote et de la matière organique)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporation des résidus" eh="f4352cb5" />
@@ -118,14 +118,7 @@
     <e k="input_SF_TOGGLE_AUTO" v="Basculer le mode automatique" eh="a8642cf0" />
     <e k="input_SF_CYCLE_MAP_LAYER" v="Changer la couche de carte du sol" eh="8e4a716c" />
     <e k="input_SF_SOIL_PDA" v="Ouvrir le PDA du sol" eh="7d70f7b4" />
-    <e k="input_SF_SENSOR_PEST" v="Activer/Désactiver le capteur de ravageurs" eh="d747a693" />
-    <e k="input_SF_SENSOR_DISEASE" v="Activer/Désactiver le capteur de maladies" eh="8e24719a" />
-    <e k="input_SF_SENSOR_NUTRIENT" v="Activer/Désactiver le capteur de nutriments" eh="8ac40270" />
-    <e k="input_SF_SEE_SPRAY_PEST" v="See &amp; Spray : Ravageurs" eh="7fd924e4" />
     <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray : Maladies" eh="a5e476a8" />
-    <e k="input_SF_SEE_SPRAY_WEED" v="See &amp; Spray : Mauvaises herbes" eh="bbdbcf08" />
-    <e k="input_SF_VARIABLE_RATE" v="Activer/Désactiver le débit variable" eh="4f2a546d" />
-    <e k="input_SF_MINIMAP_ZOOM" v="Changer le niveau de zoom de la mini-carte" eh="cca8129a" />
     <e k="sf_uan32_title" v="Engrais UAN 32 (N)" eh="90913bb8" />
     <e k="sf_uan28_title" v="Engrais UAN 28 (N)" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Ammoniac anhydre (N)" eh="3fc85c02" />
@@ -211,7 +204,7 @@
     <e k="sf_hud_yield" v="Rendement" eh="97345487" />
     <e k="sf_hud_estYield" v="Rendement estimé" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Après récolte · Fertilisation" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   RMB/Shift+H: terminer" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: déplacer/redimensionner" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibilité détectée" eh="89dbfc90" />
@@ -328,11 +321,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Toute la simulation du sol s’exécute sur le serveur. Les clients reçoivent toutes les données des champs et les paramètres à la connexion, avec une nouvelle tentative automatique si le serveur est encore en cours de chargement. Les paramètres d’affichage du HUD (position, thème, taille) sont propres à chaque joueur et ne sont jamais synchronisés avec le serveur." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Serveurs dédiés" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Les serveurs dédiés exécutent toute la simulation sans surcharge HUD ou interface graphique - c’est normal. Utilisez les commandes console (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) pour gérer et vérifier les paramètres sur un serveur dédié." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibilité et fonctionnement" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Compatibilité des mods" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Sol &amp; Engrais utilise des hooks de fonction ajoutés, il fonctionne donc sans conflit avec Courseplay, AutoDrive et la plupart des mods d'équipement. Lorsque Precision Farming est actif dans une sauvegarde, le mod le détecte et se désactive automatiquement, afin que les deux ne se disputent jamais les mêmes champs." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Modifier les réglages" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="En multijoueur, seuls les administrateurs du serveur peuvent modifier les réglages. Modifiez-les depuis le panneau ou la console sur l'hôte : chaque changement est validé puis transmis à tous les clients. En difficulté Réaliste et Hardcore, les éditeurs de réglage et les bascules qui allègent la simulation sont verrouillés, afin que personne ne puisse adoucir la simulation en cours de partie." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
     <e k="sf_crop_rotation_short" v="Rotation des cultures" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Activer/désactiver le bonus de rotation des cultures et la fatigue des monocultures (les légumineuses restaurent l’azote ; les cultures répétées augmentent la déplétion)" eh="958b4212" />
     <e k="sf_gypsum_title" v="Gypse (pH-)" eh="d66da34c" />
@@ -611,7 +604,7 @@
     <e k="sf_hud_enter_drag_desc" v="Déplacez le HUD pour le repositionner - faites glisser un coin pour le redimensionner - clic droit ou Échap pour terminer" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Disposition libre des panneaux" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Permet de positionner indépendamment les panneaux du système intelligent en mode édition" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Déplace chaque panneau librement via le mode édition Shift+H. Réduis les panneaux avec le bouton − dans leur barre de titre." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
 
     <!-- ======================================================
          PANNEAU DES PARAMÈTRES - INTERFACE
@@ -810,20 +803,14 @@
 		 
     <e k="sf_var_rate_panel_title" v="TAUX VARIABLE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Taux var." />
-    <e k="action_SF_SENSOR_PEST" v="SF : Activer/Désactiver le capteur de ravageurs" eh="e8152517" />
-    <e k="action_SF_SENSOR_DISEASE" v="SF : Activer/Désactiver le capteur de maladies" eh="94d79cce" />
-    <e k="action_SF_SENSOR_NUTRIENT" v="SF : Activer/Désactiver le capteur de nutriments" eh="cf84e8d8" />
-    <e k="action_SF_SEE_SPRAY_PEST" v="SF : Activer/Désactiver See &amp; Spray - Ravageurs" eh="65c74849" />
 
     <!-- noms d’affichage des actions d’entrée -->
     <e k="action_SF_SEE_SPRAY_DISEASE" v="SF : Activer/Désactiver See &amp; Spray Maladies" eh="205a3668" />
-    <e k="action_SF_SEE_SPRAY_WEED" v="SF : Activer/Désactiver See &amp; Spray - Mauvaises herbes" eh="c0ec3165" />
-    <e k="action_SF_VARIABLE_RATE" v="SF : Activer/Désactiver le débit variable" eh="c47214bb" />
-    <e k="sf_guide_sub_1" v="Vue d'ensemble - Ce que le mod surveille et pourquoi c'est important" eh="83e88693" />
-    <e k="sf_guide_sub_2" v="Guide du HUD - Comprendre les barres de nutriments et les indicateurs à l'écran" eh="ffbe123f" />
-    <e k="sf_guide_sub_3" v="Flux de travail - Votre routine quotidienne et saisonnière de gestion des sols" eh="75d263dd" />
-    <e k="sf_guide_sub_4" v="Produits - Effets de chaque engrais et quand les utiliser" eh="2a127c60" />
-    <e k="sf_guide_sub_5" v="F.A.Q. - Réponses aux questions fréquentes" eh="4384cacf" />
+    <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
+    <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="da09523b" />
+    <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="438cd61b" />
+    <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="ab1d5b05" />
+    <e k="sf_guide_sub_5" v="[EN] F.A.Q. - Common questions answered" eh="b383de9c" />
     <e k="sf_guide_p1_01" v="QU'EST-CE QUE CE MOD ?" eh="fe4d3283" />
     <e k="sf_guide_p1_02" v="Suit 5 paramètres du sol pour chaque champ de votre" eh="93e6595b" />
     <e k="sf_guide_p1_03" v="exploitation. Les cultures épuisent les nutriments à la récolte." eh="5e6dc5a8" />
@@ -834,7 +821,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphore         Épuisement lent. Cultures racines." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium         Fortement consommé par les cultures racines." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="MO  Matière organique Augmente lentement au fil des saisons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Acidité du sol. Plage idéale : 6,5 à 7,0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="NIVEAUX D'ÉTAT" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="BON (vert)     Au niveau optimal ou au-dessus." eh="a081208f" />
     <e k="sf_guide_p1_14" v="Aucune action nécessaire cette saison." eh="58b36ac2" />
@@ -847,27 +834,27 @@
     <e k="sf_guide_p1_21" v="2. Vérifiez les champs prioritaires dans la vue d'ensemble." eh="d4e823e8" />
     <e k="sf_guide_p1_22" v="3. Consultez le plan de traitement pour connaître les besoins." eh="1a0c7961" />
     <e k="sf_guide_p1_23" v="4. Appliquez l'engrais approprié." eh="b44bcac2" />
-    <e k="sf_guide_p1_24" v="5. Récoltez normalement : les nutriments sont déduits automatiquement." eh="ba4b5846" />
+    <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally - nutrients auto-deduct." eh="fa399c0f" />
     <e k="sf_guide_p1_25" v="OUTILS DISPONIBLES" eh="103ce1b5" />
     <e k="sf_guide_p1_26" v="Barres HUD     Niveaux du sol du champ actuel." eh="4d0661d7" />
-    <e k="sf_guide_p1_27" v="   Touche : Afficher le HUD du sol (non assignée par défaut)." eh="4e3fc48e" />
+    <e k="sf_guide_p1_27" v="Touche : Afficher le HUD du sol (non assignée par défaut)." eh="4e3fc48e" />
     <e k="sf_guide_p1_28" v="PDA            Vue d'ensemble de l'exploitation + plan de traitement." eh="a6cc969d" />
-    <e k="sf_guide_p1_29" v="   Ouvrez le menu Échap, onglet Soil &amp; Fertilizer." eh="3096c5f3" />
+    <e k="sf_guide_p1_29" v="Ouvrez le menu Échap, onglet Soil &amp; Fertilizer." eh="3096c5f3" />
     <e k="sf_guide_p1_30" v="Carte des sols Affichage des nutriments par cellule." eh="1ade7e4f" />
-    <e k="sf_guide_p1_31" v="   Touche : Changer la couche de la carte des sols (non assignée)." eh="80ee4072" />
-    <e k="sf_guide_p1_32" v="Rapport du champ Analyse détaillée d'un champ." eh="4398ce6d" />
-    <e k="sf_guide_p1_33" v="   Cliquez sur une ligne de la vue d'ensemble pour l'ouvrir." eh="56cbdc85" />
+    <e k="sf_guide_p1_31" v="Touche : Changer la couche de la carte des sols (non assignée)." eh="80ee4072" />
+    <e k="sf_guide_p1_32" v="[EN] Field Detail Per-field breakdown popup." eh="b48eb562" />
+    <e k="sf_guide_p1_33" v="Cliquez sur une ligne de la vue d'ensemble pour l'ouvrir." eh="56cbdc85" />
     <e k="sf_guide_p1_34" v="Smart Sensor Désactive les sections inutiles automatiquement." eh="dd267572" />
-    <e k="sf_guide_p1_35" v="   Fonctionnement par section. Activation dans le panneau Admin." eh="2b3e6122" />
+    <e k="sf_guide_p1_35" v="Fonctionnement par section. Activation dans le panneau Admin." eh="2b3e6122" />
     <e k="sf_guide_p1_36" v="See &amp; Spray Affiche la pression en temps réel par cellule." eh="cddacb27" />
-    <e k="sf_guide_p1_37" v="   Compatible avec tout pulvérisateur équipé de See &amp; Spray." eh="88f78e43" />
+    <e k="sf_guide_p1_37" v="Compatible avec tout pulvérisateur équipé de See &amp; Spray." eh="49ba39e2" />
     <e k="sf_guide_p1_38" v="Débit variable Ajuste automatiquement le débit selon les besoins." eh="38a5c159" />
-    <e k="sf_guide_p1_39" v="   Touche : Activer le débit variable (Alt+7). Admin requis." eh="3a71a237" />
+    <e k="sf_guide_p1_39" v="Touche : Activer le débit variable (Alt+7). Admin requis." eh="3a71a237" />
     <e k="sf_guide_p1_40" v="RACCOURCIS CLAVIER" eh="07a9ae0d" />
-    <e k="sf_guide_p1_41" v="Aucune touche n'est attribuée par défaut afin d'éviter les conflits." eh="9ec7b5b5" />
-    <e k="sf_guide_p1_42" v="Allez dans : Options &gt; Commandes &gt; Mods" eh="e4e8a969" />
-    <e k="sf_guide_p1_43" v="Recherchez les actions commençant par SF_" eh="48d5d3e4" />
-    <e k="sf_guide_p1_44" v="Attribuez des touches qui ne sont pas utilisées par d'autres mods." eh="8c2e27c5" />
+    <e k="sf_guide_p1_41" v="[EN] Most keys ship unbound. Four have defaults:" eh="d2a44aaa" />
+    <e k="sf_guide_p1_42" v="[EN] HUD Drag = Shift+H, Variable Rate = Alt+7," eh="4dde87a3" />
+    <e k="sf_guide_p1_43" v="[EN] Scout = Shift+K, Treatment = Shift+T." eh="74a97e3a" />
+    <e k="sf_guide_p1_44" v="[EN] Rebind any of them in Options &gt; Controls &gt; Mods." eh="a800a99e" />
 	<e k="sf_guide_p2_01" v="LES BARRES DE NUTRIMENTS" eh="ad76f0e9" />
 	<e k="sf_guide_p2_02" v="Le HUD affiche une barre pour chaque nutriment : N P K MO pH." eh="b84d3955" />
 	<e k="sf_guide_p2_03" v="La barre se remplit de gauche (0) à droite (100 = maximum)." eh="fb617f3c" />
@@ -927,21 +914,21 @@
     <e k="sf_guide_p3_12" v="ROUTINE HEBDOMADAIRE" eh="a303bfde" />
     <e k="sf_guide_p3_13" v="Ouvrez le PDA > onglet Plan de traitement." eh="2e03b237" />
     <e k="sf_guide_p3_14" v="Les champs sont classés par ordre de priorité (du plus urgent au moins urgent)." eh="dece938b" />
-    <e k="sf_guide_p3_15" v="Traitez-les dans cet ordre, en commençant par les plus prioritaires." eh="3fa2f44c" />
+    <e k="sf_guide_p3_15" v="[EN] Work top-down - treat highest-priority fields first." eh="4df4bfda" />
     <e k="sf_guide_p3_16" v="Cliquez sur une ligne pour afficher le détail du champ." eh="147b8267" />
     <e k="sf_guide_p3_17" v="COMPRENDRE LE PLAN DE TRAITEMENT" eh="ff6ee8e4" />
     <e k="sf_guide_p3_18" v="Le score de priorité dépend de l'écart entre les niveaux" eh="39d2360b" />
     <e k="sf_guide_p3_19" v="des nutriments et leurs valeurs cibles. Un champ en rouge" eh="dc519211" />
     <e k="sf_guide_p3_20" v="pour deux nutriments sera traité avant un champ avec un seul niveau moyen." eh="41d157db" />
     <e k="sf_guide_p3_21" v="LISTE DE CONTRÔLE AVANT LE SEMIS" eh="14b36869" />
-    <e k="sf_guide_p3_22" v="1. Vérifiez le niveau d'azote (N) : il diminue à chaque récolte." eh="3c4a5b54" />
+    <e k="sf_guide_p3_22" v="[EN] 1. Check N level - depletes every harvest." eh="c5c2a681" />
     <e k="sf_guide_p3_23" v="Appliquez de l'azote s'il est MOYEN ou FAIBLE." eh="4c69f9f8" />
-    <e k="sf_guide_p3_24" v="2. Vérifiez le phosphore (P) et le potassium (K) : ils évoluent plus lentement." eh="fa732940" />
+    <e k="sf_guide_p3_24" v="[EN] 2. Check P and K - change more slowly." eh="f121afca" />
     <e k="sf_guide_p3_25" v="Faites un apport s'ils sont sous le niveau moyen." eh="81a25810" />
-    <e k="sf_guide_p3_26" v="3. Vérifiez le pH : appliquez de la chaux si le sol est acide, du gypse s'il est alcalin." eh="fa766780" />
-    <e k="sf_guide_p3_27" v="4. Vérifiez la matière organique (MO) : ajoutez du fumier ou du compost si elle est faible." eh="08abc4f1" />
+    <e k="sf_guide_p3_26" v="[EN] 3. Check pH - lime if acidic, gypsum if alkaline." eh="29b4ac85" />
+    <e k="sf_guide_p3_27" v="[EN] 4. Check OM - add manure or compost if low." eh="d1ead06b" />
     <e k="sf_guide_p3_28" v="APRÈS LA RÉCOLTE" eh="eb52e29f" />
-    <e k="sf_guide_p3_29" v="1. L'azote est appauvri : apportez rapidement de l'engrais." eh="b2c1db96" />
+    <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted - apply fertilizer soon." eh="42800253" />
     <e k="sf_guide_p3_30" v="2. Les légumineuses (soja, trèfle) apportent naturellement de l'azote" eh="75f466af" />
     <e k="sf_guide_p3_31" v="pour la saison suivante, automatiquement." eh="80169436" />
     <e k="sf_guide_p3_32" v="3. Ajoutez du fumier ou du compost pour augmenter durablement la matière organique." eh="dc25a4c7" />
@@ -982,13 +969,13 @@
     <e k="sf_guide_p4_46" v="Le menu Traitement (Maj+T) indique les besoins actuels" eh="ccc651dc" />
     <e k="sf_guide_p4_47" v="de chaque champ, produit par produit." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="CORRECTION DU pH" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Plage idéale : pH de 6,5 à 7,0 pour la plupart des cultures." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH trop BAS (sol acide, inférieur à 6,5) :" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="Appliquez de la CHAUX pour relever le pH vers la neutralité." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH trop ÉLEVÉ (sol alcalin, supérieur à 7,5) :" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="Appliquez du GYPSE pour abaisser le pH vers la neutralité." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Comptez une à deux saisons pour un retour complet à la normale." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="MATIÈRE ORGANIQUE (MO)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Fumier : meilleur apport en matière organique, ajoute aussi de l'azote." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost : apport équilibré de matière organique." eh="d9b0e2f9" />
@@ -999,21 +986,21 @@
     <e k="sf_guide_p4_32" v="• Chargez l'engrais et vérifiez d'abord la barre fantôme." eh="2126b07c" />
     <e k="sf_guide_p4_33" v="Elle montre le résultat prévu avant application." eh="7ee23768" />
     <e k="sf_guide_p4_34" v="• Les engrais liquides agissent généralement plus vite que les solides." eh="a5b6f4a7" />
-    <e k="sf_guide_p4_35" v="• Le fumier améliore la matière organique ET apporte de l'azote." eh="707c5fe6" />
+    <e k="sf_guide_p4_35" v="[EN] * Manure improves OM AND adds N - very efficient." eh="18ca8c3e" />
     <e k="sf_guide_p4_36" v="• Si possible, appliquez l'azote liquide avant une pluie légère." eh="50d601b0" />
     <e k="sf_guide_p4_37" v="(une forte pluie peut lessiver une partie de l'azote après l'application)." eh="c10189dd" />
     <e k="sf_guide_p4_38" v="• Vérifiez les besoins de la culture que vous allez semer." eh="a3ccec1e" />
     <e k="sf_guide_p4_39" v="Chaque culture nécessite un équilibre NPK différent." eh="a83d4f85" />
-    <e k="sf_guide_p5_01" v="MES BARRES SONT TOUJOURS VIDES, EST-CE NORMAL ?" eh="8772a2e4" />
+    <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY - IS IT BROKEN?" eh="5cbd724e" />
     <e k="sf_guide_p5_02" v="Oui. Sur une nouvelle sauvegarde, le sol commence avec de faibles réserves." eh="459b03bb" />
     <e k="sf_guide_p5_03" v="Un champ jamais fertilisé affiche simplement son état réel." eh="0d7762f2" />
     <e k="sf_guide_p5_04" v="Appliquez des engrais pour améliorer progressivement les niveaux." eh="4419bc2a" />
-    <e k="sf_guide_p5_05" v="C'est volontaire afin de refléter l'appauvrissement réel des sols." eh="50618796" />
+    <e k="sf_guide_p5_05" v="[EN] This is intentional - it reflects real soil depletion." eh="510b0d5a" />
     <e k="sf_guide_p5_06" v="OÙ ATTRIBUER LES RACCOURCIS CLAVIER ?" eh="0717d029" />
     <e k="sf_guide_p5_07" v="Options > Commandes > Mods" eh="7cf00a23" />
-    <e k="sf_guide_p5_08" v="Toutes les actions SF_ sont livrées sans touche assignée" eh="f6ca8742" />
-    <e k="sf_guide_p5_09" v="afin d'éviter les conflits avec d'autres mods." eh="6bf65ffa" />
-    <e k="sf_guide_p5_10" v="Attribuez les touches qui vous conviennent." eh="66e0458d" />
+    <e k="sf_guide_p5_08" v="[EN] Most SF_ keys ship unbound. Four have defaults:" eh="aa3dd3e1" />
+    <e k="sf_guide_p5_09" v="[EN] HUD Drag Shift+H, Variable Rate Alt+7, Scout" eh="3f2f823e" />
+    <e k="sf_guide_p5_10" v="[EN] Shift+K, Treatment Shift+T. Rebind them in Mods." eh="28bfb301" />
     <e k="sf_guide_p5_11" v="POURQUOI L'AZOTE BAISSE-T-IL APRÈS LA PLUIE ?" eh="114dc15a" />
     <e k="sf_guide_p5_12" v="Les fortes pluies lessivent l'azote du sol." eh="e8e84bec" />
     <e k="sf_guide_p5_13" v="Ce comportement est volontaire et réaliste." eh="e3636ff4" />
@@ -1028,9 +1015,9 @@
     <e k="sf_guide_p5_22" v="DOIS-JE FERTILISER À CHAQUE SAISON ?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Azote : oui, idéalement à chaque saison." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Il s'épuise fortement à chaque récolte." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="Phosphore et potassium : tous les 2 à 3 ans suffisent généralement." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Matière organique : sur le long terme. Ajoutez du fumier une fois par an." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH : seulement lorsqu'il sort de la plage 6,5 à 7,0." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="COMMENT FONCTIONNENT LES SMART SENSORS ?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Les Smart Sensors coupent automatiquement les tronçons de rampe" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="lorsqu'aucun besoin n'est détecté (ravageurs, maladies ou nutriments)." eh="22de015a" />
@@ -1044,11 +1031,11 @@
     <e k="sf_guide_p5_38" v="Les clients se synchronisent automatiquement à la connexion." eh="1d2473fd" />
     <e k="sf_guide_p5_39" v="La modification des paramètres nécessite les droits administrateur." eh="a48c5146" />
     <e k="sf_guide_p5_40" v="COMMENT LE SOL INFLUENCE-T-IL LE RENDEMENT ?" eh="456d3c9f" />
-    <e k="sf_guide_p5_41" v="Sol BON : rendement maximal, aucune pénalité." eh="7fd13553" />
+    <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield - no penalty." eh="49e249c2" />
     <e k="sf_guide_p5_42" v="Sol MOYEN : environ 5 à 15 % de perte par nutriment déficient." eh="bced6a1c" />
     <e k="sf_guide_p5_43" v="Sol MAUVAIS : jusqu'à 40 % de perte. Corrigez rapidement." eh="244d5bf2" />
     <e k="sf_guide_p5_44" v="Les pénalités se cumulent : azote MAUVAIS + phosphore MOYEN = perte importante." eh="8afb61f9" />
-    <e k="sf_guide_title" v="Soil &amp; Fertilizer - Guide de terrain" eh="bb56610f" />
+    <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer - Field Guide" eh="0e662248" />
     <e k="sf_guide_tab_1" v="VUE D'ENSEMBLE" eh="3b9ae4ee" />
     <e k="sf_guide_tab_2" v="GUIDE DU HUD" eh="843ca8c2" />
     <e k="sf_guide_tab_3" v="PROCÉDURE" eh="7337e059" />
@@ -1058,11 +1045,6 @@
     <e k="sf_report_rotation_bonus"   v="Bonus de rotation" />
     <e k="sf_report_rotation_fatigue" v="Fatigue : même culture" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation : OK" />
-    <e k="sf_report_rotation_na" v="N/A" eh="382b0f51" />
-    <e k="sf_report_rec_optimal" v="Santé du sol : Optimale" />
-    <e k="sf_report_rec_good" v="Bonne" />
-    <e k="sf_report_rec_fair" v="Moyenne" />
-    <e k="sf_report_rec_poor" v="Mauvaise" />
     <e k="sf_show_sprayer_panel_long" v="Afficher/Masquer le panneau d'informations nutritives du pulvérisateur lorsque vous conduisez un pulvérisateur" eh="125a6e27" />
     <e k="sf_show_harvester_panel_long" v="Afficher/Masquer le panneau d'état de la trémie de la moissonneuse pendant la récolte" eh="977f32e8" />
     <e k="sf_hud_amend_burn" v="Pénalité de brûlure : -%d%%" eh="34059aac" />
@@ -1166,126 +1148,216 @@
     <e k="sf_scout_disabled" v="Système de maladies désactivé" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="Définir la maladie du champ" eh="faa773f5" />
     <e k="sf_admin_field_set_disease_desc" v="Définir manuellement la pression de maladie (et son type) du champ actuel" eh="d86eb3e1" />
-    <e k="sf_multi_tank_short" v="Application multi-réservoirs" eh="3225f56b" />
-    <e k="sf_multi_tank_long" v="Appliquer l'engrais simultanément à plusieurs réservoirs (avant + arrière)" eh="14ae72fc" />
-    <e k="sf_desc_multiTankApplication" v="Lorsque cette option est activée, l'application du produit remplit ou vide également les réservoirs secondaires de manière proportionnelle." eh="71033529" />
-    <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Fongicide à base de propiconazole (liquide)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobine" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobine" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Fongicide à base d'azoxystrobine (liquide)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Fongicide à base de boscalid (liquide)" />
-    <e k="sf_mancozeb_title" v="Mancozèbe" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozèbe" />
-    <e k="sf_bigBag_mancozeb_function" v="Fongicide à base de mancozèbe (liquide)" />
-    <e k="sf_metalaxyl_title" v="Métalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Métalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Fongicide à base de métalaxyl (liquide)" />
-    <e k="sf_tebuconazole_title" v="Tébuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tébuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Fongicide à base de tébuconazole (liquide)" />
-    <e k="sf_treat_tank_tag" v="cuve - pulvérisation" />
-    <e k="sf_treat_physical" v="%s est un produit pulvérisable - achetez la cuve et traitez le champ" />
-    <e k="sf_sulfur_title" v="Soufre" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Soufre" />
-    <e k="sf_bigBag_sulfur_function" v="Fongicide à base de soufre, compatible agriculture biologique (liquide)" />
-    <e k="sf_copper_hydroxide_title" v="Hydroxyde de cuivre" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Hydroxyde de cuivre" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Fongicide à base d'hydroxyde de cuivre, compatible agriculture biologique (liquide)" />
-    <e k="sf_unscouted" v="Non inspecté" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+    <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimé d'après les données de la carte" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
-    <e k="sf_dis_resistant_complex" v="Complexe multi-résistant" />
-    <e k="sf_dis_resistant_complex_cereal" v="Complexe multi-résistant des céréales" />
-    <e k="sf_dis_resistant_complex_maize" v="Complexe multi-résistant du maïs" />
-    <e k="sf_dis_resistant_complex_oilseed" v="Complexe multi-résistant des oléagineux" />
-    <e k="sf_dis_resistant_complex_root" v="Complexe multi-résistant des racines" />
-    <e k="sf_dis_resistant_complex_pulse" v="Complexe multi-résistant des légumineuses" />
-    <e k="sf_dis_resistant_complex_forage" v="Complexe multi-résistant des fourrages" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
+    <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" eh="03eda51d" />
+    <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" eh="710b7f47" />
+    <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" eh="7e4205c3" />
+    <e k="sf_dis_resistant_complex_oilseed" v="[EN] Multi-resistant oilseed complex" eh="09505aa0" />
+    <e k="sf_dis_resistant_complex_root" v="[EN] Multi-resistant root complex" eh="e1427e2f" />
+    <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" eh="45fa17e3" />
+    <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" eh="67b12041" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Évszak hatásának engedélyezése/tiltása a talaj tápanyagaira (tavaszi növekedési gyorsítás, őszi lassítás)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Eső Hatások" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Engedélyezze/tiltsa az eső hatását a talajra (tápanyag kimosódás, pH-változások)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Szántás Bónusz" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="A szántás előnyeinek engedélyezése/tiltása a talaj termékenységére (javított nitrogén és szerves anyag)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Maradvány beforgatás" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Hozam" eh="97345487" />
     <e k="sf_hud_estYield" v="Becsült hozam" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimális" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Betakarítás után · Műtrágyázás" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Húzás: mozgatás   Sarok: átméretezés   RMB/Shift+H: kész" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mozgatás/átméretezés" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -339,11 +339,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Minden szimuláció a szerveren fut. A kliensek csatlakozáskor megkapják az adatokat. A HUD beállítások egyéniek és nem szinkronizálódnak a szerverrel." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedikált szerverek" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="A dedikált szerverek HUD nélkül futtatják a szimulációt. Használja a konzol parancsokat (soilStatus, SoilSetDifficulty, stb.) a kezeléshez." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Vetésforgó" eh="def2c162" />
@@ -768,7 +768,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1020,7 +1019,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1124,114 +1122,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Felderítetlen" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Becslés a térkép adatai alapján" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1240,11 +1236,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktifkan/nonaktifkan dampak musiman pada nutrisi tanah (dorongan pertumbuhan musim semi, perlambatan musim gugur)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efek Hujan" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktifkan/nonaktifkan dampak hujan pada tanah (pencucian nutrisi, perubahan pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonus Membajak" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktifkan/nonaktifkan manfaat membajak bagi kesuburan tanah (peningkatan nitrogen dan bahan organik)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Inkorporasi Residu" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Hasil" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. Hasil" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Pasca-panen · Pupuk" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Seret: pindah   Sudut: ubah ukuran   RMB/Shift+H: selesai" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: pindah/ubah ukuran" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Semua simulasi tanah berjalan di server. Klien menerima data lahan lengkap dan pengaturan saat bergabung, dengan upaya ulang otomatis jika server masih memuat. Pengaturan tampilan HUD (posisi, tema, ukuran) bersifat per pemain dan tidak pernah disinkronkan ke server." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Server Terdedikasi" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Server terdedikasi menjalankan simulasi penuh tanpa overhead HUD atau GUI - ini diharapkan dan normal. Gunakan perintah konsol (soilStatus, SoilSetDifficulty, SoilShowSettings, dll.) untuk mengelola dan memverifikasi pengaturan pada server terdedikasi." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Rotasi Tanaman" eh="def2c162" />
@@ -795,7 +795,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1047,7 +1046,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1151,114 +1149,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Belum disurvei" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Diperkirakan dari data peta" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1267,11 +1263,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Attiva/disattiva impatto stagionale sui nutrienti del suolo (spinta primaverile, rallentamento autunnale)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Effetti Pioggia" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Attiva/disattiva impatto pioggia su suolo (lisciviazione nutrienti, cambiamenti pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonus Aratura" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Attiva/disattiva benefici aratura per fertilità suolo (miglior azoto e materia organica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporamento residui" eh="f4352cb5" />
@@ -211,7 +211,7 @@
 		<e k="sf_hud_yield" v="Resa" eh="97345487" />
 		<e k="sf_hud_estYield" v="Resa stimata" eh="32a4135e" />
 		<e k="sf_hud_optimal" v="Ottimale" eh="cb61fef1" />
-		<e k="sf_hud_post_harvest" v="Post-raccolta · Fertilizzare" eh="634de6fe" />
+		<e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
 		<e k="sf_hud_hint_edit" v="Trascina: sposta   Angolo: ridimensiona   RMB/Maiusc+H: fatto" eh="c3f1820c" />
 		<e k="sf_hud_hint_normal" v="Maiusc+H: sposta/ridimensiona" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Tutta la simulazione gira sul server. I client ricevono i dati all'accesso. Le impostazioni HUD sono personali e non vengono sincronizzate col server." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Server Dedicati" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Sui server dedicati la simulazione gira normalmente senza HUD. Usa i comandi in console (soilStatus, SoilSetDifficulty, ecc.) per gestire le impostazioni." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Rotazione Colture" eh="def2c162" />
@@ -795,7 +795,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1047,7 +1046,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1151,114 +1149,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Non esplorato" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Stimato dai dati della mappa" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1267,11 +1263,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="土壌養分への季節的な影響（春の成長促進、秋の停滞）を有効/無効にします" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="雨の影響" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="土壌への雨の影響（養分の流出、pHの変化）を有効/無効にします" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="耕耘ボーナス" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="土壌肥沃度に対する耕耘のメリット（窒素と有機物の改善）を有効/無効にします" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="残渣のすき込み" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="収量" eh="97345487" />
     <e k="sf_hud_estYield" v="推定収量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最適" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="収穫後 ・ 施肥が必要" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="ドラッグ: 移動   角: サイズ変更   右クリック/Shift+H: 完了" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: 移動/サイズ変更" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="すべての土壌シミュレーションはサーバー上で実行されます。クライアントは参加時に完全なデータと設定を受信します。HUD 設定はプレイヤー固有であり、サーバーとは同期されません。" eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="専用サーバー (Dedi)" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="専用サーバーは HUD や GUI のオーバーヘッドなしで全シミュレーションを実行します。これは正常な動作です。管理にはコンソールコマンド（soilStatus など）を使用してください。" eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="輪作" eh="def2c162" />
@@ -775,7 +775,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1027,7 +1026,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1131,114 +1129,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="未調査" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="マップデータからの推定値" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1247,11 +1243,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="토양 영양분에 대한 계절적 영향 활성화/비활성화 (봄철 성장 촉진, 가을철 성장 둔화)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="강우 효과" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="토양에 대한 강우 영향 활성화/비활성화 (영양분 용탈, pH 변화)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="쟁기질 보너스" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="토양 비옥도에 대한 쟁기질 혜택 활성화/비활성화 (질소 및 유기물 개선)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="잔사 혼입" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="수확량" eh="97345487" />
     <e k="sf_hud_estYield" v="예상 수확량" eh="32a4135e" />
     <e k="sf_hud_optimal" v="최적" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="수확 후 · 비료 살포 필요" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="드래그: 이동   모서리: 크기 조절   우클릭/Shift+H: 완료" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: 이동/크기 조절" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="모든 토양 시뮬레이션은 서버에서 실행됩니다. 클라이언트는 접속 시 모든 필드 데이터와 설정을 받으며, 서버가 로딩 중인 경우 자동으로 재시도합니다. HUD 표시 설정은 플레이어별로 유지되며 서버와 동기화되지 않습니다." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="전용 서버" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="전용 서버는 HUD나 GUI 오버헤드 없이 전체 시뮬레이션을 실행합니다. 콘솔 명령(soilStatus, SoilSetDifficulty, SoilShowSettings 등)을 사용하여 전용 서버의 설정을 관리하고 확인할 수 있습니다." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="작물 순환" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="작물 순환 보너스 및 단일 작물 연작 피해 활성화/비활성화 (콩과 식물은 질소 복구, 동일 작물 연작은 영양분 소모 증가)" eh="958b4212" />
@@ -776,7 +776,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1028,7 +1027,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1132,114 +1130,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="미조사" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="맵 데이터 기반 추정치" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1248,11 +1244,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Seizoensgebonden impact op bodemvoedingsstoffen in-/uitschakelen (groeiboost in de lente, vertraging in de herfst)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regeneffecten" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Regenimpact op de bodem in-/uitschakelen (uitspoeling van voedingsstoffen, pH-veranderingen)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Ploegbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ploegvoordelen voor bodemvruchtbaarheid in-/uitschakelen (verbeterde stikstof en organische stof)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Gewasresten inwerken" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Opbrengst" eh="97345487" />
     <e k="sf_hud_estYield" v="Verw. opbrengst" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimaal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Na de oogst · Bemesten" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Sleep: verplaats   Hoek: formaat   RMB/Shift+H: klaar" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: verplaats/formaat" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibiliteit gedetecteerd" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Alle bodemsimulatie draait op de server. Clients ontvangen volledige veldgegevens en instellingen bij het verbinden, met automatische herpoging als de server nog aan het laden is. HUD-weergave-instellingen (positie, thema, grootte) zijn per speler en worden nooit naar de server gesynchroniseerd." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedicated servers" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedicated servers draaien de volledige simulatie zonder HUD of GUI-overhead - dit is verwacht en normaal. Gebruik consoleopdrachten (soilStatus, SoilSetDifficulty, SoilShowSettings, enz.) om instellingen op een dedicated server te beheren en te controleren." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Vruchtwisseling" eh="def2c162" />
@@ -778,7 +778,6 @@
     <e k="sf_see_spray_disease"     v="Ziekte" />
     <e k="sf_see_spray_weed"        v="Onkruid" />
     <e k="sf_see_spray_suppressed"  v="Alle secties onderdrukt: geen druk gedetecteerd" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="VARIABELE DOSERING" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. dosering" />
@@ -791,7 +790,7 @@
     <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="Vrije paneelindeling" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Slimme systeempanelen toestaan onafhankelijk te worden gepositioneerd in de bewerkingsmodus" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Sleep elk paneel vrij via de Shift+H bewerkingsmodus. Klap panelen in met de − knop in hun titelbalk." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
     <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="da09523b" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="438cd61b" />
@@ -807,7 +806,7 @@
     <e k="sf_guide_p1_08" v="P   Fosfor           Langzame uitputting. Wortelgewassen." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Kalium           Wortelgewassen putten dit zwaar uit." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OS  Organische stof  Bouwt langzaam op over meerdere seizoenen." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Bodemzuurgraad.  Streefbereik: 6,5 – 7,0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
     <e k="sf_guide_p1_12" v="STATUSNIVEAUS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOED (groen)   Op of boven het optimale doel van het gewas." eh="a081208f" />
     <e k="sf_guide_p1_14" v="Geen actie nodig dit seizoen." eh="58b36ac2" />
@@ -955,13 +954,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="PH-CORRECTIE" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Streefbereik: 6,5 – 7,0 voor de meeste gewassen." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH te LAAG (zuur, onder 6,5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH te HOOG (alkalisch, boven 7,5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Laat 1–2 seizoenen toe voor volledige normalisatie." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
     <e k="sf_guide_p4_25" v="ORGANISCHE STOF (OS)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Mest           Beste OS-opbouwer. Voegt ook N toe." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Matige OS, goed gebalanceerd." eh="d9b0e2f9" />
@@ -1001,9 +1000,9 @@
     <e k="sf_guide_p5_22" v="MOET IK ELK SEIZOEN BEMESTEN?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Stikstof: Ja, elk seizoen indien mogelijk." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Het putt zwaar uit bij elke oogst." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P en K: Eens per 2–3 seizoenen is doorgaans genoeg." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
     <e k="sf_guide_p5_26" v="Organische OS: Langdurig. Eens per jaar mest toevoegen." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Alleen buiten het bereik van 6,5–7,0." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
     <e k="sf_guide_p5_28" v="HOE WERKEN DE SLIMME SENSORSYSTEMEN?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Slimme sensor blokkeert individuele boomsecties wanneer" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="geen behoefte wordt gedetecteerd (geen plaag, ziekte of voedings-" eh="22de015a" />
@@ -1031,7 +1030,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotatiebonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotatie: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Bodemgezondheid: Optimaal" />
     <e k="sf_report_rec_good"         v="Goed" />
     <e k="sf_report_rec_fair"         v="Redelijk" />
@@ -1135,114 +1133,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Niet verkend" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Geschat op basis van kaartgegevens" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1251,11 +1247,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktiver/deaktiver sesongpåvirkning på næringsstoffer i jorda (vårvekstboost, høstoppbremsing)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktiver/deaktiver regnpåvirkning på jord (næringslekkasje, pH-endringer)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Pløyebonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktiver/deaktiver fordeler ved pløying for jordfruktbarhet (forbedret nitrogen og organisk materiale)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Innforming av planterester" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Avling" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. avling" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Etter innhøsting · Gjødsle" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Dra: flytt   Hjørne: endre størrelse   RMB/Shift+H: ferdig" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: flytt/endre størrelse" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="All jordsimulering kjører på serveren. Klienter mottar alle feltdata og innstillinger når de kobler til, med automatisk nytt forsøk hvis serveren fortsatt laster. HUD-innstillinger (posisjon, tema, størrelse) er per spiller og synkroniseres aldri med serveren." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedikerte servere" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedikerte servere kjører hele simuleringen uten HUD eller GUI-belastning - dette er forventet og normalt. Bruk konsollkommandoer (soilStatus, SoilSetDifficulty, SoilShowSettings osv.) for å administrere og verifisere innstillinger på en dedikert server." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Vekstskifte" eh="def2c162" />
@@ -777,7 +777,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1029,7 +1028,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1133,114 +1131,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Ikke utforsket" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimert fra kartdata" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1249,11 +1245,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Włącz/wyłącz wpływ sezonowy na składniki odżywcze gleby (wiosenny wzrost, jesienne spowolnienie)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efekty deszczu" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Włącz/wyłącz wpływ deszczu na glebę (wypłukiwanie składników, zmiany pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonus za orkę" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Włącz/wyłącz korzyści z orki dla żyzności gleby (poprawa zawartości azotu i materii organicznej)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Mieszanie resztek" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Plon" eh="97345487" />
     <e k="sf_hud_estYield" v="Szac. plon" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optymalne" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Po zbiorach · Nawożenie" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Przeciągnij: przesuń   Róg: zmień rozmiar   PPM/Shift+H: gotowe" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: przesuń/zmień rozmiar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -338,11 +338,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Cała symulacja gleby działa na serwerze. Klienci otrzymują pełne dane pól i ustawienia przy dołączeniu, z automatycznym ponowieniem, jeśli serwer wciąż się ładuje. Ustawienia HUD są indywidualne dla każdego gracza." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Serwery dedykowane" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Serwery dedykowane uruchamiają pełną symulację bez HUDu czy GUI - jest to oczekiwane. Używaj komend konsoli (soilStatus, SoilSetDifficulty, SoilShowSettings itd.), aby zarządzać ustawieniami na serwerze dedykowanym." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Płodozmian" eh="def2c162" />
@@ -777,7 +777,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1029,7 +1028,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1133,114 +1131,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Niezbadane" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Oszacowano na podstawie danych mapy" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1249,11 +1245,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Ativar/desativar impacto sazonal nos nutrientes do solo (impulso de crescimento na primavera, abrandamento no outono)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efeitos da Chuva" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Ativar/desativar impacto da chuva no solo (lixiviação de nutrientes, mudanças de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bónus de Lavoura" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Ativar/desativar benefícios da lavoura para a fertilidade do solo (melhoria de nitrogénio e matéria orgânica)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Incorporação de Resíduos" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Rendimento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ideal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Pós-colheita · Fertilizar" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Arrastar: mover   Canto: redimensionar   RMB/Shift+H: concluído" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -339,11 +339,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Toda a simulação de solo corre no servidor. Os clientes recebem os dados e definições completos do campo ao entrar, com tentativa automática se o servidor ainda estiver a carregar. As definições de exibição do HUD (posiçao, tema, tamanho) são por jogador e nunca são sincronizadas com o servidor." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Servidores Dedicados" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Os servidores dedicados correm a simulação completa sem qualquer sobrecarga de HUD ou GUI - isto é esperado e normal. Use comandos de consola (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) para gerir e verificar as definições num servidor dedicado." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Rotação de Culturas" eh="def2c162" />
@@ -796,7 +796,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1048,7 +1047,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1152,114 +1150,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Não explorado" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimado a partir dos dados do mapa" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1268,11 +1264,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Activează/dezactivează impactul sezonier asupra nutrienților din sol (spor de creștere primăvara, încetinire toamna)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Efectele Ploii" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Activează/dezactivează impactul ploii asupra solului (spălarea nutrienților, modificări de pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Bonus de Arat" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Activează/dezactivează beneficiile aratului pentru fertilitatea solului (îmbunătățirea azotului și a materiei organice)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Încorporarea Reziduurilor" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Recoltă" eh="97345487" />
     <e k="sf_hud_estYield" v="Recoltă Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optim" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-recoltare · Fertilizare" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Tragere: mutare   Colț: redimensionare   RMB/Shift+H: gata" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mutare/redimensionare" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -339,11 +339,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Toată simularea solului rulează pe server. Clienții primesc datele complete ale câmpului și setările la conectare, cu reîncercare automată dacă serverul se încarcă încă. Setările de afișare HUD (poziție, temă, dimensiune) sunt per jucător și nu sunt niciodată sincronizate cu serverul." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Servere Dedicate" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Serverele dedicate rulează simularea completă fără HUD sau interfață grafică - acest lucru este de așteptat și normal. Folosește comenzile consolei (soilStatus, SoilSetDifficulty, SoilShowSettings etc.) pentru a gestiona și verifica setările pe un server dedicat." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
 
     <e k="sf_crop_rotation_short" v="Rotația Culturilor" eh="def2c162" />
@@ -796,7 +796,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1048,7 +1047,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1152,114 +1150,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Neexplorat" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Estimat din datele hărții" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1268,11 +1264,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Включить/отключить сезонное влияние на питательные вещества почвы (весенний рост, осеннее замедление)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Эффекты дождя" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Включить/выключить влияние дождя на почву (вымывание питательных веществ, изменение pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Бонус за вспашку" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Включить/отключить преимущества вспашки для плодородия почвы (повышение содержания азота и органического вещества)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Заделка растительных остатков" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Урожай" eh="97345487" />
     <e k="sf_hud_estYield" v="Ожид. урожай" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="После уборки · Удобрить" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Перетаскивание: переместить  Угол: размер  ПКМ/Shift+H: готово" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: переместить/размер" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -327,11 +327,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Вся симуляция идет на сервере. Клиенты получают данные при входе. Настройки HUD индивидуальны для каждого игрока и не передаются серверу." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Выделенные серверы" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Серверы крутят симуляцию без GUI. Используйте консольные команды (soilStatus, SoilSetDifficulty и др.) для управления и проверки настроек на выделенном сервере." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Севооборот" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Включить бонус за севооборот и штраф за монокультуру (бобовые восстанавливают азот; повторный посев той же культуры увеличивает истощение)" eh="958b4212" />
@@ -737,7 +737,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -989,7 +988,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1093,114 +1091,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Не разведано" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Оценка по данным карты" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1209,11 +1205,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Aktivera/inaktivera säsongspåverkan på marknäring (tillväxtökning på våren, avmattning på hösten)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Regneffekter" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Aktivera/inaktivera regnets påverkan på marken (näringsläckage, pH-förändringar)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Plogningsbonus" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Aktivera/inaktivera fördelar med plogning för markens bördighet (förbättrat kväve och organiskt material)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Residuinblandning" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Skörd" eh="97345487" />
     <e k="sf_hud_estYield" v="Ber. skörd" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimalt" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Efter skörd · Gödsla" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Dra: flytta   Hörn: ändra storlek   HMB/Skift+H: klar" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Skift+H: flytta/ändra storlek" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -326,11 +326,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="All marksimulering körs på servern. Klienter får fullständiga fältdata och inställningar vid anslutning, med automatisk omprövning om servern fortfarande laddar. HUD-inställningar (position, tema, storlek) är per spelare och synkroniseras aldrig till servern." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedikerade servrar" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Dedikerade servrar kör den fulla simuleringen utan HUD- eller GUI-overhead - detta är förväntat och normalt. Använd konsolkommandon (soilStatus, SoilSetDifficulty, SoilShowSettings, etc.) för att hantera och verifiera inställningar på en dedikerad server." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Växtföljd" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Aktivera/inaktivera växtföljdsbonus och monokulturutmattning (baljväxtsekvenser återställer kväve; samma gröda flera säsonger i rad ökar utarmning)" eh="958b4212" />
@@ -748,7 +748,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1000,7 +999,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1104,114 +1102,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Ej utforskad" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Uppskattat från kartdata" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1220,11 +1216,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Mevsimlerin toprak besin maddeleri üzerindeki etkisini etkinleştir/devre dışı bırak (bahar büyüme desteği, sonbahar yavaşlaması)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Yağmur Etkileri" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Yağmurun toprak üzerindeki etkisini etkinleştir/devre dışı bırak (besin yıkanması, pH değişiklikleri)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Sürme Bonusu" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Toprak verimliliğine sürme faydalarını etkinleştir/devre dışı bırak (iyileştirilmiş azot ve organik madde)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Anız Karıştırma" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Verim" eh="97345487" />
     <e k="sf_hud_estYield" v="Tahmini Verim" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Hasat sonrası · Gübreleyin" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Sürükle: taşı   Köşe: boyutlandır   Sağ Tık/Shift+H: tamam" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: taşı/boyutlandır" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -327,11 +327,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Tüm toprak simülasyonu sunucuda çalışır. İstemciler katıldıklarında tam tarla verilerini ve ayarlarını alırlar; sunucu hala yükleniyorsa otomatik yeniden deneme yapılır. HUD görüntüleme ayarları (konum, tema, boyut) oyuncu bazlıdır ve asla sunucuyla senkronize edilmez." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Atanmış Sunucular" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Atanmış sunucular, herhangi bir HUD veya GUI yükü olmadan tam simülasyonu çalıştırır - bu beklenen ve normal bir durumdur. Atanmış bir sunucudaki ayarları yönetmek ve doğrulamak için konsol komutlarını (soilStatus, SoilSetDifficulty, SoilShowSettings vb.) kullanın." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Münavebe" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Münavebe bonusunu ve monokültür yorgunluğunu etkinleştir/devre dışı bırak (baklagil dizileri azotu geri kazandırır; üst üste sezonlarda aynı ürün ekilmesi tükenmeyi artırır)" eh="958b4212" />
@@ -749,7 +749,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1001,7 +1000,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1105,114 +1103,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Keşfedilmemiş" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Harita verilerinden tahmin edildi" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1221,11 +1217,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Увімкнути/вимкнути сезонний вплив на поживні речовини ґрунту (весняне зростання, осіннє сповільнення)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Ефекти дощу" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Увімкнути/вимкнути вплив дощу на ґрунт (вилуговування поживних речовин, зміни pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Бонус оранки" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Увімкнути/вимкнути переваги оранки для родючості ґрунту (покращений азот та органічна речовина)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Внесення пожнивних залишків" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Врожайність" eh="97345487" />
     <e k="sf_hud_estYield" v="Очік. врожай" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Після жнив · Удобрити" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Драг: рух  Кут: розмір  ПКМ/Shift+H: готово" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: рух/розмір" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -326,11 +326,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Вся симуляція ґрунту виконується на сервері. Клієнти отримують актуальні дані при підключенні. Налаштування вигляду HUD не синхронізуються і є індивідуальними." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Виділені сервери" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Виділені сервери виконують повну симуляцію без відображення HUD/GUI. Для управління використовуйте консольні команди (soilStatus, SoilSetDifficulty, SoilShowSettings тощо)." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Сівозміна" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Увімкнути/вимкнути бонус сівозміни та втому ґрунту (бобові відновлюють азот; однакова культура поспіль виснажує ґрунт швидше)" eh="958b4212" />
@@ -748,7 +748,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1000,7 +999,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1104,114 +1102,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Не розвідано" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Оцінка за даними карти" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1220,11 +1216,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -10,18 +10,18 @@
     <e k="sf_seasonal_effects_long" v="Bật/tắt tác động theo mùa đối với chất dinh dưỡng trong đất (thúc đẩy tăng trưởng vụ xuân, làm chậm vụ thu)" eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Hiệu ứng mưa" eh="a2a1758b" />
     <e k="sf_rain_effects_long" v="Bật/tắt tác động của mưa đối với đất (rửa trôi chất dinh dưỡng, thay đổi pH)" eh="de3b14b9" />
-    <e k="sf_ws_short" v="World Climate" />
-    <e k="sf_desc_weatherSource" v="Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." />
-    <e k="sf_ws_long" v="Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." />
-    <e k="sf_ws_1" v="Real sky only" />
-    <e k="sf_ws_2" v="Arid" />
-    <e k="sf_ws_3" v="Normal" />
-    <e k="sf_ws_4" v="Wet" />
-    <e k="sf_ws_blurb_4" v="Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." />
-    <e k="sf_ws_blurb_3" v="Normal: balanced seasonal rains for short months. Default living climate." />
-    <e k="sf_ws_blurb_2" v="Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." />
-    <e k="sf_ws_blurb_1" v="Real sky only: soil follows the forecast with no fill. Short months can feel sparse." />
-    <e k="sf_ws_world_note" v="World setting - admin only in multiplayer; changes soil for everyone." />
+    <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
+    <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
+    <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
+    <e k="sf_ws_1" v="[EN] Real sky only" eh="f1cf2f61" />
+    <e k="sf_ws_2" v="[EN] Arid" eh="cf9aa4a8" />
+    <e k="sf_ws_3" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_ws_4" v="[EN] Wet" eh="ae789b86" />
+    <e k="sf_ws_blurb_4" v="[EN] Wet: wetter short-month fill. More leaching and disease pressure on rainy fills." eh="4f0d9df2" />
+    <e k="sf_ws_blurb_3" v="[EN] Normal: balanced seasonal rains for short months. Default living climate." eh="0c0ddca4" />
+    <e k="sf_ws_blurb_2" v="[EN] Arid: drier short-month fill. Nutrients hold longer; crops thirst sooner." eh="4c159062" />
+    <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
+    <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Thưởng khi cày" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Bật/tắt lợi ích của việc cày đối với độ phì nhiêu của đất (cải thiện đạm và chất hữu cơ)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Vùi phụ phẩm" eh="f4352cb5" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Sản lượng" eh="97345487" />
     <e k="sf_hud_estYield" v="Sản lượng dự tính" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Tối ưu" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Sau thu hoạch · Bón phân" eh="634de6fe" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
     <e k="sf_hud_hint_edit" v="Kéo: di chuyển   Góc: đổi cỡ   Chuột phải/Shift+H: xong" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: di chuyển/đổi cỡ" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -326,11 +326,11 @@
     <e k="helpLine_sf_mp_p1_auth_text" v="Mọi mô phỏng đất chạy trên máy chủ. Người chơi nhận dữ liệu khi tham gia. Các cài đặt hiển thị HUD là riêng tư cho từng người và không bao giờ đồng bộ lên máy chủ." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Máy chủ chuyên dụng" eh="4d3a45ba" />
     <e k="helpLine_sf_mp_p1_ded_text" v="Máy chủ chuyên dụng chạy mô phỏng đầy đủ mà không có HUD/GUI - đây là điều bình thường. Dùng lệnh console (soilStatus, SoilSetDifficulty...) để quản lý trên máy chủ chuyên dụng." eh="3df784d6" />
-    <e k="helpLine_sf_mp_p2_title" v="Compatibility and Workflow" />
-    <e k="helpLine_sf_mp_p2_compat_title" v="Mod Compatibility" />
-    <e k="helpLine_sf_mp_p2_compat_text" v="Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." />
-    <e k="helpLine_sf_mp_p2_workflow_title" v="Changing Settings" />
-    <e k="helpLine_sf_mp_p2_workflow_text" v="In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." />
+    <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
+    <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
+    <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
+    <e k="helpLine_sf_mp_p2_workflow_title" v="[EN] Changing Settings" eh="b421c88f" />
+    <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Luân canh cây trồng" eh="def2c162" />
     <e k="sf_crop_rotation_long" v="Bật/tắt thưởng luân canh và mệt mỏi do độc canh (trồng họ đậu giúp hồi đạm; trồng liên tiếp cùng một loại cây làm tăng sự cạn kiệt)" eh="958b4212" />
@@ -748,7 +748,6 @@
     <e k="sf_see_spray_disease"     v="Disease" />
     <e k="sf_see_spray_weed"        v="Weed" />
     <e k="sf_see_spray_suppressed"  v="All sections suppressed: no pressure detected" />
-    <e k="sf_see_spray_protected" v="[EN] 0% (Protected)" eh="190bfadc" />
     <!-- VARIABLE RATE PANEL -->
     <e k="sf_var_rate_panel_title" v="[EN] VARIABLE RATE" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
@@ -1000,7 +999,6 @@
     <e k="sf_report_rotation_bonus"   v="Rotation Bonus" />
     <e k="sf_report_rotation_fatigue" v="[EN] Fatigue: same crop" eh="7b173595" />
     <e k="sf_report_rotation_ok"      v="Rotation: OK" />
-    <e k="sf_report_rotation_na" v="[EN] N/A" eh="382b0f51" />
     <e k="sf_report_rec_optimal"      v="Soil Health: Optimal" />
     <e k="sf_report_rec_good"         v="Good" />
     <e k="sf_report_rec_fair"         v="Fair" />
@@ -1104,114 +1102,112 @@
 		<e k="sf_scout_disabled" v="[EN] Disease system disabled" eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="[EN] Set Field Disease" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="[EN] Manually set the disease pressure (and disease type) for the current field" eh="d86eb3e1" />
-		<e k="sf_multi_tank_short" v="[EN] Multi-Tank Application" eh="3225f56b" />
-		<e k="sf_multi_tank_long" v="[EN] Apply fertilizer to multiple tanks at once (front + rear)" eh="14ae72fc" />
-		<e k="sf_desc_multiTankApplication" v="[EN] When enabled, applying product also fills or drains secondary tanks proportionally" eh="71033529" />
-        <e k="sf_propiconazole_title" v="Propiconazole" />
-    <e k="sf_bigBag_propiconazole_name" v="IBC Propiconazole" />
-    <e k="sf_bigBag_propiconazole_function" v="Propiconazole fungicide (liquid)" />
-    <e k="sf_azoxystrobin_title" v="Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_name" v="IBC Azoxystrobin" />
-    <e k="sf_bigBag_azoxystrobin_function" v="Azoxystrobin fungicide (liquid)" />
-    <e k="sf_boscalid_title" v="Boscalid" />
-    <e k="sf_bigBag_boscalid_name" v="IBC Boscalid" />
-    <e k="sf_bigBag_boscalid_function" v="Boscalid fungicide (liquid)" />
-    <e k="sf_mancozeb_title" v="Mancozeb" />
-    <e k="sf_bigBag_mancozeb_name" v="IBC Mancozeb" />
-    <e k="sf_bigBag_mancozeb_function" v="Mancozeb fungicide (liquid)" />
-    <e k="sf_metalaxyl_title" v="Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_name" v="IBC Metalaxyl" />
-    <e k="sf_bigBag_metalaxyl_function" v="Metalaxyl fungicide (liquid)" />
-    <e k="sf_tebuconazole_title" v="Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_name" v="IBC Tebuconazole" />
-    <e k="sf_bigBag_tebuconazole_function" v="Tebuconazole fungicide (liquid)" />
-    <e k="sf_treat_tank_tag" v="tank - spray" />
-    <e k="sf_treat_physical" v="%s is a sprayable product - buy the tank and spray the field" />
-    <e k="sf_sulfur_title" v="Sulfur" />
-    <e k="sf_bigBag_sulfur_name" v="IBC Sulfur" />
-    <e k="sf_bigBag_sulfur_function" v="Sulfur fungicide, organic-approved (liquid)" />
-    <e k="sf_copper_hydroxide_title" v="Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_name" v="IBC Copper Hydroxide" />
-    <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" />
-    <e k="sf_unscouted" v="Chưa khảo sát" />
-<e k="sf_map_layer_organic_status" v="Organic Status" />
+        <e k="sf_propiconazole_title" v="[EN] Propiconazole" eh="920d7ec6" />
+    <e k="sf_bigBag_propiconazole_name" v="[EN] IBC Propiconazole" eh="fc219313" />
+    <e k="sf_bigBag_propiconazole_function" v="[EN] Propiconazole fungicide (liquid)" eh="490ed9b0" />
+    <e k="sf_azoxystrobin_title" v="[EN] Azoxystrobin" eh="34160dda" />
+    <e k="sf_bigBag_azoxystrobin_name" v="[EN] IBC Azoxystrobin" eh="b40a0610" />
+    <e k="sf_bigBag_azoxystrobin_function" v="[EN] Azoxystrobin fungicide (liquid)" eh="be5ee11a" />
+    <e k="sf_boscalid_title" v="[EN] Boscalid" eh="5c0a4c40" />
+    <e k="sf_bigBag_boscalid_name" v="[EN] IBC Boscalid" eh="92f0478a" />
+    <e k="sf_bigBag_boscalid_function" v="[EN] Boscalid fungicide (liquid)" eh="0f6520f8" />
+    <e k="sf_mancozeb_title" v="[EN] Mancozeb" eh="5117fb39" />
+    <e k="sf_bigBag_mancozeb_name" v="[EN] IBC Mancozeb" eh="1e434105" />
+    <e k="sf_bigBag_mancozeb_function" v="[EN] Mancozeb fungicide (liquid)" eh="575656e9" />
+    <e k="sf_metalaxyl_title" v="[EN] Metalaxyl" eh="2c4598e3" />
+    <e k="sf_bigBag_metalaxyl_name" v="[EN] IBC Metalaxyl" eh="9f270208" />
+    <e k="sf_bigBag_metalaxyl_function" v="[EN] Metalaxyl fungicide (liquid)" eh="cc268585" />
+    <e k="sf_tebuconazole_title" v="[EN] Tebuconazole" eh="3755d13c" />
+    <e k="sf_bigBag_tebuconazole_name" v="[EN] IBC Tebuconazole" eh="151459c1" />
+    <e k="sf_bigBag_tebuconazole_function" v="[EN] Tebuconazole fungicide (liquid)" eh="903ba330" />
+    <e k="sf_treat_tank_tag" v="[EN] tank - spray" eh="62f0dd3b" />
+    <e k="sf_treat_physical" v="[EN] %s is a sprayable product - buy the tank and spray the field" eh="6170b051" />
+    <e k="sf_sulfur_title" v="[EN] Sulfur" eh="529df3e8" />
+    <e k="sf_bigBag_sulfur_name" v="[EN] IBC Sulfur" eh="5ff5268e" />
+    <e k="sf_bigBag_sulfur_function" v="[EN] Sulfur fungicide, organic-approved (liquid)" eh="d3b65711" />
+    <e k="sf_copper_hydroxide_title" v="[EN] Copper Hydroxide" eh="6b294851" />
+    <e k="sf_bigBag_copper_hydroxide_name" v="[EN] IBC Copper Hydroxide" eh="8d35ad49" />
+    <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
+    <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
+<e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_layer_12" v="Organic Status" />
+<e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     
-<e k="sf_org_legend_conventional" v="Conventional" />
+<e k="sf_org_legend_conventional" v="[EN] Conventional" eh="e5932769" />
     
-<e k="sf_org_legend_transition" v="Transitioning" />
+<e k="sf_org_legend_transition" v="[EN] Transitioning" eh="69a4b718" />
     
-<e k="sf_org_legend_certified" v="Certified" />
+<e k="sf_org_legend_certified" v="[EN] Certified" eh="2e768a9e" />
     
-<e k="sf_org_tt_conventional" v="Not in organic conversion" />
+<e k="sf_org_tt_conventional" v="[EN] Not in organic conversion" eh="2da36ff5" />
     
-<e k="sf_org_tt_certified" v="Organic certified" />
+<e k="sf_org_tt_certified" v="[EN] Organic certified" eh="20b70b75" />
     
-    <e k="sf_org_tt_progress" v="%d%% - %d / %d days" />
-<e k="sf_rp_status_unknown" v="Unknown" />
+    <e k="sf_org_tt_progress" v="[EN] %d%% - %d / %d days" eh="b6ade20d" />
+<e k="sf_rp_status_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_no_crop" v="-" />
+<e k="sf_rp_no_crop" v="[EN] -" eh="336d5ebc" />
     
-<e k="sf_rp_no_history" v="No crop history yet" />
+<e k="sf_rp_no_history" v="[EN] No crop history yet" eh="4fabff90" />
     
-<e k="sf_rp_standing_unknown" v="Unknown" />
+<e k="sf_rp_standing_unknown" v="[EN] Unknown" eh="88183b94" />
     
-<e k="sf_rp_bonus_days" v="bonus %dd" />
+<e k="sf_rp_bonus_days" v="[EN] bonus %dd" eh="f7e148b1" />
     
-<e k="sf_rp_title" v="Rotation Planner" />
+<e k="sf_rp_title" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_open" v="Rotation Planner" />
+<e k="sf_rp_open" v="[EN] Rotation Planner" eh="5404f1c2" />
     
-<e k="sf_rp_farm_header" v="Farm standing" />
+<e k="sf_rp_farm_header" v="[EN] Farm standing" eh="f9d6920b" />
     
-<e k="sf_rp_what_if" v="What if (next crop)" />
+<e k="sf_rp_what_if" v="[EN] What if (next crop)" eh="6e9a098e" />
     
-<e k="sf_rp_hint" v="Same candidates as the field-detail foresight. Read-only; nothing is planted." />
+<e k="sf_rp_hint" v="[EN] Same candidates as the field-detail foresight. Read-only; nothing is planted." eh="4d2e12a2" />
     
-<e k="sf_rp_hint_no_history" v="No crop history yet on this field. Grow a crop before comparing." />
+<e k="sf_rp_hint_no_history" v="[EN] No crop history yet on this field. Grow a crop before comparing." eh="188eb102" />
     
-<e k="sf_rp_farm_summary" v="%d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" />
+<e k="sf_rp_farm_summary" v="[EN] %d fields - Bonus %d - OK %d - Fatigue %d - Unknown %d" eh="8c5f4ce1" />
     
-    <e k="sf_rp_no_fields" v="No fields" />
+    <e k="sf_rp_no_fields" v="[EN] No fields" eh="72cd127c" />
     
-<e k="sf_rp_prev" v="Prev field" />
+<e k="sf_rp_prev" v="[EN] Prev field" eh="2218ceab" />
     
-<e k="sf_rp_next" v="Next field" />
+<e k="sf_rp_next" v="[EN] Next field" eh="9046f8e0" />
     
-    <e k="sf_rp_field_header" v="Field #%d  (%d / %d)" />
+    <e k="sf_rp_field_header" v="[EN] Field #%d  (%d / %d)" eh="ab1619e3" />
+		<e k="sf_underwrite_notify" v="[EN] Harvest contract topped up on field %s: degraded soil compensated to the expected yield." eh="76e3ddd0" />
     <!-- Harvester panel yield estimate (SF-50) -->
-    <e k="sf_hud_tha" v="%.1f t/ha" />
-    <e k="sf_hud_yield_est_src" v="Ước tính từ dữ liệu bản đồ" />
+    <e k="sf_hud_tha" v="[EN] %.1f t/ha" eh="02c9dfd7" />
+    <e k="sf_hud_yield_est_src" v="[EN] Estimated from map data" eh="f81875ef" />
     <!-- CD-12 tank mix names (generated) -->
-    <e k="sf_blend_azoxystrobin_boscalid_title" v="Azoxystrobin + Boscalid" />
-    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="Azoxystrobin + Copper Hydroxide" />
-    <e k="sf_blend_azoxystrobin_mancozeb_title" v="Azoxystrobin + Mancozeb" />
-    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="Azoxystrobin + Metalaxyl" />
-    <e k="sf_blend_azoxystrobin_propiconazole_title" v="Azoxystrobin + Propiconazole" />
-    <e k="sf_blend_azoxystrobin_sulfur_title" v="Azoxystrobin + Sulfur" />
-    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="Azoxystrobin + Tebuconazole" />
-    <e k="sf_blend_boscalid_copper_hydroxide_title" v="Boscalid + Copper Hydroxide" />
-    <e k="sf_blend_boscalid_mancozeb_title" v="Boscalid + Mancozeb" />
-    <e k="sf_blend_boscalid_metalaxyl_title" v="Boscalid + Metalaxyl" />
-    <e k="sf_blend_boscalid_propiconazole_title" v="Boscalid + Propiconazole" />
-    <e k="sf_blend_boscalid_sulfur_title" v="Boscalid + Sulfur" />
-    <e k="sf_blend_boscalid_tebuconazole_title" v="Boscalid + Tebuconazole" />
-    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="Copper Hydroxide + Mancozeb" />
-    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="Copper Hydroxide + Metalaxyl" />
-    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="Copper Hydroxide + Propiconazole" />
-    <e k="sf_blend_copper_hydroxide_sulfur_title" v="Copper Hydroxide + Sulfur" />
-    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="Copper Hydroxide + Tebuconazole" />
-    <e k="sf_blend_mancozeb_metalaxyl_title" v="Mancozeb + Metalaxyl" />
-    <e k="sf_blend_mancozeb_propiconazole_title" v="Mancozeb + Propiconazole" />
-    <e k="sf_blend_mancozeb_sulfur_title" v="Mancozeb + Sulfur" />
-    <e k="sf_blend_mancozeb_tebuconazole_title" v="Mancozeb + Tebuconazole" />
-    <e k="sf_blend_metalaxyl_propiconazole_title" v="Metalaxyl + Propiconazole" />
-    <e k="sf_blend_metalaxyl_sulfur_title" v="Metalaxyl + Sulfur" />
-    <e k="sf_blend_metalaxyl_tebuconazole_title" v="Metalaxyl + Tebuconazole" />
-    <e k="sf_blend_propiconazole_sulfur_title" v="Propiconazole + Sulfur" />
-    <e k="sf_blend_propiconazole_tebuconazole_title" v="Propiconazole + Tebuconazole" />
-    <e k="sf_blend_sulfur_tebuconazole_title" v="Sulfur + Tebuconazole" />
+    <e k="sf_blend_azoxystrobin_boscalid_title" v="[EN] Azoxystrobin + Boscalid" eh="fe129cff" />
+    <e k="sf_blend_azoxystrobin_copper_hydroxide_title" v="[EN] Azoxystrobin + Copper Hydroxide" eh="b2ebbc6e" />
+    <e k="sf_blend_azoxystrobin_mancozeb_title" v="[EN] Azoxystrobin + Mancozeb" eh="22c043b9" />
+    <e k="sf_blend_azoxystrobin_metalaxyl_title" v="[EN] Azoxystrobin + Metalaxyl" eh="03a01200" />
+    <e k="sf_blend_azoxystrobin_propiconazole_title" v="[EN] Azoxystrobin + Propiconazole" eh="96edc7dc" />
+    <e k="sf_blend_azoxystrobin_sulfur_title" v="[EN] Azoxystrobin + Sulfur" eh="d8bef109" />
+    <e k="sf_blend_azoxystrobin_tebuconazole_title" v="[EN] Azoxystrobin + Tebuconazole" eh="9d26797e" />
+    <e k="sf_blend_boscalid_copper_hydroxide_title" v="[EN] Boscalid + Copper Hydroxide" eh="3348b944" />
+    <e k="sf_blend_boscalid_mancozeb_title" v="[EN] Boscalid + Mancozeb" eh="021e77f7" />
+    <e k="sf_blend_boscalid_metalaxyl_title" v="[EN] Boscalid + Metalaxyl" eh="4aa98c4d" />
+    <e k="sf_blend_boscalid_propiconazole_title" v="[EN] Boscalid + Propiconazole" eh="c72f945e" />
+    <e k="sf_blend_boscalid_sulfur_title" v="[EN] Boscalid + Sulfur" eh="0b50c375" />
+    <e k="sf_blend_boscalid_tebuconazole_title" v="[EN] Boscalid + Tebuconazole" eh="a1dabf6d" />
+    <e k="sf_blend_copper_hydroxide_mancozeb_title" v="[EN] Copper Hydroxide + Mancozeb" eh="11d78ed9" />
+    <e k="sf_blend_copper_hydroxide_metalaxyl_title" v="[EN] Copper Hydroxide + Metalaxyl" eh="48ef4c0b" />
+    <e k="sf_blend_copper_hydroxide_propiconazole_title" v="[EN] Copper Hydroxide + Propiconazole" eh="92ac4dfd" />
+    <e k="sf_blend_copper_hydroxide_sulfur_title" v="[EN] Copper Hydroxide + Sulfur" eh="8366560f" />
+    <e k="sf_blend_copper_hydroxide_tebuconazole_title" v="[EN] Copper Hydroxide + Tebuconazole" eh="aa0f65b8" />
+    <e k="sf_blend_mancozeb_metalaxyl_title" v="[EN] Mancozeb + Metalaxyl" eh="909841a4" />
+    <e k="sf_blend_mancozeb_propiconazole_title" v="[EN] Mancozeb + Propiconazole" eh="010df778" />
+    <e k="sf_blend_mancozeb_sulfur_title" v="[EN] Mancozeb + Sulfur" eh="edb405bb" />
+    <e k="sf_blend_mancozeb_tebuconazole_title" v="[EN] Mancozeb + Tebuconazole" eh="0bbc3c4a" />
+    <e k="sf_blend_metalaxyl_propiconazole_title" v="[EN] Metalaxyl + Propiconazole" eh="fd2a77f1" />
+    <e k="sf_blend_metalaxyl_sulfur_title" v="[EN] Metalaxyl + Sulfur" eh="50d49fb4" />
+    <e k="sf_blend_metalaxyl_tebuconazole_title" v="[EN] Metalaxyl + Tebuconazole" eh="3afc3aac" />
+    <e k="sf_blend_propiconazole_sulfur_title" v="[EN] Propiconazole + Sulfur" eh="ab3044f6" />
+    <e k="sf_blend_propiconazole_tebuconazole_title" v="[EN] Propiconazole + Tebuconazole" eh="4f87fc33" />
+    <e k="sf_blend_sulfur_tebuconazole_title" v="[EN] Sulfur + Tebuconazole" eh="51ee006b" />
     <e k="sf_dis_resistant_complex" v="[EN] Multi-resistant complex" />
     <e k="sf_dis_resistant_complex_cereal" v="[EN] Multi-resistant cereal complex" />
     <e k="sf_dis_resistant_complex_maize" v="[EN] Multi-resistant maize complex" />
@@ -1220,11 +1216,103 @@
     <e k="sf_dis_resistant_complex_pulse" v="[EN] Multi-resistant pulse complex" />
     <e k="sf_dis_resistant_complex_forage" v="[EN] Multi-resistant forage complex" />
 
-    <e k="sf_experimental_short" v="Experimental Systems" />
-    <e k="sf_experimental_long" v="Turn on experimental systems that are not released yet." />
-    <e k="sf_desc_experimentalSystems" v="Off by default. Independent of difficulty. Use at your own risk." />
-    <e k="sf_panel_hdr_experimental" v="Experimental" />
-<e k="sf_release_dialog_title" v="Release Gate" />
+    <e k="sf_experimental_short" v="[EN] Experimental Systems" eh="065b69cd" />
+    <e k="sf_experimental_long" v="[EN] Turn on experimental systems that are not released yet." eh="5226b9cb" />
+    <e k="sf_desc_experimentalSystems" v="[EN] Off by default. Independent of difficulty. Use at your own risk." eh="a8ad3206" />
+    <e k="sf_panel_hdr_experimental" v="[EN] Experimental" eh="704b5561" />
+<e k="sf_release_dialog_title" v="[EN] Release Gate" eh="74d19780" />
+		<e k="sf_map_target_no_data" v="[EN] No data" eh="42a7b262" />
+		<e k="sf_map_limiting" v="[EN] Limiting" eh="208ee821" />
+		<e k="sf_map_ph_optimal" v="[EN] Optimal" eh="cb61fef1" />
+		<e k="sf_map_weed_pressure" v="[EN] Weed Pressure" eh="53f8b936" />
+		<e k="sf_map_tip" v="[EN] Tip" eh="12ae2a12" />
+		<e k="sf_map_balanced" v="[EN] Balanced" eh="c6589f52" />
+		<e k="sf_map_ph_apply_lime" v="[EN] Apply lime" eh="5b3983de" />
+		<e k="sf_map_ph_very_acidic" v="[EN] Very acidic" eh="5f032f0b" />
+		<e k="sf_map_herbicide" v="[EN] Herbicide" eh="1029736e" />
+		<e k="sf_map_compaction_urgent" v="[EN] Subsoiling urgent" eh="62a80ea4" />
+		<e k="sf_map_ph_none_needed" v="[EN] None needed" eh="a01f2705" />
+		<e k="sf_map_not_needed" v="[EN] Not needed" eh="3ec6d6a7" />
+		<e k="sf_map_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+		<e k="sf_map_crop" v="[EN] Crop" eh="d388632d" />
+		<e k="sf_map_not_applied" v="[EN] Not applied" eh="ac612def" />
+		<e k="sf_map_ph_slightly_acidic" v="[EN] Slightly acidic" eh="908e5a88" />
+		<e k="sf_map_compaction_ok" v="[EN] No action needed" eh="f51a497f" />
+		<e k="sf_map_om_low" v="[EN] Low - add manure or digestate" eh="85262077" />
+		<e k="sf_map_disease_pressure" v="[EN] Disease Pressure" eh="2b805cc9" />
+		<e k="sf_map_condition" v="[EN] Condition" eh="9e2941b3" />
+		<e k="sf_map_target_none" v="[EN] No crop planted" eh="101c620c" />
+		<e k="sf_map_compaction_recommended" v="[EN] Subsoiling recommended" eh="d01f0d65" />
+		<e k="sf_map_om_fair" v="[EN] Incorporate straw / manure" eh="caf68ba7" />
+		<e k="sf_map_ph_apply_lime_urgent" v="[EN] Apply lime urgently" eh="b151ae45" />
+		<e k="sf_map_insecticide" v="[EN] Insecticide" eh="5650eeef" />
+		<e k="sf_map_pest_pressure" v="[EN] Pest Pressure" eh="18a7c2be" />
+		<e k="sf_map_target" v="[EN] Target" eh="c41a3189" />
+		<e k="sf_map_active" v="[EN] Active" eh="4d3d769b" />
+		<e k="sf_map_ph_severely_over_limed" v="[EN] Severely over-limed" eh="23897c47" />
+		<e k="sf_map_fungicide" v="[EN] Fungicide" eh="e8512698" />
+		<e k="sf_map_ph_normalize" v="[EN] Allow to normalize" eh="9645480a" />
+		<e k="sf_map_ph_over_limed" v="[EN] Over-limed" eh="b2a29851" />
+		<e k="sf_map_gap" v="[EN] Gap" eh="466b98ca" />
+		<e k="sf_map_ph_apply_sulfur" v="[EN] Apply sulfur" eh="73c513b6" />
+		<e k="sf_map_om_healthy" v="[EN] Healthy - maintain with straw" eh="99d4efa2" />
+
+    <!-- Esc RF PDA greenfield (2026-08-02) -->
+    <e k="rf_pda_panel_soil" v="[EN] Soil Fertilizer" eh="ed0df48a" />
+    <e k="rf_pda_menu_blurb" v="[EN] Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields." eh="a3e3f27d" />
+    <e k="rf_pda_host_blurb" v="[EN] Quick look at this module. Open Farm Tablet for the full tools." eh="8eabc065" />
+    <e k="rf_pda_suite_hint" v="[EN] This page shows nutrient levels for your fields and a treatment plan for the field you select." eh="32d7efb3" />
+    <e k="rf_pda_host_placeholder" v="[EN] How to: when this module adds Esc detail, use it here. Until then, open Farm Tablet." eh="227f25ea" />
+    <e k="rf_pda_module_soil_short" v="[EN] Soil" eh="e4b9dca2" />
+    <e k="rf_pda_module_tag_host" v="[EN] open" eh="7cef8a73" />
+    <e k="rf_pda_module_tag_loaded" v="[EN] ready" eh="b2fdab23" />
+    <e k="rf_pda_module_list_label" v="[EN] Modules" eh="bf17ac14" />
+    <e k="rf_pda_col_area" v="[EN] Area" eh="deec4ff1" />
+    <e k="rf_pda_col_fert" v="[EN] Fertilizer" eh="cd248829" />
+    <e k="rf_pda_section_treatment" v="[EN] Treatment" eh="4c4ac06f" />
+    <e k="rf_pda_treat_products" v="[EN] Products" eh="068f80c7" />
+    <e k="rf_pda_sample_hint" v="[EN] Soil sample dates appear here when available." eh="fa51cbfd" />
+    <e k="rf_pda_status_urgent" v="[EN] URGENT" eh="e395eb26" />
+    <e k="rf_pda_status_ok" v="[EN] OK" eh="e0aa021e" />
+    <e k="rf_pda_fert_chip" v="[EN] FERT" eh="c7185b0b" />
+    <e k="rf_pda_treatment_selected" v="[EN] Selected field: Field %s" eh="0c01ba54" />
+		<e k="rf_pda_treatment_next" v="[EN] Next: %s" eh="6914fabe" />
+		<e k="rf_pda_treatment_selected_next" v="[EN] Field %s · Next: %s" eh="1bfc779c" />
+    <e k="rf_pda_treatment_none_selected" v="[EN] Select a field" eh="fe1cc690" />
+    <e k="rf_pda_treatment_targets_heading" v="[EN] Target levels" eh="c3719aff" />
+    <e k="rf_pda_sample_heading" v="[EN] Soil sampling" eh="9b707834" />
+    <e k="rf_pda_sample_dated" v="[EN] Last sample" eh="67398c4b" />
+    <e k="rf_pda_sample_next" v="[EN] Next suggested" eh="3fd9ab58" />
+    <e k="rf_pda_click_hint" v="[EN] Click a field row for treatment details." eh="ab972960" />
+		<e k="rf_pda_treat_or" v="[EN] or %s" eh="a9c3981a" />
+		<e k="rf_pda_treat_method_dry" v="[EN] spreader" eh="fc40238b" />
+		<e k="rf_pda_treat_method_liquid" v="[EN] sprayer/tank" eh="463b51c3" />
+		<e k="rf_pda_treat_prod_with_how" v="[EN] %s · %s" eh="a2dac483" />
+		<e k="rf_pda_treat_next_with_amount" v="[EN] %s %s (%s total) · %s" eh="916610f2" />
+		<e k="rf_pda_treat_next_no_amount" v="[EN] %s - %s" eh="23afceb9" />
+		<e k="rf_pda_treat_next_why_ph" v="[EN] Fix pH before nutrients." eh="f1ba4606" />
+		<e k="rf_pda_treat_next_why_protect" v="[EN] Crop pressure first, then soil." eh="ad384268" />
+		<e k="rf_pda_treat_burn_amend" v="[EN] Wait: amending now can burn the crop." eh="a521d414" />
+		<e k="rf_pda_treat_next_how_dry" v="[EN] buy in shop Products, load a dry spreader, cover the field" eh="4a03cd81" />
+		<e k="rf_pda_treat_next_how_liquid" v="[EN] buy in shop Products, fill a sprayer/tank, cover the field" eh="2682c53f" />
+		<e k="rf_pda_treat_next_how_lime" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_liq_lime" v="[EN] apply with a sprayer/tank" eh="ccb22a68" />
+		<e k="rf_pda_treat_next_how_gypsum" v="[EN] spread with a dry fertilizer spreader" eh="fcca6b35" />
+		<e k="rf_pda_treat_next_how_om" v="[EN] spread manure/compost or leave chopped straw" eh="dd5833f9" />
+		<e k="rf_pda_treat_next_how_weed" v="[EN] spray (or use a weeder)" eh="b8b43874" />
+		<e k="rf_pda_treat_next_how_pest" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_next_how_disease" v="[EN] spray the field" eh="27723cda" />
+		<e k="rf_pda_treat_om_low" v="[EN] MANURE / COMPOST / chop straw · spread or leave residue" eh="8ca0887c" />
+		<e k="rf_pda_treat_om_fair" v="[EN] Maintain organic inputs (manure / compost / straw)" eh="edd90a81" />
+		<e k="rf_pda_treat_weed" v="[EN] HERBICIDE · sprayer (or mechanical weeder)" eh="dd2133cd" />
+		<e k="rf_pda_treat_weed_active" v="[EN] Herbicide still active - recheck later" eh="c119bdf0" />
+		<e k="rf_pda_treat_pest" v="[EN] INSECTICIDE · sprayer" eh="8cf7f77b" />
+		<e k="rf_pda_treat_pest_active" v="[EN] Insecticide still active - recheck later" eh="c1ee2552" />
+		<e k="rf_pda_treat_disease" v="[EN] FUNGICIDE · sprayer" eh="47f19736" />
+		<e k="rf_pda_treat_disease_active" v="[EN] Fungicide still active - recheck later" eh="8ee03e99" />
+		<e k="rf_pda_side_info_soil" v="[EN] Soil Fertilizer&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).&#10;&#10;Click a row. Treatment (below) is the plan for that field:&#10;- PRODUCT = what to buy (first is preferred; &quot;or ...&quot; is an alternate)&#10;- RATE = amount per area / TOTAL = amount for this field&#10;- Selected names the field; Next (under it) says what to do first&#10;&#10;How to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.&#10;&#10;Start with the weakest Status, open Treatment, follow Next, then the rest of the list." eh="3eba26e2" />
+		<e k="rf_pda_side_info_crop_stress" v="[EN] Crop Stress&#10;&#10;This table lists every field you own. One row = one field.&#10;&#10;Columns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).&#10;&#10;Click a row. The strip below names the field, then Next says what to do first:&#10;- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)&#10;- High Stress or a sensitive growth window → protect now; stress today cuts harvest later&#10;- Looking fine → recheck later; worse fields first&#10;&#10;Irrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.&#10;&#10;If Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.&#10;&#10;Start with Critical Status, follow Next, then work up the list." />
+		<e k="rf_pda_side_info_market_dynamics" v="[EN] Market Dynamics&amp;#10;&amp;#10;This is a pause market glance, not the full Market desk.&amp;#10;&amp;#10;Graph = price path for the crop you pick.&amp;#10;&amp;#10;Movers = biggest swings right now. Click one to change the graph.&amp;#10;&amp;#10;Events = world events still driving prices. Empty means nothing active (normal).&amp;#10;&amp;#10;Bottom strip = facts for the crop you selected.&amp;#10;&amp;#10;Contracts line = open count only. Full contracts live deeper.&amp;#10;&amp;#10;Open full Market when you need Prices / Events / Contracts admin." eh="699dc7b5" />
 </elements>
 
 

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -1,0 +1,529 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    RF Esc greenfield 2026-08-02 — vanilla InGameMenu chrome (Contracts/Animals).
+    Left nest: fs25_subCategoryContainerBg + fs25_subCategoryContainer +
+    fs25_subCategorySelector + dots + list. Right: fs25_menuContentContainer.
+    Modules MTO vs page MTO are separate bands (page shell is NOT inside filter box).
+    NO-HOST Option B (rfEscModules). No Soil-host / rfPdaHost. Phase B Map NO-GO.
+    Hang fences: GuiElement SmoothList parents; blank.png only via profile fills; no thrash reload.
+-->
+<GUI name="RfPdaMenuPage">
+    <!-- Stretch root (layout only; chrome below is vanilla fs25_subCategory*). -->
+    <GuiElement profile="RF_PageRoot" id="rfPageRoot">
+        <GuiElement profile="fs25_subCategorySelectorTabbedContainer" id="rfContentHost" absoluteSizeOffset="0px 0px">
+
+            <!-- Round 2 D2: opaque column fill painted FIRST (x 0..404, full height, behind nest/cards). -->
+            <Bitmap profile="RF_SideColUnderlay"/>
+
+            <!-- LEFT nest glass hidden (round 3): sidebar is one flat RF_SideColUnderlay tone.
+                 Element kept in tree for structure; no Lua re-shows it. -->
+            <ThreePartBitmap profile="RF_SubCategoryContainerBg" visible="false">
+                <Bitmap profile="fs25_subCategoryContainerArrow" visible="false"/>
+            </ThreePartBitmap>
+
+            <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
+                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
+                <BoxLayout profile="fs25_subCategorySelectorBox" id="rfPanelDotBox">
+                    <RoundCorner profile="fs25_subCategorySelectorDot" id="rfPanelDotTemplate"/>
+                </BoxLayout>
+                <Text profile="fs25_textGrey" id="rfDotLegend" position="8px -118px" size="380px 20px" visible="false"/>
+                <!-- Retired: side help lives in rfSideInfoShell (do not double-paint). -->
+                <Text profile="fs25_textGrey" id="rfSuiteHint" position="12px -140px" size="380px 80px"
+                      textMaxNumLines="4" textVerticalAlignment="top" visible="false"/>
+                <ThreePartBitmap profile="fs25_lineSeparatorTop" id="rfSideMidSeparator"
+                                 position="8px -130px" width="380px" visible="false"/>
+
+                <!-- Soil/CS left info (George: inside rfFilterBox, BEFORE moduleList; Text + blank.png). -->
+                <GuiElement profile="RF_SideInfoShell" id="rfSideInfoShell" visible="false" handleFocus="false">
+                    <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
+                    <Text profile="RF_SideInfoBody" id="rfSideInfoBody" position="8px -8px" size="368px 284px"
+                          textMaxNumLines="16" textVerticalAlignment="top" text=""/>
+                </GuiElement>
+
+                <GuiElement profile="fs25_subCategoryListContainer" id="rfModuleListShell">
+                    <Text profile="fs25_textGrey" id="wcSideVersion" visible="false" text=""/>
+                    <Bitmap profile="fs25_subCategoryStartClipper" name="rfModListStart"/>
+                    <Bitmap profile="fs25_subCategoryStopClipper" name="rfModListEnd"/>
+                    <SmoothList id="moduleList" profile="fs25_subCategoryList"
+                                startClipperElementName="rfModListStart"
+                                endClipperElementName="rfModListEnd">
+                        <!-- Compact rows (34px) so Soil stays clickable under taller side shell; not vanilla 100px items. -->
+                        <ListItem profile="RF_ModuleListRow" onClick="onClickModuleRow">
+                            <Bitmap profile="RF_ModuleRowBg" name="alternating"/>
+                            <Text profile="RF_ModuleItemText" name="moduleRowTitle"/>
+                            <Text profile="RF_ModuleItemTag" name="moduleRowTag"/>
+                        </ListItem>
+                    </SmoothList>
+                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                        <Slider profile="fs25_listSlider" dataElementId="moduleList" hideParentWhenEmpty="true"/>
+                    </ThreePartBitmap>
+                </GuiElement>
+            </Bitmap>
+
+            <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
+                 Must use RF_WcSubnavShell (top-left); profile-less GuiElement defaults bottom-left and falls off-screen. -->
+            <GuiElement profile="RF_WcSubnavShell" id="wcSubnavShell" visible="false">
+                <MultiTextOption profile="RF_WcSubnavSelector" id="wcSubnavSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickWcSubnavSelector"/>
+                <BoxLayout profile="RF_WcSubnavDotBox" id="wcSubnavDotBox" visible="false">
+                    <RoundCorner profile="fs25_subCategorySelectorDot"/>
+                </BoxLayout>
+                <!-- WC lower/smaller side help (under page MTO; About consolidated here). -->
+                <GuiElement profile="RF_WcSideInfoShell" id="wcSideInfoShell" visible="false" handleFocus="false">
+                    <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
+                    <Text profile="RF_WcSideBody" id="wcSideInfoBody" position="8px -8px" size="364px 224px"
+                          textMaxNumLines="12" textVerticalAlignment="top" text=""/>
+                </GuiElement>
+            </GuiElement>
+
+            <!-- MDM page chrome: Prices | Events | Contracts (WC twin; visible only for marketDynamics). -->
+            <GuiElement profile="RF_WcSubnavShell" id="mdSubnavShell" visible="false">
+                <MultiTextOption profile="RF_WcSubnavSelector" id="mdSubnavSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickMdSubnavSelector"/>
+                <BoxLayout profile="RF_WcSubnavDotBox" id="mdSubnavDotBox" visible="false">
+                    <RoundCorner profile="fs25_subCategorySelectorDot"/>
+                </BoxLayout>
+                <!-- MDM side help under page MTO (WC nest twin; hide Soil rfSideInfoShell when MDM active).
+                     Round 2 D3: inline position removed; centres via shared RF_WcSideInfoShell -367. -->
+                <GuiElement profile="RF_WcSideInfoShell" id="mdSideInfoShell" visible="false" handleFocus="false">
+                    <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
+                    <Text profile="RF_WcSideBody" id="mdSideInfoBody" position="8px -8px" size="364px 224px"
+                          textMaxNumLines="12" textVerticalAlignment="top" text=""/>
+                </GuiElement>
+            </GuiElement>
+
+            <!-- RIGHT: suite content plane (RF_MainColShell flushes X≈406 to side-info right). -->
+            <GuiElement profile="RF_MainColShell" id="rfMainCol">
+                <GuiElement profile="fs25_menuHeaderPanel" position="0px 74px">
+                    <Bitmap profile="fs25_menuHeaderIconBg">
+                        <Bitmap profile="fs25_menuHeaderIcon" imageSliceId="gui.icon_ingameMenu_options"/>
+                    </Bitmap>
+                    <Text profile="fs25_menuHeaderTitle" id="rfPageTitle" text="Realistic Farming"/>
+                </GuiElement>
+                <Text profile="RF_PageTagline" id="rfPageBlurb" position="40px -24px" size="90% 28px"
+                      textMaxNumLines="2" text=""/>
+
+                <GuiElement id="wcTitlePageShell" visible="false">
+                    <MultiTextOption profile="fs25_subCategorySelector" id="wcTitlePageSelector"
+                                     disableButtonsOnSingleText="false"
+                                     visible="false"
+                                     onClick="onClickWcTitlePageSelector"/>
+                </GuiElement>
+
+                <!-- SOIL panel content — RF_PanelContentShell is top-anchored (inline position bottoms off-screen). -->
+                <GuiElement profile="RF_PanelContentShell" id="rfPanelContent">
+
+                    <!-- F10: fields table spreads full main width -->
+                    <GuiElement profile="RF_TableRegionShell">
+                        <Bitmap profile="RF_TableWrapBg"/>
+
+                        <!-- F12: all headers centered; AREA/STATUS/Fertilizer body centered.
+                             IDs: Lua _applyChromeL10n rebinds when CS/WC created the Esc door. -->
+                        <Text profile="RF_ColHeader" id="soilColField"  text="$l10n_sf_pda_col_field"  position="16px -8px"    size="100px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColArea"   text="$l10n_rf_pda_col_area"   position="120px -8px"   size="100px 24px"/>
+                        <Text profile="RF_ColHeader" text="N"                       position="230px -8px"   size="110px 24px"/>
+                        <Text profile="RF_ColHeader" text="P"                       position="350px -8px"   size="110px 24px"/>
+                        <Text profile="RF_ColHeader" text="K"                       position="470px -8px"   size="110px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColPH" text="pH"       position="590px -8px"   size="100px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColStatus" text="$l10n_sf_pda_col_status" position="700px -8px"   size="140px 24px"/>
+                        <Text profile="RF_ColHeader" id="soilColFert"   text="$l10n_rf_pda_col_fert"   position="860px -8px"  size="160px 24px"/>
+
+                        <GuiElement profile="fs25_subCategoryListContainer" position="0px -32px"
+                                    absoluteSizeOffset="0px 40px">
+                            <SmoothList id="fieldOverviewList" profile="RF_SmoothList"
+                                        startClipperElementName="rfListStart"
+                                        endClipperElementName="rfListEnd">
+                                <ListItem profile="RF_ListRowTall" onClick="onClickFieldRow">
+                                    <Bitmap profile="RF_RowBg" name="alternating"/>
+                                    <Text profile="RF_CellLeft"   name="fieldRowId"     size="100px 44px"/>
+                                    <Text profile="RF_CellCenter" name="fieldRowArea"   position="120px 0px"  size="100px 44px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowN"      position="230px 0px"  size="110px 44px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowP"      position="350px 0px"  size="110px 44px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowK"      position="470px 0px"  size="110px 44px"/>
+                                    <Text profile="RF_CellRight"  name="fieldRowPH"     position="590px 0px"  size="100px 44px"/>
+                                    <Text profile="RF_StatusCell" name="fieldRowStatus" position="700px 0px" size="140px 44px"/>
+                                    <Text profile="RF_FertChip"   name="fieldRowFert"   position="860px 0px" size="160px 44px"/>
+                                </ListItem>
+                            </SmoothList>
+                            <Bitmap profile="fs25_secondaryMenuStartClipper" name="rfListStart"/>
+                            <Bitmap profile="fs25_secondaryMenuStopClipper"  name="rfListEnd"/>
+                            <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                <Slider profile="fs25_listSlider" dataElementId="fieldOverviewList" hideParentWhenEmpty="true"/>
+                            </ThreePartBitmap>
+                        </GuiElement>
+
+                        <Text profile="RF_EmptyHint" id="fieldsEmptyHint" text="$l10n_sf_pda_no_fields"
+                              position="0px 80px" size="100% 40px" visible="false"/>
+                    </GuiElement>
+
+                    <!-- TREATMENT PLAN (F8: clip shell keeps PRODUCTS rows inside panel) -->
+                    <GuiElement profile="RF_TreatmentStrip" id="rfTreatmentStrip">
+                        <Bitmap profile="RF_TreatmentBoxBg"/>
+                        <Text profile="RF_SectionTitle" id="soilSectionTreatment" position="10px -6px" text="$l10n_rf_pda_section_treatment"/>
+
+                        <!-- Col 1: vertical target stack (F11 positions held; Selected field moved right) -->
+                        <Text profile="RF_TreatTargetLine" id="treatTargetsHeading" position="10px -56px" size="250px 20px"/>
+                        <Text profile="RF_TreatTargetLine" id="treatTargetN" position="10px -78px" size="250px 20px"/>
+                        <Text profile="RF_TreatTargetLine" id="treatTargetP" position="10px -100px" size="250px 20px"/>
+                        <Text profile="RF_TreatTargetLine" id="treatTargetK" position="10px -122px" size="250px 20px"/>
+                        <!-- Legacy bind kept hidden (F5 replaces single multiline Text) -->
+                        <Text profile="RF_HintText" id="treatTargetsLabel" position="10px -54px" size="1px 1px"
+                              visible="false"/>
+
+                        <!-- Eyes-on 2026-08-03: Field on line 1, Next tip on line 2 (separate Text ids). -->
+                        <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="270px -22px" size="560px 20px"
+                              textAlignment="left"/>
+                        <Text profile="RF_TreatNext" id="treatNextLabel" position="270px -42px" size="560px 40px"
+                              textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
+
+                        <!-- Col 2: PRODUCTS table — wider Name; Rate/Total kept readable (no SmoothList) -->
+                        <GuiElement profile="RF_ProductsShell" id="treatProductsShell" position="270px -88px">
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="0px 0px" size="560px 18px"
+                                  text="$l10n_rf_pda_treat_products"/>
+                            <Text profile="RF_ProductColHeader" position="0px -20px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeader" position="44px -20px" size="290px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeader" position="340px -20px" size="100px 16px"
+                                  textAlignment="right" text="RATE"/>
+                            <Text profile="RF_ProductColHeader" position="450px -20px" size="100px 16px"
+                                  textAlignment="right" text="TOTAL"/>
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="0px -40px" size="560px 22px"
+                                  visible="false"/>
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="0px -40px">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd1Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd1Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd1Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd1Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -20px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd2Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd2Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd2Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd2Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -40px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd3Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd3Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd3Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd3Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -60px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd4Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd4Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd4Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd4Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -80px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd5Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd5Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd5Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd5Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -100px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd6Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd6Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd6Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd6Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -120px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd7Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd7Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd7Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd7Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -140px" visible="false">
+                                    <Text profile="RF_ProductCell" id="treatProd8Nut" position="0px 0px" size="40px 20px"/>
+                                    <Text profile="RF_ProductCell" id="treatProd8Name" position="44px 0px" size="290px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd8Rate" position="340px 0px" size="100px 20px"/>
+                                    <Text profile="RF_ProductCellRight" id="treatProd8Total" position="450px 0px" size="100px 20px"/>
+                                </GuiElement>
+                            </GuiElement>
+                        </GuiElement>
+
+                        <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
+                        <GuiElement id="samplingInfoBox" position="850px -24px" width="180px" height="220px" visible="false">
+                            <Bitmap profile="RF_InfoBoxBg"/>
+                            <Text profile="RF_HintText" id="samplingInfoText" position="8px -8px" size="164px 200px"
+                                  textMaxNumLines="8" textVerticalAlignment="top"/>
+                        </GuiElement>
+                        <Text profile="RF_HintText" id="samplingInfoFallback" position="850px -24px" size="180px 160px"
+                              textMaxNumLines="7" text="$l10n_rf_pda_sample_hint" visible="false"/>
+                    </GuiElement>
+
+                </GuiElement>
+
+                <!-- HOST placeholder: glance text + twin Crop Stress field table (GuiElement SmoothList; hang-safe) -->
+                <GuiElement profile="RF_HostPlaceholderShell" id="rfHostPlaceholder" visible="false">
+                    <!-- Stretch like Soil fert table: no fixed 856 island (F4 layout fill) -->
+                    <Bitmap profile="RF_TableWrapBg"/>
+                    <Text profile="RF_SectionTitle" id="rfHostTitle" position="16px -12px" size="1140px 24px"/>
+                    <Text profile="RF_HintText" id="rfHostBlurb" position="16px -40px" size="1140px 40px"
+                          textMaxNumLines="2"/>
+                    <Text profile="RF_BodyText" id="rfHostBody" position="16px -84px" size="1140px 56px"
+                          textMaxNumLines="4" text=""/>
+
+                    <!-- Worker Costs page bodies only (page chrome = left sibling band). -->
+                    <GuiElement profile="RF_WcPageShell" id="wcPageShell" visible="false">
+                        <!-- Dashboard -->
+                        <GuiElement profile="RF_WcPage" id="wcPageDashboard" visible="true">
+                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="0px 0px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -28px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -28px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -56px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -56px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -84px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -84px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -120px" size="1140px 360px"
+                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                        </GuiElement>
+
+                        <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
+                        <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false">
+                            <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="0px 8px" size="200px 22px" text=""/>
+                            <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="220px 0px"
+                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="0px -44px" size="200px 22px" text=""/>
+                            <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="220px -52px"
+                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="0px -96px" size="200px 22px" text=""/>
+                            <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="220px -104px"
+                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="0px -148px" size="200px 22px" text=""/>
+                            <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="220px -156px"
+                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="0px -200px" size="200px 22px" text=""/>
+                            <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="220px -208px"
+                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="0px -252px" size="200px 22px" text=""/>
+                            <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="220px -260px"
+                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            <!-- Summary band under last option (~-260); full width; not overlapping options. -->
+                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -320px" size="1140px 36px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -356px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -356px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -388px" size="1140px 120px"
+                                  textMaxNumLines="5" textVerticalAlignment="top" text=""/>
+                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -520px" size="200px 36px"
+                                    text="Reset" onClick="onClickWcWageReset"/>
+                        </GuiElement>
+
+                        <!-- Workers -->
+                        <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
+                            <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="0px 0px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px 0px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -28px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -28px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -56px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -56px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -96px" size="1140px 380px"
+                                  textMaxNumLines="16" textVerticalAlignment="top" text=""/>
+                        </GuiElement>
+
+                        <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
+                        <GuiElement profile="RF_WcPage" id="wcPageAbout" visible="false">
+                            <MultiTextOption profile="RF_WcAboutTabSelector" id="wcAboutTabSelector"
+                                             position="0px 0px" visible="false"
+                                             disableButtonsOnSingleText="false"
+                                             onClick="onClickWcAboutTabSelector"/>
+                            <Text profile="RF_TreatTargetLine" id="wcAboutVersion" visible="false" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcAboutPayInterval" visible="false" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcAboutEffRate" visible="false" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcAboutCostMode" visible="false" text=""/>
+                            <Text profile="RF_HintText" id="wcAboutBody" visible="false" text=""/>
+                        </GuiElement>
+                    </GuiElement>
+
+                    <!-- Legacy glance id kept as alias shell (hidden); guest prefers wcPageShell. -->
+                    <GuiElement id="wcGlanceShell" position="16px -150px" size="1140px 1px" visible="false"/>
+
+                    <!-- CS table: top-flush with 404 bottom reserve so the last rows clear the
+                         FIELD DETAIL band title (CS FieldDetail fix, applied in the HOST page). -->
+                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px 0px"
+                                absoluteSizeOffset="0px 404px">
+                        <Text profile="RF_ColHeader" id="csColField" text="" position="16px -8px" size="100px 24px"/>
+                        <Text profile="RF_ColHeader" id="csColCrop" text="" position="140px -8px" size="200px 24px"/>
+                        <Text profile="RF_ColHeader" id="csColMoisture" text="" position="360px -8px" size="160px 24px"/>
+                        <Text profile="RF_ColHeader" id="csColStress" text="" position="540px -8px" size="160px 24px"/>
+                        <Text profile="RF_ColHeader" id="csColIrrigated" text="" position="720px -8px" size="180px 24px"/>
+                        <Text profile="RF_ColHeader" id="csColStatus" text="" position="920px -8px" size="220px 24px"/>
+
+                        <GuiElement profile="fs25_subCategoryListContainer" position="0px -32px"
+                                    absoluteSizeOffset="0px 40px">
+                            <SmoothList id="csFieldOverviewList" profile="RF_SmoothList"
+                                        startClipperElementName="csListStart"
+                                        endClipperElementName="csListEnd">
+                                <ListItem profile="RF_ListRowTall" onClick="onClickCsFieldRow">
+                                    <Bitmap profile="RF_RowBg" name="alternating"/>
+                                    <Text profile="RF_CellLeft"   name="csFieldRowId"        size="100px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="csFieldRowCrop"      position="140px 0px" size="200px 44px"/>
+                                    <Text profile="RF_CellCenter" name="csFieldRowMoisture"  position="360px 0px" size="160px 44px"/>
+                                    <Text profile="RF_CellCenter" name="csFieldRowStress"    position="540px 0px" size="160px 44px"/>
+                                    <Text profile="RF_CellCenter" name="csFieldRowIrrigated" position="720px 0px" size="180px 44px"/>
+                                    <Text profile="RF_StatusCell" name="csFieldRowStatus"    position="920px 0px" size="220px 44px"/>
+                                </ListItem>
+                            </SmoothList>
+                            <Bitmap profile="fs25_secondaryMenuStartClipper" name="csListStart"/>
+                            <Bitmap profile="fs25_secondaryMenuStopClipper"  name="csListEnd"/>
+                            <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                <Slider profile="fs25_listSlider" dataElementId="csFieldOverviewList" hideParentWhenEmpty="true"/>
+                            </ThreePartBitmap>
+                        </GuiElement>
+
+                        <Text profile="RF_EmptyHint" id="csFieldsEmptyHint" text=""
+                              position="0px 80px" size="100% 40px" visible="false"/>
+                    </GuiElement>
+
+                    <!-- CS bottom info band: twin Soil strip chrome, Text-only detail for the
+                         selected field (no SmoothList in band; no Soil PRODUCTS/NPK content).
+                         Texts filled by CsRfPdaGuest; safe on light tick. -->
+                    <GuiElement profile="RF_TreatmentStrip" id="csDetailStrip">
+                        <Bitmap profile="RF_TreatmentBoxBg"/>
+                        <Text profile="RF_SectionTitle" id="csDetailTitle" position="10px -6px" size="700px 24px" text=""/>
+                        <Text profile="RF_TreatSelected" id="csDetailField" position="10px -52px" size="900px 22px"
+                              textAlignment="left" text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csDetailMoisture" position="10px -88px" size="420px 20px" text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csDetailStress" position="10px -112px" size="420px 20px" text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csDetailIrrigated" position="10px -136px" size="420px 20px" text=""/>
+                        <Text profile="RF_TreatTargetLine" id="csDetailStatus" position="10px -160px" size="420px 20px" text=""/>
+                        <Text profile="RF_HintText" id="csDetailEmpty" position="10px -52px" size="1000px 44px"
+                              textMaxNumLines="2" visible="false" text=""/>
+                    </GuiElement>
+
+                    <!-- MDM TOP: commodities CROP / PRICE / CHANGE (GuiElement SmoothList parent; quiet reload). -->
+                    <GuiElement profile="RF_MdTableRegionShell" id="mdTableRegion" position="0px 0px"
+                                absoluteSizeOffset="0px 388px" visible="false">
+                        <Text profile="RF_ColHeader" id="mdColCrop" text="" position="54px -8px" size="380px 24px"/>
+                        <Text profile="RF_ColHeader" id="mdColPrice" text="" position="460px -8px" size="280px 24px"/>
+                        <Text profile="RF_ColHeader" id="mdColChange" text="" position="760px -8px" size="280px 24px"/>
+
+                        <GuiElement profile="fs25_subCategoryListContainer" position="0px -32px"
+                                    absoluteSizeOffset="0px 40px">
+                            <SmoothList id="mdCommodityList" profile="RF_SmoothList"
+                                        startClipperElementName="mdListStart"
+                                        endClipperElementName="mdListEnd">
+                                <ListItem profile="RF_ListRowTall" onClick="onClickMdCommodityRow">
+                                    <Bitmap profile="RF_RowBg" name="alternating"/>
+                                    <!-- Crop icon: Lua populate sets filename + visible per row (hide if no overlay; no purple). -->
+                                    <Bitmap profile="RF_MdCropIcon" name="cropIcon" visible="false"/>
+                                    <Text profile="RF_CellLeft"   name="mdCropRowName"   position="38px 0px" size="400px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="mdCropRowPrice"  position="460px 0px" size="280px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="mdCropRowChange" position="760px 0px" size="280px 44px"/>
+                                </ListItem>
+                            </SmoothList>
+                            <Bitmap profile="fs25_secondaryMenuStartClipper" name="mdListStart"/>
+                            <Bitmap profile="fs25_secondaryMenuStopClipper"  name="mdListEnd"/>
+                            <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                <Slider profile="fs25_listSlider" dataElementId="mdCommodityList" hideParentWhenEmpty="true"/>
+                            </ThreePartBitmap>
+                        </GuiElement>
+
+                        <Text profile="RF_EmptyHint" id="mdCommoditiesEmptyHint" text=""
+                              position="0px 80px" size="100% 40px" visible="false"/>
+                    </GuiElement>
+
+                    <!-- Legacy id alias (hidden): older draw paths may resolve mdGraphRegion. -->
+                    <GuiElement id="mdGraphRegion" position="0px 0px" size="1px 1px" visible="false"/>
+                    <!-- Legacy mover MTO (retired this pass; kept nil-safe). -->
+                    <MultiTextOption profile="RF_WcWageOption" id="mdMoverSelector" visible="false"
+                                     disableButtonsOnSingleText="false"
+                                     onClick="onClickMdMoverSelector"/>
+                    <GuiElement id="mdDetailStrip" position="0px 0px" size="1px 1px" visible="false"/>
+
+                    <!-- MDM BOTTOM: page-swapped band (Prices graph+detail | Events | Contracts). -->
+                    <GuiElement profile="RF_TreatmentStrip" id="mdPageBand" visible="false">
+                        <Bitmap profile="RF_TreatmentBoxBg"/>
+
+                        <!-- Page A — Prices -->
+                        <GuiElement id="mdPricesBand" visible="true" position="0px 0px" size="100% 100%">
+                            <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
+                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea"/>
+            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="40px -96px" size="720px 40px"
+                  visible="false" text=""/>
+            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="380px 22px"
+                  textAlignment="left" text=""/>
+            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="380px 20px" text=""/>
+            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="380px 20px" text=""/>
+            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="380px 44px"
+                  textMaxNumLines="2" visible="false" text=""/>
+            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="360px 36px"
+                    onClick="onClickMdOpenMarket"/>
+                        </GuiElement>
+
+                        <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
+                        <GuiElement id="mdEventsBand" visible="false" position="0px 0px" size="100% 100%">
+                            <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdEvColIntensity" position="450px -36px" size="220px 20px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdEvColTime" position="690px -36px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow1Name" position="10px -64px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow1Intensity" position="450px -64px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow1Time" position="690px -64px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow2Name" position="10px -92px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow2Intensity" position="450px -92px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow2Time" position="690px -92px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow3Name" position="10px -120px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow3Intensity" position="450px -120px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow3Time" position="690px -120px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow4Name" position="10px -148px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow4Intensity" position="450px -148px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow4Time" position="690px -148px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow5Name" position="10px -176px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow5Intensity" position="450px -176px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow5Time" position="690px -176px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow6Name" position="10px -204px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow6Intensity" position="450px -204px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvRow6Time" position="690px -204px" size="420px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdEvMore" position="10px -240px" size="1100px 20px" text=""/>
+                            <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -64px" size="1100px 44px"
+                                  textMaxNumLines="2" visible="false" text=""/>
+            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="360px 36px"
+                    onClick="onClickMdOpenMarket"/>
+                        </GuiElement>
+
+                        <!-- Page C — Contracts (read-only fixed rows). -->
+                        <GuiElement id="mdContractsBand" visible="false" position="0px 0px" size="100% 100%">
+                            <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdCtColQty" position="300px -36px" size="220px 20px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdCtColPrice" position="540px -36px" size="280px 20px" text=""/>
+                            <Text profile="RF_ColHeader" id="mdCtColStatus" position="840px -36px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Crop" position="10px -64px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Qty" position="300px -64px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Price" position="540px -64px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Status" position="840px -64px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Crop" position="10px -92px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Qty" position="300px -92px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Price" position="540px -92px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Status" position="840px -92px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Crop" position="10px -120px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Qty" position="300px -120px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Price" position="540px -120px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Status" position="840px -120px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Crop" position="10px -148px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Qty" position="300px -148px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Price" position="540px -148px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Status" position="840px -148px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Crop" position="10px -176px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Qty" position="300px -176px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Price" position="540px -176px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Status" position="840px -176px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="mdCtMore" position="10px -212px" size="1100px 20px" text=""/>
+                            <Text profile="RF_HintText" id="mdContractsEmpty" position="10px -64px" size="1100px 44px"
+                                  textMaxNumLines="2" visible="false" text=""/>
+            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="360px 36px"
+                    onClick="onClickMdOpenMarket"/>
+                        </GuiElement>
+                    </GuiElement>
+
+                </GuiElement>
+            </GuiElement>
+
+        </GuiElement>
+
+    </GuiElement>
+</GUI>
+

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,0 +1,576 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<GUIProfiles>
+    <!-- ============================================================ -->
+    <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
+    <!-- Main #222222 (0.133) · Side #2A2D28 (0.165 0.176 0.157)     -->
+    <!-- Lime #8cc63f (0.549 0.776 0.247) · blank.png avoids purple   -->
+    <!-- ============================================================ -->
+
+    <Profile name="RF_RowBoxH" extends="emptyPanel" with="anchorTopLeft">
+        <layoutDirection value="horizontal"/>
+        <layoutSpacing value="10px"/>
+        <clipChildren value="false"/>
+    </Profile>
+
+    <Profile name="RF_ColBoxV" extends="emptyPanel" with="anchorTopLeft">
+        <layoutDirection value="vertical"/>
+        <layoutSpacing value="6px"/>
+        <clipChildren value="false"/>
+    </Profile>
+
+    <!-- F12: TREATMENT PLAN section title (+2 vs F11 19). -->
+    <Profile name="RF_SectionTitle" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="21px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.95 0.95 0.95 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+
+    <!-- F12: Soil Fertilizer hero (~74; still bold header via textBold). -->
+    <Profile name="RF_PageTitle" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="74px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.95 0.95 0.95 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+
+    <!-- F12: tagline a bit larger so it sits closer to the hero title. -->
+    <Profile name="RF_PageTagline" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="23px"/>
+        <textBold value="false"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+        <textMaxNumLines value="2"/>
+    </Profile>
+
+    <!-- F11: one-line brand REALISTIC FARMING (lime arrows clear; tint forced in Lua). -->
+    <Profile name="RF_BrandSelector" extends="fs25_subCategorySelector">
+        <size value="100% 44px"/>
+        <absoluteSizeOffset value="56px 0px"/>
+        <position value="0px -48px"/>
+        <disableButtonsOnSingleText value="false"/>
+        <defaultProfileText value="RF_BrandSelectorText"/>
+    </Profile>
+    <Profile name="RF_BrandSelectorText" extends="fs25_subCategorySelectorText">
+        <textSize value="20px"/>
+        <textBold value="true"/>
+        <textMaxWidth value="320px"/>
+        <textMaxNumLines value="1"/>
+        <textLayoutMode value="resize"/>
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <!-- Soil/CS left help (mid-band under Modules MTO; before moduleList in XML). -->
+    <Profile name="RF_SideInfoShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="384px 300px"/>
+        <position value="10px -148px"/>
+        <clipChildren value="false"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_SideInfoBody" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="16px"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+        <textMaxNumLines value="16"/>
+    </Profile>
+    <!-- Fresh WC: page band = sibling of rfFilterBox; grow height so side info under MTO is not clipped. -->
+    <Profile name="RF_WcSubnavShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="410px 370px"/>
+        <position value="0px -118px"/>
+        <clipChildren value="false"/>
+    </Profile>
+    <!-- Page MTO: same width/offset/left as Modules fs25_subCategorySelector (100% 42 + 56 offset). -->
+    <Profile name="RF_WcSubnavSelector" extends="fs25_subCategorySelector">
+        <size value="100% 42px"/>
+        <absoluteSizeOffset value="56px 0px"/>
+        <position value="0px -10px"/>
+        <disableButtonsOnSingleText value="false"/>
+        <defaultProfileText value="RF_WcSubnavSelectorText"/>
+    </Profile>
+    <Profile name="RF_WcSubnavSelectorText" extends="fs25_subCategorySelectorText">
+        <textSize value="18px"/>
+        <textBold value="false"/>
+        <textMaxWidth value="240px"/>
+        <textMaxNumLines value="1"/>
+        <textLayoutMode value="resize"/>
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <!-- Page dots under page selector inside sibling shell (not in rfFilterBox). -->
+    <Profile name="RF_WcSubnavDotBox" extends="fs25_subCategorySelectorBox">
+        <position value="0px -60px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- Retired title-chrome (RESTORE): keep profiles for nil-safe ids; never shown. -->
+    <Profile name="RF_WcTitlePageShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="1px 1px"/>
+        <position value="0px 0px"/>
+        <clipChildren value="false"/>
+    </Profile>
+    <Profile name="RF_WcTitlePageSelector" extends="fs25_subCategorySelector">
+        <size value="1px 1px"/>
+        <absoluteSizeOffset value="0px 0px"/>
+        <position value="0px 0px"/>
+        <disableButtonsOnSingleText value="false"/>
+        <defaultProfileText value="RF_BrandSelectorText"/>
+    </Profile>
+    <!-- CLEARED ship: page bodies under hero title/blurb. -->
+    <Profile name="RF_WcPageShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="1140px 520px"/>
+        <position value="16px -84px"/>
+        <clipChildren value="false"/>
+    </Profile>
+    <Profile name="RF_WcPage" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="1140px 500px"/>
+        <position value="0px 0px"/>
+        <clipChildren value="false"/>
+    </Profile>
+    <Profile name="RF_WcWageOption" extends="fs25_subCategorySelector">
+        <size value="360px 40px"/>
+        <absoluteSizeOffset value="56px 0px"/>
+        <position value="0px 0px"/>
+        <disableButtonsOnSingleText value="false"/>
+        <defaultProfileText value="RF_BrandSelectorText"/>
+    </Profile>
+    <Profile name="RF_WcAboutTabSelector" extends="fs25_subCategorySelector">
+        <size value="520px 40px"/>
+        <absoluteSizeOffset value="56px 0px"/>
+        <position value="0px 0px"/>
+        <disableButtonsOnSingleText value="false"/>
+        <defaultProfileText value="RF_BrandSelectorText"/>
+    </Profile>
+    <!-- WC/MDM help card top-aligned under the page selector cluster (round 3: abs top -198 =
+         shell -118 + child -80; 10px air under the page dot row at -70). Shared by both cards. -->
+    <Profile name="RF_WcSideInfoShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="384px 240px"/>
+        <position value="10px -80px"/>
+        <clipChildren value="false"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_WcSideHeading" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="16px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.659 0.878 0.290 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+    <Profile name="RF_WcSideBody" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="16px"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+        <textMaxNumLines value="12"/>
+    </Profile>
+
+    <Profile name="RF_RowLabel" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="22px"/>
+        <textBold value="false"/>
+        <textColor value="1 1 1 0.8"/>
+        <textAlignment value="left"/>
+        <width value="200px"/>
+    </Profile>
+
+    <Profile name="RF_RowValue" extends="fs25_textDefault" with="anchorTopRight">
+        <textSize value="22px"/>
+        <textBold value="true"/>
+        <textColor value="1 1 1 1"/>
+        <textAlignment value="right"/>
+        <width value="220px"/>
+    </Profile>
+
+    <Profile name="RF_RowValueGreen" extends="fs25_textDefault" with="anchorTopRight">
+        <textSize value="20px"/>
+        <textBold value="true"/>
+        <textColor value="0.659 0.878 0.290 1"/>
+        <textAlignment value="right"/>
+        <width value="220px"/>
+    </Profile>
+
+    <!-- Treatment "Selected field" — left align (mock treat-meta .sel) -->
+    <Profile name="RF_TreatSelected" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="19px"/>
+        <textBold value="true"/>
+        <textColor value="0.659 0.878 0.290 1"/>
+        <textAlignment value="left"/>
+        <textMaxNumLines value="1"/>
+    </Profile>
+    <!-- Eyes-on 2026-08-03: Next tip under Field (may wrap once). -->
+    <Profile name="RF_TreatNext" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="18px"/>
+        <textBold value="true"/>
+        <textColor value="0.659 0.878 0.290 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+        <textMaxNumLines value="2"/>
+    </Profile>
+
+    <Profile name="RF_BigStat" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="40px"/>
+        <textBold value="true"/>
+        <textColor value="0.549 0.776 0.247 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+
+    <Profile name="RF_BigStatLabel" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="18px"/>
+        <textBold value="false"/>
+        <textUpperCase value="true"/>
+        <textColor value="1 1 1 0.6"/>
+    </Profile>
+
+    <Profile name="RF_BodyText" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="18px"/>
+        <textBold value="false"/>
+        <textColor value="1 1 1 0.85"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+        <textMaxNumLines value="5"/>
+        <width value="380px"/>
+    </Profile>
+
+    <!-- F5/F11: Target levels stacked lines (no embedded newlines); section +1. -->
+    <Profile name="RF_TreatTargetLine" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="19px"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+    </Profile>
+
+    <!-- F7/F8/F12: PRODUCTS table cells (fixed columns; no SmoothList). -->
+    <!-- F12: PRODUCTS section title (+1 vs F11 RF_ColHeader 17) — do not inherit fields +2. -->
+    <Profile name="RF_ProductsTitle" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="18px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.478 0.502 0.533 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+    <Profile name="RF_ProductColHeader" extends="RF_ColHeader">
+        <textSize value="17px"/>
+    </Profile>
+    <Profile name="RF_ProductCell" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="17px"/>
+        <textColor value="0.941 0.753 0.251 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <Profile name="RF_ProductCellRight" extends="RF_ProductCell">
+        <textAlignment value="right"/>
+    </Profile>
+    <Profile name="RF_ProductOk" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="18px"/>
+        <textColor value="0.659 0.878 0.290 1"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="top"/>
+    </Profile>
+
+    <!-- F8 pink: clip shell so PRODUCTS rows stay inside treatment panel. Wider Name (eyes-on 2026-08-03). -->
+    <Profile name="RF_ProductsShell" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="560px 248px"/>
+        <clipChildren value="true"/>
+    </Profile>
+    <Profile name="RF_ProductsRowsClip" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="560px 160px"/>
+        <clipChildren value="true"/>
+    </Profile>
+    <Profile name="RF_ProductRow" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="560px 20px"/>
+        <clipChildren value="false"/>
+    </Profile>
+
+    <Profile name="RF_EmptyText" extends="fs25_textGrey" with="anchorMiddleCenter">
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="middle"/>
+        <textSize value="26px"/>
+    </Profile>
+
+    <Profile name="RF_BtnBgGreen" extends="baseReference" with="anchorTopLeft">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.12 0.35 0.12 0.95"/>
+    </Profile>
+
+    <Profile name="RF_BtnHit" extends="emptyPanel" with="anchorTopLeft">
+        <isFocusable value="true"/>
+    </Profile>
+
+    <Profile name="RF_BtnText" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="20px"/>
+        <textBold value="true"/>
+        <textColor value="1 1 1 1"/>
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+
+    <Profile name="RF_tabListItemButton" extends="fs25_tabListItemButton">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0 0 0 0"/>
+    </Profile>
+
+    <!-- Kept for RfSoilFrame / other Esc pages (Phase 1 A7: do not delete shared header chrome). -->
+    <Profile name="RF_IconMenu" extends="baseReference" with="anchorMiddleCenter">
+        <size value="50px 50px"/>
+        <imageSliceId value="noSlice"/>
+        <imageFilename value="g_SFIconMenu"/>
+        <imageColor value="1 1 1 1"/>
+    </Profile>
+
+    <!-- Kept for other Esc pages; RfPdaMenuPage omits money (Phase 1 Q3 = B). -->
+    <Profile name="RF_MoneyBoxShell" extends="emptyPanel" with="anchorTopRight"/>
+
+    <!--
+        F9 page root: fill Esc paging content (uiInGameMenuPaging already sits
+        past the 125px icon rail). Do NOT use vanilla uiInGameMenuFrame here —
+        that profile is fixed 1400x756 + anchorMiddleCenter and leaves constant gutters.
+        George cite: extract/dataS/guiProfiles.xml uiInGameMenuFrame.
+    -->
+    <Profile name="RF_PageRoot" extends="emptyPanel" with="anchorStretchingYStretchingX">
+        <size value="100% 100%"/>
+        <absoluteSizeOffset value="0px 0px"/>
+        <position value="0px 0px"/>
+    </Profile>
+
+    <!-- F8: side ~1/4 of Esc RF content (Wizard yellow line); wider than vanilla 410/463. -->
+    <!-- F10: keep side 520; shrink chrome overhang (was +53) and butt main — closes centre black bar. -->
+    <Profile name="RF_SideColShell" extends="fs25_subCategoryContainer">
+        <width value="520px"/>
+    </Profile>
+    <Profile name="RF_SideColChrome" extends="fs25_subCategoryContainerBg">
+        <width value="548px"/>
+    </Profile>
+
+    <!-- MDM pre-kiss chrome: parent fs25_menuContentContainer center traits, X 226. -->
+    <!-- Kiss seam: X=404 left edge via pivot X 0; Y vanilla bottom-up via pivot Y 0 (round 2 D1:
+         pivotTopLeft's pivot Y 1 multiplied the 192 absOff into a +192 lift and beheaded the title). -->
+    <Profile name="RF_MainColShell" extends="fs25_menuContentContainer" with="anchorStretchingYLeft pivotBottomLeft">
+        <position value="404px 40px"/>
+        <absoluteSizeOffset value="178px 192px"/>
+    </Profile>
+
+    <!-- Nest surface narrowed to the 404 seam. Keeps vanilla texture slices:
+         blank.png + noSlice on a ThreePartBitmap paints the raw gui atlas (2026-08-04 lesson). -->
+    <Profile name="RF_SubCategoryContainerBg" extends="fs25_subCategoryContainerBg">
+        <width value="404px"/>
+    </Profile>
+
+    <Profile name="RF_PanelContentShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
+        <absoluteSizeOffset value="0px 36px"/>
+        <position value="0px -52px"/>
+    </Profile>
+
+    <Profile name="RF_HostPlaceholderShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
+        <absoluteSizeOffset value="0px 36px"/>
+        <position value="0px -52px"/>
+    </Profile>
+
+    <!-- F11: registered modules docked at bottom of side strip. -->
+    <Profile name="RF_ModuleListShellBottom" extends="emptyPanel" with="anchorBottomLeft pivotBottomLeft">
+        <!-- Default 220; host Lua shrinks to ~170 on WC while About side info is up. -->
+        <size value="504px 220px"/>
+        <position value="8px 16px"/>
+    </Profile>
+
+    <!-- Table viewport reserve. -->
+    <Profile name="RF_TableRegionShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
+        <absoluteSizeOffset value="0px 392px"/>
+        <position value="0px 0px"/>
+    </Profile>
+
+    <!-- MDM TOP commodities vs BOTTOM band (368)+L(~20): MDM-only; do not change shared Soil table shell. -->
+    <Profile name="RF_MdTableRegionShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
+        <absoluteSizeOffset value="0px 388px"/>
+        <position value="0px 0px"/>
+    </Profile>
+
+    <!-- MDM Esc TOP crop icon twin of deep mdm_cropIcon (26x26 @ 5px). Esc loads rfEscProfiles only. -->
+    <Profile name="RF_MdCropIcon" extends="baseReference" with="anchorMiddleLeft">
+        <size value="26px 26px"/>
+        <position value="5px 0px"/>
+        <imageSliceId value="noSlice"/>
+    </Profile>
+
+    <!-- MDM Prices graph rect: top-left under PRICE TREND (draw slaves to abs box).
+         Round 3: Y -28 -> -38 for 10px air under the graph title (title bottom -28). -->
+    <Profile name="RF_MdGraphArea" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="720px 200px"/>
+        <position value="40px -38px"/>
+        <clipChildren value="false"/>
+        <handleFocus value="false"/>
+    </Profile>
+
+    <!-- Treatment / CS detail: clipChildren keeps PRODUCTS inside strip. -->
+    <Profile name="RF_TreatmentStrip" extends="emptyPanel" with="anchorBottomStretchingX pivotBottomLeft">
+        <height value="384px"/>
+        <position value="0px 0px"/>
+        <clipChildren value="true"/>
+    </Profile>
+
+    <!-- Wizard swatches: blank.png + imageColor (never nil filename); stretch fill parents -->
+    <Profile name="RF_SideColBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.165 0.176 0.157 0.92"/>
+        <handleFocus value="false"/>
+    </Profile>
+
+    <!-- Round 4: sidebar repaint with the vanilla glass slice (George, extract gui.xml UV 936 441 10 104).
+         extends baseReference = gui atlas + engine white; NO blank.png, NO imageColor (vanilla tone is
+         baked in the atlas pixels, zero tint). anchorStretchingYLeft -> x 0..404, full column height. -->
+    <Profile name="RF_SideColUnderlay" extends="baseReference" with="anchorStretchingYLeft">
+        <width value="404px"/>
+        <imageSliceId value="gui.animalScreen_left"/>
+        <handleFocus value="false"/>
+    </Profile>
+
+    <Profile name="RF_MainColBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.133 0.133 0.133 0.96"/>
+    </Profile>
+
+    <Profile name="RF_TableWrapBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.078 0.086 0.094 0.92"/>
+    </Profile>
+
+    <Profile name="RF_TreatmentBoxBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.078 0.086 0.094 0.92"/>
+    </Profile>
+
+    <Profile name="RF_HintText" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="17px"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+
+    <Profile name="RF_DotLegend" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="15px"/>
+        <textColor value="0.478 0.502 0.533 1"/>
+        <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="RF_ModuleListLabel" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="14px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.478 0.502 0.533 1"/>
+        <textAlignment value="left"/>
+    </Profile>
+
+    <!-- F12: fields col headers +2 (17->19); all centered in cells. -->
+    <Profile name="RF_ColHeader" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="19px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textColor value="0.478 0.502 0.533 1"/>
+        <textAlignment value="center"/>
+    </Profile>
+
+    <!-- Kept for other pages; fields table uses centered RF_ColHeader (F12). -->
+    <Profile name="RF_ColHeaderRight" extends="RF_ColHeader">
+        <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="RF_SmoothList" extends="emptyPanel" with="anchorStretchingYLeft pivotTopLeft"/>
+
+    <Profile name="RF_ListRow" extends="emptyPanel" with="anchorTopStretchingX pivotTopLeft">
+        <height value="28px"/>
+    </Profile>
+
+    <Profile name="RF_RowBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0.118 0.129 0.141 0.85"/>
+        <imageSelectedColor value="0.549 0.776 0.247 0.18"/>
+        <alternateBackgroundColor value="0.145 0.157 0.173 0.85"/>
+    </Profile>
+
+    <Profile name="RF_CellLeft" extends="fs25_textDefault" with="anchorStretchingYLeft">
+        <position value="8px 0px"/>
+        <textSize value="20px"/>
+        <textBold value="true"/>
+        <textAlignment value="left"/>
+        <textColor value="0.95 0.95 0.95 1"/>
+        <textSelectedColor value="0.95 0.95 0.95 1"/>
+    </Profile>
+
+    <Profile name="RF_CellRight" extends="RF_CellLeft">
+        <textBold value="false"/>
+        <textAlignment value="center"/>
+    </Profile>
+
+    <!-- F12: AREA body cells centered in column. -->
+    <Profile name="RF_CellCenter" extends="RF_CellLeft">
+        <textBold value="false"/>
+        <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="RF_EmptyHint" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="19px"/>
+        <textAlignment value="center"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+    </Profile>
+
+    <!-- F8: taller rows for +2 textSize -->
+    <Profile name="RF_ListRowTall" extends="emptyPanel" with="anchorTopStretchingX pivotTopLeft">
+        <height value="44px"/>
+    </Profile>
+
+    <!-- F12: STATUS body cells centered. -->
+    <Profile name="RF_StatusCell" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="17px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="middle"/>
+        <textColor value="0.95 0.95 0.95 1"/>
+        <textSelectedColor value="0.95 0.95 0.95 1"/>
+    </Profile>
+
+    <Profile name="RF_FertChip" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="17px"/>
+        <textBold value="true"/>
+        <textUpperCase value="true"/>
+        <textAlignment value="center"/>
+        <textVerticalAlignment value="middle"/>
+        <textColor value="0.941 0.753 0.251 1"/>
+    </Profile>
+
+    <Profile name="RF_ModuleListRow" extends="emptyPanel" with="anchorTopStretchingX pivotTopLeft">
+        <height value="34px"/>
+    </Profile>
+
+    <Profile name="RF_ModuleRowBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0 0 0 0"/>
+        <imageSelectedColor value="0.549 0.776 0.247 0.15"/>
+        <alternateBackgroundColor value="0 0 0 0"/>
+    </Profile>
+
+    <Profile name="RF_ModuleItemText" extends="fs25_textDefault" with="anchorStretchingYLeft">
+        <position value="10px 0px"/>
+        <textSize value="16px"/>
+        <textAlignment value="left"/>
+        <textVerticalAlignment value="middle"/>
+        <textColor value="0.659 0.678 0.702 1"/>
+        <textSelectedColor value="0.659 0.878 0.290 1"/>
+    </Profile>
+
+    <Profile name="RF_ModuleItemTag" extends="fs25_textDefault" with="anchorStretchingYRight">
+        <position value="-8px 0px"/>
+        <size value="80px 28px"/>
+        <textSize value="13px"/>
+        <textUpperCase value="true"/>
+        <textAlignment value="right"/>
+        <textVerticalAlignment value="middle"/>
+        <textColor value="0.478 0.502 0.533 1"/>
+        <textSelectedColor value="0.478 0.502 0.533 1"/>
+    </Profile>
+
+    <!-- WC blank.png pattern: color Bitmap must have a filename or GuiOverlay returns nil (purple) -->
+    <Profile name="RF_InfoBoxBg" extends="baseReference" with="anchorStretchingYStretchingX">
+        <filename value="$dataS/menu/blank.png"/>
+        <imageColor value="0 0 0 0.35"/>
+    </Profile>
+</GUIProfiles>


### PR DESCRIPTION
## Summary
- Ships Wizard eyes-on **STABLE** Esc RF PDA chrome (NO-HOST module stack): shared `RfPdaMenuPage` + `rfEscProfiles`, door bootstrap/modules, guest joiners.
- Chrome is freeze-identical across door-capable joiners so partial installs paint the same menu.
- Joiner cookbook: `ecosystem-dev-tracking/Office Wizard/esc-rf-pda/REF-Esc-RF-NO-HOST-joiner-cookbook-STABLE-2026-08-05.md`

## Test plan
- [ ] Esc opens Realistic Farming door; Modules list shows installed joiners
- [ ] Full suite matches Wizard STABLE playtest
- [ ] This mod alone: same chrome; no stuck map / no second Esc tab
- [ ] No purple atlas bleed; no orphan slider sliver
- [ ] Legacy Esc icon stands down when RF door present
