### PR TITLE
fix(l10n): define sf_hud_pass_noproduct, it existed in no language file

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,9 @@
 ## Docs / localization
 - [ ] Keep all 26 languages in step for any new setting or fill type.
 - [ ] Update SoilVersionDialog CHANGELOG + README version on every release.
+- [x] `sf_hud_pass_noproduct` (SoilHUD.lua:687) was defined in no language file at all, English included, so the HUD rendered the raw key name whenever a session pass had no known product. Added to all 27 files, each derived from that language's `sf_hud_pass_coverage` sibling minus the product parenthetical, so every file keeps its existing translated or `[EN]` state instead of gaining invented text. 2026-08-06.
+- [ ] 90 strings still read `[EN]` in French and every one is `rf_pda_*` (Esc RF PDA chrome). Hold that ask until the Esc door work settles those surfaces, or the strings move under the translator.
+- [ ] Worth a guard: nothing catches a `g_i18n:getText` key that exists in no translation file. The one above shipped and was only found by reading the source.
 
 ## Blocked / waiting on
 - [!] getFieldInfo FieldSentry-state decision (waits on: audit answer).

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -556,6 +556,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -555,6 +555,7 @@
     <e k="sf_hud_unit_ppm" v="(百万分比)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="作业覆盖率：%d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="达标区域：%d%%（%s）" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="达标区域：%d%%" />
     <e k="sf_hud_compaction" v="土壤板结度：%d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="产量效率：%d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="肥害减产：-%d%%" eh="34059aac" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -555,6 +555,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Coverage: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -556,6 +556,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Pokrytí: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Přejezd: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Přejezd: %d%%" />
     <e k="sf_hud_compaction" v="Zhutnění: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Výnos: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -532,6 +532,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dækning: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passage: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Passage: %d%%" />
     <e k="sf_hud_compaction" v="Pakning: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Udbytte: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -549,6 +549,7 @@
     <e k="sf_hud_unit_ppm" v="kg/ha" eh="71b18c32" />
     <e k="sf_hud_coverage" v="[EN] Coverage: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="[EN] Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -532,6 +532,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -555,6 +555,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Coverage: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -532,6 +532,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compactación: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -555,6 +555,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Coverage: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compaction: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -533,6 +533,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Peitto: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Tiivistyminen: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -541,6 +541,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Couverture : %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Passage : %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Passage : %d%%" />
     <e k="sf_hud_compaction" v="Compaction : %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Rendement : %d%%" eh="7b49cf24" />
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -551,6 +551,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Lefedettség: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Tömörödés: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -555,6 +555,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cakupan: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Pemadatan: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -555,6 +555,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Copertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compattazione: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -551,6 +551,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="被覆率: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="踏み固め: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -552,6 +552,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="범위: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="압축도: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -553,6 +553,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dekking: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="Beurt: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="Beurt: %d%%" />
     <e k="sf_hud_compaction" v="Verdichting: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="Opbrengst: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -553,6 +553,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Dekning: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Pakking: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -553,6 +553,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Pokrycie: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Zagęszczenie: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -556,6 +556,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Cobertura: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compactação: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -556,6 +556,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Acoperire: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Compactare: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -531,6 +531,7 @@
     <e k="sf_hud_unit_ppm" v="(млн⁻¹)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Покрытие: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Уплотнение: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -532,6 +532,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Täckning: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Packning: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -533,6 +533,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Kapsama: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Sıkışma: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -532,6 +532,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Покриття: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Ущільнення: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -532,6 +532,7 @@
     <e k="sf_hud_unit_ppm" v="(ppm)" eh="71b18c32" />
     <e k="sf_hud_coverage" v="Độ phủ: %d%% / %d%%" eh="d407bb6d" />
     <e k="sf_hud_pass_coverage" v="[EN] Pass: %d%% (%s)" eh="531a10ef" />
+    <e k="sf_hud_pass_noproduct" v="[EN] Pass: %d%%" />
     <e k="sf_hud_compaction" v="Độ nén: %d%%" eh="bef3a4f5" />
     <e k="sf_hud_yield_eff" v="[EN] Yield: %d%%" eh="7b49cf24" />
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />


### PR DESCRIPTION
`sf_hud_pass_noproduct` was called but never defined, in any language.

`src/ui/SoilHUD.lua:687` runs `g_i18n:getText("sf_hud_pass_noproduct")` on the branch where a session pass has no known product. The key existed in no translation file at all, English included, so the player saw the raw key name in the HUD instead of a coverage line.

## The fix

Added to all 27 translation files.

Each value is derived from that file's own `sf_hud_pass_coverage` sibling with the product parenthetical removed. That sibling is already the same line with the product in it, so a language that had a real translation gets a real one and a language still on a placeholder keeps the placeholder:

| File | `sf_hud_pass_coverage` (existing) | `sf_hud_pass_noproduct` (added) |
|---|---|---|
| en | `Pass: %d%% (%s)` | `Pass: %d%%` |
| fr | `Passage : %d%% (%s)` | `Passage : %d%%` |
| de | `[EN] Pass: %d%% (%s)` | `[EN] Pass: %d%%` |

Nothing is invented, and no file gains English text it did not already carry. French keeps its space before the colon because the value comes from the French string rather than from a rule.

`translation_cs.xml` uses full width CJK parentheses rather than ASCII, so it was handled separately instead of being left half done.

## Checks

- All 27 files parse.
- Every file carries exactly one `%d` conversion, matching the single `sessPct` argument at the call site. A stray `%s` here would have thrown at runtime.
- 30 insertions, 0 deletions, across 28 files. One line per translation file plus the TODO entries.

Not yet tested in game. The branch that triggers this needs a session pass with no recorded product.

## Also in this PR

`TODO.md` records the fix, the 90 `rf_pda_*` strings still reading `[EN]` in French, and one gap worth closing later: nothing in the repo catches a `g_i18n:getText` key that exists in no translation file. This one shipped and was only found by reading the source.

`ROADMAP.md` is deliberately untouched. No design intent moved.
