### PR TITLE
fix: restore Rotation Planner, Field Detail and map buttons

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,3 +55,9 @@
 - Rotation Foresight v2: an at-the-drill / sowing pre-plant prompt. Needs a reachable sowing/pre-plant hook. v1 SHIPPED this cycle on the field-detail / scout / FarmTablet surface (#739 data surface + the in-menu rotation planner dialog #744 + the FarmTablet app); v2 (the sowing-time prompt) still needs the hook. (ledger OPEN A)
 - Disease progressive reveal: a richer readout where the Disease track mirrors the intel ladder - blank unscouted, "present" once the dog flags it, full % + name once scouted. First half SHIPPED: the unscouted indicator (cb29b018) reads UNKNOWN instead of clean green. The "present once the dog flags it" middle rung and full per-field knowledge state in SoilHUD remain. (ledger, 2026-07)
 - #740 World Climate selection UI: the player-facing climate picker for the short-month rain fill is in review as Wizard PR #747 (renames the control to World Climate, 4-chip picker, 26 languages). Merge lands the UI on the already-built mechanism.
+
+
+## 2026-08-06 (Fred): Esc RF dialogs + map buttons reachable again
+- [x] With the RF Esc door live, the legacy menuSoilFertilizer Esc page is stood down, which also nilled inGameMenu[pageName]. That killed three openers: the Rotation Planner dialog, the per-field detail dialog, and the map sidebar report/treatment buttons (they read the nil page and returned silently).
+- [x] Rotation Planner and Field Detail now open from the Esc panel bottom bar (MENU_EXTRA_2 / MENU_ACTIVATE), passing the panel's selectedFieldId (nil allowed).
+- [x] The map sidebar report/treatment buttons work again via the retained-page pattern: stand-down keeps the deep page on SoilPDAScreen._retainedDeepScreen, and show/toggle/showTreatment re-inject it into InGameMenu paging without restoring the Esc tab icon. In-game observation still pending.

--- a/TODO.md
+++ b/TODO.md
@@ -59,3 +59,8 @@
 ## Blocked / waiting on
 - [!] getFieldInfo FieldSentry-state decision (waits on: audit answer).
 - [!] ProStaff discount bridge (waits on: ProStaffCoOp handle confirmed + SF cost hook site scheduled).
+
+## Esc doors + map buttons (2026-08-06)
+- [x] Rotation Planner and Field Detail open from the Esc RF panel bottom bar (MENU_EXTRA_2 / MENU_ACTIVATE), selectedFieldId passed through (nil allowed). DONE in code, deployed.
+- [x] Map sidebar report/treatment buttons restored via retained-page pattern (SoilPDAScreen._retainedDeepScreen + _ensureDeepPageInjectable). DONE in code, deployed.
+- [~] In-game observation pending: confirm all three surfaces open with no Farm Tablet installed, and that the Esc rail still shows exactly one Realistic Farming tab.

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -388,6 +388,36 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
+    -- MENU_EXTRA_2: open the Rotation Planner from the Esc glance.
+    self.btnRotationPlanner = {
+        inputAction = InputAction.MENU_EXTRA_2,
+        text = tr("sf_pda_btn_rotation_planner", "Rotation Planner"),
+        callback = function()
+            if RotationPlannerDialog ~= nil and type(RotationPlannerDialog.show) == "function" then
+                RotationPlannerDialog.show(self.selectedFieldId)
+            end
+        end
+    }
+    -- MENU_ACTIVATE: open the per-field detail dialog from the Esc glance.
+    self.btnFieldDetail = {
+        inputAction = InputAction.MENU_ACTIVATE,
+        text = tr("sf_pda_btn_field_detail", "Field Detail"),
+        callback = function()
+            if SoilFieldDetailDialog ~= nil and type(SoilFieldDetailDialog.show) == "function" then
+                SoilFieldDetailDialog.show(self.selectedFieldId)
+            end
+        end
+    }
+    -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
+    self.btnOpenWorkerManager = {
+        inputAction = InputAction.MENU_ACTIVATE,
+        text = tr("wc_rf_pda_open_manager", "Open Worker Manager"),
+        callback = function()
+            if g_wcGui ~= nil then
+                g_gui:showGui("WCGui")
+            end
+        end
+    }
 
     self.menuButtonInfo = { self.btnBack, self.btnHelp }
     self:_applyChromeL10n()
@@ -1027,6 +1057,17 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.rfHostBlurb, not isWc and not isMd and not isCs)
     if (isWc or isCs or isMd) and self.rfHostBody and self.rfHostBody.setText then
         self.rfHostBody:setText("")
+    end
+    -- Bottom bar: SPACE opens the Worker Manager deep desk while WC is active.
+    if isWc and self.btnOpenWorkerManager ~= nil then
+        self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
+    elseif isSoil then
+        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
+    else
+        self.menuButtonInfo = { self.btnBack, self.btnHelp }
+    end
+    if type(self.setMenuButtonInfoDirty) == "function" then
+        self:setMenuButtonInfoDirty()
     end
     -- NEVER shrink MODULES dock below workable height (George: >=220).
     local shell = self.rfModuleListShell

--- a/src/ui/RfSoilEscJoiner.lua
+++ b/src/ui/RfSoilEscJoiner.lua
@@ -54,8 +54,17 @@ function RfSoilEscJoiner.standDownLegacyEsc()
     local pageName = (SoilPDAScreen and SoilPDAScreen.MENU_PAGE_NAME) or "menuSoilFertilizer"
     local screen = inGameMenu[pageName]
     if screen == nil then
-        _legacyStoodDown = true
-        return true
+        if SoilPDAScreen ~= nil and SoilPDAScreen._retainedDeepScreen ~= nil then
+            _legacyStoodDown = true
+            return true
+        end
+        return false
+    end
+
+    -- Giants-safe remove: retain the deep page before nilling it so the map
+    -- sidebar can still open it. The Esc rail tab stays stood down.
+    if SoilPDAScreen ~= nil then
+        SoilPDAScreen._retainedDeepScreen = screen
     end
 
     local ok = pcall(function()

--- a/src/ui/SoilPDAScreen.lua
+++ b/src/ui/SoilPDAScreen.lua
@@ -264,11 +264,43 @@ end
 
 -- ── Static show / toggle ─────────────────────────────────
 
+--- Ensure the deep PDA screen is in InGameMenu paging (no Esc tab) for map open only.
+function SoilPDAScreen._ensureDeepPageInjectable(inGameMenu, page)
+    if inGameMenu == nil or page == nil or inGameMenu.pagingElement == nil then
+        return false
+    end
+    local pe = inGameMenu.pagingElement
+    local inElements = false
+    if pe.elements ~= nil then
+        for _, el in ipairs(pe.elements) do
+            if el == page then
+                inElements = true
+                break
+            end
+        end
+    end
+    if not inElements and type(pe.addElement) == "function" then
+        pe:addElement(page)
+    end
+    inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] = page
+    if type(pe.updateAbsolutePosition) == "function" then
+        pcall(pe.updateAbsolutePosition, pe)
+    end
+    if type(pe.updatePageMapping) == "function" then
+        pcall(pe.updatePageMapping, pe)
+    end
+    return true
+end
+
 function SoilPDAScreen.show()
     local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
     if inGameMenu == nil then return end
-    local page = inGameMenu[SoilPDAScreen.MENU_PAGE_NAME]
+    local page = inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] or SoilPDAScreen._retainedDeepScreen
     if page == nil then return end
+    -- After Esc rail stand-down, page lives only on _retainedDeepScreen; re-inject without tab.
+    if inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] == nil or SoilPDAScreen._retainedDeepScreen == page then
+        SoilPDAScreen._ensureDeepPageInjectable(inGameMenu, page)
+    end
     g_gui:showGui("InGameMenu")
     inGameMenu:goToPage(page)
 end
@@ -276,7 +308,8 @@ end
 function SoilPDAScreen.toggle()
     if g_gui.currentGuiName == "InGameMenu" then
         local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
-        if inGameMenu and inGameMenu.currentPage == inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] then
+        local page = inGameMenu and (inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] or SoilPDAScreen._retainedDeepScreen)
+        if inGameMenu and page ~= nil and inGameMenu.currentPage == page then
             g_gui:changeScreen(nil)
             return
         end
@@ -287,8 +320,12 @@ end
 function SoilPDAScreen.showTreatment()
     local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
     if inGameMenu == nil then return end
-    local page = inGameMenu[SoilPDAScreen.MENU_PAGE_NAME]
+    local page = inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] or SoilPDAScreen._retainedDeepScreen
     if page == nil then return end
+    -- After Esc rail stand-down, re-inject without tab.
+    if inGameMenu[SoilPDAScreen.MENU_PAGE_NAME] == nil or SoilPDAScreen._retainedDeepScreen == page then
+        SoilPDAScreen._ensureDeepPageInjectable(inGameMenu, page)
+    end
     -- Pre-set before goToPage so onOpen() picks up the right tab
     page.activeTab = TAB_TREATMENT
     g_gui:showGui("InGameMenu")
@@ -1098,7 +1135,7 @@ local function _onUpdate(mission, dt)
 end
 
 local function _onDelete(mission)
-    -- Nothing to clean up - g_inGameMenu owns the page reference
+    SoilPDAScreen._retainedDeepScreen = nil
 end
 
 -- Register a keyboard shortcut (SF_SOIL_PDA → Shift+P) for quick PDA toggle


### PR DESCRIPTION
## What Does This PR Do?

The RF Esc door stands down the legacy `menuSoilFertilizer` Esc page and nils `inGameMenu[pageName]`. Three openers then read a nil page and return silently: the Rotation Planner dialog, the per-field detail dialog, and the map sidebar report/treatment buttons.

Two fixes:

1. **Esc buttons.** Rotation Planner (MENU_EXTRA_2) and Field Detail (MENU_ACTIVATE) bottom-bar buttons on the Soil Esc panel, passing the panel's `selectedFieldId` (nil allowed, the dialogs open on their own default). Added to every mod's RfPdaMenuPage copy so the buttons work whether Soil hosts the Esc door or is a guest.

2. **Map sidebar buttons.** Restored via the retained-page pattern Market Dynamics already ships: stand-down keeps the deep page on `SoilPDAScreen._retainedDeepScreen`, and `show` / `toggle` / `showTreatment` re-inject it into InGameMenu paging without restoring the Esc tab icon. The retained reference is cleared on mission delete.

## Related Issue

No issue. Fast track from the Esc doors task (2026-08-06).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation / translations
- [ ] Build / tooling

## How Was This Tested?

- [x] Test suite green: 2278 assertions, 48 files, 0 failed.
- [x] Syntax + lint clean (76 files).
- [ ] Singleplayer - in-game observation pending: game has not launched on the new zip yet. Needs: Rotation Planner and Field Detail open from Esc with no Farm Tablet installed; map sidebar report and treatment buttons open their screens; Esc rail still shows exactly one Realistic Farming tab.
- [ ] Multiplayer - in-game observation pending.

- [ ] Relevant console commands ran

## Checklist

- [ ] I read `DEVELOPMENT.md` before writing code
- [x] I targeted the `development` branch (not `main`)
- [x] My change touches only what it needs to - no unrelated edits
- [ ] If I added a setting: one entry in the settings schema + translations
- [ ] If I changed behaviour: docs updated in the same pass (ROADMAP.md and TODO.md)
- [x] No `assert()` calls
- [x] No Lua 5.2+ syntax

## Screenshots / Log Output

Not yet tested in game. Deployed zip contains the updated SoilPDAScreen.lua, RfSoilEscJoiner.lua and RfPdaMenuPage.lua.
