### PR TITLE
docs: mark SF-19 tunables as awaiting the spine split

### DIFF
--- a/src/SpatialPressures.lua
+++ b/src/SpatialPressures.lua
@@ -34,7 +34,10 @@ SpatialPressures = {}
 
 SpatialPressures.ENABLED = true
 
--- Tunables (the brief's numbers; ratio-pass owned, one-line changes)
+-- Tunables (the brief's numbers; awaiting the SF-19 spine split, one-line changes)
+-- The pending spine split is ruled: the pest half routes onto Agronomy, the
+-- disease half onto Biological. Until the spine builds, these four dials are the
+-- neutral default character (same awaiting-the-spine form as EmergencyLoan).
 SpatialPressures.PEST_EDGE_MIN_M   = 10      -- edge band inner radius (m)
 SpatialPressures.PEST_EDGE_MAX_M   = 30      -- edge band outer radius (m)
 SpatialPressures.CEILING_FRACTION  = 0.5     -- max outbreak = half the field


### PR DESCRIPTION
## What Does This PR Do?

Marking nicety, not a defect: the four SF-19 outbreak dials (`SpatialPressures.lua:37-41`, edge band min/max, ceiling fraction, seed cap) carried a "ratio-pass owned" header. Per the 2026-08-07 retro-audit marker, they now use the ruled awaiting-the-spine form, naming the two dials the pending spine split already ruled: the pest half routes onto Agronomy, the disease half onto Biological. Same form as EmergencyLoan.

## Related Issue

No issue. Marker note from the retro-audit (2026-08-07).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [x] Documentation / translations
- [ ] Build / tooling

## How Was This Tested?

- [x] Test suite green: 2278 assertions / 48 files.
- [x] Syntax + lint clean (76 files).
- [ ] Singleplayer - no in-game change expected (comment-only).

- [ ] Relevant console commands ran

## Checklist

- [ ] I read `DEVELOPMENT.md` before writing code
- [x] I targeted the `development` branch (not `main`)
- [x] My change touches only what it needs to - no unrelated edits
- [ ] If I added a setting: one entry in the settings schema + translations
- [ ] If I changed behaviour: docs updated in the same pass
- [x] No `assert()` calls
- [x] No Lua 5.2+ syntax

## Screenshots / Log Output

Comment-only change.
