### PR TITLE
feat: CD-14 heat scorch + SF-74 spray-path sky read

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -53,6 +53,23 @@ local function invalidatePolyVerts(field)
     end
 end
 
+-- SF-74: the spray-path sky read, in the MaterialWetness.lua:305-323 pattern.
+-- WeatherGuard's handle is published on g_currentMission by main.lua; absent
+-- means we do not know, and heat scorch HOLDS rather than inventing a day.
+local function weatherGuard()
+    return (g_currentMission ~= nil and g_currentMission.weatherGuard) or nil
+end
+
+--- Current temperature at spray time. nil means we do not know, and scorch
+--- HOLDS rather than inventing one: no WeatherGuard is not a mild day.
+local function readSprayTemperature()
+    local wg = weatherGuard()
+    if wg == nil or wg.getCurrentSky == nil then return nil end
+    local ok, sky = pcall(function() return wg:getCurrentSky() end)
+    if not ok or sky == nil then return nil end
+    return sky.temperature   -- number or nil; nil propagates as NO SCORCH
+end
+
 -- CD-9: Lookup the FRAC group for a fungicide fill type name.
 -- Returns nil for generic FUNGICIDE (no MOA assigned).
 ---@param fillTypeName string
@@ -6132,6 +6149,131 @@ function SoilFertilitySystem:applyBurnEffect(fieldId, rateMultiplier)
     if g_server and g_currentMission and g_currentMission.missionDynamicInfo and g_currentMission.missionDynamicInfo.isMultiplayer then
         if SoilFieldUpdateEvent and (not field._lastBurnBroadcast or (now - field._lastBurnBroadcast) >= gapMs) then
             field._lastBurnBroadcast = now
+            SoilNetworkEvents_BroadcastFieldUpdate(fieldId, field)
+        end
+    end
+end
+
+--- Heat scorch (CD-14): the correct dose on the wrong day. Spraying a
+--- heat-sensitive product (SULFUR, COPPER_HYDROXIDE) when the air is hot
+--- damages the SOIL under a standing established crop: pH down, nitrogen
+--- drained - exactly the currency this mod trades in. The crop is not killed
+--- and the chemical still works; the farmer who checks the forecast pays
+--- nothing. Composes the rate burn's band-and-accumulator engine (on a
+--- temperature scale) with the amendment burn's crop gate; invents no new
+--- machinery class. Server-only by inheritance (it lives under the hook's
+--- isServer gate), actor-blind (no getIsAIActive anywhere - an AI pass
+--- scorches like a player's), and nil-honest (nil temperature or an absent
+--- HEAT_SENSITIVITY entry means NO scorch and NO state change).
+--- Called UNCONDITIONALLY from both spray closures, BESIDE the burn branch,
+--- never inside the FERTILIZER_PROFILES N/P/K guard (SULFUR and COPPER_HYDROXIDE
+--- take the fungicide branch and never reach the guarded lines). The sensitivity
+--- probe here is the whole cost of that unconditional call.
+---@param fieldId number
+---@param fillTypeName string
+function SoilFertilitySystem:applyScorchEffect(fieldId, fillTypeName)
+    local field = self.fieldData[fieldId]
+    if not field then return end
+
+    -- Absent sensitivity entry: the unconditional closure call costs one probe.
+    local s = SoilConstants.HEAT_SENSITIVITY[fillTypeName]
+    if s == nil then return end
+
+    -- Nil-honest: no WeatherGuard read means no scorch, no state change.
+    local tempC = readSprayTemperature()
+    if tempC == nil then return end
+
+    local scorchCfg = SoilConstants.SPRAYER_RATE
+    local limits    = SoilConstants.NUTRIENT_LIMITS
+    local now       = (g_currentMission and g_currentMission.time) or 0
+    local gapMs     = scorchCfg.BURN_PASS_GAP_MS or 1500
+    local fullMs    = scorchCfg.BURN_FULL_DAMAGE_MS or 8000
+
+    -- Risk band on the temperature scale: below riskT nothing, at/above certainT
+    -- the full band caps every application, between them magnitude scales
+    -- linearly with the excess (the rate burn's exact clamp shape).
+    local riskT    = (scorchCfg.HEAT_RISK_BASE or 30) - (s.shift or 0)
+    local certainT = riskT + (scorchCfg.HEAT_BAND_WIDTH or 6)
+    if tempC < riskT then return end
+
+    local fullPh, fullN
+    if tempC >= certainT then
+        fullPh = scorchCfg.SCORCH_PH_DROP_CERTAIN or 0.30
+        fullN  = scorchCfg.SCORCH_N_DRAIN_CERTAIN or 12.0
+    else
+        local excess = (tempC - riskT) / (certainT - riskT)
+        excess = math.max(0.0, math.min(1.0, excess))
+        fullPh = (scorchCfg.SCORCH_PH_DROP_RISK or 0.15) * excess
+        fullN  = (scorchCfg.SCORCH_N_DRAIN_RISK or 5.0) * excess
+    end
+    if fullPh <= 0 and fullN <= 0 then return end
+
+    -- Crop gate (the #532 pattern, shared shape with applyFertilizer): resolve
+    -- the crop the way applyFertilizer does - _lastSprayX/_lastSprayZ plus a
+    -- live FieldState query - and require an established standing crop. Bare
+    -- ground and seedlings cannot scorch.
+    local hasCrop = false
+    local cropFruitIndex, cropGrowthState = nil, nil
+    local spx, spz = self._lastSprayX, self._lastSprayZ
+    if spx and spz and g_farmlandManager then
+        local farmlandTmp = g_farmlandManager:getFarmlandAtWorldPosition(spx, spz)
+        local fsField = farmlandTmp and g_fieldManager and
+                        g_fieldManager.farmlandIdFieldMapping and
+                        g_fieldManager.farmlandIdFieldMapping[farmlandTmp.id]
+        if fsField and fsField.posX and fsField.posZ then
+            local ok, fs = pcall(function()
+                local s2 = FieldState.new()
+                s2:update(fsField.posX, fsField.posZ)
+                return s2
+            end)
+            if ok and fs and fs.fruitTypeIndex ~= nil and fs.fruitTypeIndex ~= FruitType.UNKNOWN then
+                hasCrop          = true
+                cropFruitIndex   = fs.fruitTypeIndex
+                cropGrowthState  = fs.growthState
+            end
+        end
+    end
+    if not hasCrop or not self:isAmendmentBurnRisk(cropFruitIndex, cropGrowthState) then
+        return
+    end
+
+    -- ── Scorch's OWN accumulator (mirrored on the rate burn) ──────────────────
+    -- Pass continuity on the burn's gap/full clock, but with scorch's own fields
+    -- so a pass tripping both scorch and the rate burn pays each cap once, and
+    -- resetting one never resets the other.
+    local dt
+    if field._scorchTickTime and (now - field._scorchTickTime) <= gapMs then
+        dt = now - field._scorchTickTime
+    else
+        -- New pass: reset the per-pass accumulators.
+        dt = 0
+        field._scorchPassPh = 0
+        field._scorchPassN  = 0
+    end
+    field._scorchTickTime = now
+    if dt <= 0 then return end   -- first tick of a pass, or a sibling section this tick
+
+    -- ── Full-pass magnitude for the current band (the per-pass cap) ───────────
+    local frac   = math.min(1.0, dt / fullMs)
+    local phDrop = math.min(fullPh * frac, math.max(0.0, fullPh - (field._scorchPassPh or 0)))
+    local nDrain = math.min(fullN  * frac, math.max(0.0, fullN  - (field._scorchPassN  or 0)))
+    if phDrop <= 0 and nDrain <= 0 then return end
+
+    field.pH          = math.max(limits.PH_MIN, field.pH - phDrop)
+    field.nitrogen    = math.max(limits.MIN, field.nitrogen - nDrain)
+    field._scorchPassPh = (field._scorchPassPh or 0) + phDrop
+    field._scorchPassN  = (field._scorchPassN  or 0) + nDrain
+
+    self:log("Scorch slice field %d: pH -%.3f, N -%.2f (%.1f C)",
+        fieldId, phDrop, nDrain, tempC)
+
+    -- Broadcast on the existing field event, throttled by scorch's OWN timestamp
+    -- (never share _lastBurnBroadcast, so scorch and the rate burn each throttle
+    -- independently).
+    if g_server and g_currentMission and g_currentMission.missionDynamicInfo and
+       g_currentMission.missionDynamicInfo.isMultiplayer then
+        if SoilFieldUpdateEvent and (not field._scorchBroadcast or (now - field._scorchBroadcast) >= gapMs) then
+            field._scorchBroadcast = now
             SoilNetworkEvents_BroadcastFieldUpdate(fieldId, field)
         end
     end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -553,6 +553,23 @@ SoilConstants.FERTILIZER_PROFILES = {
 }
 
 -- ========================================
+-- HEAT SCORCH (CD-14): the correct dose on the wrong day
+-- ========================================
+-- Products whose active ingredient damages the SOIL under a standing established
+-- crop when sprayed hot (pH down, nitrogen drained; the crop is not killed and
+-- the chemical still works). shift lowers the product's risk temperature:
+--   riskT    = HEAT_RISK_BASE - shift          (first scorch risk here)
+--   certainT = riskT + HEAT_BAND_WIDTH         (full band damage at/above here)
+-- HEAT_RISK_BASE / HEAT_BAND_WIDTH and the per-band caps live in SPRAYER_RATE.
+-- SHIP stand-ins marked ARISSANI'S at the unlock (steward C2); every number here
+-- is a ratio-pass candidate recorded awaiting the spine. v1 carries no lime/OM
+-- amendment entries (the table fence: nothing with entry.pH/entry.OM).
+SoilConstants.HEAT_SENSITIVITY = {
+    SULFUR           = { shift = 4 },  -- elemental S oxidises hot; the classic case
+    COPPER_HYDROXIDE = { shift = 2 },
+}
+
+-- ========================================
 -- ORGANIC CERTIFICATION (per-field state layer over the OM substrate)
 -- ========================================
 -- A field moves conventional -> in_transition -> certified by being farmed with
@@ -961,6 +978,19 @@ SoilConstants.SPRAYER_RATE = {
     -- longer than BURN_PASS_GAP_MS (boom lifted, headland turn) starts a fresh pass.
     BURN_PASS_GAP_MS          = 1500,  -- ms of over-spray inactivity that ends a burn pass
     BURN_FULL_DAMAGE_MS       = 8000,  -- ms of continuous over-spray to reach full burn magnitude
+
+    -- Heat scorch (CD-14) risk band on the temperature scale, deg C.
+    -- riskT = HEAT_RISK_BASE - HEAT_SENSITIVITY[product].shift; the band is
+    -- HEAT_BAND_WIDTH wide, so certain damage sits at riskT + HEAT_BAND_WIDTH.
+    -- Between risk and certain the per-pass caps scale linearly with the excess,
+    -- the rate burn's exact clamp shape. SHIP stand-ins marked ARISSANI'S at the
+    -- unlock (steward C2); ratio-pass candidates recorded awaiting the spine.
+    HEAT_RISK_BASE             = 30,    -- deg C: first scorch risk for a shift-0 product
+    HEAT_BAND_WIDTH            = 6,     -- deg C: risk grows to certainty across this band
+    SCORCH_PH_DROP_RISK        = 0.15,  -- max pH lost over a full scorch pass in the risk band (scaled by excess)
+    SCORCH_PH_DROP_CERTAIN     = 0.30,  -- max pH lost over a full scorch pass at/above certainT
+    SCORCH_N_DRAIN_RISK        = 5.0,   -- max N drained over a full scorch pass in the risk band (scaled by excess)
+    SCORCH_N_DRAIN_CERTAIN     = 12.0,  -- max N drained over a full scorch pass at/above certainT
     FERTILIZER_COVERAGE_THRESHOLD = 0.90, -- % field coverage needed before nutrients are credited (V1.6 Realism Update)
 
     -- Reference application rates at 1.0x (step 10) per fill type.

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3743,6 +3743,12 @@ function HookManager:installSprayerAreaHook()
                        rateMultiplier > SoilConstants.SPRAYER_RATE.BURN_RISK_THRESHOLD then
                         soilSys:applyBurnEffect(fId, rateMultiplier)
                     end
+                    -- CD-14 heat scorch: called UNCONDITIONALLY, BESIDE the burn
+                    -- branch, never inside the FERTILIZER_PROFILES N/P/K guard
+                    -- (SULFUR / COPPER_HYDROXIDE take the fungicide branch above and
+                    -- would never reach a guarded line). The HEAT_SENSITIVITY probe
+                    -- inside applyScorchEffect is the whole cost when absent.
+                    soilSys:applyScorchEffect(fId, fillType.name)
                 end
 
                 if vww and vww.sections and #vww.sections > 0 then
@@ -3897,6 +3903,9 @@ function HookManager:installSprayerAreaHook()
                                                     if rateMultiplier > SoilConstants.SPRAYER_RATE.BURN_RISK_THRESHOLD then
                                                         soilSys:applyBurnEffect(fId2, rateMultiplier)
                                                     end
+                                                    -- CD-14 heat scorch: unconditional,
+                                                    -- beside the burn branch (see applySingle).
+                                                    soilSys:applyScorchEffect(fId2, ftName)
                                                 end
 
                                                 if vww and vww.sections and #vww.sections > 0 and scratchN > 0 then

--- a/tools/test/lua/scorch_cd14_test.lua
+++ b/tools/test/lua/scorch_cd14_test.lua
@@ -1,0 +1,235 @@
+-- scorch_cd14_test.lua - heat scorch (CD-14): the correct dose on the wrong day.
+-- Verifies applyScorchEffect damages the SOIL under an established standing crop
+-- when a heat-sensitive product (SULFUR, COPPER_HYDROXIDE) is sprayed hot, pays
+-- nothing on a mild day, ignores bare ground / seedlings, meters on its OWN
+-- accumulator (never the rate burn's), and stays nil-honest (no WeatherGuard =
+-- no scorch).
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/SoilFertilitySystem.lua
+
+local SFS = SoilConstants.SPRAYER_RATE
+local HEAT = SoilConstants.HEAT_SENSITIVITY
+local CERTAIN_PH = SFS.SCORCH_PH_DROP_CERTAIN
+local CERTAIN_N  = SFS.SCORCH_N_DRAIN_CERTAIN
+local FULL_MS    = SFS.BURN_FULL_DAMAGE_MS
+local GAP_MS     = SFS.BURN_PASS_GAP_MS
+
+-- SULFUR shift=4 → riskT=26, certainT=32 (HEAT_RISK_BASE 30 - 4, band 6).
+local SULFUR_RISK    = SFS.HEAT_RISK_BASE - HEAT.SULFUR.shift
+local SULFUR_CERTAIN = SULFUR_RISK + SFS.HEAT_BAND_WIDTH
+
+-- ── world stubs (crop gate + sky read) ─────────────────────
+local WHEAT = { fruitTypeIndex = 14, growthState = 6 }
+local function stubWorld(tempC, state)
+  state = state or WHEAT
+  g_currentMission = {
+    time = 1000,
+    environment = { currentDay = 1, daysPerPeriod = 1 },
+    missionInfo = {},
+    weatherGuard = tempC ~= nil and {
+      getCurrentSky = function() return { temperature = tempC } end,
+    } or nil,
+  }
+  g_server = nil
+  g_farmlandManager = { getFarmlandAtWorldPosition = function() return { id = 5 } end }
+  g_fieldManager = {
+    farmlandIdFieldMapping = { [5] = { posX = 100, posZ = 200 } },
+  }
+  FieldState = FieldState or {}
+  FieldState.new = function()
+    return {
+      update = function(_self, _x, _z) end,
+      fruitTypeIndex = state and state.fruitTypeIndex,
+      growthState     = state and state.growthState,
+    }
+  end
+  FruitType = FruitType or {}
+  FruitType.UNKNOWN = 0
+  g_fruitTypeManager = {
+    getFruitTypeByIndex = function(_self, idx)
+      if idx == WHEAT.fruitTypeIndex then
+        return { name = "WHEAT", minHarvestingGrowthState = 6, maxHarvestingGrowthState = 8, cutStates = nil }
+      end
+      return nil
+    end,
+  }
+end
+
+local function newSys(field)
+  local sys = setmetatable({
+    fieldData = { [1] = field },
+    settings  = { showNotifications = false },
+  }, { __index = SoilFertilitySystem })
+  sys._lastSprayX = 100
+  sys._lastSprayZ = 200
+  return sys
+end
+
+local function at(t) g_currentMission.time = t end
+
+-- ── insensitive product: the unconditional closure call costs one probe ──────
+do
+  stubWorld(SULFUR_CERTAIN + 1)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  sys:applyScorchEffect(1, "FUNGICIDE")
+  T.eq("scorch: an insensitive product changes nothing", field.pH, 7.0)
+  T.eq("scorch: insensitive product drains no N", field.nitrogen, 60)
+end
+
+-- ── nil-honest: no WeatherGuard means no scorch, no state change ─────────────
+do
+  stubWorld(nil)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.eq("scorch: absent WeatherGuard holds (no pH change)", field.pH, 7.0)
+  T.eq("scorch: absent WeatherGuard holds (no N change)", field.nitrogen, 60)
+end
+
+-- ── below the risk temperature: nothing ─────────────────────────────────────
+do
+  stubWorld(SULFUR_RISK - 1)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.eq("scorch: a mild day below riskT pays nothing", field.pH, 7.0)
+  T.eq("scorch: mild day drains no N", field.nitrogen, 60)
+end
+
+-- ── first tick of a pass establishes it but docks nothing (dt == 0) ─────────
+do
+  stubWorld(SULFUR_CERTAIN)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0); sys:applyScorchEffect(1, "SULFUR")
+  T.eq("scorch: first tick of a pass does nothing", field.pH, 7.0)
+end
+
+-- ── a 1000ms slice docks one proportional slice at certain temperature ───────
+do
+  stubWorld(SULFUR_CERTAIN)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  local expectedPh = CERTAIN_PH * (1000 / FULL_MS)
+  local expectedN  = CERTAIN_N  * (1000 / FULL_MS)
+  T.near("scorch: 1000ms slice docks one proportional pH slice", 7.0 - field.pH, expectedPh, 1e-6)
+  T.near("scorch: 1000ms slice drains one proportional N slice", 60 - field.nitrogen, expectedN, 1e-6)
+end
+
+-- ── sibling boom section in the same tick (dt == 0) docks nothing extra ──────
+do
+  stubWorld(SULFUR_CERTAIN)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  local afterFirstPh = field.pH
+  local afterFirstN  = field.nitrogen
+  sys:applyScorchEffect(1, "SULFUR")   -- sibling, same time=1000 → dt==0
+  T.eq("scorch: sibling section (dt==0) adds no extra pH dock", field.pH, afterFirstPh)
+  T.eq("scorch: sibling section (dt==0) adds no extra N drain", field.nitrogen, afterFirstN)
+end
+
+-- ── sustained heat ramps to - and caps at - the certain per-pass magnitude ───
+do
+  stubWorld(SULFUR_CERTAIN)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0); sys:applyScorchEffect(1, "SULFUR")
+  local t = 0
+  while t < FULL_MS * 2 do
+    t = t + 1000
+    at(t); sys:applyScorchEffect(1, "SULFUR")
+  end
+  T.near("scorch: sustained heat caps pH drop at the certain magnitude", 7.0 - field.pH, CERTAIN_PH, 1e-6)
+  T.near("scorch: sustained heat caps N drain at the certain magnitude", 60 - field.nitrogen, CERTAIN_N, 1e-6)
+end
+
+-- ── risk band: magnitude scales linearly with excess ─────────────────────────
+-- At the band midpoint the excess is 0.5, so the per-pass caps halve.
+do
+  stubWorld(SULFUR_RISK + SFS.HEAT_BAND_WIDTH * 0.5)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  local excess = 0.5
+  local expectedPh = (SFS.SCORCH_PH_DROP_RISK * excess) * (1000 / FULL_MS)
+  local expectedN  = (SFS.SCORCH_N_DRAIN_RISK  * excess) * (1000 / FULL_MS)
+  T.near("scorch: mid-band slice scales pH by excess", 7.0 - field.pH, expectedPh, 1e-6)
+  T.near("scorch: mid-band slice scales N by excess", 60 - field.nitrogen, expectedN, 1e-6)
+end
+
+-- ── crop gate: bare ground and seedlings cannot scorch ───────────────────────
+do
+  stubWorld(SULFUR_CERTAIN, { fruitTypeIndex = FruitType.UNKNOWN, growthState = 6 })
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.eq("scorch: bare ground cannot scorch", field.pH, 7.0)
+end
+
+do
+  stubWorld(SULFUR_CERTAIN, { fruitTypeIndex = WHEAT.fruitTypeIndex, growthState = 1 })
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.eq("scorch: a seedling cannot scorch", field.pH, 7.0)
+end
+
+-- ── an established crop DOES scorch ──────────────────────────────────────────
+do
+  stubWorld(SULFUR_CERTAIN, WHEAT)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.ok("scorch: an established crop takes a proportional slice", field.pH < 7.0)
+  T.ok("scorch: established crop loses N too", field.nitrogen < 60)
+end
+
+-- ── own accumulator: a gap opens a fresh pass (its first tick docks nothing) ─
+do
+  stubWorld(SULFUR_CERTAIN, WHEAT)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")   -- one slice
+  local afterPass1 = field.pH
+  at(1000 + GAP_MS + 1); sys:applyScorchEffect(1, "SULFUR")  -- gap → fresh pass
+  T.eq("scorch: a gap > BURN_PASS_GAP_MS opens a fresh pass (no dock that tick)",
+       field.pH, afterPass1)
+end
+
+-- ── scorch's accumulator is independent of the rate burn's ───────────────────
+-- A pass that trips scorch writes _scorchTickTime/_scorchPassPh, never the
+-- burn's _lastBurnTickTime/_burnPassPh: resetting one must not reset the other.
+do
+  stubWorld(SULFUR_CERTAIN, WHEAT)
+  local field = { pH = 7.0, nitrogen = 60 }
+  local sys = newSys(field)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.ok("scorch: uses its own tick timestamp", field._scorchTickTime ~= nil)
+  T.ok("scorch: does not write the burn's tick timestamp", field._lastBurnTickTime == nil)
+  T.ok("scorch: own pass accumulator exists", field._scorchPassPh ~= nil and field._scorchPassPh > 0)
+end
+
+-- ── the pH floor still applies under the nutrient limits ─────────────────────
+do
+  stubWorld(SULFUR_CERTAIN, WHEAT)
+  local low = { pH = SoilConstants.NUTRIENT_LIMITS.PH_MIN + 0.01, nitrogen = 0.5 }
+  local sys = newSys(low)
+  at(0);    sys:applyScorchEffect(1, "SULFUR")
+  at(1000); sys:applyScorchEffect(1, "SULFUR")
+  T.ok("scorch: pH docks toward but never below the floor",
+       low.pH >= SoilConstants.NUTRIENT_LIMITS.PH_MIN)
+  T.ok("scorch: N docks toward but never below the floor",
+       low.nitrogen >= SoilConstants.NUTRIENT_LIMITS.MIN)
+end


### PR DESCRIPTION
## What Does This PR Do?

CD-14 Spray Scorch + the carried SF-74 spray-path sky read. "I sprayed sulfur on a thirty-degree afternoon and burned my own crop." Spraying a heat-sensitive product on a hot day damages the SOIL under a standing established crop: pH down, nitrogen drained - exactly the currency this mod trades in. The crop is not killed and the chemical still works; the farmer who checks the forecast pays nothing.

- **NEW `SoilFertilitySystem:applyScorchEffect(fieldId, fillTypeName)`** (src/SoilFertilitySystem.lua), mirrored on `applyBurnEffect`'s band-and-accumulator shape but on a temperature scale:
  - risk band: `riskT = HEAT_RISK_BASE - shift`, `certainT = riskT + HEAT_BAND_WIDTH`; below riskT nothing, at/above certainT the full per-pass caps, between them magnitude scales linearly with the excess (the rate burn's exact clamp shape)
  - crop gate (the #532 pattern): resolves the crop via `_lastSprayX/_lastSprayZ` + a live `FieldState` query, requires `hasCrop` and `isAmendmentBurnRisk` - bare ground and seedlings cannot scorch
  - scorch's OWN accumulator (`_scorchTickTime`/`_scorchPassPh`/`_scorchPassN`) and OWN broadcast throttle (`_scorchBroadcast`), pass continuity on the burn's gap/full clock - never shared with the rate burn, so a pass tripping both pays each cap once
  - pH/N docked under the existing `NUTRIENT_LIMITS` floors
- **SF-74:** the spray-path sky read, one module-local accessor pair in the `MaterialWetness.lua:305-323` pattern (`weatherGuard` + `readSprayTemperature`). nil temperature means NO scorch and NO state change; no WeatherGuard is not a mild day.
- **NEW `SoilConstants.HEAT_SENSITIVITY`** (SULFUR shift 4, COPPER_HYDROXIDE shift 2) beside `FERTILIZER_PROFILES`, plus `HEAT_RISK_BASE`/`HEAT_BAND_WIDTH` and per-band `SCORCH_PH_DROP_*`/`SCORCH_N_DRAIN_*` caps in `SPRAYER_RATE`. **SHIP stand-ins marked ARISSANI'S at the unlock (steward C2); ratio-pass candidates awaiting the spine.**
- **CALLED UNCONDITIONALLY from BOTH spray closures** (applySingle and applyMulti's twin), immediately after the burn branch, BESIDE it, never inside the `FERTILIZER_PROFILES` N/P/K guard - SULFUR and COPPER_HYDROXIDE take the fungicide branch and never reach the guarded lines. The sensitivity probe is the whole cost of the unconditional call.

## Related Issue

CD-14, build brief `Office Tyson/mods/FS25_SoilFertilizer/CD-14-spray-scorch-BUILD-BRIEF.md` (carries SF-74 as its named prerequisite, steward C1). Steward review SOUND WITH CONDITIONS; C1 discharged by the accessor; C2 (Arissani's numbers pass) gates the UNLOCK and never the merge.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation / translations
- [ ] Build / tooling

## How Was This Tested?

- [x] Test suite green: 2303 assertions / 49 files (new `scorch_cd14_test.lua`, 25 assertions: insensitive product, nil-honest absent WeatherGuard, below-risk no-op, first-tick no-op, proportional slice, sibling dt==0, sustained cap at the certain magnitude, mid-band linear scaling, bare-ground and seedling gates, established crop takes damage, fresh-pass gap, own-accumulator independence, pH/N floors).
- [x] Lua 5.1 syntax + lint clean (76 files).
- [ ] Singleplayer - in-game observation pending: game has not launched on the new zip yet. Needs: 30+ deg C + SULFUR on a standing crop drains pH/N after ~8s of continuous spray; a mild day pays nothing; the WeatherGuard handle is live at the moment `onEndWorkAreaProcessing` fires (load order).

- [ ] Relevant console commands ran

## Checklist

- [ ] I read `DEVELOPMENT.md` before writing code
- [x] I targeted the `development` branch (not `main`)
- [x] My change touches only what it needs to - no unrelated edits
- [ ] If I added a setting: one entry in the settings schema + translations
- [ ] If I changed behaviour: docs updated in the same pass (notes.md)
- [x] No `assert()` calls
- [x] No Lua 5.2+ syntax

## Screenshots / Log Output

Not yet tested in game. Deployed zip contains the updated files.
