### PR TITLE
fix: AI-1 buy-mode helper soil consequence

### DIFF
--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -3540,6 +3540,82 @@ function HookManager:installSprayerAreaHook()
                 end
             end
 
+            -- AI-1: an AI helper spraying in buy mode currently leaves the ground
+            -- untouched. Buy mode ships zero usage and zero sprayFillLevel (the tank
+            -- is externally filled, never drained, so the two guards below exit
+            -- every frame) while Hook 9's getExternalFill already charged the farm
+            -- at the 1.5x AI premium. Suite doctrine: an AI action triggers our
+            -- consequence like a player's. Detect a genuinely-working AI helper in
+            -- buy mode and inject the three work-area parameters the guards read.
+            -- Genuinely working is established upstream (the turnedOn / folded guards
+            -- above already passed; the speed guard below stays). The usage is the
+            -- SAME speed x width x litersPerSecond figure the external-fill billing
+            -- uses (Hook 9, getExternalFill), so agronomy matches what was paid for.
+            -- wap.sprayVehicle is NEVER set: the :4023 self-skip is the double-charge
+            -- protection and it keys on that field staying nil on the external-fill
+            -- path. isInBuyMode is scoped inside installPurchaseRefillHook, so the
+            -- detection is mirrored inline (same three mission flags, same AI paths).
+            if (liters == nil or liters <= 0) and (sprayFillLevel == nil or sprayFillLevel <= 0) then
+                local isAI = false
+                local okAIb, resAIb = pcall(function() return self:getIsAIActive() end)
+                if okAIb and resAIb then isAI = true end
+                if not isAI and self.spec_aiVehicle and self.spec_aiVehicle.isActive then isAI = true end
+                if not isAI and self.spec_aiJobVehicle and self.spec_aiJobVehicle.job ~= nil then isAI = true end
+                if not isAI and self.spec_cpAIWorker and self.spec_cpAIWorker.isActive then isAI = true end
+                if not isAI and self.cp and self.cp.isActive then isAI = true end
+
+                local buyActive = false
+                if isAI and g_currentMission and g_currentMission.missionInfo then
+                    local mi = g_currentMission.missionInfo
+                    local ftB = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(fillTypeIndex)
+                    local ftNameB = ftB and ftB.name or "UNKNOWN"
+                    if ftNameB == "LIQUIDMANURE" or ftNameB == "DIGESTATE" then
+                        buyActive = (mi.helperSlurrySource == 2)
+                    elseif ftNameB == "MANURE" then
+                        buyActive = (mi.helperManureSource == 2)
+                    else
+                        buyActive = (mi.helperBuyFertilizer == true)
+                    end
+                end
+
+                if buyActive then
+                    -- Same billing figure as getExternalFill (Hook 9):
+                    -- scale x litersPerSecond x actualSpeed_km/h x workWidth_m x dt_ms x 0.001
+                    local actualSpeedKmh = math.abs(self.lastSpeed or 0) * 3600
+                    if actualSpeedKmh >= 0.5 then
+                        local specB   = self.spec_sprayer
+                        local usScaleB = specB and specB.usageScale
+                        local okASTb, activeSpTB = pcall(function() return self:getActiveSprayType() end)
+                        if okASTb and activeSpTB and activeSpTB.usageScale then
+                            usScaleB = activeSpTB.usageScale
+                        end
+                        local workWidthB = (usScaleB and usScaleB.workingWidth) or 12
+                        if usScaleB and usScaleB.workAreaIndex then
+                            local okWB, wB = pcall(function() return self:getWorkAreaWidth(usScaleB.workAreaIndex) end)
+                            if okWB and wB and wB > 0 then workWidthB = wB end
+                        end
+                        local fillScaleB = 1
+                        if specB and specB.usageScale then
+                            local ftScalesB = specB.usageScale.fillTypeScales
+                            fillScaleB = (ftScalesB and ftScalesB[fillTypeIndex]) or specB.usageScale.default or 1
+                        end
+                        local spTB = g_sprayTypeManager and g_sprayTypeManager:getSprayTypeByFillTypeIndex(fillTypeIndex)
+                        local lpsB = spTB and spTB.litersPerSecond or 1
+                        local injectedUsage = fillScaleB * lpsB * actualSpeedKmh * workWidthB * dt * 0.001
+
+                        if injectedUsage > 0 then
+                            spec.workAreaParameters.usage          = injectedUsage
+                            spec.workAreaParameters.sprayFillLevel = injectedUsage
+                            spec.workAreaParameters.sprayFillType  = fillTypeIndex
+                            liters         = injectedUsage
+                            sprayFillLevel = injectedUsage
+                            SoilLogger.debug("AI-1: buy-mode AI helper injected usage=%.2f L (agronomy matches billing)",
+                                injectedUsage)
+                        end
+                    end
+                end
+            end
+
             if not liters or liters <= 0 then
                 -- Throttle: log at most once per 3 s per vehicle to avoid headland-turn spam
                 local _now = g_currentMission and g_currentMission.time or 0


### PR DESCRIPTION
## What Does This PR Do?

AI-1: a hired AI helper spraying in buy mode now triggers the soil consequence exactly like a player's (suite doctrine). Previously buy mode shipped zero `usage` and zero `sprayFillLevel`, so the two guards read nothing-happened while Hook 9's `getExternalFill` charged the farm at the 1.5x AI premium: the player paid and got no agronomy.

**ONE injection block** inside `installSprayerAreaHook`'s closure, before the usage guard (src/hooks/HookManager.lua). It detects a genuinely-working AI helper in buy mode and injects the three work-area parameters the guards read:
- **`usage`** computed from the SAME speed x width x litersPerSecond billing figure the external-fill charge uses (Hook 9's `getExternalFill`), so agronomy matches what was paid for
- **`sprayFillLevel`** set to the injected usage (the minimal honest value that passes the guard; it enters no coverage math)
- **`sprayFillType`**

**NEVER sets `wap.sprayVehicle`** — the `:4023` self-skip is the double-charge protection and it keys on that field staying nil on the external-fill path. Genuinely-working is established upstream (the turnedOn/folded guards already passed); the speed guard below stays. Neutral when absent/non-buy: a player pass, a non-buy AI pass, a parked/folded rig inject nothing and hit the shipped guards unchanged. Zero new strings.

## Related Issue

AI-1, build brief `Office Tyson/mods/FS25_SoilFertilizer/AI-1-buymode-BUILD-BRIEF.md` (SDS v1.1, cold-reviewed to convergence 2026-07-24). Steward SOUND; ratification covered by Arissani's 2026-08-07 blanket.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation / translations
- [ ] Build / tooling

## How Was This Tested?

- [x] Test suite green: 2303 assertions / 49 files; Lua 5.1 syntax + lint clean.
- [ ] Singleplayer - in-game observation pending: game has not launched on the new zip yet. Needs: (a) a buy-mode AI helper on a fertilizer pass changes soil values and paints the boom strip; (b) the farm is charged ONCE (the external-fill site with the premium; the backup block self-skips); (c) a player pass is bit-identical to before; (e) the injected fill level shows no coverage-accounting artifact.

- [ ] Relevant console commands ran

## Notes for reviewers

One build-time adjustment disclosed in the ledger: the brief cites the shipped `isInBuyMode` helper (HookManager.lua:6190) as callable from the injection block, but that helper is a local scoped inside `installPurchaseRefillHook` and is not reachable from `installSprayerAreaHook`'s closure. The block mirrors its detection inline - the same three mission flags and the same five AI paths - matching the file's existing pattern (the backup block at :4049 does the same mirroring). Same truth table, no behavior difference.

## Checklist

- [ ] I read `DEVELOPMENT.md` before writing code
- [x] I targeted the `development` branch (not `main`)
- [x] My change touches only what it needs to - no unrelated edits
- [ ] If I added a setting: one entry in the settings schema + translations
- [ ] If I changed behaviour: docs updated in the same pass (notes.md)
- [x] No `assert()` calls
- [x] No Lua 5.2+ syntax

## Screenshots / Log Output

Not yet tested in game. Deployed zip contains the updated HookManager.lua.
