### PR TITLE
fix: module page dots always visible on the Esc panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,6 +62,9 @@
 - [x] Rotation Planner and Field Detail now open from the Esc panel bottom bar (MENU_EXTRA_2 / MENU_ACTIVATE), passing the panel's selectedFieldId (nil allowed).
 - [x] The map sidebar report/treatment buttons work again via the retained-page pattern: stand-down keeps the deep page on SoilPDAScreen._retainedDeepScreen, and show/toggle/showTreatment re-inject it into InGameMenu paging without restoring the Esc tab icon. In-game observation still pending.
 
+## 2026-08-07 (Fred): module page dots always visible
+- [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.
+
 
 ## 2026-08-07 (Bob): SF #764 root-caused and fixed - AI out-of-fill stop restored
 - [x] Issue #764 (Courseplay empty-tank): the diagnostic 2.5.0.6 trace build proved the tank reaches exactly zero in the failing runs but the fill unit type does NOT reset to UNKNOWN, so Sprayer:processSprayerArea never raises stopCurrentAIJob(OutOfFill) and Courseplay keeps driving. Root cause: the final drain leaves a sub-threshold residual (0 < level < 0.0005) above the engine's 0.00001 reset threshold; our speed-based getSprayerUsage makes that exact arithmetic vary run to run, which is the intermittency. Fix: in the appended onEndWorkAreaProcessing, complete the drain through the engine's own addFillUnitFillLevel when the tank is effectively empty (level < 0.001, type still set), so the engine's UNKNOWN reset fires and the AI stop works. In-game verification still pending.

--- a/TODO.md
+++ b/TODO.md
@@ -74,3 +74,6 @@
 - [x] Cross-mod resolution: the door can be built by another mod's RfPdaMenuPage (MDM loads first), so callbacks now resolve Soil classes via the g_currentMission handoff instead of bare globals. Deployed and verified in-game.
 - [x] Treatment button dropped after in-game pass: the map sidebar still opens the Treatment tab; the Esc panel keeps Back, Help, Rotation Planner, Field Detail.
 - [x] Help button shows only on the Soil module; other modules show Back only (the Soil guide is Soil-specific).
+
+## Module page dots always visible (2026-08-07)
+- [x] The Esc RF module page dots were hidden while Worker Costs or Market Dynamics was active, so WC never read as the 3rd module. All four RfPdaMenuPage copies now keep them visible. Built, deployed, PR open.

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1113,8 +1113,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcSideInfoShell, isWc)
     setVis(self.wcSideVersion, false)
     setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
-    -- On WC: hide Brand mid chrome so page sibling band owns that Y; Modules dock stays.
-    setVis(self.rfPanelDotBox, not isWc)
+    -- Module page dots always visible (umbrella: dots = N, chrome geometry unchanged).
+    setVis(self.rfPanelDotBox, true)
     setVis(self.rfDotLegend, false)
     setVis(self.rfSuiteHint, false)
     setVis(self.rfSideMidSeparator, false)


### PR DESCRIPTION
The Esc RF module selector hides its page dots when Worker Costs or Market Dynamics is the active module. Soil and Crop Stress always showed theirs, so the left panel read inconsistently and WC never displayed as the 3rd module. The dots now stay visible for every module and stay in sync with the module selector (dots = N, per the esc-rf-pda umbrella brief).

Verified: built and deployed, Lua 5.1 syntax gate clean, full suite green.