### PR TITLE
SF-20 relief weight: organic matter follows the ground

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3482,6 +3482,32 @@ local VM_SEED_SPREAD = {
     compaction    = 0,
 }
 
+-- SF-20 RELIEF WEIGHT: seed one nutrient layer. Organic matter is painted from
+-- the field's own terrain relief (low ground is richer); every other layer keeps
+-- the cosmetic Perlin spread. Relief REPLACES the spread only where relief
+-- exists - on a field flatter than the guard, seedPolygonByRelief declines and
+-- this falls through to exactly today's behaviour.
+--
+-- Organic matter is the ONE property where a static terrain-derived deviation is
+-- honest. Nitrogen here is plant-available N, a seasonal weather-driven
+-- quantity, not a landscape-structural one: do NOT extend this to N/P/K/pH.
+local function vmSeedNutrient(vm, key, verts, baseValue, spread)
+    if key == "organicMatter" and baseValue and baseValue > 0 then
+        local relief = SoilConstants.RELIEF
+        -- Guarded on the method as well as the constants: seeding must degrade
+        -- to the existing path on any value-maps object that predates SF-20
+        -- rather than take a field's seeding down with it.
+        if relief and vm.seedPolygonByRelief then
+            local amplitude = baseValue * relief.AMPLITUDE_FRACTION * relief.AGRONOMY_SCALE
+            if amplitude >= (relief.MIN_AMPLITUDE or 0)
+               and vm:seedPolygonByRelief(key, verts, baseValue, amplitude) then
+                return
+            end
+        end
+    end
+    vm:seedPolygon(key, verts, baseValue, spread)
+end
+
 --- True when the per-pixel value maps are usable.
 function SoilFertilitySystem:vmAvailable()
     return self.valueMaps ~= nil and self.valueMaps.available
@@ -3574,10 +3600,14 @@ function SoilFertilitySystem:vmSeedField(fieldId, force)
             end
         end
         if migrated then
-            -- Base fill first so gaps between stamped cells are covered
+            -- Base fill first so gaps between stamped cells are covered.
+            -- [SF-20] The OM base fill is relief-painted; the legacy per-cell
+            -- stamp below then lands ON TOP of it, so a migrated save's real
+            -- stored soil always beats the derived relief picture and only the
+            -- gaps between stamped cells take the terrain-true fill.
             for _, key in ipairs(VM_NUTRIENT_KEYS) do
                 if vmShouldSeed(vm, key, force) then
-                    vm:seedPolygon(key, verts, field[key]
+                    vmSeedNutrient(vm, key, verts, field[key]
                         or SoilConstants.FIELD_DEFAULTS[key], VM_SEED_SPREAD[key])
                 end
             end
@@ -3633,7 +3663,7 @@ function SoilFertilitySystem:vmSeedField(fieldId, force)
     if not migrated then
         for _, key in ipairs(VM_NUTRIENT_KEYS) do
             if vmShouldSeed(vm, key, force) then
-                vm:seedPolygon(key, verts, field[key]
+                vmSeedNutrient(vm, key, verts, field[key]
                     or SoilConstants.FIELD_DEFAULTS[key], VM_SEED_SPREAD[key])
             end
         end

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -102,6 +102,39 @@ SoilConstants.FIELD_VARIATION = {
 }
 
 -- ========================================
+-- RELIEF WEIGHT (SF-20)
+-- ========================================
+-- Organic matter varies within a field by where each patch sits in that field's
+-- own relief: water and material collect downhill, so LOW ground is richer.
+-- Painted into the organicMatter value map at seed time (and as the base fill on
+-- the legacy migration); nothing new is stored and nothing new goes on the wire.
+SoilConstants.RELIEF = {
+    -- Peak-to-peak OM variation across one field, as a FRACTION of that field's
+    -- own OM stock. The brief's balance anchor is roughly 5-20% of stock.
+    -- This is the AGRONOMY dial magnitude of the suite difficulty framework,
+    -- resolved through the vendored resolver (OptionScalingResolver,
+    -- FS25_SettingsHub) when the Option-Scaling Spine ships. Until then the
+    -- neutral identity below is the honest value. One-line change when the
+    -- resolver lands, and deliberately NOT a SoilFertilizer setting (the brief's
+    -- dial-neutral contract: this mod already carries two local difficulty axes).
+    AMPLITUDE_FRACTION = 0.15,
+    -- Neutral identity for the Agronomy dial until the spine resolves it.
+    AGRONOMY_SCALE = 1.0,
+    -- Height range (metres) across a field below which the field carries no
+    -- relief information. Under it every deviation is zero and seeding falls
+    -- back to the existing cosmetic spread, so a flat field looks exactly as it
+    -- does today rather than becoming a flat colour block.
+    MIN_RANGE = 1.5,
+    -- Terrain-sample and paint block size (metres). Matches the existing seed
+    -- block size; sampling finer than the heightmap unit returns interpolation
+    -- rather than information.
+    BLOCK_SIZE = 8,
+    -- Floor on the computed amplitude (OM points). Below this the deviation is
+    -- not worth a second pass over the polygon.
+    MIN_AMPLITUDE = 0.05,
+}
+
+-- ========================================
 -- PLOWING
 -- ========================================
 -- Thresholds for plowing operations

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -801,7 +801,16 @@ function SoilValueMaps:seedPolygonByRelief(key, verts, baseValue, amplitude)
     local dev = SoilValueMaps.computeReliefDeviations(heights, amplitude, minRange)
     if dev == nil then return false end
 
-    -- Pass 2: paint base + deviation over the same blocks. encode() clamps to
+    -- BASE COAT FIRST, and it is not optional. The block loop below only paints
+    -- blocks whose CENTRE falls inside the polygon (isPointInPoly), so pixels in
+    -- the boundary blocks would be left untouched. The path this replaces used
+    -- setPolygonRegion, which covers the polygon EXACTLY, so without this the
+    -- organicMatter layer would lose its field edges on every machine where
+    -- engine polygon ops work. paintPolygon takes the precise path when it can
+    -- and the same block fallback when it cannot.
+    self:paintPolygon(key, verts, baseValue)
+
+    -- Pass 2: overlay base + deviation over the same blocks. encode() clamps to
     -- the layer's range; on a decayed field sitting near its floor the clamp can
     -- absorb part of the deviation (the brief's measured "clamp residual").
     local def = entry.def

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -715,6 +715,107 @@ function SoilValueMaps:seedPolygon(key, verts, baseValue, spread)
     end)
 end
 
+--- SF-20 RELIEF WEIGHT: the pure maths, engine-free so the bench can prove it.
+--- Each sample gets a weight from 0 to 1 by its position in the field's own
+--- relief, LOWEST ground weighing 1 (water and material collect downhill). The
+--- deviation is the amplitude times the signed difference between that sample's
+--- weight and the field's mean weight.
+---
+--- Three properties hold BY CONSTRUCTION, for every possible field shape:
+---   * the deviations sum to exactly zero, so the field-level figure cannot move;
+---   * weights span exactly 0..1 (min and max are drawn from the sample set), so
+---     the peak-to-peak spread is exactly `amplitude` and never more - this is
+---     what the additive form buys, and it is why a narrow valley strip cannot
+---     blow the bound the way a multiplicative form did;
+---   * low ground reads richer than high ground.
+---@param heights number[]  terrain height per sample
+---@param amplitude number  peak-to-peak spread in semantic units
+---@param minRange number|nil  flat-field guard, in metres of height range
+---@return number[]|nil deviations  nil when the field is flatter than minRange
+---@return number|nil meanWeight
+---@return number|nil range
+function SoilValueMaps.computeReliefDeviations(heights, amplitude, minRange)
+    local n = heights and #heights or 0
+    if n == 0 or not amplitude or amplitude <= 0 then return nil end
+
+    local minH, maxH = heights[1], heights[1]
+    for i = 2, n do
+        local h = heights[i]
+        if h < minH then minH = h end
+        if h > maxH then maxH = h end
+    end
+
+    local range = maxH - minH
+    -- Flat guard: no relief means no relief information. The caller falls back.
+    if range < (minRange or 0) or range <= 0 then return nil end
+
+    local weights, sum = {}, 0
+    for i = 1, n do
+        local w = (maxH - heights[i]) / range   -- lowest ground weighs 1
+        weights[i] = w
+        sum = sum + w
+    end
+    local meanWeight = sum / n
+
+    local dev = {}
+    for i = 1, n do
+        dev[i] = amplitude * (weights[i] - meanWeight)
+    end
+    return dev, meanWeight, range
+end
+
+--- SF-20: seed a field polygon's layer from terrain relief instead of cosmetic
+--- noise. Two passes over the SAME block set: sample height, then paint
+--- base + deviation. Sharing the block set is what makes the zero-mean exact.
+---
+--- Returns false when relief cannot or should not drive this field (no terrain
+--- node, no samples, a failed sample, or a field flatter than the guard). The
+--- caller then seeds exactly as it does today - a flat field is unchanged.
+function SoilValueMaps:seedPolygonByRelief(key, verts, baseValue, amplitude)
+    if not self.available or not verts or #verts < 3 then return false end
+    local entry = self.layers[key]
+    if not entry then return false end
+    if g_terrainNode == nil or g_terrainNode == 0 then return false end
+    if getTerrainHeightAtWorldPos == nil then return false end
+
+    local relief = SoilConstants and SoilConstants.RELIEF or nil
+    local blockSize = (relief and relief.BLOCK_SIZE) or 8
+    local minRange  = (relief and relief.MIN_RANGE) or 0
+
+    -- Pass 1: sample terrain height at every in-polygon block centre.
+    local xs, zs, halves, heights = {}, {}, {}, {}
+    local n = 0
+    local sampleFailed = false
+    forEachPolyBlock(verts, blockSize, function(cx, cz, half)
+        if sampleFailed then return end
+        local ok, h = pcall(getTerrainHeightAtWorldPos, g_terrainNode, cx, 0, cz)
+        if not ok or type(h) ~= "number" then
+            sampleFailed = true
+            return
+        end
+        n = n + 1
+        xs[n], zs[n], halves[n], heights[n] = cx, cz, half, h
+    end)
+    if sampleFailed or n == 0 then return false end
+
+    local dev = SoilValueMaps.computeReliefDeviations(heights, amplitude, minRange)
+    if dev == nil then return false end
+
+    -- Pass 2: paint base + deviation over the same blocks. encode() clamps to
+    -- the layer's range; on a decayed field sitting near its floor the clamp can
+    -- absorb part of the deviation (the brief's measured "clamp residual").
+    local def = entry.def
+    local m   = entry.modifier
+    for i = 1, n do
+        local half = halves[i]
+        m:setParallelogramWorldCoords(
+            xs[i] - half, zs[i] - half, xs[i] + half, zs[i] - half, xs[i] - half, zs[i] + half,
+            DensityCoordType.POINT_POINT_POINT)
+        m:executeSet(encode(baseValue + dev[i], def))
+    end
+    return true
+end
+
 --- Shift every written pixel of a field polygon by a semantic delta while
 --- preserving spatial variation (daily processes, rain leaching, harvest
 --- extraction). Deltas smaller than one raw step must be accumulated by the

--- a/tools/test/lua/relief_weight_sf20_test.lua
+++ b/tools/test/lua/relief_weight_sf20_test.lua
@@ -1,0 +1,160 @@
+-- relief_weight_sf20_test.lua
+-- SF-20 THE RELIEF WEIGHT: the executable bar for the seed-time maths.
+-- Locks the three properties the design claims hold BY CONSTRUCTION rather than
+-- by tuning, across four field shapes and four amplitudes:
+--   * DIRECTION  - low ground reads richer than high ground (acceptance check 4)
+--   * CONSERVATION - deviations sum to exactly zero, so the field figure cannot
+--     move (acceptance check 5)
+--   * MAGNITUDE  - peak-to-peak spread is exactly the amplitude and never more,
+--     including the valley strip that broke an earlier design (check 6)
+--   * FLAT GUARD - a field below the relief threshold yields no deviations at
+--     all and the caller falls back to today's behaviour (check 3)
+-- Engine-free: drives SoilValueMaps.computeReliefDeviations directly.
+--!load: src/utils/Logger.lua, src/maps/SoilValueMaps.lua
+
+local compute = SoilValueMaps.computeReliefDeviations
+
+local EPS = 1e-9
+
+-- Field shapes, as terrain heights per sample block.
+local SHAPES = {}
+
+-- 1. A clean slope: heights rise steadily across the field.
+SHAPES.slope = {}
+for i = 1, 40 do SHAPES.slope[i] = 100 + i * 0.5 end
+
+-- 2. A bowl: low in the middle, high at both ends.
+SHAPES.bowl = {}
+for i = 1, 41 do
+  local d = math.abs(i - 21)
+  SHAPES.bowl[i] = 100 + d * 0.4
+end
+
+-- 3. THE VALLEY STRIP - a narrow band of low ground in otherwise flat field.
+--    This is the shape that broke an earlier version of this design: nearly
+--    every sample sits at one height and a handful sit far below.
+SHAPES.valleyStrip = {}
+for i = 1, 60 do SHAPES.valleyStrip[i] = 120.0 end
+for i = 28, 32 do SHAPES.valleyStrip[i] = 112.0 end
+
+-- 4. A ridge - the mirror of the valley strip, a narrow band of HIGH ground.
+SHAPES.ridge = {}
+for i = 1, 60 do SHAPES.ridge[i] = 95.0 end
+for i = 10, 13 do SHAPES.ridge[i] = 103.0 end
+
+local AMPLITUDES = { 0.15, 0.45, 1.2, 3.0 }
+
+local function sum(t)
+  local s = 0
+  for i = 1, #t do s = s + t[i] end
+  return s
+end
+
+local function minMax(t)
+  local lo, hi = t[1], t[1]
+  for i = 2, #t do
+    if t[i] < lo then lo = t[i] end
+    if t[i] > hi then hi = t[i] end
+  end
+  return lo, hi
+end
+
+-- 1. CONSERVATION + MAGNITUDE + BOUND across every shape and amplitude.
+for shapeName, heights in pairs(SHAPES) do
+  for _, amp in ipairs(AMPLITUDES) do
+    local tag = shapeName .. "@" .. tostring(amp)
+    local dev = compute(heights, amp, 1.5)
+    T.ok(tag .. ".produced", dev ~= nil)
+
+    -- CONSERVATION: the deviations sum to zero, so the field total cannot move.
+    T.near(tag .. ".zeroMean", sum(dev), 0, 1e-9)
+
+    -- MAGNITUDE: peak-to-peak is exactly the amplitude, never more.
+    local lo, hi = minMax(dev)
+    T.near(tag .. ".spreadIsAmplitude", hi - lo, amp, 1e-9)
+
+    -- BOUND: no single deviation may exceed the amplitude in either direction.
+    T.ok(tag .. ".withinBound", (hi <= amp + EPS) and (lo >= -amp - EPS))
+  end
+end
+
+-- 2. DIRECTION: the lowest ground must gain and the highest must lose.
+--    Getting this backwards is agronomically inverted and is an easy slip.
+do
+  local heights = SHAPES.slope
+  local dev = compute(heights, 1.0, 1.5)
+  local lowIdx, highIdx = 1, 1
+  for i = 2, #heights do
+    if heights[i] < heights[lowIdx]  then lowIdx  = i end
+    if heights[i] > heights[highIdx] then highIdx = i end
+  end
+  T.ok("direction.lowGroundGains",  dev[lowIdx]  > 0)
+  T.ok("direction.highGroundLoses", dev[highIdx] < 0)
+  T.ok("direction.lowBeatsHigh",    dev[lowIdx]  > dev[highIdx])
+  -- The extremes carry the full amplitude between them.
+  T.near("direction.extremeSpread", dev[lowIdx] - dev[highIdx], 1.0, 1e-9)
+end
+
+-- 3. THE VALLEY STRIP, called out on its own because it is the failure case.
+--    A handful of low cells among many flat ones must NOT blow the bound.
+do
+  local dev = compute(SHAPES.valleyStrip, 0.45, 1.5)
+  local lo, hi = minMax(dev)
+  T.near("valley.spread", hi - lo, 0.45, 1e-9)
+  T.ok("valley.valleyIsRicher", dev[30] > dev[1])
+  -- The valley is the minority, so the mean weight sits near zero and the
+  -- majority's deviation is small and negative while the strip carries most
+  -- of the amplitude. Asymmetry is correct; exceeding the bound is not.
+  T.ok("valley.majorityNearZero", math.abs(dev[1]) < 0.45 * 0.25)
+  T.ok("valley.stripCarriesMost", dev[30] > 0.45 * 0.75)
+end
+
+-- 4. FLAT GUARD: below the relief threshold there is nothing to paint.
+do
+  local flat = {}
+  for i = 1, 30 do flat[i] = 88.0 end
+  T.eq("flat.identical", compute(flat, 1.0, 1.5), nil)
+
+  -- Gently undulating, but still under the 1.5 m guard.
+  local gentle = {}
+  for i = 1, 30 do gentle[i] = 88.0 + (i % 3) * 0.4 end   -- range 0.8 m
+  T.eq("flat.underThreshold", compute(gentle, 1.0, 1.5), nil)
+
+  -- Just over the guard: it must engage.
+  local justOver = {}
+  for i = 1, 30 do justOver[i] = 88.0 + (i % 2) * 1.6 end -- range 1.6 m
+  T.ok("flat.overThresholdEngages", compute(justOver, 1.0, 1.5) ~= nil)
+end
+
+-- 5. DEGENERATE INPUTS never produce a deviation.
+do
+  T.eq("degenerate.empty",        compute({}, 1.0, 1.5), nil)
+  T.eq("degenerate.nilHeights",   compute(nil, 1.0, 1.5), nil)
+  T.eq("degenerate.zeroAmp",      compute(SHAPES.slope, 0, 1.5), nil)
+  T.eq("degenerate.negativeAmp",  compute(SHAPES.slope, -1.0, 1.5), nil)
+  -- A single sample has no range and must be treated as flat, not divided by 0.
+  T.eq("degenerate.singleSample", compute({ 100.0 }, 1.0, 0), nil)
+end
+
+-- 6. SCALE INVARIANCE: the spread follows the amplitude, not the terrain.
+--    A 200 m mountain and a 2 m rise produce the same OM spread for the same
+--    amplitude - relief decides WHERE, the dial decides HOW MUCH.
+do
+  local gentle, steep = {}, {}
+  for i = 1, 25 do
+    gentle[i] = 50 + i * 0.1     -- 2.4 m of range
+    steep[i]  = 50 + i * 8.0     -- 192 m of range
+  end
+  local dg = compute(gentle, 0.6, 1.5)
+  local ds = compute(steep,  0.6, 1.5)
+  local glo, ghi = minMax(dg)
+  local slo, shi = minMax(ds)
+  T.near("scale.gentleSpread", ghi - glo, 0.6, 1e-9)
+  T.near("scale.steepSpread",  shi - slo, 0.6, 1e-9)
+  -- Same shape, same normalised weights, so identical deviations throughout.
+  for i = 1, #dg do
+    T.near("scale.identical." .. i, dg[i], ds[i], 1e-9)
+  end
+end
+
+T.summary()


### PR DESCRIPTION
Organic matter has always read as one flat number across a whole field. It now varies by where each patch sits in that field's own relief: water and material collect downhill, so **low ground is richer**.

Builds `RELIEF-WEIGHT-BUILD-BRIEF.md` per its **assembly rebase addendum (2026-07-22)** — compute-at-read is dead (the fork renders raw map states through the DMV pipeline with no read hook), so the relief deviations are painted into the `organicMatter` value map at seed time and as the base fill on the legacy migration.

## What it does

- Nothing new is stored, nothing new goes on the wire, no save-format or schema change.
- Server and client derive identical values from identical static terrain, so there is nothing to desynchronise.
- Scope is organic matter only. No yield change and no money change in this version.

## The three properties hold by construction, not by tuning

| Property | Why it cannot fail | Acceptance check |
|---|---|---|
| The field total cannot move | deviations sum to exactly zero | 5 (conservation) |
| Spread is exactly the amplitude, never more | weights span exactly 0..1, since min and max are drawn from the sample set | 6 (magnitude) |
| Low ground reads richer | weight is `(maxH - h) / range`, so the lowest ground weighs 1 | 4 (direction) |

The additive form is what buys the bound. A **narrow valley strip** — the shape that broke an earlier multiplicative version of this design — produces an asymmetric but correctly bounded result, and the bench asserts that explicitly.

## Two judgment calls

**Flat fields keep the cosmetic Perlin spread.** Relief replaces it only where relief exists. Below the 1.5 m guard the painter declines and seeding falls through to today's path unchanged — going uniform would have turned every flat map's minimap into a solid colour block, which is exactly what `seedPolygon`'s own comment says the spread exists to prevent. This also matches the brief's "a flat field behaves exactly as it does today".

**Migration keeps real stored soil.** Relief is the base fill only; the legacy per-cell stamp lands on top of it. Derived terrain never overwrites a player's saved values — only the gaps between stamped cells take the relief picture.

## The dial

Amplitude is **15% of the field's own OM stock**, inside the brief's 5–20% balance anchor. It is the **Agronomy** dial magnitude of the suite difficulty framework and resolves to its neutral identity until the Option-Scaling Spine ships. Deliberately **not** a SoilFertilizer setting, per the brief's dial-neutral contract — this mod already carries two local difficulty axes and a third is the fragmentation the shared framework exists to end.

## Not extended to other nutrients, deliberately

N, P, K and pH stay uniform here. Plant-available nitrogen is a seasonal weather-driven quantity, not a landscape-structural one; three independent agronomy consultations agreed, and organic matter is the one property where a static terrain-derived deviation is honest.

## Tests

`tools/test/lua/relief_weight_sf20_test.lua` — 107 assertions across four field shapes (slope, bowl, valley strip, ridge) and four amplitudes, covering direction, zero-mean, the bound, the flat guard, degenerate inputs and scale invariance.

**Full suite: 2435 assertions passed, 0 failed, across 51 files.**

## One correction to the brief

**Section 6 measurement 1 (terrain-sample cost) is retired by the rebase.** It was scoped to a lazy-at-read weight adding a terrain sample per cell read, and named the boom paths (`HookManager.lua:1376`, `:1576`) as the risk that could reopen the design. Seed-time painting does **zero** reads, so that risk no longer exists. Measurement 2, the clamp residual on a decayed field, still stands and needs the game running.

## Owed before release

- **In-game acceptance checks 4, 5 and 6** (direction, conservation, magnitude) plus the clamp-residual measurement. These need FS25 open.
- **The bundled starting-maps deletion rides this build in the same release** — `resources/soilmaps/*.grle`, `SoilBundledMaps.lua`, and its wiring at `main.lua:58` and `SoilFertilitySystem.lua:138,3038`. Deliberately not in this PR: the brief says never remove them before this build lands, and pulling six hand-baked starting-soil maps before the replacement is confirmed in-game would regress opening soil on those maps. Follow-up commit once the checks pass.
