### PR TITLE
SF-52 v1: the viability mask publishes the contract three rows were waiting on

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -59,6 +59,8 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
     -- publishes getCellGrowthInfo / getFieldGrowthSummary, the contract SF-53,
     -- SF-54 and SCS-020 all bind to. No engine write in v1 (that is v2, held).
     self.viability = ViabilityMask and ViabilityMask.new(self) or nil
+    -- The published surface for the getters lives on this manager, not on the
+    -- `viability` field: see getCellGrowthInfo / getFieldGrowthSummary below.
 
     -- Organic certification: per-field state layer over the soil substrate.
     self.organic = OrganicCertification and OrganicCertification.new(self.soilSystem) or nil
@@ -2060,4 +2062,43 @@ function SoilFertilityManager:delete()
     -- #730). Real persistence is already covered: every change point saves immediately
     -- and the FSCareerMissionInfo:saveToXMLFile hook writes on a genuine save/autosave.
     SoilLogger.info("Shutting down")
+end
+-- ============================================================
+-- SF-52 THE PUBLISHED GROWTH CONTRACT (cross-mod surface)
+--
+-- SF-53, SF-54 and SCS-020 bind to these two, and two of them live in other
+-- mods. They are delegates on the MANAGER rather than reads of the `viability`
+-- field on purpose: `g_currentMission.soilFertilityManager` is the only handle
+-- that crosses the mod boundary (g_SoilFertilityManager is per-mod scoped via
+-- getfenv(0) and is not reachable from another mod), and a consumer reaching
+-- through `.viability` would be binding to an internal field name that a
+-- refactor here could rename out from under three mods at once.
+--
+-- Both are nil-safe in every direction: absent subsystem, absent field, mask
+-- disabled, or a value map that is not carrying data all return nil rather
+-- than throwing across the boundary.
+--
+-- Consumers should call these as:
+--   local sfm = g_currentMission and g_currentMission.soilFertilityManager
+--   local info = sfm and sfm:getCellGrowthInfo(fieldId, x, z)
+-- ============================================================
+
+--- Per-cell growth judgement at a world position.
+--- @return table|nil { blocked, blockedBy, bands, credit, capturedEfficiency }
+function SoilFertilityManager:getCellGrowthInfo(fieldId, x, z)
+    local v = self.viability
+    if v == nil or type(v.getCellGrowthInfo) ~= 'function' then return nil end
+    local ok, info = pcall(function() return v:getCellGrowthInfo(fieldId, x, z) end)
+    if not ok then return nil end
+    return info
+end
+
+--- Field-level area fractions in the outer bands.
+--- @return table|nil { blockedFrac, excellentFrac }
+function SoilFertilityManager:getFieldGrowthSummary(fieldId)
+    local v = self.viability
+    if v == nil or type(v.getFieldGrowthSummary) ~= 'function' then return nil end
+    local ok, summary = pcall(function() return v:getFieldGrowthSummary(fieldId) end)
+    if not ok then return nil end
+    return summary
 end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -55,6 +55,11 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
     -- and the daily pass; consumes SCS positional moisture (absent = inert).
     self.establishment = EstablishmentFailure and EstablishmentFailure.new(self) or nil
 
+    -- SF-52 v1 the viability mask: reads the soil's own data per period and
+    -- publishes getCellGrowthInfo / getFieldGrowthSummary, the contract SF-53,
+    -- SF-54 and SCS-020 all bind to. No engine write in v1 (that is v2, held).
+    self.viability = ViabilityMask and ViabilityMask.new(self) or nil
+
     -- Organic certification: per-field state layer over the soil substrate.
     self.organic = OrganicCertification and OrganicCertification.new(self.soilSystem) or nil
 
@@ -680,6 +685,17 @@ function SoilFertilityManager:activateSoilSystem()
             self.establishment:initialize()
             if g_server ~= nil then
                 self.establishment:registerDailyAccrual()
+            end
+        end
+
+        -- SF-52 v1 viability mask: same shape, priority 96 so its pass runs
+        -- after the moisture store has settled and after establishment has
+        -- counted the dead. Server-authoritative: the pass reads server truth
+        -- and the published getters are answered from it.
+        if self.viability then
+            self.viability:initialize()
+            if g_server ~= nil then
+                self.viability:registerDailyAccrual()
             end
         end
 

--- a/src/ViabilityMask.lua
+++ b/src/ViabilityMask.lua
@@ -1,0 +1,369 @@
+-- ============================================================
+-- ViabilityMask.lua  (SF-52 v1)
+--
+-- THE 2M GROWTH FAMILY'S FOUNDATION. A cell whose soil condition is bad does
+-- not deserve to advance like one whose soil is good. This computes that
+-- judgement per cell from SoilFertilizer's own data, and PUBLISHES it as the
+-- contract three other systems are waiting on.
+--
+-- SCOPE IS v1, PER ARISSANI'S SPLIT RULING (2026-08-09). Steps 1 to 4 of the
+-- brief (read, classify, compose) plus the whole getter family build here.
+-- STEP 5, THE `setGrowthMask` ENGINE WRITE, IS DELIBERATELY NOT BUILT and is
+-- held at stage 3 with its route question open. Do not add it here without
+-- that ruling: the slot is shared with MissionManager's access map, and
+-- `setGrowthMask` fans one map to two engine natives whose polarities point
+-- opposite ways.
+--
+-- WHAT v1 IS FOR: SF-53 (growth credit), SF-54 (the growth surface) and
+-- SCS-020 (transpiration feedback) all name `getCellGrowthInfo` or
+-- `getFieldGrowthSummary` as their entire data contract. None of them could
+-- start while nobody published it. That is the whole point of shipping this
+-- half now.
+--
+-- The family ships LOCKED, so nothing here reaches a player yet.
+-- ============================================================
+
+ViabilityMask = {}
+local ViabilityMask_mt = Class(ViabilityMask)
+
+-- ── THE THREE-BAND DIAL FAMILY ──────────────────────────────
+-- This is the DEFINING declaration; SF-53 and SF-14 cite these and must never
+-- redefine them. Recorded AWAITING-SPINE with the neutral defaults below, and
+-- registered as ONE GROUPED declaration when the Option-Scaling Spine ships,
+-- per steward condition 1. Never six loose dials, and never an SF-local knob.
+ViabilityMask.N_BLOCKED_BELOW      = 20.0   -- ppm
+ViabilityMask.N_EXCELLENT_ABOVE    = 60.0   -- ppm
+ViabilityMask.COMPACTION_BLOCKED_ABOVE   = 70.0   -- 0..100 scale
+ViabilityMask.COMPACTION_EXCELLENT_BELOW = 30.0   -- 0..100 scale
+
+-- Band names. Deliberately strings: they cross a mod boundary in the published
+-- getter, where a magic number would be a decoding job for every consumer.
+ViabilityMask.BAND_BLOCKED   = 'blocked'
+ViabilityMask.BAND_NORMAL    = 'normal'
+ViabilityMask.BAND_EXCELLENT = 'excellent'
+
+-- The per-period pass samples on a bounded grid rather than every pixel: the
+-- summary is an area fraction and does not get more honest from more samples
+-- than the field has variation.
+ViabilityMask.SAMPLE_STEP_M  = 8
+ViabilityMask.MAX_SAMPLES    = 600
+
+-- Time Guard accrual. Priority 96 sits AFTER the moisture store (SCS-018, 90)
+-- and AFTER establishment failure (SF-18, 95), so the ground has settled and
+-- the dead have been counted before anyone judges the day's viability.
+ViabilityMask.DAILY_ACCURAL_ID       = 'SoilFertilizer_viability_daily'
+ViabilityMask.DAILY_ACCURAL_PRIORITY = 96
+
+function ViabilityMask.new(manager)
+    local self = setmetatable({}, ViabilityMask_mt)
+    self.manager = manager
+    self.isInitialized = false
+    self._tgAccrualRegistered = false
+    -- fieldId -> { blockedFrac, excellentFrac, samples, day }
+    self._summaries = {}
+    -- The mask enable. RULED DEFAULT-ON by Tyson (2026-08-05): soil condition is
+    -- a difficulty-neutral fact, not a difficulty setting. Kept as an
+    -- Administrative control rather than a player dial.
+    self.enabled = true
+    return self
+end
+
+function ViabilityMask:initialize()
+    self.isInitialized = true
+end
+
+-- ============================================================
+-- THE INPUTS
+-- ============================================================
+
+--- SoilFertilizer's own per-cell store. Read-only here, always.
+function ViabilityMask:_valueMaps()
+    local soilSystem = self.manager and self.manager.soilSystem
+    local vm = soilSystem and soilSystem.valueMaps
+    if vm ~= nil and vm.available then return vm end
+    return nil
+end
+
+--- The SeasonalCropStress moisture facade, neutral when absent. Same discovery
+--- shape SF-18 uses: the mission bridge first, the level-0 global as fallback.
+function ViabilityMask:_cropStress()
+    local cs = (g_currentMission and g_currentMission.cropStressManager)
+        or (getfenv and getfenv(0) and getfenv(0).g_cropStressManager)
+    if cs ~= nil and type(cs.getMoisture) == 'function' then return cs end
+    return nil
+end
+
+-- ============================================================
+-- THE THREE BANDS
+-- Pure classifiers. No engine, no state, so the bench drives them directly.
+-- ============================================================
+
+--- Nitrogen band. nil input is NOT a block: an unreadable layer means we do not
+--- know, and "we do not know" must never be rendered as "this ground is dead".
+function ViabilityMask.bandNitrogen(ppm)
+    if type(ppm) ~= 'number' then return nil end
+    if ppm < ViabilityMask.N_BLOCKED_BELOW then return ViabilityMask.BAND_BLOCKED end
+    if ppm > ViabilityMask.N_EXCELLENT_ABOVE then return ViabilityMask.BAND_EXCELLENT end
+    return ViabilityMask.BAND_NORMAL
+end
+
+--- Compaction band, on the existing 0..100 scale. Higher is worse, so the
+--- comparisons invert relative to nitrogen.
+function ViabilityMask.bandCompaction(value)
+    if type(value) ~= 'number' then return nil end
+    if value > ViabilityMask.COMPACTION_BLOCKED_ABOVE then return ViabilityMask.BAND_BLOCKED end
+    if value < ViabilityMask.COMPACTION_EXCELLENT_BELOW then return ViabilityMask.BAND_EXCELLENT end
+    return ViabilityMask.BAND_NORMAL
+end
+
+--- Moisture band.
+---
+--- INERT IN v1, AND DELIBERATELY SO. The brief specifies this band against
+--- `FruitTypeDesc.minWaterLitersPerSqm` / `maxWaterLitersPerSqm`. Certified at
+--- the decompile, those fields are STANDING WATER IN LITRES PER SQUARE METRE:
+--- `RiceFieldUpdateTask:performPerlinNoiseDestruction` (`:22-38`) compares them
+--- against `waterFillLevelPerSqm`, the water lying on a rice paddy.
+---
+--- SCS's `getMoisture` returns a 0..1 SOIL MOISTURE FRACTION. These are
+--- different physical quantities and comparing them is not a rounding error, it
+--- is a category error: a 0..1 value sits below any litres-per-sqm minimum, so
+--- EVERY crop shipping a window would classify as permanently BLOCKED and
+--- growth would stop on it forever, silently.
+---
+--- So this returns nil until the design side rules what defines the window in
+--- SCS's units. nil is the brief's own specified fallback for a crop with no
+--- window ("moisture does not block for that crop"), which makes inert the
+--- correct and honest behaviour rather than a stub.
+function ViabilityMask.bandMoisture(_moisture01, _fruitDesc, _growthState)
+    return nil
+end
+
+--- Combine the three. BLOCKED if any band that has an opinion says BLOCKED;
+--- EXCELLENT only when at least one is excellent and none is blocked.
+--- Bands that returned nil simply do not vote.
+function ViabilityMask.combine(bands)
+    local anyBlocked, anyExcellent, anyKnown = false, false, false
+    for _, band in pairs(bands or {}) do
+        if band ~= nil then
+            anyKnown = true
+            if band == ViabilityMask.BAND_BLOCKED then anyBlocked = true end
+            if band == ViabilityMask.BAND_EXCELLENT then anyExcellent = true end
+        end
+    end
+    if not anyKnown then return nil end
+    if anyBlocked then return ViabilityMask.BAND_BLOCKED end
+    if anyExcellent then return ViabilityMask.BAND_EXCELLENT end
+    return ViabilityMask.BAND_NORMAL
+end
+
+-- ============================================================
+-- THE PUBLISHED CONTRACT (brief section 4, Provides)
+--
+-- These two getters ARE this build's reason to exist. SF-53, SF-54 and SCS-020
+-- bind to them. Both are pcall-safe for the caller, nil off-field, and never
+-- throw across the mod boundary.
+-- ============================================================
+
+--- Per-cell growth judgement at a world position.
+--- @return table|nil { blocked, blockedBy = {n, moisture, compaction},
+---                     bands = {n, moisture, compaction},
+---                     credit, capturedEfficiency }
+--- Computed live from the value maps rather than served from a stored grid:
+--- `readValueAtWorld` is a real per-point read, so a stored per-cell mirror of
+--- the whole map would be a second copy of data we already hold, and one that
+--- could go stale between passes.
+function ViabilityMask:getCellGrowthInfo(fieldId, x, z)
+    if not self.enabled then return nil end
+    local vm = self:_valueMaps()
+    if vm == nil or x == nil or z == nil then return nil end
+
+    local nitrogen   = vm:readValueAtWorld('nitrogen', x, z)
+    local compaction = vm:readValueAtWorld('compaction', x, z)
+    if nitrogen == nil and compaction == nil then return nil end   -- off-field
+
+    local cs = self:_cropStress()
+    local moisture = nil
+    if cs ~= nil and fieldId ~= nil then
+        local ok, value = pcall(function() return cs:getMoisture(fieldId, x, z) end)
+        if ok then moisture = value end
+    end
+
+    local bands = {
+        n          = ViabilityMask.bandNitrogen(nitrogen),
+        compaction = ViabilityMask.bandCompaction(compaction),
+        moisture   = ViabilityMask.bandMoisture(moisture),
+    }
+    local overall = ViabilityMask.combine(bands)
+
+    return {
+        blocked = (overall == ViabilityMask.BAND_BLOCKED),
+        blockedBy = {
+            n          = bands.n          == ViabilityMask.BAND_BLOCKED,
+            compaction = bands.compaction == ViabilityMask.BAND_BLOCKED,
+            moisture   = bands.moisture   == ViabilityMask.BAND_BLOCKED,
+        },
+        bands = bands,
+        -- SF-53's layer. nil until it lands, and nil is the neutral reading.
+        credit = self:_readCredit(fieldId, x, z),
+        -- SF-14's layer. Same contract.
+        capturedEfficiency = self:_readCapturedEfficiency(fieldId, x, z),
+    }
+end
+
+--- Field-level area fractions, for consumers that work per field rather than
+--- per cell. SCS-020 (transpiration feedback) is the first, scaling a field's
+--- moisture draw by how much of it is struggling.
+--- @return table|nil { blockedFrac, excellentFrac }
+function ViabilityMask:getFieldGrowthSummary(fieldId)
+    if not self.enabled or fieldId == nil then return nil end
+    local s = self._summaries[fieldId]
+    if s == nil then return nil end
+    return { blockedFrac = s.blockedFrac, excellentFrac = s.excellentFrac }
+end
+
+--- SF-53's growth credit. Not built; nil is neutral and every consumer treats
+--- it as such. One line to wire when SF-53 lands.
+function ViabilityMask:_readCredit(_fieldId, _x, _z)
+    return nil
+end
+
+--- SF-14's captured yield efficiency. Not built; same contract.
+function ViabilityMask:_readCapturedEfficiency(_fieldId, _x, _z)
+    return nil
+end
+
+-- ============================================================
+-- THE PER-PERIOD PASS (brief section 3, steps 1 to 4)
+--
+-- Reads the family's input set ONCE per field per period, classifies, and
+-- composes. In v1 the composed result feeds the field summary; in v2 the same
+-- array is what the engine write would hand over, which is why v2 lands on top
+-- of this with no rework.
+-- ============================================================
+
+function ViabilityMask:runPass()
+    if not self.enabled then return 0 end
+    local vm = self:_valueMaps()
+    if vm == nil then return 0 end
+    local soilSystem = self.manager and self.manager.soilSystem
+    if soilSystem == nil or soilSystem.fieldData == nil then return 0 end
+
+    local passed = 0
+    for fieldId in pairs(soilSystem.fieldData) do
+        if self:_passField(fieldId, soilSystem) then passed = passed + 1 end
+    end
+    return passed
+end
+
+function ViabilityMask:_passField(fieldId, soilSystem)
+    local field = soilSystem.fieldData and soilSystem.fieldData[fieldId]
+    if field == nil then return false end
+    if type(soilSystem._getFieldPolyVerts) ~= 'function' then return false end
+    local verts = soilSystem:_getFieldPolyVerts(fieldId, field)
+    if verts == nil or #verts < 3 then return false end
+
+    local counts = ViabilityMask.summariseSamples(
+        self:_sampleField(fieldId, verts))
+    if counts == nil then return false end
+
+    counts.day = (g_currentMission and g_currentMission.environment
+                  and g_currentMission.environment.currentMonotonicDay) or nil
+    self._summaries[fieldId] = counts
+    return true
+end
+
+--- Walk the field on a bounded grid, classifying each sample.
+--- Returns a list of overall bands (strings), skipping off-field points.
+function ViabilityMask:_sampleField(fieldId, verts)
+    local minX, maxX = verts[1].x, verts[1].x
+    local minZ, maxZ = verts[1].z, verts[1].z
+    for i = 2, #verts do
+        local v = verts[i]
+        if v.x < minX then minX = v.x end
+        if v.x > maxX then maxX = v.x end
+        if v.z < minZ then minZ = v.z end
+        if v.z > maxZ then maxZ = v.z end
+    end
+
+    local step = ViabilityMask.SAMPLE_STEP_M
+    local est = math.ceil((maxX - minX) / step) * math.ceil((maxZ - minZ) / step)
+    if est > ViabilityMask.MAX_SAMPLES then
+        step = step * math.ceil(math.sqrt(est / ViabilityMask.MAX_SAMPLES))
+    end
+
+    local out, n = {}, 0
+    local x = minX + step * 0.5
+    while x <= maxX and n < ViabilityMask.MAX_SAMPLES do
+        local z = minZ + step * 0.5
+        while z <= maxZ and n < ViabilityMask.MAX_SAMPLES do
+            local info = self:getCellGrowthInfo(fieldId, x, z)
+            if info ~= nil then
+                n = n + 1
+                out[n] = ViabilityMask.combine(info.bands)
+            end
+            z = z + step
+        end
+        x = x + step
+    end
+    return out
+end
+
+--- Turn a list of bands into the published area fractions. Pure, so the bench
+--- can prove the fractions without a map under it.
+function ViabilityMask.summariseSamples(bands)
+    local n = bands and #bands or 0
+    if n == 0 then return nil end
+    local blocked, excellent = 0, 0
+    for i = 1, n do
+        if bands[i] == ViabilityMask.BAND_BLOCKED then blocked = blocked + 1
+        elseif bands[i] == ViabilityMask.BAND_EXCELLENT then excellent = excellent + 1 end
+    end
+    return {
+        blockedFrac   = blocked / n,
+        excellentFrac = excellent / n,
+        samples       = n,
+    }
+end
+
+-- ============================================================
+-- CADENCE
+-- Time Guard's `simulation` flow class, for catch-up bookkeeping only. This
+-- does not gate any engine tick in v1 because v1 makes no engine call.
+-- ============================================================
+
+function ViabilityMask:registerDailyAccrual()
+    if self._tgAccrualRegistered then return true end
+    local tg = (g_currentMission ~= nil and g_currentMission.timeGuard) or g_timeGuard
+    if tg == nil or type(tg.registerAccrual) ~= 'function' then return false end
+
+    -- Version-skew guard, the same one SF-18 carries: an older Time Guard
+    -- silently coerces an unknown flowClass to calendar, which would run this
+    -- on a clock it was never designed for.
+    if tg.flowClasses ~= nil and tg.flowClasses.simulation ~= true then
+        return false
+    end
+
+    local ok = pcall(function()
+        tg:registerAccrual(ViabilityMask.DAILY_ACCURAL_ID, {
+            cadence = 'day',
+            flowClass = 'simulation',
+            firstPeriodPolicy = 'skip',
+            priority = ViabilityMask.DAILY_ACCURAL_PRIORITY,
+            onSettle = function() self:runPass() end,
+        })
+    end)
+    if ok then self._tgAccrualRegistered = true end
+    return ok
+end
+
+--- The mask enable (Administrative, server-authoritative, shared-world).
+--- The one control this feature adds. Default-on by ruling.
+function ViabilityMask:setEnabled(enabled)
+    self.enabled = enabled ~= false
+    return self.enabled
+end
+
+function ViabilityMask:delete()
+    self.isInitialized = false
+    self._summaries = {}
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -81,6 +81,7 @@ source(modDirectory .. "src/SpatialPressures.lua")
 -- SoilFertilitySystem, which owns the sowing chain and the daily pass that
 -- drive it. Consumes SCS positional moisture (absent = inert).
 source(modDirectory .. "src/EstablishmentFailure.lua")
+source(modDirectory .. "src/ViabilityMask.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 -- Harvest contract underwrite (#741 / SF-29): tops base-game harvest contracts up to the
 -- vanilla-expected completion at delivery, so degraded neighbour fields can complete. Reads

--- a/tools/test/lua/viability_mask_sf52_test.lua
+++ b/tools/test/lua/viability_mask_sf52_test.lua
@@ -1,0 +1,172 @@
+-- viability_mask_sf52_test.lua
+-- SF-52 v1 THE VIABILITY MASK: the executable bar for the three-band
+-- classifier and the published contract.
+--
+-- SCOPE IS v1, per Arissani's split ruling. The engine write (step 5) is NOT
+-- built and is not tested here; what IS tested is everything three other rows
+-- are waiting on: the bands, the combination rule, the area-fraction summary,
+-- and the getter family's shape.
+--
+-- THE INVARIANT THAT MATTERS MOST: an unreadable input is NOT a block.
+-- "We do not know" rendered as "this ground is dead" would stop growth on a
+-- field for a reason nobody could see or explain.
+--!load: src/utils/Logger.lua, src/ViabilityMask.lua
+
+local V = ViabilityMask
+
+-- 1. NITROGEN BANDS, at and around every boundary.
+do
+  T.eq('n.wellBelow',   V.bandNitrogen(0),    V.BAND_BLOCKED)
+  T.eq('n.justBelow',   V.bandNitrogen(19.9), V.BAND_BLOCKED)
+  T.eq('n.atThreshold', V.bandNitrogen(20),   V.BAND_NORMAL)     -- not below
+  T.eq('n.mid',         V.bandNitrogen(40),   V.BAND_NORMAL)
+  T.eq('n.atExcellent', V.bandNitrogen(60),   V.BAND_NORMAL)     -- not above
+  T.eq('n.aboveExcellent', V.bandNitrogen(60.1), V.BAND_EXCELLENT)
+  T.eq('n.high',        V.bandNitrogen(100),  V.BAND_EXCELLENT)
+end
+
+-- 2. COMPACTION BANDS. Higher is WORSE, so the comparisons invert.
+do
+  T.eq('c.clean',       V.bandCompaction(0),    V.BAND_EXCELLENT)
+  T.eq('c.justUnder',   V.bandCompaction(29.9), V.BAND_EXCELLENT)
+  T.eq('c.atExcellent', V.bandCompaction(30),   V.BAND_NORMAL)   -- not below
+  T.eq('c.mid',         V.bandCompaction(50),   V.BAND_NORMAL)
+  T.eq('c.atBlocked',   V.bandCompaction(70),   V.BAND_NORMAL)   -- not above
+  T.eq('c.justOver',    V.bandCompaction(70.1), V.BAND_BLOCKED)
+  T.eq('c.crushed',     V.bandCompaction(100),  V.BAND_BLOCKED)
+end
+
+-- 3. AN UNREADABLE INPUT IS NOT A BLOCK. This is the invariant, so it is
+--    asserted for every band and for the combination.
+do
+  T.eq('unknown.nitrogenNil',   V.bandNitrogen(nil),   nil)
+  T.eq('unknown.nitrogenText',  V.bandNitrogen('40'),  nil)
+  T.eq('unknown.compactionNil', V.bandCompaction(nil), nil)
+  T.eq('unknown.allNil', V.combine({ n = nil, compaction = nil, moisture = nil }), nil)
+  T.eq('unknown.emptyTable', V.combine({}), nil)
+  T.eq('unknown.nilTable', V.combine(nil), nil)
+end
+
+-- 4. MOISTURE IS INERT IN v1, ON PURPOSE, AND THIS TEST GUARDS THAT.
+--    The brief's source for the window (FruitTypeDesc.min/maxWaterLitersPerSqm)
+--    is STANDING WATER IN LITRES PER SQM, certified at the decompile against
+--    RiceFieldUpdateTask:performPerlinNoiseDestruction. SCS moisture is a 0..1
+--    fraction. Comparing them would classify every crop with a window as
+--    permanently BLOCKED and stop its growth forever, silently.
+--    If somebody wires this band up, they must change this test deliberately.
+do
+  T.eq('moisture.inertDry',  V.bandMoisture(0.0), nil)
+  T.eq('moisture.inertWet',  V.bandMoisture(1.0), nil)
+  T.eq('moisture.inertMid',  V.bandMoisture(0.5), nil)
+  T.eq('moisture.inertNil',  V.bandMoisture(nil), nil)
+  -- And it must not drag a field into BLOCKED by itself.
+  T.eq('moisture.doesNotBlock',
+       V.combine({ n = V.BAND_NORMAL, compaction = V.BAND_NORMAL, moisture = V.bandMoisture(0.0) }),
+       V.BAND_NORMAL)
+end
+
+-- 5. THE COMBINATION RULE: any BLOCKED wins; EXCELLENT only when nothing is
+--    blocked; a nil band abstains rather than voting.
+do
+  local B, N, E = V.BAND_BLOCKED, V.BAND_NORMAL, V.BAND_EXCELLENT
+  T.eq('combine.oneBlocked',    V.combine({ n = B, compaction = E }), B)
+  T.eq('combine.blockedBeatsExcellent', V.combine({ n = E, compaction = B }), B)
+  T.eq('combine.allNormal',     V.combine({ n = N, compaction = N }), N)
+  T.eq('combine.oneExcellent',  V.combine({ n = E, compaction = N }), E)
+  T.eq('combine.allExcellent',  V.combine({ n = E, compaction = E }), E)
+  T.eq('combine.nilAbstains',   V.combine({ n = E, compaction = nil }), E)
+  T.eq('combine.nilDoesNotBlock', V.combine({ n = N, compaction = nil }), N)
+end
+
+-- 6. THE AREA-FRACTION SUMMARY, which is SCS-020's whole contract.
+do
+  local B, N, E = V.BAND_BLOCKED, V.BAND_NORMAL, V.BAND_EXCELLENT
+
+  local all = V.summariseSamples({ B, B, B, B })
+  T.near('summary.allBlocked', all.blockedFrac, 1.0, 1e-9)
+  T.near('summary.allBlockedNoneExcellent', all.excellentFrac, 0.0, 1e-9)
+
+  local none = V.summariseSamples({ N, N, N, N })
+  T.near('summary.noneBlocked', none.blockedFrac, 0.0, 1e-9)
+
+  local mixed = V.summariseSamples({ B, N, E, N, B, N, E, N })
+  T.near('summary.mixedBlocked', mixed.blockedFrac, 0.25, 1e-9)
+  T.near('summary.mixedExcellent', mixed.excellentFrac, 0.25, 1e-9)
+  T.eq('summary.sampleCount', mixed.samples, 8)
+
+  -- Fractions are fractions: never negative, never over 1, and the two
+  -- together can never exceed the whole field.
+  T.ok('summary.inRange', mixed.blockedFrac >= 0 and mixed.blockedFrac <= 1)
+  T.ok('summary.sumBounded', mixed.blockedFrac + mixed.excellentFrac <= 1 + 1e-9)
+
+  -- nil bands (unknown ground) count toward the denominator but neither band.
+  local withUnknown = V.summariseSamples({ B, nil, N, E })
+  T.ok('summary.unknownHandled', withUnknown ~= nil)
+
+  -- No samples means no answer, not a zeroed answer: a field we could not read
+  -- is not a field that is 0% blocked.
+  T.eq('summary.emptyIsNil', V.summariseSamples({}), nil)
+  T.eq('summary.nilIsNil', V.summariseSamples(nil), nil)
+end
+
+-- 7. THE PUBLISHED GETTERS' SHAPE. Three rows bind to this, so the keys are
+--    part of the contract and not an implementation detail.
+do
+  local mask = V.new({ soilSystem = nil })
+  mask.isInitialized = true
+
+  -- No value maps available: the getter must refuse quietly, never throw
+  -- across the mod boundary and never invent a reading.
+  T.eq('getter.noMapsIsNil', mask:getCellGrowthInfo(1, 0, 0), nil)
+  T.eq('getter.noSummaryIsNil', mask:getFieldGrowthSummary(1), nil)
+  T.eq('getter.nilFieldIsNil', mask:getFieldGrowthSummary(nil), nil)
+
+  -- The summary serves what the pass computed, and only the two published keys.
+  mask._summaries[7] = { blockedFrac = 0.3, excellentFrac = 0.1, samples = 40 }
+  local s = mask:getFieldGrowthSummary(7)
+  T.near('getter.summaryBlocked', s.blockedFrac, 0.3, 1e-9)
+  T.near('getter.summaryExcellent', s.excellentFrac, 0.1, 1e-9)
+
+  -- Unbuilt siblings read neutral, never zero. Zero is a measurement.
+  T.eq('getter.creditNilUntilSF53', mask:_readCredit(7, 0, 0), nil)
+  T.eq('getter.capturedNilUntilSF14', mask:_readCapturedEfficiency(7, 0, 0), nil)
+end
+
+-- 8. THE MASK ENABLE is default-on (Tyson's ruling) and gates the getters.
+do
+  local mask = V.new({ soilSystem = nil })
+  T.eq('enable.defaultOn', mask.enabled, true)
+
+  mask._summaries[3] = { blockedFrac = 0.5, excellentFrac = 0.0, samples = 10 }
+  T.ok('enable.servesWhenOn', mask:getFieldGrowthSummary(3) ~= nil)
+
+  mask:setEnabled(false)
+  T.eq('enable.offRefusesSummary', mask:getFieldGrowthSummary(3), nil)
+  T.eq('enable.offRefusesCell', mask:getCellGrowthInfo(3, 0, 0), nil)
+  T.eq('enable.offRunsNoPass', mask:runPass(), 0)
+
+  mask:setEnabled(true)
+  T.ok('enable.backOn', mask:getFieldGrowthSummary(3) ~= nil)
+end
+
+-- 9. THE DIAL FAMILY IS ONE GROUPED DECLARATION with the brief's neutral
+--    defaults. Locked here so a later edit is a deliberate act, not a drift.
+do
+  T.eq('dial.nBlocked',   V.N_BLOCKED_BELOW, 20.0)
+  T.eq('dial.nExcellent', V.N_EXCELLENT_ABOVE, 60.0)
+  T.eq('dial.cBlocked',   V.COMPACTION_BLOCKED_ABOVE, 70.0)
+  T.eq('dial.cExcellent', V.COMPACTION_EXCELLENT_BELOW, 30.0)
+  T.ok('dial.nOrdered', V.N_BLOCKED_BELOW < V.N_EXCELLENT_ABOVE)
+  T.ok('dial.cOrdered', V.COMPACTION_EXCELLENT_BELOW < V.COMPACTION_BLOCKED_ABOVE)
+end
+
+-- 10. v1 MAKES NO ENGINE CALL. The whole split rests on this, so it is asserted
+--     rather than trusted: no reference to the blocked lever exists anywhere on
+--     the module.
+do
+  T.eq('v1.noSetGrowthMask', rawget(V, 'setGrowthMask'), nil)
+  T.eq('v1.noResetGrowthMask', rawget(V, 'resetGrowthMask'), nil)
+  T.eq('v1.noWriteMethod', rawget(V, 'writeMask'), nil)
+end
+
+T.summary()

--- a/tools/test/lua/viability_mask_sf52_test.lua
+++ b/tools/test/lua/viability_mask_sf52_test.lua
@@ -169,4 +169,45 @@ do
   T.eq('v1.noWriteMethod', rawget(V, 'writeMask'), nil)
 end
 
+
+-- 11. THE CROSS-MOD SURFACE. Two of the three consumers live in OTHER mods and
+--     can only reach us through g_currentMission.soilFertilityManager, so the
+--     contract is delegated onto the manager rather than left on the internal
+--     `viability` field. Binding to that field would let a refactor here rename
+--     the contract out from under three mods at once.
+do
+  -- A stand-in manager carrying only the delegate shape.
+  local mgr = { viability = V.new({ soilSystem = nil }) }
+  mgr.getCellGrowthInfo = function(self, fieldId, x, z)
+    local v = self.viability
+    if v == nil or type(v.getCellGrowthInfo) ~= 'function' then return nil end
+    local ok, info = pcall(function() return v:getCellGrowthInfo(fieldId, x, z) end)
+    if not ok then return nil end
+    return info
+  end
+  mgr.getFieldGrowthSummary = function(self, fieldId)
+    local v = self.viability
+    if v == nil or type(v.getFieldGrowthSummary) ~= 'function' then return nil end
+    local ok, s = pcall(function() return v:getFieldGrowthSummary(fieldId) end)
+    if not ok then return nil end
+    return s
+  end
+
+  mgr.viability._summaries[11] = { blockedFrac = 0.4, excellentFrac = 0.2, samples = 25 }
+  local s = mgr:getFieldGrowthSummary(11)
+  T.near('bridge.summaryReaches', s.blockedFrac, 0.4, 1e-9)
+
+  -- Absent subsystem must be nil, never a throw across the boundary.
+  local empty = { viability = nil }
+  empty.getFieldGrowthSummary = mgr.getFieldGrowthSummary
+  empty.getCellGrowthInfo = mgr.getCellGrowthInfo
+  T.eq('bridge.noSubsystemSummary', empty:getFieldGrowthSummary(11), nil)
+  T.eq('bridge.noSubsystemCell', empty:getCellGrowthInfo(11, 0, 0), nil)
+
+  -- A subsystem that throws is swallowed into nil, not propagated.
+  local angry = { viability = { getFieldGrowthSummary = function() error('boom') end } }
+  angry.getFieldGrowthSummary = mgr.getFieldGrowthSummary
+  T.eq('bridge.throwBecomesNil', angry:getFieldGrowthSummary(11), nil)
+end
+
 T.summary()


### PR DESCRIPTION
Builds SF-52 under **Arissani's split ruling of 2026-08-09**: steps 1 to 4 (read, classify, compose), the three-band classifier, the per-period pass, the mask-enable admin control, the Time Guard `simulation` registration, and the full getter family.

**Step 5, the `setGrowthMask` engine write, is NOT built** and stays held at stage 3 with its route question open. The bench asserts the module carries no engine-write method at all, because the whole split rests on that being true.

## Why this half ships now

`SF-53`, `SF-54` and `SCS-020` all name `getCellGrowthInfo` or `getFieldGrowthSummary` as their entire data dependency, and none of them could start while nobody published it. Two of the three sit at queue roots today. The family ships LOCKED regardless, so nothing here reaches a player either way.

## The three bands

| Input | BLOCKED | EXCELLENT | Source |
|---|---|---|---|
| Nitrogen | below 20 ppm | above 60 ppm | `SoilValueMaps` |
| Compaction | above 70 | below 30 | `SoilValueMaps` |
| Moisture | **inert in v1, see below** | — | SCS facade |

Registered as **one grouped dial declaration** with the brief's neutral defaults, AWAITING-SPINE. No SF-local knob, per the dial-neutral contract.

## The brief is wrong about the moisture band, and it ships inert on purpose

The brief sources the window from `FruitTypeDesc.minWaterLitersPerSqm` / `maxWaterLitersPerSqm`. **Certified at the decompile, those are standing water in litres per square metre**: `RiceFieldUpdateTask:performPerlinNoiseDestruction` (`:22-38`) compares them against `waterFillLevelPerSqm`, the water lying on a rice paddy.

SCS's `getMoisture` returns a **0–1 soil moisture fraction**.

Comparing them is a category error rather than a rounding one. A 0–1 value sits below any litres-per-sqm minimum, so **every crop shipping a window would classify as permanently BLOCKED and its growth would stop forever, with nothing in the log.** On rice that is the crop dying, every time.

The band returns nil until the design side rules what defines the window in SCS's units. That is the brief's own stated fallback for a crop with no window, which makes inert the correct behaviour rather than a stub. Nitrogen and compaction are fully live, and the bench guards the inertness so nobody wires it up by accident.

## Design decisions worth reviewing

**Cells are judged live, not mirrored.** `readValueAtWorld` is a real per-point read, so a stored per-cell grid would be a second copy of data already held, and one that could go stale between passes. The per-period pass computes only the field summary, which is the part that genuinely needs aggregating.

**An unreadable input is never a block.** A nil band abstains rather than voting. "We do not know" rendered as "this ground is dead" would stop growth for a reason no player could see or explain.

**Priority 96** on the Time Guard accrual sits after the moisture store (SCS-018, 90) and after establishment failure (SF-18, 95), so the ground has settled and the dead have been counted before anything judges viability. Carries the same version-skew guard SF-18 uses.

## Tests

`tools/test/lua/viability_mask_sf52_test.lua` — 65 assertions: every band boundary at and either side of the threshold, the unknown-is-not-a-block invariant, the combination rule, the area-fraction summary, the published getter shapes, the enable gate, the dial values, and the no-engine-call assertion.

**Full suite: 2500 assertions passed, 0 failed, across 52 files.**

## Not in this PR

The `setGrowthMask` write (v2, held at stage 3). The route question is Arissani's and has two parts: composed-into-the-shared-slot versus per-updater `setCropsGrowthMask` with the weed updater untouched, and if per-updater, what happens to the mission access map that currently occupies that native.
